### PR TITLE
perf: Improve parser performance for typescript

### DIFF
--- a/benchmark/babel-parser/real-case-ts/bench.mjs
+++ b/benchmark/babel-parser/real-case-ts/bench.mjs
@@ -1,0 +1,37 @@
+import Benchmark from "benchmark";
+import baseline from "@babel-baseline/parser";
+import current from "@babel/parser";
+import { report } from "../../util.mjs";
+import { readFileSync } from "fs";
+
+const suite = new Benchmark.Suite();
+
+function createInput(length) {
+  return readFileSync(new URL("ts-parser.txt", import.meta.url), {
+    encoding: "utf-8",
+  }).repeat(length);
+}
+
+const inputs = [1].map(length => ({
+  tag: length,
+  body: createInput(length),
+}));
+
+function benchCases(name, implementation, options) {
+  for (const input of inputs) {
+    suite.add(`${name} ${input.tag} typescript parser.ts`, () => {
+      implementation(input.body, {
+        sourceType: "module",
+        plugins: ["typescript"],
+        ...options,
+      });
+    });
+  }
+}
+
+benchCases("current", current.parse);
+benchCases("baseline", baseline.parse);
+benchCases("current", current.parse);
+benchCases("baseline", baseline.parse);
+
+suite.on("cycle", report).run();

--- a/benchmark/babel-parser/real-case-ts/ts-parser.txt
+++ b/benchmark/babel-parser/real-case-ts/ts-parser.txt
@@ -1,0 +1,10673 @@
+import {
+    AccessorDeclaration,
+    addRange,
+    addRelatedInfo,
+    append,
+    ArrayBindingElement,
+    ArrayBindingPattern,
+    ArrayLiteralExpression,
+    ArrayTypeNode,
+    ArrowFunction,
+    AsExpression,
+    AssertionLevel,
+    AsteriskToken,
+    attachFileToDiagnostics,
+    AwaitExpression,
+    BaseNodeFactory,
+    BinaryExpression,
+    BinaryOperatorToken,
+    BindingElement,
+    BindingName,
+    BindingPattern,
+    Block,
+    BooleanLiteral,
+    BreakOrContinueStatement,
+    BreakStatement,
+    CallExpression,
+    CallSignatureDeclaration,
+    canHaveJSDoc,
+    canHaveModifiers,
+    CaseBlock,
+    CaseClause,
+    CaseOrDefaultClause,
+    CatchClause,
+    CharacterCodes,
+    ClassDeclaration,
+    ClassElement,
+    ClassExpression,
+    ClassLikeDeclaration,
+    ClassStaticBlockDeclaration,
+    CommaListExpression,
+    CommentDirective,
+    commentPragmas,
+    CommentRange,
+    ComputedPropertyName,
+    concatenate,
+    ConditionalExpression,
+    ConditionalTypeNode,
+    ConstructorDeclaration,
+    ConstructorTypeNode,
+    ConstructSignatureDeclaration,
+    containsParseError,
+    ContinueStatement,
+    convertToJson,
+    createDetachedDiagnostic,
+    createNodeFactory,
+    createScanner,
+    createTextChangeRange,
+    createTextSpanFromBounds,
+    Debug,
+    Decorator,
+    DefaultClause,
+    DeleteExpression,
+    Diagnostic,
+    DiagnosticArguments,
+    DiagnosticMessage,
+    Diagnostics,
+    DiagnosticWithDetachedLocation,
+    DoStatement,
+    DotDotDotToken,
+    ElementAccessExpression,
+    emptyArray,
+    emptyMap,
+    EndOfFileToken,
+    ensureScriptKind,
+    EntityName,
+    EnumDeclaration,
+    EnumMember,
+    ExclamationToken,
+    ExportAssignment,
+    ExportDeclaration,
+    ExportSpecifier,
+    Expression,
+    ExpressionStatement,
+    ExpressionWithTypeArguments,
+    Extension,
+    ExternalModuleReference,
+    fileExtensionIs,
+    fileExtensionIsOneOf,
+    findIndex,
+    firstOrUndefined,
+    forEach,
+    ForEachChildNodes,
+    ForInOrOfStatement,
+    ForInStatement,
+    ForOfStatement,
+    ForStatement,
+    FunctionDeclaration,
+    FunctionExpression,
+    FunctionOrConstructorTypeNode,
+    FunctionTypeNode,
+    GetAccessorDeclaration,
+    getBaseFileName,
+    getBinaryOperatorPrecedence,
+    getFullWidth,
+    getJSDocCommentRanges,
+    getLanguageVariant,
+    getLastChild,
+    getLeadingCommentRanges,
+    getSpellingSuggestion,
+    getTextOfNodeFromSourceText,
+    HasJSDoc,
+    hasJSDocNodes,
+    HasModifiers,
+    HeritageClause,
+    Identifier,
+    idText,
+    IfStatement,
+    ImportAttribute,
+    ImportAttributes,
+    ImportClause,
+    ImportDeclaration,
+    ImportEqualsDeclaration,
+    ImportOrExportSpecifier,
+    ImportSpecifier,
+    ImportTypeAssertionContainer,
+    ImportTypeNode,
+    IndexedAccessTypeNode,
+    IndexSignatureDeclaration,
+    InferTypeNode,
+    InterfaceDeclaration,
+    IntersectionTypeNode,
+    isArray,
+    isAssignmentOperator,
+    isAsyncModifier,
+    isClassMemberModifier,
+    isExportAssignment,
+    isExportDeclaration,
+    isExportModifier,
+    isExpressionWithTypeArguments,
+    isExternalModuleReference,
+    isFunctionTypeNode,
+    isIdentifier as isIdentifierNode,
+    isIdentifierText,
+    isImportDeclaration,
+    isImportEqualsDeclaration,
+    isJSDocFunctionType,
+    isJSDocNullableType,
+    isJSDocReturnTag,
+    isJSDocTypeTag,
+    isJsxNamespacedName,
+    isJsxOpeningElement,
+    isJsxOpeningFragment,
+    isKeyword,
+    isKeywordOrPunctuation,
+    isLeftHandSideExpression,
+    isLiteralKind,
+    isMetaProperty,
+    isModifierKind,
+    isNonNullExpression,
+    isPrivateIdentifier,
+    isSetAccessorDeclaration,
+    isStringOrNumericLiteralLike,
+    isTaggedTemplateExpression,
+    isTemplateLiteralKind,
+    isTypeReferenceNode,
+    IterationStatement,
+    JSDoc,
+    JSDocAllType,
+    JSDocAugmentsTag,
+    JSDocAuthorTag,
+    JSDocCallbackTag,
+    JSDocClassTag,
+    JSDocComment,
+    JSDocDeprecatedTag,
+    JSDocEnumTag,
+    JSDocFunctionType,
+    JSDocImplementsTag,
+    JSDocLink,
+    JSDocLinkCode,
+    JSDocLinkPlain,
+    JSDocMemberName,
+    JSDocNameReference,
+    JSDocNamespaceDeclaration,
+    JSDocNonNullableType,
+    JSDocNullableType,
+    JSDocOptionalType,
+    JSDocOverloadTag,
+    JSDocOverrideTag,
+    JSDocParameterTag,
+    JSDocParsingMode,
+    JSDocPrivateTag,
+    JSDocPropertyLikeTag,
+    JSDocPropertyTag,
+    JSDocProtectedTag,
+    JSDocPublicTag,
+    JSDocReadonlyTag,
+    JSDocReturnTag,
+    JSDocSatisfiesTag,
+    JSDocSeeTag,
+    JSDocSignature,
+    JSDocSyntaxKind,
+    JSDocTag,
+    JSDocTemplateTag,
+    JSDocText,
+    JSDocThisTag,
+    JSDocThrowsTag,
+    JSDocTypedefTag,
+    JSDocTypeExpression,
+    JSDocTypeLiteral,
+    JSDocTypeTag,
+    JSDocUnknownTag,
+    JSDocUnknownType,
+    JSDocVariadicType,
+    JsonMinusNumericLiteral,
+    JsonObjectExpressionStatement,
+    JsonSourceFile,
+    JsxAttribute,
+    JsxAttributes,
+    JsxAttributeValue,
+    JsxChild,
+    JsxClosingElement,
+    JsxClosingFragment,
+    JsxElement,
+    JsxExpression,
+    JsxFragment,
+    JsxNamespacedName,
+    JsxOpeningElement,
+    JsxOpeningFragment,
+    JsxOpeningLikeElement,
+    JsxSelfClosingElement,
+    JsxSpreadAttribute,
+    JsxTagNameExpression,
+    JsxText,
+    JsxTokenSyntaxKind,
+    LabeledStatement,
+    LanguageVariant,
+    lastOrUndefined,
+    LeftHandSideExpression,
+    LiteralExpression,
+    LiteralLikeNode,
+    LiteralTypeNode,
+    map,
+    mapDefined,
+    MappedTypeNode,
+    MemberExpression,
+    MetaProperty,
+    MethodDeclaration,
+    MethodSignature,
+    MinusToken,
+    MissingDeclaration,
+    Modifier,
+    ModifierFlags,
+    ModifierLike,
+    modifiersToFlags,
+    ModuleBlock,
+    ModuleDeclaration,
+    ModuleKind,
+    Mutable,
+    NamedExportBindings,
+    NamedExports,
+    NamedImports,
+    NamedImportsOrExports,
+    NamedTupleMember,
+    NamespaceDeclaration,
+    NamespaceExport,
+    NamespaceExportDeclaration,
+    NamespaceImport,
+    NewExpression,
+    Node,
+    NodeArray,
+    NodeFactory,
+    NodeFactoryFlags,
+    NodeFlags,
+    nodeIsMissing,
+    nodeIsPresent,
+    NonNullExpression,
+    noop,
+    normalizePath,
+    NoSubstitutionTemplateLiteral,
+    NullLiteral,
+    NumericLiteral,
+    objectAllocator,
+    ObjectBindingPattern,
+    ObjectLiteralElementLike,
+    ObjectLiteralExpression,
+    OperatorPrecedence,
+    OptionalTypeNode,
+    PackageJsonInfo,
+    ParameterDeclaration,
+    ParenthesizedExpression,
+    ParenthesizedTypeNode,
+    PartiallyEmittedExpression,
+    perfLogger,
+    PlusToken,
+    PostfixUnaryExpression,
+    PostfixUnaryOperator,
+    PragmaContext,
+    PragmaDefinition,
+    PragmaKindFlags,
+    PragmaMap,
+    PragmaPseudoMap,
+    PragmaPseudoMapEntry,
+    PrefixUnaryExpression,
+    PrefixUnaryOperator,
+    PrimaryExpression,
+    PrivateIdentifier,
+    PropertyAccessEntityNameExpression,
+    PropertyAccessExpression,
+    PropertyAssignment,
+    PropertyDeclaration,
+    PropertyName,
+    PropertySignature,
+    PunctuationOrKeywordSyntaxKind,
+    PunctuationSyntaxKind,
+    QualifiedName,
+    QuestionDotToken,
+    QuestionToken,
+    ReadonlyKeyword,
+    ReadonlyPragmaMap,
+    ReadonlyTextRange,
+    ResolutionMode,
+    RestTypeNode,
+    ReturnStatement,
+    SatisfiesExpression,
+    ScriptKind,
+    ScriptTarget,
+    SetAccessorDeclaration,
+    setParent,
+    setParentRecursive,
+    setTextRange,
+    setTextRangePos,
+    setTextRangePosEnd,
+    setTextRangePosWidth,
+    ShorthandPropertyAssignment,
+    skipTrivia,
+    some,
+    SourceFile,
+    SpreadAssignment,
+    SpreadElement,
+    startsWith,
+    Statement,
+    StringLiteral,
+    supportedDeclarationExtensions,
+    SwitchStatement,
+    SyntaxKind,
+    TaggedTemplateExpression,
+    TemplateExpression,
+    TemplateHead,
+    TemplateLiteralToken,
+    TemplateLiteralTypeNode,
+    TemplateLiteralTypeSpan,
+    TemplateMiddle,
+    TemplateSpan,
+    TemplateTail,
+    TextChangeRange,
+    textChangeRangeIsUnchanged,
+    textChangeRangeNewSpan,
+    TextRange,
+    textSpanEnd,
+    textToKeywordObj,
+    ThisExpression,
+    ThisTypeNode,
+    ThrowStatement,
+    toArray,
+    Token,
+    TokenFlags,
+    tokenIsIdentifierOrKeyword,
+    tokenIsIdentifierOrKeywordOrGreaterThan,
+    tokenToString,
+    tracing,
+    TransformFlags,
+    TryStatement,
+    TupleTypeNode,
+    TypeAliasDeclaration,
+    TypeAssertion,
+    TypeElement,
+    TypeLiteralNode,
+    TypeNode,
+    TypeOfExpression,
+    TypeOperatorNode,
+    TypeParameterDeclaration,
+    TypePredicateNode,
+    TypeQueryNode,
+    TypeReferenceNode,
+    UnaryExpression,
+    unescapeLeadingUnderscores,
+    UnionOrIntersectionTypeNode,
+    UnionTypeNode,
+    UpdateExpression,
+    VariableDeclaration,
+    VariableDeclarationList,
+    VariableStatement,
+    VoidExpression,
+    WhileStatement,
+    WithStatement,
+    YieldExpression,
+} from "./_namespaces/ts";
+import * as performance from "./_namespaces/ts.performance";
+
+const enum SignatureFlags {
+    None = 0,
+    Yield = 1 << 0,
+    Await = 1 << 1,
+    Type = 1 << 2,
+    IgnoreMissingOpenBrace = 1 << 4,
+    JSDoc = 1 << 5,
+}
+
+const enum SpeculationKind {
+    TryParse,
+    Lookahead,
+    Reparse,
+}
+
+let NodeConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
+let TokenConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
+let IdentifierConstructor: new (kind: SyntaxKind.Identifier, pos: number, end: number) => Node;
+let PrivateIdentifierConstructor: new (kind: SyntaxKind.PrivateIdentifier, pos: number, end: number) => Node;
+let SourceFileConstructor: new (kind: SyntaxKind.SourceFile, pos: number, end: number) => Node;
+
+/**
+ * NOTE: You should not use this, it is only exported to support `createNode` in `~/src/deprecatedCompat/deprecations.ts`.
+ *
+ * @internal
+ */
+export const parseBaseNodeFactory: BaseNodeFactory = {
+    createBaseSourceFileNode: kind => new (SourceFileConstructor || (SourceFileConstructor = objectAllocator.getSourceFileConstructor()))(kind, -1, -1),
+    createBaseIdentifierNode: kind => new (IdentifierConstructor || (IdentifierConstructor = objectAllocator.getIdentifierConstructor()))(kind, -1, -1),
+    createBasePrivateIdentifierNode: kind => new (PrivateIdentifierConstructor || (PrivateIdentifierConstructor = objectAllocator.getPrivateIdentifierConstructor()))(kind, -1, -1),
+    createBaseTokenNode: kind => new (TokenConstructor || (TokenConstructor = objectAllocator.getTokenConstructor()))(kind, -1, -1),
+    createBaseNode: kind => new (NodeConstructor || (NodeConstructor = objectAllocator.getNodeConstructor()))(kind, -1, -1),
+};
+
+/** @internal */
+export const parseNodeFactory: NodeFactory = createNodeFactory(NodeFactoryFlags.NoParenthesizerRules, parseBaseNodeFactory);
+
+function visitNode<T>(cbNode: (node: Node) => T, node: Node | undefined): T | undefined {
+    return node && cbNode(node);
+}
+
+function visitNodes<T>(cbNode: (node: Node) => T, cbNodes: ((node: NodeArray<Node>) => T | undefined) | undefined, nodes: NodeArray<Node> | undefined): T | undefined {
+    if (nodes) {
+        if (cbNodes) {
+            return cbNodes(nodes);
+        }
+        for (const node of nodes) {
+            const result = cbNode(node);
+            if (result) {
+                return result;
+            }
+        }
+    }
+}
+
+/** @internal */
+export function isJSDocLikeText(text: string, start: number) {
+    return text.charCodeAt(start + 1) === CharacterCodes.asterisk &&
+        text.charCodeAt(start + 2) === CharacterCodes.asterisk &&
+        text.charCodeAt(start + 3) !== CharacterCodes.slash;
+}
+
+/** @internal */
+export function isFileProbablyExternalModule(sourceFile: SourceFile) {
+    // Try to use the first top-level import/export when available, then
+    // fall back to looking for an 'import.meta' somewhere in the tree if necessary.
+    return forEach(sourceFile.statements, isAnExternalModuleIndicatorNode) ||
+        getImportMetaIfNecessary(sourceFile);
+}
+
+function isAnExternalModuleIndicatorNode(node: Node) {
+    return canHaveModifiers(node) && hasModifierOfKind(node, SyntaxKind.ExportKeyword)
+            || isImportEqualsDeclaration(node) && isExternalModuleReference(node.moduleReference)
+            || isImportDeclaration(node)
+            || isExportAssignment(node)
+            || isExportDeclaration(node) ? node : undefined;
+}
+
+function getImportMetaIfNecessary(sourceFile: SourceFile) {
+    return sourceFile.flags & NodeFlags.PossiblyContainsImportMeta ?
+        walkTreeForImportMeta(sourceFile) :
+        undefined;
+}
+
+function walkTreeForImportMeta(node: Node): Node | undefined {
+    return isImportMeta(node) ? node : forEachChild(node, walkTreeForImportMeta);
+}
+
+/** Do not use hasModifier inside the parser; it relies on parent pointers. Use this instead. */
+function hasModifierOfKind(node: HasModifiers, kind: SyntaxKind) {
+    return some(node.modifiers, m => m.kind === kind);
+}
+
+function isImportMeta(node: Node): boolean {
+    return isMetaProperty(node) && node.keywordToken === SyntaxKind.ImportKeyword && node.name.escapedText === "meta";
+}
+
+type ForEachChildFunction<TNode> = <T>(node: TNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined) => T | undefined;
+type ForEachChildTable = { [TNode in ForEachChildNodes as TNode["kind"]]: ForEachChildFunction<TNode>; };
+const forEachChildTable: ForEachChildTable = {
+    [SyntaxKind.QualifiedName]: function forEachChildInQualifiedName<T>(node: QualifiedName, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.left) ||
+            visitNode(cbNode, node.right);
+    },
+    [SyntaxKind.TypeParameter]: function forEachChildInTypeParameter<T>(node: TypeParameterDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.constraint) ||
+            visitNode(cbNode, node.default) ||
+            visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.ShorthandPropertyAssignment]: function forEachChildInShorthandPropertyAssignment<T>(node: ShorthandPropertyAssignment, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.questionToken) ||
+            visitNode(cbNode, node.exclamationToken) ||
+            visitNode(cbNode, node.equalsToken) ||
+            visitNode(cbNode, node.objectAssignmentInitializer);
+    },
+    [SyntaxKind.SpreadAssignment]: function forEachChildInSpreadAssignment<T>(node: SpreadAssignment, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.Parameter]: function forEachChildInParameter<T>(node: ParameterDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.dotDotDotToken) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.questionToken) ||
+            visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.initializer);
+    },
+    [SyntaxKind.PropertyDeclaration]: function forEachChildInPropertyDeclaration<T>(node: PropertyDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.questionToken) ||
+            visitNode(cbNode, node.exclamationToken) ||
+            visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.initializer);
+    },
+    [SyntaxKind.PropertySignature]: function forEachChildInPropertySignature<T>(node: PropertySignature, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.questionToken) ||
+            visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.initializer);
+    },
+    [SyntaxKind.PropertyAssignment]: function forEachChildInPropertyAssignment<T>(node: PropertyAssignment, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.questionToken) ||
+            visitNode(cbNode, node.exclamationToken) ||
+            visitNode(cbNode, node.initializer);
+    },
+    [SyntaxKind.VariableDeclaration]: function forEachChildInVariableDeclaration<T>(node: VariableDeclaration, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.exclamationToken) ||
+            visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.initializer);
+    },
+    [SyntaxKind.BindingElement]: function forEachChildInBindingElement<T>(node: BindingElement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.dotDotDotToken) ||
+            visitNode(cbNode, node.propertyName) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.initializer);
+    },
+    [SyntaxKind.IndexSignature]: function forEachChildInIndexSignature<T>(node: IndexSignatureDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type);
+    },
+    [SyntaxKind.ConstructorType]: function forEachChildInConstructorType<T>(node: ConstructorTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type);
+    },
+    [SyntaxKind.FunctionType]: function forEachChildInFunctionType<T>(node: FunctionTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type);
+    },
+    [SyntaxKind.CallSignature]: forEachChildInCallOrConstructSignature,
+    [SyntaxKind.ConstructSignature]: forEachChildInCallOrConstructSignature,
+    [SyntaxKind.MethodDeclaration]: function forEachChildInMethodDeclaration<T>(node: MethodDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.asteriskToken) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.questionToken) ||
+            visitNode(cbNode, node.exclamationToken) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.body);
+    },
+    [SyntaxKind.MethodSignature]: function forEachChildInMethodSignature<T>(node: MethodSignature, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.questionToken) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type);
+    },
+    [SyntaxKind.Constructor]: function forEachChildInConstructor<T>(node: ConstructorDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.body);
+    },
+    [SyntaxKind.GetAccessor]: function forEachChildInGetAccessor<T>(node: GetAccessorDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.body);
+    },
+    [SyntaxKind.SetAccessor]: function forEachChildInSetAccessor<T>(node: SetAccessorDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.body);
+    },
+    [SyntaxKind.FunctionDeclaration]: function forEachChildInFunctionDeclaration<T>(node: FunctionDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.asteriskToken) ||
+            visitNode(cbNode, node.name) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.body);
+    },
+    [SyntaxKind.FunctionExpression]: function forEachChildInFunctionExpression<T>(node: FunctionExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.asteriskToken) ||
+            visitNode(cbNode, node.name) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.body);
+    },
+    [SyntaxKind.ArrowFunction]: function forEachChildInArrowFunction<T>(node: ArrowFunction, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.equalsGreaterThanToken) ||
+            visitNode(cbNode, node.body);
+    },
+    [SyntaxKind.ClassStaticBlockDeclaration]: function forEachChildInClassStaticBlockDeclaration<T>(node: ClassStaticBlockDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.body);
+    },
+    [SyntaxKind.TypeReference]: function forEachChildInTypeReference<T>(node: TypeReferenceNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.typeName) ||
+            visitNodes(cbNode, cbNodes, node.typeArguments);
+    },
+    [SyntaxKind.TypePredicate]: function forEachChildInTypePredicate<T>(node: TypePredicateNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.assertsModifier) ||
+            visitNode(cbNode, node.parameterName) ||
+            visitNode(cbNode, node.type);
+    },
+    [SyntaxKind.TypeQuery]: function forEachChildInTypeQuery<T>(node: TypeQueryNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.exprName) ||
+            visitNodes(cbNode, cbNodes, node.typeArguments);
+    },
+    [SyntaxKind.TypeLiteral]: function forEachChildInTypeLiteral<T>(node: TypeLiteralNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.members);
+    },
+    [SyntaxKind.ArrayType]: function forEachChildInArrayType<T>(node: ArrayTypeNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.elementType);
+    },
+    [SyntaxKind.TupleType]: function forEachChildInTupleType<T>(node: TupleTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.elements);
+    },
+    [SyntaxKind.UnionType]: forEachChildInUnionOrIntersectionType,
+    [SyntaxKind.IntersectionType]: forEachChildInUnionOrIntersectionType,
+    [SyntaxKind.ConditionalType]: function forEachChildInConditionalType<T>(node: ConditionalTypeNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.checkType) ||
+            visitNode(cbNode, node.extendsType) ||
+            visitNode(cbNode, node.trueType) ||
+            visitNode(cbNode, node.falseType);
+    },
+    [SyntaxKind.InferType]: function forEachChildInInferType<T>(node: InferTypeNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.typeParameter);
+    },
+    [SyntaxKind.ImportType]: function forEachChildInImportType<T>(node: ImportTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.argument) ||
+            visitNode(cbNode, node.attributes) ||
+            visitNode(cbNode, node.qualifier) ||
+            visitNodes(cbNode, cbNodes, node.typeArguments);
+    },
+    [SyntaxKind.ImportTypeAssertionContainer]: function forEachChildInImportTypeAssertionContainer<T>(node: ImportTypeAssertionContainer, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.assertClause);
+    },
+    [SyntaxKind.ParenthesizedType]: forEachChildInParenthesizedTypeOrTypeOperator,
+    [SyntaxKind.TypeOperator]: forEachChildInParenthesizedTypeOrTypeOperator,
+    [SyntaxKind.IndexedAccessType]: function forEachChildInIndexedAccessType<T>(node: IndexedAccessTypeNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.objectType) ||
+            visitNode(cbNode, node.indexType);
+    },
+    [SyntaxKind.MappedType]: function forEachChildInMappedType<T>(node: MappedTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.readonlyToken) ||
+            visitNode(cbNode, node.typeParameter) ||
+            visitNode(cbNode, node.nameType) ||
+            visitNode(cbNode, node.questionToken) ||
+            visitNode(cbNode, node.type) ||
+            visitNodes(cbNode, cbNodes, node.members);
+    },
+    [SyntaxKind.LiteralType]: function forEachChildInLiteralType<T>(node: LiteralTypeNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.literal);
+    },
+    [SyntaxKind.NamedTupleMember]: function forEachChildInNamedTupleMember<T>(node: NamedTupleMember, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.dotDotDotToken) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.questionToken) ||
+            visitNode(cbNode, node.type);
+    },
+    [SyntaxKind.ObjectBindingPattern]: forEachChildInObjectOrArrayBindingPattern,
+    [SyntaxKind.ArrayBindingPattern]: forEachChildInObjectOrArrayBindingPattern,
+    [SyntaxKind.ArrayLiteralExpression]: function forEachChildInArrayLiteralExpression<T>(node: ArrayLiteralExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.elements);
+    },
+    [SyntaxKind.ObjectLiteralExpression]: function forEachChildInObjectLiteralExpression<T>(node: ObjectLiteralExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.properties);
+    },
+    [SyntaxKind.PropertyAccessExpression]: function forEachChildInPropertyAccessExpression<T>(node: PropertyAccessExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression) ||
+            visitNode(cbNode, node.questionDotToken) ||
+            visitNode(cbNode, node.name);
+    },
+    [SyntaxKind.ElementAccessExpression]: function forEachChildInElementAccessExpression<T>(node: ElementAccessExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression) ||
+            visitNode(cbNode, node.questionDotToken) ||
+            visitNode(cbNode, node.argumentExpression);
+    },
+    [SyntaxKind.CallExpression]: forEachChildInCallOrNewExpression,
+    [SyntaxKind.NewExpression]: forEachChildInCallOrNewExpression,
+    [SyntaxKind.TaggedTemplateExpression]: function forEachChildInTaggedTemplateExpression<T>(node: TaggedTemplateExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.tag) ||
+            visitNode(cbNode, node.questionDotToken) ||
+            visitNodes(cbNode, cbNodes, node.typeArguments) ||
+            visitNode(cbNode, node.template);
+    },
+    [SyntaxKind.TypeAssertionExpression]: function forEachChildInTypeAssertionExpression<T>(node: TypeAssertion, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.ParenthesizedExpression]: function forEachChildInParenthesizedExpression<T>(node: ParenthesizedExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.DeleteExpression]: function forEachChildInDeleteExpression<T>(node: DeleteExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.TypeOfExpression]: function forEachChildInTypeOfExpression<T>(node: TypeOfExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.VoidExpression]: function forEachChildInVoidExpression<T>(node: VoidExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.PrefixUnaryExpression]: function forEachChildInPrefixUnaryExpression<T>(node: PrefixUnaryExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.operand);
+    },
+    [SyntaxKind.YieldExpression]: function forEachChildInYieldExpression<T>(node: YieldExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.asteriskToken) ||
+            visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.AwaitExpression]: function forEachChildInAwaitExpression<T>(node: AwaitExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.PostfixUnaryExpression]: function forEachChildInPostfixUnaryExpression<T>(node: PostfixUnaryExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.operand);
+    },
+    [SyntaxKind.BinaryExpression]: function forEachChildInBinaryExpression<T>(node: BinaryExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.left) ||
+            visitNode(cbNode, node.operatorToken) ||
+            visitNode(cbNode, node.right);
+    },
+    [SyntaxKind.AsExpression]: function forEachChildInAsExpression<T>(node: AsExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression) ||
+            visitNode(cbNode, node.type);
+    },
+    [SyntaxKind.NonNullExpression]: function forEachChildInNonNullExpression<T>(node: NonNullExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.SatisfiesExpression]: function forEachChildInSatisfiesExpression<T>(node: SatisfiesExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression) || visitNode(cbNode, node.type);
+    },
+    [SyntaxKind.MetaProperty]: function forEachChildInMetaProperty<T>(node: MetaProperty, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.name);
+    },
+    [SyntaxKind.ConditionalExpression]: function forEachChildInConditionalExpression<T>(node: ConditionalExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.condition) ||
+            visitNode(cbNode, node.questionToken) ||
+            visitNode(cbNode, node.whenTrue) ||
+            visitNode(cbNode, node.colonToken) ||
+            visitNode(cbNode, node.whenFalse);
+    },
+    [SyntaxKind.SpreadElement]: function forEachChildInSpreadElement<T>(node: SpreadElement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.Block]: forEachChildInBlock,
+    [SyntaxKind.ModuleBlock]: forEachChildInBlock,
+    [SyntaxKind.SourceFile]: function forEachChildInSourceFile<T>(node: SourceFile, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.statements) ||
+            visitNode(cbNode, node.endOfFileToken);
+    },
+    [SyntaxKind.VariableStatement]: function forEachChildInVariableStatement<T>(node: VariableStatement, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.declarationList);
+    },
+    [SyntaxKind.VariableDeclarationList]: function forEachChildInVariableDeclarationList<T>(node: VariableDeclarationList, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.declarations);
+    },
+    [SyntaxKind.ExpressionStatement]: function forEachChildInExpressionStatement<T>(node: ExpressionStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.IfStatement]: function forEachChildInIfStatement<T>(node: IfStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression) ||
+            visitNode(cbNode, node.thenStatement) ||
+            visitNode(cbNode, node.elseStatement);
+    },
+    [SyntaxKind.DoStatement]: function forEachChildInDoStatement<T>(node: DoStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.statement) ||
+            visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.WhileStatement]: function forEachChildInWhileStatement<T>(node: WhileStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression) ||
+            visitNode(cbNode, node.statement);
+    },
+    [SyntaxKind.ForStatement]: function forEachChildInForStatement<T>(node: ForStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.initializer) ||
+            visitNode(cbNode, node.condition) ||
+            visitNode(cbNode, node.incrementor) ||
+            visitNode(cbNode, node.statement);
+    },
+    [SyntaxKind.ForInStatement]: function forEachChildInForInStatement<T>(node: ForInStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.initializer) ||
+            visitNode(cbNode, node.expression) ||
+            visitNode(cbNode, node.statement);
+    },
+    [SyntaxKind.ForOfStatement]: function forEachChildInForOfStatement<T>(node: ForOfStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.awaitModifier) ||
+            visitNode(cbNode, node.initializer) ||
+            visitNode(cbNode, node.expression) ||
+            visitNode(cbNode, node.statement);
+    },
+    [SyntaxKind.ContinueStatement]: forEachChildInContinueOrBreakStatement,
+    [SyntaxKind.BreakStatement]: forEachChildInContinueOrBreakStatement,
+    [SyntaxKind.ReturnStatement]: function forEachChildInReturnStatement<T>(node: ReturnStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.WithStatement]: function forEachChildInWithStatement<T>(node: WithStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression) ||
+            visitNode(cbNode, node.statement);
+    },
+    [SyntaxKind.SwitchStatement]: function forEachChildInSwitchStatement<T>(node: SwitchStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression) ||
+            visitNode(cbNode, node.caseBlock);
+    },
+    [SyntaxKind.CaseBlock]: function forEachChildInCaseBlock<T>(node: CaseBlock, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.clauses);
+    },
+    [SyntaxKind.CaseClause]: function forEachChildInCaseClause<T>(node: CaseClause, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression) ||
+            visitNodes(cbNode, cbNodes, node.statements);
+    },
+    [SyntaxKind.DefaultClause]: function forEachChildInDefaultClause<T>(node: DefaultClause, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.statements);
+    },
+    [SyntaxKind.LabeledStatement]: function forEachChildInLabeledStatement<T>(node: LabeledStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.label) ||
+            visitNode(cbNode, node.statement);
+    },
+    [SyntaxKind.ThrowStatement]: function forEachChildInThrowStatement<T>(node: ThrowStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.TryStatement]: function forEachChildInTryStatement<T>(node: TryStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.tryBlock) ||
+            visitNode(cbNode, node.catchClause) ||
+            visitNode(cbNode, node.finallyBlock);
+    },
+    [SyntaxKind.CatchClause]: function forEachChildInCatchClause<T>(node: CatchClause, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.variableDeclaration) ||
+            visitNode(cbNode, node.block);
+    },
+    [SyntaxKind.Decorator]: function forEachChildInDecorator<T>(node: Decorator, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.ClassDeclaration]: forEachChildInClassDeclarationOrExpression,
+    [SyntaxKind.ClassExpression]: forEachChildInClassDeclarationOrExpression,
+    [SyntaxKind.InterfaceDeclaration]: function forEachChildInInterfaceDeclaration<T>(node: InterfaceDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNodes(cbNode, cbNodes, node.heritageClauses) ||
+            visitNodes(cbNode, cbNodes, node.members);
+    },
+    [SyntaxKind.TypeAliasDeclaration]: function forEachChildInTypeAliasDeclaration<T>(node: TypeAliasDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            visitNode(cbNode, node.type);
+    },
+    [SyntaxKind.EnumDeclaration]: function forEachChildInEnumDeclaration<T>(node: EnumDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNodes(cbNode, cbNodes, node.members);
+    },
+    [SyntaxKind.EnumMember]: function forEachChildInEnumMember<T>(node: EnumMember, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.initializer);
+    },
+    [SyntaxKind.ModuleDeclaration]: function forEachChildInModuleDeclaration<T>(node: ModuleDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.body);
+    },
+    [SyntaxKind.ImportEqualsDeclaration]: function forEachChildInImportEqualsDeclaration<T>(node: ImportEqualsDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.moduleReference);
+    },
+    [SyntaxKind.ImportDeclaration]: function forEachChildInImportDeclaration<T>(node: ImportDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.importClause) ||
+            visitNode(cbNode, node.moduleSpecifier) ||
+            visitNode(cbNode, node.attributes);
+    },
+    [SyntaxKind.ImportClause]: function forEachChildInImportClause<T>(node: ImportClause, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.namedBindings);
+    },
+    [SyntaxKind.ImportAttributes]: function forEachChildInImportAttributes<T>(node: ImportAttributes, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.elements);
+    },
+    [SyntaxKind.ImportAttribute]: function forEachChildInImportAttribute<T>(node: ImportAttribute, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.value);
+    },
+    [SyntaxKind.NamespaceExportDeclaration]: function forEachChildInNamespaceExportDeclaration<T>(node: NamespaceExportDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.name);
+    },
+    [SyntaxKind.NamespaceImport]: function forEachChildInNamespaceImport<T>(node: NamespaceImport, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.name);
+    },
+    [SyntaxKind.NamespaceExport]: function forEachChildInNamespaceExport<T>(node: NamespaceExport, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.name);
+    },
+    [SyntaxKind.NamedImports]: forEachChildInNamedImportsOrExports,
+    [SyntaxKind.NamedExports]: forEachChildInNamedImportsOrExports,
+    [SyntaxKind.ExportDeclaration]: function forEachChildInExportDeclaration<T>(node: ExportDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.exportClause) ||
+            visitNode(cbNode, node.moduleSpecifier) ||
+            visitNode(cbNode, node.attributes);
+    },
+    [SyntaxKind.ImportSpecifier]: forEachChildInImportOrExportSpecifier,
+    [SyntaxKind.ExportSpecifier]: forEachChildInImportOrExportSpecifier,
+    [SyntaxKind.ExportAssignment]: function forEachChildInExportAssignment<T>(node: ExportAssignment, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers) ||
+            visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.TemplateExpression]: function forEachChildInTemplateExpression<T>(node: TemplateExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.head) ||
+            visitNodes(cbNode, cbNodes, node.templateSpans);
+    },
+    [SyntaxKind.TemplateSpan]: function forEachChildInTemplateSpan<T>(node: TemplateSpan, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression) ||
+            visitNode(cbNode, node.literal);
+    },
+    [SyntaxKind.TemplateLiteralType]: function forEachChildInTemplateLiteralType<T>(node: TemplateLiteralTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.head) ||
+            visitNodes(cbNode, cbNodes, node.templateSpans);
+    },
+    [SyntaxKind.TemplateLiteralTypeSpan]: function forEachChildInTemplateLiteralTypeSpan<T>(node: TemplateLiteralTypeSpan, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.type) ||
+            visitNode(cbNode, node.literal);
+    },
+    [SyntaxKind.ComputedPropertyName]: function forEachChildInComputedPropertyName<T>(node: ComputedPropertyName, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.HeritageClause]: function forEachChildInHeritageClause<T>(node: HeritageClause, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.types);
+    },
+    [SyntaxKind.ExpressionWithTypeArguments]: function forEachChildInExpressionWithTypeArguments<T>(node: ExpressionWithTypeArguments, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression) ||
+            visitNodes(cbNode, cbNodes, node.typeArguments);
+    },
+    [SyntaxKind.ExternalModuleReference]: function forEachChildInExternalModuleReference<T>(node: ExternalModuleReference, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.MissingDeclaration]: function forEachChildInMissingDeclaration<T>(node: MissingDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.modifiers);
+    },
+    [SyntaxKind.CommaListExpression]: function forEachChildInCommaListExpression<T>(node: CommaListExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.elements);
+    },
+    [SyntaxKind.JsxElement]: function forEachChildInJsxElement<T>(node: JsxElement, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.openingElement) ||
+            visitNodes(cbNode, cbNodes, node.children) ||
+            visitNode(cbNode, node.closingElement);
+    },
+    [SyntaxKind.JsxFragment]: function forEachChildInJsxFragment<T>(node: JsxFragment, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.openingFragment) ||
+            visitNodes(cbNode, cbNodes, node.children) ||
+            visitNode(cbNode, node.closingFragment);
+    },
+    [SyntaxKind.JsxSelfClosingElement]: forEachChildInJsxOpeningOrSelfClosingElement,
+    [SyntaxKind.JsxOpeningElement]: forEachChildInJsxOpeningOrSelfClosingElement,
+    [SyntaxKind.JsxAttributes]: function forEachChildInJsxAttributes<T>(node: JsxAttributes, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.properties);
+    },
+    [SyntaxKind.JsxAttribute]: function forEachChildInJsxAttribute<T>(node: JsxAttribute, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.name) ||
+            visitNode(cbNode, node.initializer);
+    },
+    [SyntaxKind.JsxSpreadAttribute]: function forEachChildInJsxSpreadAttribute<T>(node: JsxSpreadAttribute, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.JsxExpression]: function forEachChildInJsxExpression<T>(node: JsxExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.dotDotDotToken) ||
+            visitNode(cbNode, node.expression);
+    },
+    [SyntaxKind.JsxClosingElement]: function forEachChildInJsxClosingElement<T>(node: JsxClosingElement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.tagName);
+    },
+    [SyntaxKind.JsxNamespacedName]: function forEachChildInJsxNamespacedName<T>(node: JsxNamespacedName, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.namespace) ||
+            visitNode(cbNode, node.name);
+    },
+    [SyntaxKind.OptionalType]: forEachChildInOptionalRestOrJSDocParameterModifier,
+    [SyntaxKind.RestType]: forEachChildInOptionalRestOrJSDocParameterModifier,
+    [SyntaxKind.JSDocTypeExpression]: forEachChildInOptionalRestOrJSDocParameterModifier,
+    [SyntaxKind.JSDocNonNullableType]: forEachChildInOptionalRestOrJSDocParameterModifier,
+    [SyntaxKind.JSDocNullableType]: forEachChildInOptionalRestOrJSDocParameterModifier,
+    [SyntaxKind.JSDocOptionalType]: forEachChildInOptionalRestOrJSDocParameterModifier,
+    [SyntaxKind.JSDocVariadicType]: forEachChildInOptionalRestOrJSDocParameterModifier,
+    [SyntaxKind.JSDocFunctionType]: function forEachChildInJSDocFunctionType<T>(node: JSDocFunctionType, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNodes(cbNode, cbNodes, node.parameters) ||
+            visitNode(cbNode, node.type);
+    },
+    [SyntaxKind.JSDoc]: function forEachChildInJSDoc<T>(node: JSDoc, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment))
+            || visitNodes(cbNode, cbNodes, node.tags);
+    },
+    [SyntaxKind.JSDocSeeTag]: function forEachChildInJSDocSeeTag<T>(node: JSDocSeeTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.tagName) ||
+            visitNode(cbNode, node.name) ||
+            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+    },
+    [SyntaxKind.JSDocNameReference]: function forEachChildInJSDocNameReference<T>(node: JSDocNameReference, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.name);
+    },
+    [SyntaxKind.JSDocMemberName]: function forEachChildInJSDocMemberName<T>(node: JSDocMemberName, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.left) ||
+            visitNode(cbNode, node.right);
+    },
+    [SyntaxKind.JSDocParameterTag]: forEachChildInJSDocParameterOrPropertyTag,
+    [SyntaxKind.JSDocPropertyTag]: forEachChildInJSDocParameterOrPropertyTag,
+    [SyntaxKind.JSDocAuthorTag]: function forEachChildInJSDocAuthorTag<T>(node: JSDocAuthorTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.tagName) ||
+            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+    },
+    [SyntaxKind.JSDocImplementsTag]: function forEachChildInJSDocImplementsTag<T>(node: JSDocImplementsTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.tagName) ||
+            visitNode(cbNode, node.class) ||
+            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+    },
+    [SyntaxKind.JSDocAugmentsTag]: function forEachChildInJSDocAugmentsTag<T>(node: JSDocAugmentsTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.tagName) ||
+            visitNode(cbNode, node.class) ||
+            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+    },
+    [SyntaxKind.JSDocTemplateTag]: function forEachChildInJSDocTemplateTag<T>(node: JSDocTemplateTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.tagName) ||
+            visitNode(cbNode, node.constraint) ||
+            visitNodes(cbNode, cbNodes, node.typeParameters) ||
+            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+    },
+    [SyntaxKind.JSDocTypedefTag]: function forEachChildInJSDocTypedefTag<T>(node: JSDocTypedefTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.tagName) ||
+            (node.typeExpression &&
+                    node.typeExpression.kind === SyntaxKind.JSDocTypeExpression
+                ? visitNode(cbNode, node.typeExpression) ||
+                    visitNode(cbNode, node.fullName) ||
+                    (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment))
+                : visitNode(cbNode, node.fullName) ||
+                    visitNode(cbNode, node.typeExpression) ||
+                    (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment)));
+    },
+    [SyntaxKind.JSDocCallbackTag]: function forEachChildInJSDocCallbackTag<T>(node: JSDocCallbackTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return visitNode(cbNode, node.tagName) ||
+            visitNode(cbNode, node.fullName) ||
+            visitNode(cbNode, node.typeExpression) ||
+            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+    },
+    [SyntaxKind.JSDocReturnTag]: forEachChildInJSDocTypeLikeTag,
+    [SyntaxKind.JSDocTypeTag]: forEachChildInJSDocTypeLikeTag,
+    [SyntaxKind.JSDocThisTag]: forEachChildInJSDocTypeLikeTag,
+    [SyntaxKind.JSDocEnumTag]: forEachChildInJSDocTypeLikeTag,
+    [SyntaxKind.JSDocSatisfiesTag]: forEachChildInJSDocTypeLikeTag,
+    [SyntaxKind.JSDocThrowsTag]: forEachChildInJSDocTypeLikeTag,
+    [SyntaxKind.JSDocOverloadTag]: forEachChildInJSDocTypeLikeTag,
+    [SyntaxKind.JSDocSignature]: function forEachChildInJSDocSignature<T>(node: JSDocSignature, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return forEach(node.typeParameters, cbNode) ||
+            forEach(node.parameters, cbNode) ||
+            visitNode(cbNode, node.type);
+    },
+    [SyntaxKind.JSDocLink]: forEachChildInJSDocLinkCodeOrPlain,
+    [SyntaxKind.JSDocLinkCode]: forEachChildInJSDocLinkCodeOrPlain,
+    [SyntaxKind.JSDocLinkPlain]: forEachChildInJSDocLinkCodeOrPlain,
+    [SyntaxKind.JSDocTypeLiteral]: function forEachChildInJSDocTypeLiteral<T>(node: JSDocTypeLiteral, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+        return forEach(node.jsDocPropertyTags, cbNode);
+    },
+    [SyntaxKind.JSDocTag]: forEachChildInJSDocTag,
+    [SyntaxKind.JSDocClassTag]: forEachChildInJSDocTag,
+    [SyntaxKind.JSDocPublicTag]: forEachChildInJSDocTag,
+    [SyntaxKind.JSDocPrivateTag]: forEachChildInJSDocTag,
+    [SyntaxKind.JSDocProtectedTag]: forEachChildInJSDocTag,
+    [SyntaxKind.JSDocReadonlyTag]: forEachChildInJSDocTag,
+    [SyntaxKind.JSDocDeprecatedTag]: forEachChildInJSDocTag,
+    [SyntaxKind.JSDocOverrideTag]: forEachChildInJSDocTag,
+    [SyntaxKind.PartiallyEmittedExpression]: forEachChildInPartiallyEmittedExpression,
+};
+
+// shared
+
+function forEachChildInCallOrConstructSignature<T>(node: CallSignatureDeclaration | ConstructSignatureDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNodes(cbNode, cbNodes, node.typeParameters) ||
+        visitNodes(cbNode, cbNodes, node.parameters) ||
+        visitNode(cbNode, node.type);
+}
+
+function forEachChildInUnionOrIntersectionType<T>(node: UnionTypeNode | IntersectionTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNodes(cbNode, cbNodes, node.types);
+}
+
+function forEachChildInParenthesizedTypeOrTypeOperator<T>(node: ParenthesizedTypeNode | TypeOperatorNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNode(cbNode, node.type);
+}
+
+function forEachChildInObjectOrArrayBindingPattern<T>(node: BindingPattern, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNodes(cbNode, cbNodes, node.elements);
+}
+
+function forEachChildInCallOrNewExpression<T>(node: CallExpression | NewExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNode(cbNode, node.expression) ||
+        // TODO: should we separate these branches out?
+        visitNode(cbNode, (node as CallExpression).questionDotToken) ||
+        visitNodes(cbNode, cbNodes, node.typeArguments) ||
+        visitNodes(cbNode, cbNodes, node.arguments);
+}
+
+function forEachChildInBlock<T>(node: Block | ModuleBlock, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNodes(cbNode, cbNodes, node.statements);
+}
+
+function forEachChildInContinueOrBreakStatement<T>(node: ContinueStatement | BreakStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNode(cbNode, node.label);
+}
+
+function forEachChildInClassDeclarationOrExpression<T>(node: ClassDeclaration | ClassExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNodes(cbNode, cbNodes, node.modifiers) ||
+        visitNode(cbNode, node.name) ||
+        visitNodes(cbNode, cbNodes, node.typeParameters) ||
+        visitNodes(cbNode, cbNodes, node.heritageClauses) ||
+        visitNodes(cbNode, cbNodes, node.members);
+}
+
+function forEachChildInNamedImportsOrExports<T>(node: NamedImports | NamedExports, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNodes(cbNode, cbNodes, node.elements);
+}
+
+function forEachChildInImportOrExportSpecifier<T>(node: ImportSpecifier | ExportSpecifier, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNode(cbNode, node.propertyName) ||
+        visitNode(cbNode, node.name);
+}
+
+function forEachChildInJsxOpeningOrSelfClosingElement<T>(node: JsxOpeningLikeElement, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNode(cbNode, node.tagName) ||
+        visitNodes(cbNode, cbNodes, node.typeArguments) ||
+        visitNode(cbNode, node.attributes);
+}
+
+function forEachChildInOptionalRestOrJSDocParameterModifier<T>(node: OptionalTypeNode | RestTypeNode | JSDocTypeExpression | JSDocNullableType | JSDocNonNullableType | JSDocOptionalType | JSDocVariadicType, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNode(cbNode, node.type);
+}
+
+function forEachChildInJSDocParameterOrPropertyTag<T>(node: JSDocParameterTag | JSDocPropertyTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNode(cbNode, node.tagName) ||
+        (node.isNameFirst
+            ? visitNode(cbNode, node.name) || visitNode(cbNode, node.typeExpression)
+            : visitNode(cbNode, node.typeExpression) || visitNode(cbNode, node.name)) ||
+        (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+}
+
+function forEachChildInJSDocTypeLikeTag<T>(node: JSDocReturnTag | JSDocTypeTag | JSDocThisTag | JSDocEnumTag | JSDocThrowsTag | JSDocOverloadTag | JSDocSatisfiesTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNode(cbNode, node.tagName) ||
+        visitNode(cbNode, node.typeExpression) ||
+        (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+}
+
+function forEachChildInJSDocLinkCodeOrPlain<T>(node: JSDocLink | JSDocLinkCode | JSDocLinkPlain, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNode(cbNode, node.name);
+}
+
+function forEachChildInJSDocTag<T>(node: JSDocUnknownTag | JSDocClassTag | JSDocPublicTag | JSDocPrivateTag | JSDocProtectedTag | JSDocReadonlyTag | JSDocDeprecatedTag | JSDocOverrideTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNode(cbNode, node.tagName)
+        || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+}
+
+function forEachChildInPartiallyEmittedExpression<T>(node: PartiallyEmittedExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    return visitNode(cbNode, node.expression);
+}
+
+/**
+ * Invokes a callback for each child of the given node. The 'cbNode' callback is invoked for all child nodes
+ * stored in properties. If a 'cbNodes' callback is specified, it is invoked for embedded arrays; otherwise,
+ * embedded arrays are flattened and the 'cbNode' callback is invoked for each element. If a callback returns
+ * a truthy value, iteration stops and that value is returned. Otherwise, undefined is returned.
+ *
+ * @param node a given node to visit its children
+ * @param cbNode a callback to be invoked for all child nodes
+ * @param cbNodes a callback to be invoked for embedded array
+ *
+ * @remarks `forEachChild` must visit the children of a node in the order
+ * that they appear in the source code. The language service depends on this property to locate nodes by position.
+ */
+export function forEachChild<T>(node: Node, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
+    if (node === undefined || node.kind <= SyntaxKind.LastToken) {
+        return;
+    }
+    const fn = (forEachChildTable as Record<SyntaxKind, ForEachChildFunction<any>>)[node.kind];
+    return fn === undefined ? undefined : fn(node, cbNode, cbNodes);
+}
+
+/**
+ * Invokes a callback for each child of the given node. The 'cbNode' callback is invoked for all child nodes
+ * stored in properties. If a 'cbNodes' callback is specified, it is invoked for embedded arrays; additionally,
+ * unlike `forEachChild`, embedded arrays are flattened and the 'cbNode' callback is invoked for each element.
+ *  If a callback returns a truthy value, iteration stops and that value is returned. Otherwise, undefined is returned.
+ *
+ * @param node a given node to visit its children
+ * @param cbNode a callback to be invoked for all child nodes
+ * @param cbNodes a callback to be invoked for embedded array
+ *
+ * @remarks Unlike `forEachChild`, `forEachChildRecursively` handles recursively invoking the traversal on each child node found,
+ * and while doing so, handles traversing the structure without relying on the callstack to encode the tree structure.
+ *
+ * @internal
+ */
+export function forEachChildRecursively<T>(rootNode: Node, cbNode: (node: Node, parent: Node) => T | "skip" | undefined, cbNodes?: (nodes: NodeArray<Node>, parent: Node) => T | "skip" | undefined): T | undefined {
+    const queue: (Node | NodeArray<Node>)[] = gatherPossibleChildren(rootNode);
+    const parents: Node[] = []; // tracks parent references for elements in queue
+    while (parents.length < queue.length) {
+        parents.push(rootNode);
+    }
+    while (queue.length !== 0) {
+        const current = queue.pop()!;
+        const parent = parents.pop()!;
+        if (isArray(current)) {
+            if (cbNodes) {
+                const res = cbNodes(current, parent);
+                if (res) {
+                    if (res === "skip") continue;
+                    return res;
+                }
+            }
+            for (let i = current.length - 1; i >= 0; --i) {
+                queue.push(current[i]);
+                parents.push(parent);
+            }
+        }
+        else {
+            const res = cbNode(current, parent);
+            if (res) {
+                if (res === "skip") continue;
+                return res;
+            }
+            if (current.kind >= SyntaxKind.FirstNode) {
+                // add children in reverse order to the queue, so popping gives the first child
+                for (const child of gatherPossibleChildren(current)) {
+                    queue.push(child);
+                    parents.push(current);
+                }
+            }
+        }
+    }
+}
+
+function gatherPossibleChildren(node: Node) {
+    const children: (Node | NodeArray<Node>)[] = [];
+    forEachChild(node, addWorkItem, addWorkItem); // By using a stack above and `unshift` here, we emulate a depth-first preorder traversal
+    return children;
+
+    function addWorkItem(n: Node | NodeArray<Node>) {
+        children.unshift(n);
+    }
+}
+
+export interface CreateSourceFileOptions {
+    languageVersion: ScriptTarget;
+    /**
+     * Controls the format the file is detected as - this can be derived from only the path
+     * and files on disk, but needs to be done with a module resolution cache in scope to be performant.
+     * This is usually `undefined` for compilations that do not have `moduleResolution` values of `node16` or `nodenext`.
+     */
+    impliedNodeFormat?: ResolutionMode;
+    /**
+     * Controls how module-y-ness is set for the given file. Usually the result of calling
+     * `getSetExternalModuleIndicator` on a valid `CompilerOptions` object. If not present, the default
+     * check specified by `isFileProbablyExternalModule` will be used to set the field.
+     */
+    setExternalModuleIndicator?: (file: SourceFile) => void;
+    /** @internal */ packageJsonLocations?: readonly string[];
+    /** @internal */ packageJsonScope?: PackageJsonInfo;
+    jsDocParsingMode?: JSDocParsingMode;
+}
+
+function setExternalModuleIndicator(sourceFile: SourceFile) {
+    sourceFile.externalModuleIndicator = isFileProbablyExternalModule(sourceFile);
+}
+
+export function createSourceFile(fileName: string, sourceText: string, languageVersionOrOptions: ScriptTarget | CreateSourceFileOptions, setParentNodes = false, scriptKind?: ScriptKind): SourceFile {
+    tracing?.push(tracing.Phase.Parse, "createSourceFile", { path: fileName }, /*separateBeginAndEnd*/ true);
+    performance.mark("beforeParse");
+    let result: SourceFile;
+
+    perfLogger?.logStartParseSourceFile(fileName);
+    const {
+        languageVersion,
+        setExternalModuleIndicator: overrideSetExternalModuleIndicator,
+        impliedNodeFormat: format,
+        jsDocParsingMode,
+    } = typeof languageVersionOrOptions === "object" ? languageVersionOrOptions : ({ languageVersion: languageVersionOrOptions } as CreateSourceFileOptions);
+    if (languageVersion === ScriptTarget.JSON) {
+        result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, ScriptKind.JSON, noop, jsDocParsingMode);
+    }
+    else {
+        const setIndicator = format === undefined ? overrideSetExternalModuleIndicator : (file: SourceFile) => {
+            file.impliedNodeFormat = format;
+            return (overrideSetExternalModuleIndicator || setExternalModuleIndicator)(file);
+        };
+        result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, scriptKind, setIndicator, jsDocParsingMode);
+    }
+    perfLogger?.logStopParseSourceFile();
+
+    performance.mark("afterParse");
+    performance.measure("Parse", "beforeParse", "afterParse");
+    tracing?.pop();
+    return result;
+}
+
+export function parseIsolatedEntityName(text: string, languageVersion: ScriptTarget): EntityName | undefined {
+    return Parser.parseIsolatedEntityName(text, languageVersion);
+}
+
+/**
+ * Parse json text into SyntaxTree and return node and parse errors if any
+ * @param fileName
+ * @param sourceText
+ */
+export function parseJsonText(fileName: string, sourceText: string): JsonSourceFile {
+    return Parser.parseJsonText(fileName, sourceText);
+}
+
+// See also `isExternalOrCommonJsModule` in utilities.ts
+export function isExternalModule(file: SourceFile): boolean {
+    return file.externalModuleIndicator !== undefined;
+}
+
+// Produces a new SourceFile for the 'newText' provided. The 'textChangeRange' parameter
+// indicates what changed between the 'text' that this SourceFile has and the 'newText'.
+// The SourceFile will be created with the compiler attempting to reuse as many nodes from
+// this file as possible.
+//
+// Note: this function mutates nodes from this SourceFile. That means any existing nodes
+// from this SourceFile that are being held onto may change as a result (including
+// becoming detached from any SourceFile).  It is recommended that this SourceFile not
+// be used once 'update' is called on it.
+export function updateSourceFile(sourceFile: SourceFile, newText: string, textChangeRange: TextChangeRange, aggressiveChecks = false): SourceFile {
+    const newSourceFile = IncrementalParser.updateSourceFile(sourceFile, newText, textChangeRange, aggressiveChecks);
+    // Because new source file node is created, it may not have the flag PossiblyContainDynamicImport. This is the case if there is no new edit to add dynamic import.
+    // We will manually port the flag to the new source file.
+    (newSourceFile as Mutable<SourceFile>).flags |= sourceFile.flags & NodeFlags.PermanentlySetIncrementalFlags;
+    return newSourceFile;
+}
+
+/** @internal */
+export function parseIsolatedJSDocComment(content: string, start?: number, length?: number) {
+    const result = Parser.JSDocParser.parseIsolatedJSDocComment(content, start, length);
+    if (result && result.jsDoc) {
+        // because the jsDocComment was parsed out of the source file, it might
+        // not be covered by the fixupParentReferences.
+        Parser.fixupParentReferences(result.jsDoc);
+    }
+
+    return result;
+}
+
+/** @internal */
+// Exposed only for testing.
+export function parseJSDocTypeExpressionForTests(content: string, start?: number, length?: number) {
+    return Parser.JSDocParser.parseJSDocTypeExpressionForTests(content, start, length);
+}
+
+// Implement the parser as a singleton module.  We do this for perf reasons because creating
+// parser instances can actually be expensive enough to impact us on projects with many source
+// files.
+namespace Parser {
+    // Why var? It avoids TDZ checks in the runtime which can be costly.
+    // See: https://github.com/microsoft/TypeScript/issues/52924
+    /* eslint-disable no-var */
+
+    // Share a single scanner across all calls to parse a source file.  This helps speed things
+    // up by avoiding the cost of creating/compiling scanners over and over again.
+    var scanner = createScanner(ScriptTarget.Latest, /*skipTrivia*/ true);
+
+    var disallowInAndDecoratorContext = NodeFlags.DisallowInContext | NodeFlags.DecoratorContext;
+
+    // capture constructors in 'initializeState' to avoid null checks
+    var NodeConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
+    var TokenConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
+    var IdentifierConstructor: new (kind: SyntaxKind.Identifier, pos: number, end: number) => Identifier;
+    var PrivateIdentifierConstructor: new (kind: SyntaxKind.PrivateIdentifier, pos: number, end: number) => PrivateIdentifier;
+    var SourceFileConstructor: new (kind: SyntaxKind.SourceFile, pos: number, end: number) => SourceFile;
+
+    function countNode(node: Node) {
+        nodeCount++;
+        return node;
+    }
+
+    // Rather than using `createBaseNodeFactory` here, we establish a `BaseNodeFactory` that closes over the
+    // constructors above, which are reset each time `initializeState` is called.
+    var baseNodeFactory: BaseNodeFactory = {
+        createBaseSourceFileNode: kind => countNode(new SourceFileConstructor(kind, /*pos*/ 0, /*end*/ 0)),
+        createBaseIdentifierNode: kind => countNode(new IdentifierConstructor(kind, /*pos*/ 0, /*end*/ 0)),
+        createBasePrivateIdentifierNode: kind => countNode(new PrivateIdentifierConstructor(kind, /*pos*/ 0, /*end*/ 0)),
+        createBaseTokenNode: kind => countNode(new TokenConstructor(kind, /*pos*/ 0, /*end*/ 0)),
+        createBaseNode: kind => countNode(new NodeConstructor(kind, /*pos*/ 0, /*end*/ 0)),
+    };
+
+    var factory = createNodeFactory(NodeFactoryFlags.NoParenthesizerRules | NodeFactoryFlags.NoNodeConverters | NodeFactoryFlags.NoOriginalNode, baseNodeFactory);
+
+    var {
+        createNodeArray: factoryCreateNodeArray,
+        createNumericLiteral: factoryCreateNumericLiteral,
+        createStringLiteral: factoryCreateStringLiteral,
+        createLiteralLikeNode: factoryCreateLiteralLikeNode,
+        createIdentifier: factoryCreateIdentifier,
+        createPrivateIdentifier: factoryCreatePrivateIdentifier,
+        createToken: factoryCreateToken,
+        createArrayLiteralExpression: factoryCreateArrayLiteralExpression,
+        createObjectLiteralExpression: factoryCreateObjectLiteralExpression,
+        createPropertyAccessExpression: factoryCreatePropertyAccessExpression,
+        createPropertyAccessChain: factoryCreatePropertyAccessChain,
+        createElementAccessExpression: factoryCreateElementAccessExpression,
+        createElementAccessChain: factoryCreateElementAccessChain,
+        createCallExpression: factoryCreateCallExpression,
+        createCallChain: factoryCreateCallChain,
+        createNewExpression: factoryCreateNewExpression,
+        createParenthesizedExpression: factoryCreateParenthesizedExpression,
+        createBlock: factoryCreateBlock,
+        createVariableStatement: factoryCreateVariableStatement,
+        createExpressionStatement: factoryCreateExpressionStatement,
+        createIfStatement: factoryCreateIfStatement,
+        createWhileStatement: factoryCreateWhileStatement,
+        createForStatement: factoryCreateForStatement,
+        createForOfStatement: factoryCreateForOfStatement,
+        createVariableDeclaration: factoryCreateVariableDeclaration,
+        createVariableDeclarationList: factoryCreateVariableDeclarationList,
+    } = factory;
+
+    var fileName: string;
+    var sourceFlags: NodeFlags;
+    var sourceText: string;
+    var languageVersion: ScriptTarget;
+    var scriptKind: ScriptKind;
+    var languageVariant: LanguageVariant;
+    var parseDiagnostics: DiagnosticWithDetachedLocation[];
+    var jsDocDiagnostics: DiagnosticWithDetachedLocation[];
+    var syntaxCursor: IncrementalParser.SyntaxCursor | undefined;
+
+    var currentToken: SyntaxKind;
+    var nodeCount: number;
+    var identifiers: Map<string, string>;
+    var identifierCount: number;
+
+    // TODO(jakebailey): This type is a lie; this value actually contains the result
+    // of ORing a bunch of `1 << ParsingContext.XYZ`.
+    var parsingContext: ParsingContext;
+
+    var notParenthesizedArrow: Set<number> | undefined;
+
+    // Flags that dictate what parsing context we're in.  For example:
+    // Whether or not we are in strict parsing mode.  All that changes in strict parsing mode is
+    // that some tokens that would be considered identifiers may be considered keywords.
+    //
+    // When adding more parser context flags, consider which is the more common case that the
+    // flag will be in.  This should be the 'false' state for that flag.  The reason for this is
+    // that we don't store data in our nodes unless the value is in the *non-default* state.  So,
+    // for example, more often than code 'allows-in' (or doesn't 'disallow-in').  We opt for
+    // 'disallow-in' set to 'false'.  Otherwise, if we had 'allowsIn' set to 'true', then almost
+    // all nodes would need extra state on them to store this info.
+    //
+    // Note: 'allowIn' and 'allowYield' track 1:1 with the [in] and [yield] concepts in the ES6
+    // grammar specification.
+    //
+    // An important thing about these context concepts.  By default they are effectively inherited
+    // while parsing through every grammar production.  i.e. if you don't change them, then when
+    // you parse a sub-production, it will have the same context values as the parent production.
+    // This is great most of the time.  After all, consider all the 'expression' grammar productions
+    // and how nearly all of them pass along the 'in' and 'yield' context values:
+    //
+    // EqualityExpression[In, Yield] :
+    //      RelationalExpression[?In, ?Yield]
+    //      EqualityExpression[?In, ?Yield] == RelationalExpression[?In, ?Yield]
+    //      EqualityExpression[?In, ?Yield] != RelationalExpression[?In, ?Yield]
+    //      EqualityExpression[?In, ?Yield] === RelationalExpression[?In, ?Yield]
+    //      EqualityExpression[?In, ?Yield] !== RelationalExpression[?In, ?Yield]
+    //
+    // Where you have to be careful is then understanding what the points are in the grammar
+    // where the values are *not* passed along.  For example:
+    //
+    // SingleNameBinding[Yield,GeneratorParameter]
+    //      [+GeneratorParameter]BindingIdentifier[Yield] Initializer[In]opt
+    //      [~GeneratorParameter]BindingIdentifier[?Yield]Initializer[In, ?Yield]opt
+    //
+    // Here this is saying that if the GeneratorParameter context flag is set, that we should
+    // explicitly set the 'yield' context flag to false before calling into the BindingIdentifier
+    // and we should explicitly unset the 'yield' context flag before calling into the Initializer.
+    // production.  Conversely, if the GeneratorParameter context flag is not set, then we
+    // should leave the 'yield' context flag alone.
+    //
+    // Getting this all correct is tricky and requires careful reading of the grammar to
+    // understand when these values should be changed versus when they should be inherited.
+    //
+    // Note: it should not be necessary to save/restore these flags during speculative/lookahead
+    // parsing.  These context flags are naturally stored and restored through normal recursive
+    // descent parsing and unwinding.
+    var contextFlags: NodeFlags;
+
+    // Indicates whether we are currently parsing top-level statements.
+    var topLevel = true;
+
+    // Whether or not we've had a parse error since creating the last AST node.  If we have
+    // encountered an error, it will be stored on the next AST node we create.  Parse errors
+    // can be broken down into three categories:
+    //
+    // 1) An error that occurred during scanning.  For example, an unterminated literal, or a
+    //    character that was completely not understood.
+    //
+    // 2) A token was expected, but was not present.  This type of error is commonly produced
+    //    by the 'parseExpected' function.
+    //
+    // 3) A token was present that no parsing function was able to consume.  This type of error
+    //    only occurs in the 'abortParsingListOrMoveToNextToken' function when the parser
+    //    decides to skip the token.
+    //
+    // In all of these cases, we want to mark the next node as having had an error before it.
+    // With this mark, we can know in incremental settings if this node can be reused, or if
+    // we have to reparse it.  If we don't keep this information around, we may just reuse the
+    // node.  in that event we would then not produce the same errors as we did before, causing
+    // significant confusion problems.
+    //
+    // Note: it is necessary that this value be saved/restored during speculative/lookahead
+    // parsing.  During lookahead parsing, we will often create a node.  That node will have
+    // this value attached, and then this value will be set back to 'false'.  If we decide to
+    // rewind, we must get back to the same value we had prior to the lookahead.
+    //
+    // Note: any errors at the end of the file that do not precede a regular node, should get
+    // attached to the EOF token.
+    var parseErrorBeforeNextFinishedNode = false;
+    /* eslint-enable no-var */
+
+    export function parseSourceFile(
+        fileName: string,
+        sourceText: string,
+        languageVersion: ScriptTarget,
+        syntaxCursor: IncrementalParser.SyntaxCursor | undefined,
+        setParentNodes = false,
+        scriptKind?: ScriptKind,
+        setExternalModuleIndicatorOverride?: (file: SourceFile) => void,
+        jsDocParsingMode = JSDocParsingMode.ParseAll,
+    ): SourceFile {
+        scriptKind = ensureScriptKind(fileName, scriptKind);
+        if (scriptKind === ScriptKind.JSON) {
+            const result = parseJsonText(fileName, sourceText, languageVersion, syntaxCursor, setParentNodes);
+            convertToJson(result, result.statements[0]?.expression, result.parseDiagnostics, /*returnValue*/ false, /*jsonConversionNotifier*/ undefined);
+            result.referencedFiles = emptyArray;
+            result.typeReferenceDirectives = emptyArray;
+            result.libReferenceDirectives = emptyArray;
+            result.amdDependencies = emptyArray;
+            result.hasNoDefaultLib = false;
+            result.pragmas = emptyMap as ReadonlyPragmaMap;
+            return result;
+        }
+
+        initializeState(fileName, sourceText, languageVersion, syntaxCursor, scriptKind, jsDocParsingMode);
+
+        const result = parseSourceFileWorker(languageVersion, setParentNodes, scriptKind, setExternalModuleIndicatorOverride || setExternalModuleIndicator, jsDocParsingMode);
+
+        clearState();
+
+        return result;
+    }
+
+    export function parseIsolatedEntityName(content: string, languageVersion: ScriptTarget): EntityName | undefined {
+        // Choice of `isDeclarationFile` should be arbitrary
+        initializeState("", content, languageVersion, /*syntaxCursor*/ undefined, ScriptKind.JS, JSDocParsingMode.ParseAll);
+        // Prime the scanner.
+        nextToken();
+        const entityName = parseEntityName(/*allowReservedWords*/ true);
+        const isValid = token() === SyntaxKind.EndOfFileToken && !parseDiagnostics.length;
+        clearState();
+        return isValid ? entityName : undefined;
+    }
+
+    export function parseJsonText(fileName: string, sourceText: string, languageVersion: ScriptTarget = ScriptTarget.ES2015, syntaxCursor?: IncrementalParser.SyntaxCursor, setParentNodes = false): JsonSourceFile {
+        initializeState(fileName, sourceText, languageVersion, syntaxCursor, ScriptKind.JSON, JSDocParsingMode.ParseAll);
+        sourceFlags = contextFlags;
+
+        // Prime the scanner.
+        nextToken();
+        const pos = getNodePos();
+        let statements, endOfFileToken;
+        if (token() === SyntaxKind.EndOfFileToken) {
+            statements = createNodeArray([], pos, pos);
+            endOfFileToken = parseTokenNode<EndOfFileToken>();
+        }
+        else {
+            // Loop and synthesize an ArrayLiteralExpression if there are more than
+            // one top-level expressions to ensure all input text is consumed.
+            let expressions: Expression[] | Expression | undefined;
+            while (token() !== SyntaxKind.EndOfFileToken) {
+                let expression;
+                switch (token()) {
+                    case SyntaxKind.OpenBracketToken:
+                        expression = parseArrayLiteralExpression();
+                        break;
+                    case SyntaxKind.TrueKeyword:
+                    case SyntaxKind.FalseKeyword:
+                    case SyntaxKind.NullKeyword:
+                        expression = parseTokenNode<BooleanLiteral | NullLiteral>();
+                        break;
+                    case SyntaxKind.MinusToken:
+                        if (lookAhead(() => nextToken() === SyntaxKind.NumericLiteral && nextToken() !== SyntaxKind.ColonToken)) {
+                            expression = parsePrefixUnaryExpression() as JsonMinusNumericLiteral;
+                        }
+                        else {
+                            expression = parseObjectLiteralExpression();
+                        }
+                        break;
+                    case SyntaxKind.NumericLiteral:
+                    case SyntaxKind.StringLiteral:
+                        if (lookAhead(() => nextToken() !== SyntaxKind.ColonToken)) {
+                            expression = parseLiteralNode() as StringLiteral | NumericLiteral;
+                            break;
+                        }
+                        // falls through
+                    default:
+                        expression = parseObjectLiteralExpression();
+                        break;
+                }
+
+                // Error recovery: collect multiple top-level expressions
+                if (expressions && isArray(expressions)) {
+                    expressions.push(expression);
+                }
+                else if (expressions) {
+                    expressions = [expressions, expression];
+                }
+                else {
+                    expressions = expression;
+                    if (token() !== SyntaxKind.EndOfFileToken) {
+                        parseErrorAtCurrentToken(Diagnostics.Unexpected_token);
+                    }
+                }
+            }
+
+            const expression = isArray(expressions) ? finishNode(factoryCreateArrayLiteralExpression(expressions), pos) : Debug.checkDefined(expressions);
+            const statement = factoryCreateExpressionStatement(expression) as JsonObjectExpressionStatement;
+            finishNode(statement, pos);
+            statements = createNodeArray([statement], pos);
+            endOfFileToken = parseExpectedToken(SyntaxKind.EndOfFileToken, Diagnostics.Unexpected_token) as EndOfFileToken;
+        }
+
+        // Set source file so that errors will be reported with this file name
+        const sourceFile = createSourceFile(fileName, ScriptTarget.ES2015, ScriptKind.JSON, /*isDeclarationFile*/ false, statements, endOfFileToken, sourceFlags, noop);
+
+        if (setParentNodes) {
+            fixupParentReferences(sourceFile);
+        }
+
+        sourceFile.nodeCount = nodeCount;
+        sourceFile.identifierCount = identifierCount;
+        sourceFile.identifiers = identifiers;
+        sourceFile.parseDiagnostics = attachFileToDiagnostics(parseDiagnostics, sourceFile);
+        if (jsDocDiagnostics) {
+            sourceFile.jsDocDiagnostics = attachFileToDiagnostics(jsDocDiagnostics, sourceFile);
+        }
+
+        const result = sourceFile as JsonSourceFile;
+        clearState();
+        return result;
+    }
+
+    function initializeState(_fileName: string, _sourceText: string, _languageVersion: ScriptTarget, _syntaxCursor: IncrementalParser.SyntaxCursor | undefined, _scriptKind: ScriptKind, _jsDocParsingMode: JSDocParsingMode) {
+        NodeConstructor = objectAllocator.getNodeConstructor();
+        TokenConstructor = objectAllocator.getTokenConstructor();
+        IdentifierConstructor = objectAllocator.getIdentifierConstructor();
+        PrivateIdentifierConstructor = objectAllocator.getPrivateIdentifierConstructor();
+        SourceFileConstructor = objectAllocator.getSourceFileConstructor();
+
+        fileName = normalizePath(_fileName);
+        sourceText = _sourceText;
+        languageVersion = _languageVersion;
+        syntaxCursor = _syntaxCursor;
+        scriptKind = _scriptKind;
+        languageVariant = getLanguageVariant(_scriptKind);
+
+        parseDiagnostics = [];
+        parsingContext = 0;
+        identifiers = new Map<string, string>();
+        identifierCount = 0;
+        nodeCount = 0;
+        sourceFlags = 0;
+        topLevel = true;
+
+        switch (scriptKind) {
+            case ScriptKind.JS:
+            case ScriptKind.JSX:
+                contextFlags = NodeFlags.JavaScriptFile;
+                break;
+            case ScriptKind.JSON:
+                contextFlags = NodeFlags.JavaScriptFile | NodeFlags.JsonFile;
+                break;
+            default:
+                contextFlags = NodeFlags.None;
+                break;
+        }
+        parseErrorBeforeNextFinishedNode = false;
+
+        // Initialize and prime the scanner before parsing the source elements.
+        scanner.setText(sourceText);
+        scanner.setOnError(scanError);
+        scanner.setScriptTarget(languageVersion);
+        scanner.setLanguageVariant(languageVariant);
+        scanner.setScriptKind(scriptKind);
+        scanner.setJSDocParsingMode(_jsDocParsingMode);
+    }
+
+    function clearState() {
+        // Clear out the text the scanner is pointing at, so it doesn't keep anything alive unnecessarily.
+        scanner.clearCommentDirectives();
+        scanner.setText("");
+        scanner.setOnError(undefined);
+        scanner.setScriptKind(ScriptKind.Unknown);
+        scanner.setJSDocParsingMode(JSDocParsingMode.ParseAll);
+
+        // Clear any data.  We don't want to accidentally hold onto it for too long.
+        sourceText = undefined!;
+        languageVersion = undefined!;
+        syntaxCursor = undefined;
+        scriptKind = undefined!;
+        languageVariant = undefined!;
+        sourceFlags = 0;
+        parseDiagnostics = undefined!;
+        jsDocDiagnostics = undefined!;
+        parsingContext = 0;
+        identifiers = undefined!;
+        notParenthesizedArrow = undefined;
+        topLevel = true;
+    }
+
+    function parseSourceFileWorker(languageVersion: ScriptTarget, setParentNodes: boolean, scriptKind: ScriptKind, setExternalModuleIndicator: (file: SourceFile) => void, jsDocParsingMode: JSDocParsingMode): SourceFile {
+        const isDeclarationFile = isDeclarationFileName(fileName);
+        if (isDeclarationFile) {
+            contextFlags |= NodeFlags.Ambient;
+        }
+
+        sourceFlags = contextFlags;
+
+        // Prime the scanner.
+        nextToken();
+
+        const statements = parseList(ParsingContext.SourceElements, parseStatement);
+        Debug.assert(token() === SyntaxKind.EndOfFileToken);
+        const endHasJSDoc = hasPrecedingJSDocComment();
+        const endOfFileToken = withJSDoc(parseTokenNode<EndOfFileToken>(), endHasJSDoc);
+
+        const sourceFile = createSourceFile(fileName, languageVersion, scriptKind, isDeclarationFile, statements, endOfFileToken, sourceFlags, setExternalModuleIndicator);
+
+        // A member of ReadonlyArray<T> isn't assignable to a member of T[] (and prevents a direct cast) - but this is where we set up those members so they can be readonly in the future
+        processCommentPragmas(sourceFile as {} as PragmaContext, sourceText);
+        processPragmasIntoFields(sourceFile as {} as PragmaContext, reportPragmaDiagnostic);
+
+        sourceFile.commentDirectives = scanner.getCommentDirectives();
+        sourceFile.nodeCount = nodeCount;
+        sourceFile.identifierCount = identifierCount;
+        sourceFile.identifiers = identifiers;
+        sourceFile.parseDiagnostics = attachFileToDiagnostics(parseDiagnostics, sourceFile);
+        sourceFile.jsDocParsingMode = jsDocParsingMode;
+        if (jsDocDiagnostics) {
+            sourceFile.jsDocDiagnostics = attachFileToDiagnostics(jsDocDiagnostics, sourceFile);
+        }
+
+        if (setParentNodes) {
+            fixupParentReferences(sourceFile);
+        }
+
+        return sourceFile;
+
+        function reportPragmaDiagnostic(pos: number, end: number, diagnostic: DiagnosticMessage) {
+            parseDiagnostics.push(createDetachedDiagnostic(fileName, sourceText, pos, end, diagnostic));
+        }
+    }
+
+    let hasDeprecatedTag = false;
+    function withJSDoc<T extends HasJSDoc>(node: T, hasJSDoc: boolean): T {
+        if (!hasJSDoc) {
+            return node;
+        }
+
+        Debug.assert(!node.jsDoc); // Should only be called once per node
+        const jsDoc = mapDefined(getJSDocCommentRanges(node, sourceText), comment => JSDocParser.parseJSDocComment(node, comment.pos, comment.end - comment.pos));
+        if (jsDoc.length) node.jsDoc = jsDoc;
+        if (hasDeprecatedTag) {
+            hasDeprecatedTag = false;
+            (node as Mutable<T>).flags |= NodeFlags.Deprecated;
+        }
+        return node;
+    }
+
+    function reparseTopLevelAwait(sourceFile: SourceFile) {
+        const savedSyntaxCursor = syntaxCursor;
+        const baseSyntaxCursor = IncrementalParser.createSyntaxCursor(sourceFile);
+        syntaxCursor = { currentNode };
+
+        const statements: Statement[] = [];
+        const savedParseDiagnostics = parseDiagnostics;
+
+        parseDiagnostics = [];
+
+        let pos = 0;
+        let start = findNextStatementWithAwait(sourceFile.statements, 0);
+        while (start !== -1) {
+            // append all statements between pos and start
+            const prevStatement = sourceFile.statements[pos];
+            const nextStatement = sourceFile.statements[start];
+            addRange(statements, sourceFile.statements, pos, start);
+            pos = findNextStatementWithoutAwait(sourceFile.statements, start);
+
+            // append all diagnostics associated with the copied range
+            const diagnosticStart = findIndex(savedParseDiagnostics, diagnostic => diagnostic.start >= prevStatement.pos);
+            const diagnosticEnd = diagnosticStart >= 0 ? findIndex(savedParseDiagnostics, diagnostic => diagnostic.start >= nextStatement.pos, diagnosticStart) : -1;
+            if (diagnosticStart >= 0) {
+                addRange(parseDiagnostics, savedParseDiagnostics, diagnosticStart, diagnosticEnd >= 0 ? diagnosticEnd : undefined);
+            }
+
+            // reparse all statements between start and pos. We skip existing diagnostics for the same range and allow the parser to generate new ones.
+            speculationHelper(() => {
+                const savedContextFlags = contextFlags;
+                contextFlags |= NodeFlags.AwaitContext;
+                scanner.resetTokenState(nextStatement.pos);
+                nextToken();
+
+                while (token() !== SyntaxKind.EndOfFileToken) {
+                    const startPos = scanner.getTokenFullStart();
+                    const statement = parseListElement(ParsingContext.SourceElements, parseStatement);
+                    statements.push(statement);
+                    if (startPos === scanner.getTokenFullStart()) {
+                        nextToken();
+                    }
+
+                    if (pos >= 0) {
+                        const nonAwaitStatement = sourceFile.statements[pos];
+                        if (statement.end === nonAwaitStatement.pos) {
+                            // done reparsing this section
+                            break;
+                        }
+                        if (statement.end > nonAwaitStatement.pos) {
+                            // we ate into the next statement, so we must reparse it.
+                            pos = findNextStatementWithoutAwait(sourceFile.statements, pos + 1);
+                        }
+                    }
+                }
+
+                contextFlags = savedContextFlags;
+            }, SpeculationKind.Reparse);
+
+            // find the next statement containing an `await`
+            start = pos >= 0 ? findNextStatementWithAwait(sourceFile.statements, pos) : -1;
+        }
+
+        // append all statements between pos and the end of the list
+        if (pos >= 0) {
+            const prevStatement = sourceFile.statements[pos];
+            addRange(statements, sourceFile.statements, pos);
+
+            // append all diagnostics associated with the copied range
+            const diagnosticStart = findIndex(savedParseDiagnostics, diagnostic => diagnostic.start >= prevStatement.pos);
+            if (diagnosticStart >= 0) {
+                addRange(parseDiagnostics, savedParseDiagnostics, diagnosticStart);
+            }
+        }
+
+        syntaxCursor = savedSyntaxCursor;
+        return factory.updateSourceFile(sourceFile, setTextRange(factoryCreateNodeArray(statements), sourceFile.statements));
+
+        function containsPossibleTopLevelAwait(node: Node) {
+            return !(node.flags & NodeFlags.AwaitContext)
+                && !!(node.transformFlags & TransformFlags.ContainsPossibleTopLevelAwait);
+        }
+
+        function findNextStatementWithAwait(statements: NodeArray<Statement>, start: number) {
+            for (let i = start; i < statements.length; i++) {
+                if (containsPossibleTopLevelAwait(statements[i])) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        function findNextStatementWithoutAwait(statements: NodeArray<Statement>, start: number) {
+            for (let i = start; i < statements.length; i++) {
+                if (!containsPossibleTopLevelAwait(statements[i])) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        function currentNode(position: number) {
+            const node = baseSyntaxCursor.currentNode(position);
+            if (topLevel && node && containsPossibleTopLevelAwait(node)) {
+                node.intersectsChange = true;
+            }
+            return node;
+        }
+    }
+
+    export function fixupParentReferences(rootNode: Node) {
+        // normally parent references are set during binding. However, for clients that only need
+        // a syntax tree, and no semantic features, then the binding process is an unnecessary
+        // overhead.  This functions allows us to set all the parents, without all the expense of
+        // binding.
+        setParentRecursive(rootNode, /*incremental*/ true);
+    }
+
+    function createSourceFile(
+        fileName: string,
+        languageVersion: ScriptTarget,
+        scriptKind: ScriptKind,
+        isDeclarationFile: boolean,
+        statements: readonly Statement[],
+        endOfFileToken: EndOfFileToken,
+        flags: NodeFlags,
+        setExternalModuleIndicator: (sourceFile: SourceFile) => void,
+    ): SourceFile {
+        // code from createNode is inlined here so createNode won't have to deal with special case of creating source files
+        // this is quite rare comparing to other nodes and createNode should be as fast as possible
+        let sourceFile = factory.createSourceFile(statements, endOfFileToken, flags);
+        setTextRangePosWidth(sourceFile, 0, sourceText.length);
+        setFields(sourceFile);
+
+        // If we parsed this as an external module, it may contain top-level await
+        if (!isDeclarationFile && isExternalModule(sourceFile) && sourceFile.transformFlags & TransformFlags.ContainsPossibleTopLevelAwait) {
+            sourceFile = reparseTopLevelAwait(sourceFile);
+            setFields(sourceFile);
+        }
+
+        return sourceFile;
+
+        function setFields(sourceFile: SourceFile) {
+            sourceFile.text = sourceText;
+            sourceFile.bindDiagnostics = [];
+            sourceFile.bindSuggestionDiagnostics = undefined;
+            sourceFile.languageVersion = languageVersion;
+            sourceFile.fileName = fileName;
+            sourceFile.languageVariant = getLanguageVariant(scriptKind);
+            sourceFile.isDeclarationFile = isDeclarationFile;
+            sourceFile.scriptKind = scriptKind;
+
+            setExternalModuleIndicator(sourceFile);
+            sourceFile.setExternalModuleIndicator = setExternalModuleIndicator;
+        }
+    }
+
+    function setContextFlag(val: boolean, flag: NodeFlags) {
+        if (val) {
+            contextFlags |= flag;
+        }
+        else {
+            contextFlags &= ~flag;
+        }
+    }
+
+    function setDisallowInContext(val: boolean) {
+        setContextFlag(val, NodeFlags.DisallowInContext);
+    }
+
+    function setYieldContext(val: boolean) {
+        setContextFlag(val, NodeFlags.YieldContext);
+    }
+
+    function setDecoratorContext(val: boolean) {
+        setContextFlag(val, NodeFlags.DecoratorContext);
+    }
+
+    function setAwaitContext(val: boolean) {
+        setContextFlag(val, NodeFlags.AwaitContext);
+    }
+
+    function doOutsideOfContext<T>(context: NodeFlags, func: () => T): T {
+        // contextFlagsToClear will contain only the context flags that are
+        // currently set that we need to temporarily clear
+        // We don't just blindly reset to the previous flags to ensure
+        // that we do not mutate cached flags for the incremental
+        // parser (ThisNodeHasError, ThisNodeOrAnySubNodesHasError, and
+        // HasAggregatedChildData).
+        const contextFlagsToClear = context & contextFlags;
+        if (contextFlagsToClear) {
+            // clear the requested context flags
+            setContextFlag(/*val*/ false, contextFlagsToClear);
+            const result = func();
+            // restore the context flags we just cleared
+            setContextFlag(/*val*/ true, contextFlagsToClear);
+            return result;
+        }
+
+        // no need to do anything special as we are not in any of the requested contexts
+        return func();
+    }
+
+    function doInsideOfContext<T>(context: NodeFlags, func: () => T): T {
+        // contextFlagsToSet will contain only the context flags that
+        // are not currently set that we need to temporarily enable.
+        // We don't just blindly reset to the previous flags to ensure
+        // that we do not mutate cached flags for the incremental
+        // parser (ThisNodeHasError, ThisNodeOrAnySubNodesHasError, and
+        // HasAggregatedChildData).
+        const contextFlagsToSet = context & ~contextFlags;
+        if (contextFlagsToSet) {
+            // set the requested context flags
+            setContextFlag(/*val*/ true, contextFlagsToSet);
+            const result = func();
+            // reset the context flags we just set
+            setContextFlag(/*val*/ false, contextFlagsToSet);
+            return result;
+        }
+
+        // no need to do anything special as we are already in all of the requested contexts
+        return func();
+    }
+
+    function allowInAnd<T>(func: () => T): T {
+        return doOutsideOfContext(NodeFlags.DisallowInContext, func);
+    }
+
+    function disallowInAnd<T>(func: () => T): T {
+        return doInsideOfContext(NodeFlags.DisallowInContext, func);
+    }
+
+    function allowConditionalTypesAnd<T>(func: () => T): T {
+        return doOutsideOfContext(NodeFlags.DisallowConditionalTypesContext, func);
+    }
+
+    function disallowConditionalTypesAnd<T>(func: () => T): T {
+        return doInsideOfContext(NodeFlags.DisallowConditionalTypesContext, func);
+    }
+
+    function doInYieldContext<T>(func: () => T): T {
+        return doInsideOfContext(NodeFlags.YieldContext, func);
+    }
+
+    function doInDecoratorContext<T>(func: () => T): T {
+        return doInsideOfContext(NodeFlags.DecoratorContext, func);
+    }
+
+    function doInAwaitContext<T>(func: () => T): T {
+        return doInsideOfContext(NodeFlags.AwaitContext, func);
+    }
+
+    function doOutsideOfAwaitContext<T>(func: () => T): T {
+        return doOutsideOfContext(NodeFlags.AwaitContext, func);
+    }
+
+    function doInYieldAndAwaitContext<T>(func: () => T): T {
+        return doInsideOfContext(NodeFlags.YieldContext | NodeFlags.AwaitContext, func);
+    }
+
+    function doOutsideOfYieldAndAwaitContext<T>(func: () => T): T {
+        return doOutsideOfContext(NodeFlags.YieldContext | NodeFlags.AwaitContext, func);
+    }
+
+    function inContext(flags: NodeFlags) {
+        return (contextFlags & flags) !== 0;
+    }
+
+    function inYieldContext() {
+        return inContext(NodeFlags.YieldContext);
+    }
+
+    function inDisallowInContext() {
+        return inContext(NodeFlags.DisallowInContext);
+    }
+
+    function inDisallowConditionalTypesContext() {
+        return inContext(NodeFlags.DisallowConditionalTypesContext);
+    }
+
+    function inDecoratorContext() {
+        return inContext(NodeFlags.DecoratorContext);
+    }
+
+    function inAwaitContext() {
+        return inContext(NodeFlags.AwaitContext);
+    }
+
+    function parseErrorAtCurrentToken(message: DiagnosticMessage, ...args: DiagnosticArguments): DiagnosticWithDetachedLocation | undefined {
+        return parseErrorAt(scanner.getTokenStart(), scanner.getTokenEnd(), message, ...args);
+    }
+
+    function parseErrorAtPosition(start: number, length: number, message: DiagnosticMessage, ...args: DiagnosticArguments): DiagnosticWithDetachedLocation | undefined {
+        // Don't report another error if it would just be at the same position as the last error.
+        const lastError = lastOrUndefined(parseDiagnostics);
+        let result: DiagnosticWithDetachedLocation | undefined;
+        if (!lastError || start !== lastError.start) {
+            result = createDetachedDiagnostic(fileName, sourceText, start, length, message, ...args);
+            parseDiagnostics.push(result);
+        }
+
+        // Mark that we've encountered an error.  We'll set an appropriate bit on the next
+        // node we finish so that it can't be reused incrementally.
+        parseErrorBeforeNextFinishedNode = true;
+        return result;
+    }
+
+    function parseErrorAt(start: number, end: number, message: DiagnosticMessage, ...args: DiagnosticArguments): DiagnosticWithDetachedLocation | undefined {
+        return parseErrorAtPosition(start, end - start, message, ...args);
+    }
+
+    function parseErrorAtRange(range: TextRange, message: DiagnosticMessage, ...args: DiagnosticArguments): void {
+        parseErrorAt(range.pos, range.end, message, ...args);
+    }
+
+    function scanError(message: DiagnosticMessage, length: number, arg0?: any): void {
+        parseErrorAtPosition(scanner.getTokenEnd(), length, message, arg0);
+    }
+
+    function getNodePos(): number {
+        return scanner.getTokenFullStart();
+    }
+
+    function hasPrecedingJSDocComment() {
+        return scanner.hasPrecedingJSDocComment();
+    }
+
+    // Use this function to access the current token instead of reading the currentToken
+    // variable. Since function results aren't narrowed in control flow analysis, this ensures
+    // that the type checker doesn't make wrong assumptions about the type of the current
+    // token (e.g. a call to nextToken() changes the current token but the checker doesn't
+    // reason about this side effect).  Mainstream VMs inline simple functions like this, so
+    // there is no performance penalty.
+    function token(): SyntaxKind {
+        return currentToken;
+    }
+
+    function nextTokenWithoutCheck() {
+        return currentToken = scanner.scan();
+    }
+
+    function nextTokenAnd<T>(func: () => T): T {
+        nextToken();
+        return func();
+    }
+
+    function nextToken(): SyntaxKind {
+        // if the keyword had an escape
+        if (isKeyword(currentToken) && (scanner.hasUnicodeEscape() || scanner.hasExtendedUnicodeEscape())) {
+            // issue a parse error for the escape
+            parseErrorAt(scanner.getTokenStart(), scanner.getTokenEnd(), Diagnostics.Keywords_cannot_contain_escape_characters);
+        }
+        return nextTokenWithoutCheck();
+    }
+
+    function nextTokenJSDoc(): JSDocSyntaxKind {
+        return currentToken = scanner.scanJsDocToken();
+    }
+
+    function nextJSDocCommentTextToken(inBackticks: boolean): JSDocSyntaxKind | SyntaxKind.JSDocCommentTextToken {
+        return currentToken = scanner.scanJSDocCommentTextToken(inBackticks);
+    }
+
+    function reScanGreaterToken(): SyntaxKind {
+        return currentToken = scanner.reScanGreaterToken();
+    }
+
+    function reScanSlashToken(): SyntaxKind {
+        return currentToken = scanner.reScanSlashToken();
+    }
+
+    function reScanTemplateToken(isTaggedTemplate: boolean): SyntaxKind {
+        return currentToken = scanner.reScanTemplateToken(isTaggedTemplate);
+    }
+
+    function reScanLessThanToken(): SyntaxKind {
+        return currentToken = scanner.reScanLessThanToken();
+    }
+
+    function reScanHashToken(): SyntaxKind {
+        return currentToken = scanner.reScanHashToken();
+    }
+
+    function scanJsxIdentifier(): SyntaxKind {
+        return currentToken = scanner.scanJsxIdentifier();
+    }
+
+    function scanJsxText(): SyntaxKind {
+        return currentToken = scanner.scanJsxToken();
+    }
+
+    function scanJsxAttributeValue(): SyntaxKind {
+        return currentToken = scanner.scanJsxAttributeValue();
+    }
+
+    function speculationHelper<T>(callback: () => T, speculationKind: SpeculationKind): T {
+        // Keep track of the state we'll need to rollback to if lookahead fails (or if the
+        // caller asked us to always reset our state).
+        const saveToken = currentToken;
+        const saveParseDiagnosticsLength = parseDiagnostics.length;
+        const saveParseErrorBeforeNextFinishedNode = parseErrorBeforeNextFinishedNode;
+
+        // Note: it is not actually necessary to save/restore the context flags here.  That's
+        // because the saving/restoring of these flags happens naturally through the recursive
+        // descent nature of our parser.  However, we still store this here just so we can
+        // assert that invariant holds.
+        const saveContextFlags = contextFlags;
+
+        // If we're only looking ahead, then tell the scanner to only lookahead as well.
+        // Otherwise, if we're actually speculatively parsing, then tell the scanner to do the
+        // same.
+        const result = speculationKind !== SpeculationKind.TryParse
+            ? scanner.lookAhead(callback)
+            : scanner.tryScan(callback);
+
+        Debug.assert(saveContextFlags === contextFlags);
+
+        // If our callback returned something 'falsy' or we're just looking ahead,
+        // then unconditionally restore us to where we were.
+        if (!result || speculationKind !== SpeculationKind.TryParse) {
+            currentToken = saveToken;
+            if (speculationKind !== SpeculationKind.Reparse) {
+                parseDiagnostics.length = saveParseDiagnosticsLength;
+            }
+            parseErrorBeforeNextFinishedNode = saveParseErrorBeforeNextFinishedNode;
+        }
+
+        return result;
+    }
+
+    /** Invokes the provided callback then unconditionally restores the parser to the state it
+     * was in immediately prior to invoking the callback.  The result of invoking the callback
+     * is returned from this function.
+     */
+    function lookAhead<T>(callback: () => T): T {
+        return speculationHelper(callback, SpeculationKind.Lookahead);
+    }
+
+    /** Invokes the provided callback.  If the callback returns something falsy, then it restores
+     * the parser to the state it was in immediately prior to invoking the callback.  If the
+     * callback returns something truthy, then the parser state is not rolled back.  The result
+     * of invoking the callback is returned from this function.
+     */
+    function tryParse<T>(callback: () => T): T {
+        return speculationHelper(callback, SpeculationKind.TryParse);
+    }
+
+    function isBindingIdentifier(): boolean {
+        if (token() === SyntaxKind.Identifier) {
+            return true;
+        }
+
+        // `let await`/`let yield` in [Yield] or [Await] are allowed here and disallowed in the binder.
+        return token() > SyntaxKind.LastReservedWord;
+    }
+
+    // Ignore strict mode flag because we will report an error in type checker instead.
+    function isIdentifier(): boolean {
+        if (token() === SyntaxKind.Identifier) {
+            return true;
+        }
+
+        // If we have a 'yield' keyword, and we're in the [yield] context, then 'yield' is
+        // considered a keyword and is not an identifier.
+        if (token() === SyntaxKind.YieldKeyword && inYieldContext()) {
+            return false;
+        }
+
+        // If we have a 'await' keyword, and we're in the [Await] context, then 'await' is
+        // considered a keyword and is not an identifier.
+        if (token() === SyntaxKind.AwaitKeyword && inAwaitContext()) {
+            return false;
+        }
+
+        return token() > SyntaxKind.LastReservedWord;
+    }
+
+    function parseExpected(kind: PunctuationOrKeywordSyntaxKind, diagnosticMessage?: DiagnosticMessage, shouldAdvance = true): boolean {
+        if (token() === kind) {
+            if (shouldAdvance) {
+                nextToken();
+            }
+            return true;
+        }
+
+        // Report specific message if provided with one.  Otherwise, report generic fallback message.
+        if (diagnosticMessage) {
+            parseErrorAtCurrentToken(diagnosticMessage);
+        }
+        else {
+            parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(kind));
+        }
+        return false;
+    }
+
+    const viableKeywordSuggestions = Object.keys(textToKeywordObj).filter(keyword => keyword.length > 2);
+
+    /**
+     * Provides a better error message than the generic "';' expected" if possible for
+     * known common variants of a missing semicolon, such as from a mispelled names.
+     *
+     * @param node Node preceding the expected semicolon location.
+     */
+    function parseErrorForMissingSemicolonAfter(node: Expression | PropertyName): void {
+        // Tagged template literals are sometimes used in places where only simple strings are allowed, i.e.:
+        //   module `M1` {
+        //   ^^^^^^^^^^^ This block is parsed as a template literal like module`M1`.
+        if (isTaggedTemplateExpression(node)) {
+            parseErrorAt(skipTrivia(sourceText, node.template.pos), node.template.end, Diagnostics.Module_declaration_names_may_only_use_or_quoted_strings);
+            return;
+        }
+
+        // Otherwise, if this isn't a well-known keyword-like identifier, give the generic fallback message.
+        const expressionText = isIdentifierNode(node) ? idText(node) : undefined;
+        if (!expressionText || !isIdentifierText(expressionText, languageVersion)) {
+            parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(SyntaxKind.SemicolonToken));
+            return;
+        }
+
+        const pos = skipTrivia(sourceText, node.pos);
+
+        // Some known keywords are likely signs of syntax being used improperly.
+        switch (expressionText) {
+            case "const":
+            case "let":
+            case "var":
+                parseErrorAt(pos, node.end, Diagnostics.Variable_declaration_not_allowed_at_this_location);
+                return;
+
+            case "declare":
+                // If a declared node failed to parse, it would have emitted a diagnostic already.
+                return;
+
+            case "interface":
+                parseErrorForInvalidName(Diagnostics.Interface_name_cannot_be_0, Diagnostics.Interface_must_be_given_a_name, SyntaxKind.OpenBraceToken);
+                return;
+
+            case "is":
+                parseErrorAt(pos, scanner.getTokenStart(), Diagnostics.A_type_predicate_is_only_allowed_in_return_type_position_for_functions_and_methods);
+                return;
+
+            case "module":
+            case "namespace":
+                parseErrorForInvalidName(Diagnostics.Namespace_name_cannot_be_0, Diagnostics.Namespace_must_be_given_a_name, SyntaxKind.OpenBraceToken);
+                return;
+
+            case "type":
+                parseErrorForInvalidName(Diagnostics.Type_alias_name_cannot_be_0, Diagnostics.Type_alias_must_be_given_a_name, SyntaxKind.EqualsToken);
+                return;
+        }
+
+        // The user alternatively might have misspelled or forgotten to add a space after a common keyword.
+        const suggestion = getSpellingSuggestion(expressionText, viableKeywordSuggestions, n => n) ?? getSpaceSuggestion(expressionText);
+        if (suggestion) {
+            parseErrorAt(pos, node.end, Diagnostics.Unknown_keyword_or_identifier_Did_you_mean_0, suggestion);
+            return;
+        }
+
+        // Unknown tokens are handled with their own errors in the scanner
+        if (token() === SyntaxKind.Unknown) {
+            return;
+        }
+
+        // Otherwise, we know this some kind of unknown word, not just a missing expected semicolon.
+        parseErrorAt(pos, node.end, Diagnostics.Unexpected_keyword_or_identifier);
+    }
+
+    /**
+     * Reports a diagnostic error for the current token being an invalid name.
+     *
+     * @param blankDiagnostic Diagnostic to report for the case of the name being blank (matched tokenIfBlankName).
+     * @param nameDiagnostic Diagnostic to report for all other cases.
+     * @param tokenIfBlankName Current token if the name was invalid for being blank (not provided / skipped).
+     */
+    function parseErrorForInvalidName(nameDiagnostic: DiagnosticMessage, blankDiagnostic: DiagnosticMessage, tokenIfBlankName: SyntaxKind) {
+        if (token() === tokenIfBlankName) {
+            parseErrorAtCurrentToken(blankDiagnostic);
+        }
+        else {
+            parseErrorAtCurrentToken(nameDiagnostic, scanner.getTokenValue());
+        }
+    }
+
+    function getSpaceSuggestion(expressionText: string) {
+        for (const keyword of viableKeywordSuggestions) {
+            if (expressionText.length > keyword.length + 2 && startsWith(expressionText, keyword)) {
+                return `${keyword} ${expressionText.slice(keyword.length)}`;
+            }
+        }
+
+        return undefined;
+    }
+
+    function parseSemicolonAfterPropertyName(name: PropertyName, type: TypeNode | undefined, initializer: Expression | undefined) {
+        if (token() === SyntaxKind.AtToken && !scanner.hasPrecedingLineBreak()) {
+            parseErrorAtCurrentToken(Diagnostics.Decorators_must_precede_the_name_and_all_keywords_of_property_declarations);
+            return;
+        }
+
+        if (token() === SyntaxKind.OpenParenToken) {
+            parseErrorAtCurrentToken(Diagnostics.Cannot_start_a_function_call_in_a_type_annotation);
+            nextToken();
+            return;
+        }
+
+        if (type && !canParseSemicolon()) {
+            if (initializer) {
+                parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(SyntaxKind.SemicolonToken));
+            }
+            else {
+                parseErrorAtCurrentToken(Diagnostics.Expected_for_property_initializer);
+            }
+            return;
+        }
+
+        if (tryParseSemicolon()) {
+            return;
+        }
+
+        if (initializer) {
+            parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(SyntaxKind.SemicolonToken));
+            return;
+        }
+
+        parseErrorForMissingSemicolonAfter(name);
+    }
+
+    function parseExpectedJSDoc(kind: JSDocSyntaxKind) {
+        if (token() === kind) {
+            nextTokenJSDoc();
+            return true;
+        }
+        Debug.assert(isKeywordOrPunctuation(kind));
+        parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(kind));
+        return false;
+    }
+
+    function parseExpectedMatchingBrackets(openKind: PunctuationSyntaxKind, closeKind: PunctuationSyntaxKind, openParsed: boolean, openPosition: number) {
+        if (token() === closeKind) {
+            nextToken();
+            return;
+        }
+        const lastError = parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(closeKind));
+        if (!openParsed) {
+            return;
+        }
+        if (lastError) {
+            addRelatedInfo(
+                lastError,
+                createDetachedDiagnostic(fileName, sourceText, openPosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, tokenToString(openKind), tokenToString(closeKind)),
+            );
+        }
+    }
+
+    function parseOptional(t: SyntaxKind): boolean {
+        if (token() === t) {
+            nextToken();
+            return true;
+        }
+        return false;
+    }
+
+    function parseOptionalToken<TKind extends SyntaxKind>(t: TKind): Token<TKind>;
+    function parseOptionalToken(t: SyntaxKind): Node | undefined {
+        if (token() === t) {
+            return parseTokenNode();
+        }
+        return undefined;
+    }
+
+    function parseOptionalTokenJSDoc<TKind extends JSDocSyntaxKind>(t: TKind): Token<TKind>;
+    function parseOptionalTokenJSDoc(t: JSDocSyntaxKind): Node | undefined {
+        if (token() === t) {
+            return parseTokenNodeJSDoc();
+        }
+        return undefined;
+    }
+
+    function parseExpectedToken<TKind extends SyntaxKind>(t: TKind, diagnosticMessage?: DiagnosticMessage, arg0?: string): Token<TKind>;
+    function parseExpectedToken(t: SyntaxKind, diagnosticMessage?: DiagnosticMessage, arg0?: string): Node {
+        return parseOptionalToken(t) ||
+            createMissingNode(t, /*reportAtCurrentPosition*/ false, diagnosticMessage || Diagnostics._0_expected, arg0 || tokenToString(t)!);
+    }
+
+    function parseExpectedTokenJSDoc<TKind extends JSDocSyntaxKind>(t: TKind): Token<TKind>;
+    function parseExpectedTokenJSDoc(t: JSDocSyntaxKind): Node {
+        const optional = parseOptionalTokenJSDoc(t);
+        if (optional) return optional;
+        Debug.assert(isKeywordOrPunctuation(t));
+        return createMissingNode(t, /*reportAtCurrentPosition*/ false, Diagnostics._0_expected, tokenToString(t));
+    }
+
+    function parseTokenNode<T extends Node>(): T {
+        const pos = getNodePos();
+        const kind = token();
+        nextToken();
+        return finishNode(factoryCreateToken(kind), pos) as T;
+    }
+
+    function parseTokenNodeJSDoc<T extends Node>(): T {
+        const pos = getNodePos();
+        const kind = token();
+        nextTokenJSDoc();
+        return finishNode(factoryCreateToken(kind), pos) as T;
+    }
+
+    function canParseSemicolon() {
+        // If there's a real semicolon, then we can always parse it out.
+        if (token() === SyntaxKind.SemicolonToken) {
+            return true;
+        }
+
+        // We can parse out an optional semicolon in ASI cases in the following cases.
+        return token() === SyntaxKind.CloseBraceToken || token() === SyntaxKind.EndOfFileToken || scanner.hasPrecedingLineBreak();
+    }
+
+    function tryParseSemicolon() {
+        if (!canParseSemicolon()) {
+            return false;
+        }
+
+        if (token() === SyntaxKind.SemicolonToken) {
+            // consume the semicolon if it was explicitly provided.
+            nextToken();
+        }
+
+        return true;
+    }
+
+    function parseSemicolon(): boolean {
+        return tryParseSemicolon() || parseExpected(SyntaxKind.SemicolonToken);
+    }
+
+    function createNodeArray<T extends Node>(elements: T[], pos: number, end?: number, hasTrailingComma?: boolean): NodeArray<T> {
+        const array = factoryCreateNodeArray(elements, hasTrailingComma);
+        setTextRangePosEnd(array, pos, end ?? scanner.getTokenFullStart());
+        return array;
+    }
+
+    function finishNode<T extends Node>(node: T, pos: number, end?: number): T {
+        setTextRangePosEnd(node, pos, end ?? scanner.getTokenFullStart());
+        if (contextFlags) {
+            (node as Mutable<T>).flags |= contextFlags;
+        }
+
+        // Keep track on the node if we encountered an error while parsing it.  If we did, then
+        // we cannot reuse the node incrementally.  Once we've marked this node, clear out the
+        // flag so that we don't mark any subsequent nodes.
+        if (parseErrorBeforeNextFinishedNode) {
+            parseErrorBeforeNextFinishedNode = false;
+            (node as Mutable<T>).flags |= NodeFlags.ThisNodeHasError;
+        }
+
+        return node;
+    }
+
+    function createMissingNode<T extends Node>(kind: T["kind"], reportAtCurrentPosition: false, diagnosticMessage?: DiagnosticMessage, ...args: DiagnosticArguments): T;
+    function createMissingNode<T extends Node>(kind: T["kind"], reportAtCurrentPosition: boolean, diagnosticMessage: DiagnosticMessage, ...args: DiagnosticArguments): T;
+    function createMissingNode<T extends Node>(kind: T["kind"], reportAtCurrentPosition: boolean, diagnosticMessage?: DiagnosticMessage, ...args: DiagnosticArguments): T {
+        if (reportAtCurrentPosition) {
+            parseErrorAtPosition(scanner.getTokenFullStart(), 0, diagnosticMessage!, ...args);
+        }
+        else if (diagnosticMessage) {
+            parseErrorAtCurrentToken(diagnosticMessage, ...args);
+        }
+
+        const pos = getNodePos();
+        const result = kind === SyntaxKind.Identifier ? factoryCreateIdentifier("", /*originalKeywordKind*/ undefined) :
+            isTemplateLiteralKind(kind) ? factory.createTemplateLiteralLikeNode(kind, "", "", /*templateFlags*/ undefined) :
+            kind === SyntaxKind.NumericLiteral ? factoryCreateNumericLiteral("", /*numericLiteralFlags*/ undefined) :
+            kind === SyntaxKind.StringLiteral ? factoryCreateStringLiteral("", /*isSingleQuote*/ undefined) :
+            kind === SyntaxKind.MissingDeclaration ? factory.createMissingDeclaration() :
+            factoryCreateToken(kind);
+        return finishNode(result, pos) as T;
+    }
+
+    function internIdentifier(text: string): string {
+        let identifier = identifiers.get(text);
+        if (identifier === undefined) {
+            identifiers.set(text, identifier = text);
+        }
+        return identifier;
+    }
+
+    // An identifier that starts with two underscores has an extra underscore character prepended to it to avoid issues
+    // with magic property names like '__proto__'. The 'identifiers' object is used to share a single string instance for
+    // each identifier in order to reduce memory consumption.
+    function createIdentifier(isIdentifier: boolean, diagnosticMessage?: DiagnosticMessage, privateIdentifierDiagnosticMessage?: DiagnosticMessage): Identifier {
+        if (isIdentifier) {
+            identifierCount++;
+            const pos = getNodePos();
+            // Store original token kind if it is not just an Identifier so we can report appropriate error later in type checker
+            const originalKeywordKind = token();
+            const text = internIdentifier(scanner.getTokenValue());
+            const hasExtendedUnicodeEscape = scanner.hasExtendedUnicodeEscape();
+            nextTokenWithoutCheck();
+            return finishNode(factoryCreateIdentifier(text, originalKeywordKind, hasExtendedUnicodeEscape), pos);
+        }
+
+        if (token() === SyntaxKind.PrivateIdentifier) {
+            parseErrorAtCurrentToken(privateIdentifierDiagnosticMessage || Diagnostics.Private_identifiers_are_not_allowed_outside_class_bodies);
+            return createIdentifier(/*isIdentifier*/ true);
+        }
+
+        if (token() === SyntaxKind.Unknown && scanner.tryScan(() => scanner.reScanInvalidIdentifier() === SyntaxKind.Identifier)) {
+            // Scanner has already recorded an 'Invalid character' error, so no need to add another from the parser.
+            return createIdentifier(/*isIdentifier*/ true);
+        }
+
+        identifierCount++;
+        // Only for end of file because the error gets reported incorrectly on embedded script tags.
+        const reportAtCurrentPosition = token() === SyntaxKind.EndOfFileToken;
+
+        const isReservedWord = scanner.isReservedWord();
+        const msgArg = scanner.getTokenText();
+
+        const defaultMessage = isReservedWord ?
+            Diagnostics.Identifier_expected_0_is_a_reserved_word_that_cannot_be_used_here :
+            Diagnostics.Identifier_expected;
+
+        return createMissingNode<Identifier>(SyntaxKind.Identifier, reportAtCurrentPosition, diagnosticMessage || defaultMessage, msgArg);
+    }
+
+    function parseBindingIdentifier(privateIdentifierDiagnosticMessage?: DiagnosticMessage) {
+        return createIdentifier(isBindingIdentifier(), /*diagnosticMessage*/ undefined, privateIdentifierDiagnosticMessage);
+    }
+
+    function parseIdentifier(diagnosticMessage?: DiagnosticMessage, privateIdentifierDiagnosticMessage?: DiagnosticMessage): Identifier {
+        return createIdentifier(isIdentifier(), diagnosticMessage, privateIdentifierDiagnosticMessage);
+    }
+
+    function parseIdentifierName(diagnosticMessage?: DiagnosticMessage): Identifier {
+        return createIdentifier(tokenIsIdentifierOrKeyword(token()), diagnosticMessage);
+    }
+
+    function parseIdentifierNameErrorOnUnicodeEscapeSequence(): Identifier {
+        if (scanner.hasUnicodeEscape() || scanner.hasExtendedUnicodeEscape()) {
+            parseErrorAtCurrentToken(Diagnostics.Unicode_escape_sequence_cannot_appear_here);
+        }
+        return createIdentifier(tokenIsIdentifierOrKeyword(token()));
+    }
+
+    function isLiteralPropertyName(): boolean {
+        return tokenIsIdentifierOrKeyword(token()) ||
+            token() === SyntaxKind.StringLiteral ||
+            token() === SyntaxKind.NumericLiteral;
+    }
+
+    function isImportAttributeName(): boolean {
+        return tokenIsIdentifierOrKeyword(token()) || token() === SyntaxKind.StringLiteral;
+    }
+
+    function parsePropertyNameWorker(allowComputedPropertyNames: boolean): PropertyName {
+        if (token() === SyntaxKind.StringLiteral || token() === SyntaxKind.NumericLiteral) {
+            const node = parseLiteralNode() as StringLiteral | NumericLiteral;
+            node.text = internIdentifier(node.text);
+            return node;
+        }
+        if (allowComputedPropertyNames && token() === SyntaxKind.OpenBracketToken) {
+            return parseComputedPropertyName();
+        }
+        if (token() === SyntaxKind.PrivateIdentifier) {
+            return parsePrivateIdentifier();
+        }
+        return parseIdentifierName();
+    }
+
+    function parsePropertyName(): PropertyName {
+        return parsePropertyNameWorker(/*allowComputedPropertyNames*/ true);
+    }
+
+    function parseComputedPropertyName(): ComputedPropertyName {
+        // PropertyName [Yield]:
+        //      LiteralPropertyName
+        //      ComputedPropertyName[?Yield]
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.OpenBracketToken);
+        // We parse any expression (including a comma expression). But the grammar
+        // says that only an assignment expression is allowed, so the grammar checker
+        // will error if it sees a comma expression.
+        const expression = allowInAnd(parseExpression);
+        parseExpected(SyntaxKind.CloseBracketToken);
+        return finishNode(factory.createComputedPropertyName(expression), pos);
+    }
+
+    function parsePrivateIdentifier(): PrivateIdentifier {
+        const pos = getNodePos();
+        const node = factoryCreatePrivateIdentifier(internIdentifier(scanner.getTokenValue()));
+        nextToken();
+        return finishNode(node, pos);
+    }
+
+    function parseContextualModifier(t: SyntaxKind): boolean {
+        return token() === t && tryParse(nextTokenCanFollowModifier);
+    }
+
+    function nextTokenIsOnSameLineAndCanFollowModifier() {
+        nextToken();
+        if (scanner.hasPrecedingLineBreak()) {
+            return false;
+        }
+        return canFollowModifier();
+    }
+
+    function nextTokenCanFollowModifier() {
+        switch (token()) {
+            case SyntaxKind.ConstKeyword:
+                // 'const' is only a modifier if followed by 'enum'.
+                return nextToken() === SyntaxKind.EnumKeyword;
+            case SyntaxKind.ExportKeyword:
+                nextToken();
+                if (token() === SyntaxKind.DefaultKeyword) {
+                    return lookAhead(nextTokenCanFollowDefaultKeyword);
+                }
+                if (token() === SyntaxKind.TypeKeyword) {
+                    return lookAhead(nextTokenCanFollowExportModifier);
+                }
+                return canFollowExportModifier();
+            case SyntaxKind.DefaultKeyword:
+                return nextTokenCanFollowDefaultKeyword();
+            case SyntaxKind.StaticKeyword:
+            case SyntaxKind.GetKeyword:
+            case SyntaxKind.SetKeyword:
+                nextToken();
+                return canFollowModifier();
+            default:
+                return nextTokenIsOnSameLineAndCanFollowModifier();
+        }
+    }
+
+    function canFollowExportModifier(): boolean {
+        return token() === SyntaxKind.AtToken
+            || token() !== SyntaxKind.AsteriskToken
+                && token() !== SyntaxKind.AsKeyword
+                && token() !== SyntaxKind.OpenBraceToken
+                && canFollowModifier();
+    }
+
+    function nextTokenCanFollowExportModifier(): boolean {
+        nextToken();
+        return canFollowExportModifier();
+    }
+
+    function parseAnyContextualModifier(): boolean {
+        return isModifierKind(token()) && tryParse(nextTokenCanFollowModifier);
+    }
+
+    function canFollowModifier(): boolean {
+        return token() === SyntaxKind.OpenBracketToken
+            || token() === SyntaxKind.OpenBraceToken
+            || token() === SyntaxKind.AsteriskToken
+            || token() === SyntaxKind.DotDotDotToken
+            || isLiteralPropertyName();
+    }
+
+    function nextTokenCanFollowDefaultKeyword(): boolean {
+        nextToken();
+        return token() === SyntaxKind.ClassKeyword
+            || token() === SyntaxKind.FunctionKeyword
+            || token() === SyntaxKind.InterfaceKeyword
+            || token() === SyntaxKind.AtToken
+            || (token() === SyntaxKind.AbstractKeyword && lookAhead(nextTokenIsClassKeywordOnSameLine))
+            || (token() === SyntaxKind.AsyncKeyword && lookAhead(nextTokenIsFunctionKeywordOnSameLine));
+    }
+
+    // True if positioned at the start of a list element
+    function isListElement(parsingContext: ParsingContext, inErrorRecovery: boolean): boolean {
+        const node = currentNode(parsingContext);
+        if (node) {
+            return true;
+        }
+
+        switch (parsingContext) {
+            case ParsingContext.SourceElements:
+            case ParsingContext.BlockStatements:
+            case ParsingContext.SwitchClauseStatements:
+                // If we're in error recovery, then we don't want to treat ';' as an empty statement.
+                // The problem is that ';' can show up in far too many contexts, and if we see one
+                // and assume it's a statement, then we may bail out inappropriately from whatever
+                // we're parsing.  For example, if we have a semicolon in the middle of a class, then
+                // we really don't want to assume the class is over and we're on a statement in the
+                // outer module.  We just want to consume and move on.
+                return !(token() === SyntaxKind.SemicolonToken && inErrorRecovery) && isStartOfStatement();
+            case ParsingContext.SwitchClauses:
+                return token() === SyntaxKind.CaseKeyword || token() === SyntaxKind.DefaultKeyword;
+            case ParsingContext.TypeMembers:
+                return lookAhead(isTypeMemberStart);
+            case ParsingContext.ClassMembers:
+                // We allow semicolons as class elements (as specified by ES6) as long as we're
+                // not in error recovery.  If we're in error recovery, we don't want an errant
+                // semicolon to be treated as a class member (since they're almost always used
+                // for statements.
+                return lookAhead(isClassMemberStart) || (token() === SyntaxKind.SemicolonToken && !inErrorRecovery);
+            case ParsingContext.EnumMembers:
+                // Include open bracket computed properties. This technically also lets in indexers,
+                // which would be a candidate for improved error reporting.
+                return token() === SyntaxKind.OpenBracketToken || isLiteralPropertyName();
+            case ParsingContext.ObjectLiteralMembers:
+                switch (token()) {
+                    case SyntaxKind.OpenBracketToken:
+                    case SyntaxKind.AsteriskToken:
+                    case SyntaxKind.DotDotDotToken:
+                    case SyntaxKind.DotToken: // Not an object literal member, but don't want to close the object (see `tests/cases/fourslash/completionsDotInObjectLiteral.ts`)
+                        return true;
+                    default:
+                        return isLiteralPropertyName();
+                }
+            case ParsingContext.RestProperties:
+                return isLiteralPropertyName();
+            case ParsingContext.ObjectBindingElements:
+                return token() === SyntaxKind.OpenBracketToken || token() === SyntaxKind.DotDotDotToken || isLiteralPropertyName();
+            case ParsingContext.ImportAttributes:
+                return isImportAttributeName();
+            case ParsingContext.HeritageClauseElement:
+                // If we see `{ ... }` then only consume it as an expression if it is followed by `,` or `{`
+                // That way we won't consume the body of a class in its heritage clause.
+                if (token() === SyntaxKind.OpenBraceToken) {
+                    return lookAhead(isValidHeritageClauseObjectLiteral);
+                }
+
+                if (!inErrorRecovery) {
+                    return isStartOfLeftHandSideExpression() && !isHeritageClauseExtendsOrImplementsKeyword();
+                }
+                else {
+                    // If we're in error recovery we tighten up what we're willing to match.
+                    // That way we don't treat something like "this" as a valid heritage clause
+                    // element during recovery.
+                    return isIdentifier() && !isHeritageClauseExtendsOrImplementsKeyword();
+                }
+            case ParsingContext.VariableDeclarations:
+                return isBindingIdentifierOrPrivateIdentifierOrPattern();
+            case ParsingContext.ArrayBindingElements:
+                return token() === SyntaxKind.CommaToken || token() === SyntaxKind.DotDotDotToken || isBindingIdentifierOrPrivateIdentifierOrPattern();
+            case ParsingContext.TypeParameters:
+                return token() === SyntaxKind.InKeyword || token() === SyntaxKind.ConstKeyword || isIdentifier();
+            case ParsingContext.ArrayLiteralMembers:
+                switch (token()) {
+                    case SyntaxKind.CommaToken:
+                    case SyntaxKind.DotToken: // Not an array literal member, but don't want to close the array (see `tests/cases/fourslash/completionsDotInArrayLiteralInObjectLiteral.ts`)
+                        return true;
+                }
+                // falls through
+            case ParsingContext.ArgumentExpressions:
+                return token() === SyntaxKind.DotDotDotToken || isStartOfExpression();
+            case ParsingContext.Parameters:
+                return isStartOfParameter(/*isJSDocParameter*/ false);
+            case ParsingContext.JSDocParameters:
+                return isStartOfParameter(/*isJSDocParameter*/ true);
+            case ParsingContext.TypeArguments:
+            case ParsingContext.TupleElementTypes:
+                return token() === SyntaxKind.CommaToken || isStartOfType();
+            case ParsingContext.HeritageClauses:
+                return isHeritageClause();
+            case ParsingContext.ImportOrExportSpecifiers:
+                // bail out if the next token is [FromKeyword StringLiteral].
+                // That means we're in something like `import { from "mod"`. Stop here can give better error message.
+                if (token() === SyntaxKind.FromKeyword && lookAhead(nextTokenIsStringLiteral)) {
+                    return false;
+                }
+                return tokenIsIdentifierOrKeyword(token());
+            case ParsingContext.JsxAttributes:
+                return tokenIsIdentifierOrKeyword(token()) || token() === SyntaxKind.OpenBraceToken;
+            case ParsingContext.JsxChildren:
+                return true;
+            case ParsingContext.JSDocComment:
+                return true;
+            case ParsingContext.Count:
+                return Debug.fail("ParsingContext.Count used as a context"); // Not a real context, only a marker.
+            default:
+                Debug.assertNever(parsingContext, "Non-exhaustive case in 'isListElement'.");
+        }
+    }
+
+    function isValidHeritageClauseObjectLiteral() {
+        Debug.assert(token() === SyntaxKind.OpenBraceToken);
+        if (nextToken() === SyntaxKind.CloseBraceToken) {
+            // if we see "extends {}" then only treat the {} as what we're extending (and not
+            // the class body) if we have:
+            //
+            //      extends {} {
+            //      extends {},
+            //      extends {} extends
+            //      extends {} implements
+
+            const next = nextToken();
+            return next === SyntaxKind.CommaToken || next === SyntaxKind.OpenBraceToken || next === SyntaxKind.ExtendsKeyword || next === SyntaxKind.ImplementsKeyword;
+        }
+
+        return true;
+    }
+
+    function nextTokenIsIdentifier() {
+        nextToken();
+        return isIdentifier();
+    }
+
+    function nextTokenIsIdentifierOrKeyword() {
+        nextToken();
+        return tokenIsIdentifierOrKeyword(token());
+    }
+
+    function nextTokenIsIdentifierOrKeywordOrGreaterThan() {
+        nextToken();
+        return tokenIsIdentifierOrKeywordOrGreaterThan(token());
+    }
+
+    function isHeritageClauseExtendsOrImplementsKeyword(): boolean {
+        if (
+            token() === SyntaxKind.ImplementsKeyword ||
+            token() === SyntaxKind.ExtendsKeyword
+        ) {
+            return lookAhead(nextTokenIsStartOfExpression);
+        }
+
+        return false;
+    }
+
+    function nextTokenIsStartOfExpression() {
+        nextToken();
+        return isStartOfExpression();
+    }
+
+    function nextTokenIsStartOfType() {
+        nextToken();
+        return isStartOfType();
+    }
+
+    // True if positioned at a list terminator
+    function isListTerminator(kind: ParsingContext): boolean {
+        if (token() === SyntaxKind.EndOfFileToken) {
+            // Being at the end of the file ends all lists.
+            return true;
+        }
+
+        switch (kind) {
+            case ParsingContext.BlockStatements:
+            case ParsingContext.SwitchClauses:
+            case ParsingContext.TypeMembers:
+            case ParsingContext.ClassMembers:
+            case ParsingContext.EnumMembers:
+            case ParsingContext.ObjectLiteralMembers:
+            case ParsingContext.ObjectBindingElements:
+            case ParsingContext.ImportOrExportSpecifiers:
+            case ParsingContext.ImportAttributes:
+                return token() === SyntaxKind.CloseBraceToken;
+            case ParsingContext.SwitchClauseStatements:
+                return token() === SyntaxKind.CloseBraceToken || token() === SyntaxKind.CaseKeyword || token() === SyntaxKind.DefaultKeyword;
+            case ParsingContext.HeritageClauseElement:
+                return token() === SyntaxKind.OpenBraceToken || token() === SyntaxKind.ExtendsKeyword || token() === SyntaxKind.ImplementsKeyword;
+            case ParsingContext.VariableDeclarations:
+                return isVariableDeclaratorListTerminator();
+            case ParsingContext.TypeParameters:
+                // Tokens other than '>' are here for better error recovery
+                return token() === SyntaxKind.GreaterThanToken || token() === SyntaxKind.OpenParenToken || token() === SyntaxKind.OpenBraceToken || token() === SyntaxKind.ExtendsKeyword || token() === SyntaxKind.ImplementsKeyword;
+            case ParsingContext.ArgumentExpressions:
+                // Tokens other than ')' are here for better error recovery
+                return token() === SyntaxKind.CloseParenToken || token() === SyntaxKind.SemicolonToken;
+            case ParsingContext.ArrayLiteralMembers:
+            case ParsingContext.TupleElementTypes:
+            case ParsingContext.ArrayBindingElements:
+                return token() === SyntaxKind.CloseBracketToken;
+            case ParsingContext.JSDocParameters:
+            case ParsingContext.Parameters:
+            case ParsingContext.RestProperties:
+                // Tokens other than ')' and ']' (the latter for index signatures) are here for better error recovery
+                return token() === SyntaxKind.CloseParenToken || token() === SyntaxKind.CloseBracketToken /*|| token === SyntaxKind.OpenBraceToken*/;
+            case ParsingContext.TypeArguments:
+                // All other tokens should cause the type-argument to terminate except comma token
+                return token() !== SyntaxKind.CommaToken;
+            case ParsingContext.HeritageClauses:
+                return token() === SyntaxKind.OpenBraceToken || token() === SyntaxKind.CloseBraceToken;
+            case ParsingContext.JsxAttributes:
+                return token() === SyntaxKind.GreaterThanToken || token() === SyntaxKind.SlashToken;
+            case ParsingContext.JsxChildren:
+                return token() === SyntaxKind.LessThanToken && lookAhead(nextTokenIsSlash);
+            default:
+                return false;
+        }
+    }
+
+    function isVariableDeclaratorListTerminator(): boolean {
+        // If we can consume a semicolon (either explicitly, or with ASI), then consider us done
+        // with parsing the list of variable declarators.
+        if (canParseSemicolon()) {
+            return true;
+        }
+
+        // in the case where we're parsing the variable declarator of a 'for-in' statement, we
+        // are done if we see an 'in' keyword in front of us. Same with for-of
+        if (isInOrOfKeyword(token())) {
+            return true;
+        }
+
+        // ERROR RECOVERY TWEAK:
+        // For better error recovery, if we see an '=>' then we just stop immediately.  We've got an
+        // arrow function here and it's going to be very unlikely that we'll resynchronize and get
+        // another variable declaration.
+        if (token() === SyntaxKind.EqualsGreaterThanToken) {
+            return true;
+        }
+
+        // Keep trying to parse out variable declarators.
+        return false;
+    }
+
+    // True if positioned at element or terminator of the current list or any enclosing list
+    function isInSomeParsingContext(): boolean {
+        // We should be in at least one parsing context, be it SourceElements while parsing
+        // a SourceFile, or JSDocComment when lazily parsing JSDoc.
+        Debug.assert(parsingContext, "Missing parsing context");
+        for (let kind = 0; kind < ParsingContext.Count; kind++) {
+            if (parsingContext & (1 << kind)) {
+                if (isListElement(kind, /*inErrorRecovery*/ true) || isListTerminator(kind)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    // Parses a list of elements
+    function parseList<T extends Node>(kind: ParsingContext, parseElement: () => T): NodeArray<T> {
+        const saveParsingContext = parsingContext;
+        parsingContext |= 1 << kind;
+        const list = [];
+        const listPos = getNodePos();
+
+        while (!isListTerminator(kind)) {
+            if (isListElement(kind, /*inErrorRecovery*/ false)) {
+                list.push(parseListElement(kind, parseElement));
+
+                continue;
+            }
+
+            if (abortParsingListOrMoveToNextToken(kind)) {
+                break;
+            }
+        }
+
+        parsingContext = saveParsingContext;
+        return createNodeArray(list, listPos);
+    }
+
+    function parseListElement<T extends Node | undefined>(parsingContext: ParsingContext, parseElement: () => T): T {
+        const node = currentNode(parsingContext);
+        if (node) {
+            return consumeNode(node) as T;
+        }
+
+        return parseElement();
+    }
+
+    function currentNode(parsingContext: ParsingContext, pos?: number): Node | undefined {
+        // If we don't have a cursor or the parsing context isn't reusable, there's nothing to reuse.
+        //
+        // If there is an outstanding parse error that we've encountered, but not attached to
+        // some node, then we cannot get a node from the old source tree.  This is because we
+        // want to mark the next node we encounter as being unusable.
+        //
+        // Note: This may be too conservative.  Perhaps we could reuse the node and set the bit
+        // on it (or its leftmost child) as having the error.  For now though, being conservative
+        // is nice and likely won't ever affect perf.
+        if (!syntaxCursor || !isReusableParsingContext(parsingContext) || parseErrorBeforeNextFinishedNode) {
+            return undefined;
+        }
+
+        const node = syntaxCursor.currentNode(pos ?? scanner.getTokenFullStart());
+
+        // Can't reuse a missing node.
+        // Can't reuse a node that intersected the change range.
+        // Can't reuse a node that contains a parse error.  This is necessary so that we
+        // produce the same set of errors again.
+        if (nodeIsMissing(node) || node.intersectsChange || containsParseError(node)) {
+            return undefined;
+        }
+
+        // We can only reuse a node if it was parsed under the same strict mode that we're
+        // currently in.  i.e. if we originally parsed a node in non-strict mode, but then
+        // the user added 'using strict' at the top of the file, then we can't use that node
+        // again as the presence of strict mode may cause us to parse the tokens in the file
+        // differently.
+        //
+        // Note: we *can* reuse tokens when the strict mode changes.  That's because tokens
+        // are unaffected by strict mode.  It's just the parser will decide what to do with it
+        // differently depending on what mode it is in.
+        //
+        // This also applies to all our other context flags as well.
+        const nodeContextFlags = node.flags & NodeFlags.ContextFlags;
+        if (nodeContextFlags !== contextFlags) {
+            return undefined;
+        }
+
+        // Ok, we have a node that looks like it could be reused.  Now verify that it is valid
+        // in the current list parsing context that we're currently at.
+        if (!canReuseNode(node, parsingContext)) {
+            return undefined;
+        }
+
+        if (canHaveJSDoc(node) && node.jsDoc?.jsDocCache) {
+            // jsDocCache may include tags from parent nodes, which might have been modified.
+            node.jsDoc.jsDocCache = undefined;
+        }
+
+        return node;
+    }
+
+    function consumeNode(node: Node) {
+        // Move the scanner so it is after the node we just consumed.
+        scanner.resetTokenState(node.end);
+        nextToken();
+        return node;
+    }
+
+    function isReusableParsingContext(parsingContext: ParsingContext): boolean {
+        switch (parsingContext) {
+            case ParsingContext.ClassMembers:
+            case ParsingContext.SwitchClauses:
+            case ParsingContext.SourceElements:
+            case ParsingContext.BlockStatements:
+            case ParsingContext.SwitchClauseStatements:
+            case ParsingContext.EnumMembers:
+            case ParsingContext.TypeMembers:
+            case ParsingContext.VariableDeclarations:
+            case ParsingContext.JSDocParameters:
+            case ParsingContext.Parameters:
+                return true;
+        }
+        return false;
+    }
+
+    function canReuseNode(node: Node, parsingContext: ParsingContext): boolean {
+        switch (parsingContext) {
+            case ParsingContext.ClassMembers:
+                return isReusableClassMember(node);
+
+            case ParsingContext.SwitchClauses:
+                return isReusableSwitchClause(node);
+
+            case ParsingContext.SourceElements:
+            case ParsingContext.BlockStatements:
+            case ParsingContext.SwitchClauseStatements:
+                return isReusableStatement(node);
+
+            case ParsingContext.EnumMembers:
+                return isReusableEnumMember(node);
+
+            case ParsingContext.TypeMembers:
+                return isReusableTypeMember(node);
+
+            case ParsingContext.VariableDeclarations:
+                return isReusableVariableDeclaration(node);
+
+            case ParsingContext.JSDocParameters:
+            case ParsingContext.Parameters:
+                return isReusableParameter(node);
+
+                // Any other lists we do not care about reusing nodes in.  But feel free to add if
+                // you can do so safely.  Danger areas involve nodes that may involve speculative
+                // parsing.  If speculative parsing is involved with the node, then the range the
+                // parser reached while looking ahead might be in the edited range (see the example
+                // in canReuseVariableDeclaratorNode for a good case of this).
+
+                // case ParsingContext.HeritageClauses:
+                // This would probably be safe to reuse.  There is no speculative parsing with
+                // heritage clauses.
+
+                // case ParsingContext.TypeParameters:
+                // This would probably be safe to reuse.  There is no speculative parsing with
+                // type parameters.  Note that that's because type *parameters* only occur in
+                // unambiguous *type* contexts.  While type *arguments* occur in very ambiguous
+                // *expression* contexts.
+
+                // case ParsingContext.TupleElementTypes:
+                // This would probably be safe to reuse.  There is no speculative parsing with
+                // tuple types.
+
+                // Technically, type argument list types are probably safe to reuse.  While
+                // speculative parsing is involved with them (since type argument lists are only
+                // produced from speculative parsing a < as a type argument list), we only have
+                // the types because speculative parsing succeeded.  Thus, the lookahead never
+                // went past the end of the list and rewound.
+                // case ParsingContext.TypeArguments:
+
+                // Note: these are almost certainly not safe to ever reuse.  Expressions commonly
+                // need a large amount of lookahead, and we should not reuse them as they may
+                // have actually intersected the edit.
+                // case ParsingContext.ArgumentExpressions:
+
+                // This is not safe to reuse for the same reason as the 'AssignmentExpression'
+                // cases.  i.e. a property assignment may end with an expression, and thus might
+                // have lookahead far beyond it's old node.
+                // case ParsingContext.ObjectLiteralMembers:
+
+                // This is probably not safe to reuse.  There can be speculative parsing with
+                // type names in a heritage clause.  There can be generic names in the type
+                // name list, and there can be left hand side expressions (which can have type
+                // arguments.)
+                // case ParsingContext.HeritageClauseElement:
+
+                // Perhaps safe to reuse, but it's unlikely we'd see more than a dozen attributes
+                // on any given element. Same for children.
+                // case ParsingContext.JsxAttributes:
+                // case ParsingContext.JsxChildren:
+        }
+
+        return false;
+    }
+
+    function isReusableClassMember(node: Node) {
+        if (node) {
+            switch (node.kind) {
+                case SyntaxKind.Constructor:
+                case SyntaxKind.IndexSignature:
+                case SyntaxKind.GetAccessor:
+                case SyntaxKind.SetAccessor:
+                case SyntaxKind.PropertyDeclaration:
+                case SyntaxKind.SemicolonClassElement:
+                    return true;
+                case SyntaxKind.MethodDeclaration:
+                    // Method declarations are not necessarily reusable.  An object-literal
+                    // may have a method calls "constructor(...)" and we must reparse that
+                    // into an actual .ConstructorDeclaration.
+                    const methodDeclaration = node as MethodDeclaration;
+                    const nameIsConstructor = methodDeclaration.name.kind === SyntaxKind.Identifier &&
+                        methodDeclaration.name.escapedText === "constructor";
+
+                    return !nameIsConstructor;
+            }
+        }
+
+        return false;
+    }
+
+    function isReusableSwitchClause(node: Node) {
+        if (node) {
+            switch (node.kind) {
+                case SyntaxKind.CaseClause:
+                case SyntaxKind.DefaultClause:
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    function isReusableStatement(node: Node) {
+        if (node) {
+            switch (node.kind) {
+                case SyntaxKind.FunctionDeclaration:
+                case SyntaxKind.VariableStatement:
+                case SyntaxKind.Block:
+                case SyntaxKind.IfStatement:
+                case SyntaxKind.ExpressionStatement:
+                case SyntaxKind.ThrowStatement:
+                case SyntaxKind.ReturnStatement:
+                case SyntaxKind.SwitchStatement:
+                case SyntaxKind.BreakStatement:
+                case SyntaxKind.ContinueStatement:
+                case SyntaxKind.ForInStatement:
+                case SyntaxKind.ForOfStatement:
+                case SyntaxKind.ForStatement:
+                case SyntaxKind.WhileStatement:
+                case SyntaxKind.WithStatement:
+                case SyntaxKind.EmptyStatement:
+                case SyntaxKind.TryStatement:
+                case SyntaxKind.LabeledStatement:
+                case SyntaxKind.DoStatement:
+                case SyntaxKind.DebuggerStatement:
+                case SyntaxKind.ImportDeclaration:
+                case SyntaxKind.ImportEqualsDeclaration:
+                case SyntaxKind.ExportDeclaration:
+                case SyntaxKind.ExportAssignment:
+                case SyntaxKind.ModuleDeclaration:
+                case SyntaxKind.ClassDeclaration:
+                case SyntaxKind.InterfaceDeclaration:
+                case SyntaxKind.EnumDeclaration:
+                case SyntaxKind.TypeAliasDeclaration:
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    function isReusableEnumMember(node: Node) {
+        return node.kind === SyntaxKind.EnumMember;
+    }
+
+    function isReusableTypeMember(node: Node) {
+        if (node) {
+            switch (node.kind) {
+                case SyntaxKind.ConstructSignature:
+                case SyntaxKind.MethodSignature:
+                case SyntaxKind.IndexSignature:
+                case SyntaxKind.PropertySignature:
+                case SyntaxKind.CallSignature:
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    function isReusableVariableDeclaration(node: Node) {
+        if (node.kind !== SyntaxKind.VariableDeclaration) {
+            return false;
+        }
+
+        // Very subtle incremental parsing bug.  Consider the following code:
+        //
+        //      let v = new List < A, B
+        //
+        // This is actually legal code.  It's a list of variable declarators "v = new List<A"
+        // on one side and "B" on the other. If you then change that to:
+        //
+        //      let v = new List < A, B >()
+        //
+        // then we have a problem.  "v = new List<A" doesn't intersect the change range, so we
+        // start reparsing at "B" and we completely fail to handle this properly.
+        //
+        // In order to prevent this, we do not allow a variable declarator to be reused if it
+        // has an initializer.
+        const variableDeclarator = node as VariableDeclaration;
+        return variableDeclarator.initializer === undefined;
+    }
+
+    function isReusableParameter(node: Node) {
+        if (node.kind !== SyntaxKind.Parameter) {
+            return false;
+        }
+
+        // See the comment in isReusableVariableDeclaration for why we do this.
+        const parameter = node as ParameterDeclaration;
+        return parameter.initializer === undefined;
+    }
+
+    // Returns true if we should abort parsing.
+    function abortParsingListOrMoveToNextToken(kind: ParsingContext) {
+        parsingContextErrors(kind);
+        if (isInSomeParsingContext()) {
+            return true;
+        }
+
+        nextToken();
+        return false;
+    }
+
+    function parsingContextErrors(context: ParsingContext) {
+        switch (context) {
+            case ParsingContext.SourceElements:
+                return token() === SyntaxKind.DefaultKeyword
+                    ? parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(SyntaxKind.ExportKeyword))
+                    : parseErrorAtCurrentToken(Diagnostics.Declaration_or_statement_expected);
+            case ParsingContext.BlockStatements:
+                return parseErrorAtCurrentToken(Diagnostics.Declaration_or_statement_expected);
+            case ParsingContext.SwitchClauses:
+                return parseErrorAtCurrentToken(Diagnostics.case_or_default_expected);
+            case ParsingContext.SwitchClauseStatements:
+                return parseErrorAtCurrentToken(Diagnostics.Statement_expected);
+            case ParsingContext.RestProperties: // fallthrough
+            case ParsingContext.TypeMembers:
+                return parseErrorAtCurrentToken(Diagnostics.Property_or_signature_expected);
+            case ParsingContext.ClassMembers:
+                return parseErrorAtCurrentToken(Diagnostics.Unexpected_token_A_constructor_method_accessor_or_property_was_expected);
+            case ParsingContext.EnumMembers:
+                return parseErrorAtCurrentToken(Diagnostics.Enum_member_expected);
+            case ParsingContext.HeritageClauseElement:
+                return parseErrorAtCurrentToken(Diagnostics.Expression_expected);
+            case ParsingContext.VariableDeclarations:
+                return isKeyword(token())
+                    ? parseErrorAtCurrentToken(Diagnostics._0_is_not_allowed_as_a_variable_declaration_name, tokenToString(token())!)
+                    : parseErrorAtCurrentToken(Diagnostics.Variable_declaration_expected);
+            case ParsingContext.ObjectBindingElements:
+                return parseErrorAtCurrentToken(Diagnostics.Property_destructuring_pattern_expected);
+            case ParsingContext.ArrayBindingElements:
+                return parseErrorAtCurrentToken(Diagnostics.Array_element_destructuring_pattern_expected);
+            case ParsingContext.ArgumentExpressions:
+                return parseErrorAtCurrentToken(Diagnostics.Argument_expression_expected);
+            case ParsingContext.ObjectLiteralMembers:
+                return parseErrorAtCurrentToken(Diagnostics.Property_assignment_expected);
+            case ParsingContext.ArrayLiteralMembers:
+                return parseErrorAtCurrentToken(Diagnostics.Expression_or_comma_expected);
+            case ParsingContext.JSDocParameters:
+                return parseErrorAtCurrentToken(Diagnostics.Parameter_declaration_expected);
+            case ParsingContext.Parameters:
+                return isKeyword(token())
+                    ? parseErrorAtCurrentToken(Diagnostics._0_is_not_allowed_as_a_parameter_name, tokenToString(token())!)
+                    : parseErrorAtCurrentToken(Diagnostics.Parameter_declaration_expected);
+            case ParsingContext.TypeParameters:
+                return parseErrorAtCurrentToken(Diagnostics.Type_parameter_declaration_expected);
+            case ParsingContext.TypeArguments:
+                return parseErrorAtCurrentToken(Diagnostics.Type_argument_expected);
+            case ParsingContext.TupleElementTypes:
+                return parseErrorAtCurrentToken(Diagnostics.Type_expected);
+            case ParsingContext.HeritageClauses:
+                return parseErrorAtCurrentToken(Diagnostics.Unexpected_token_expected);
+            case ParsingContext.ImportOrExportSpecifiers:
+                if (token() === SyntaxKind.FromKeyword) {
+                    return parseErrorAtCurrentToken(Diagnostics._0_expected, "}");
+                }
+                return parseErrorAtCurrentToken(Diagnostics.Identifier_expected);
+            case ParsingContext.JsxAttributes:
+                return parseErrorAtCurrentToken(Diagnostics.Identifier_expected);
+            case ParsingContext.JsxChildren:
+                return parseErrorAtCurrentToken(Diagnostics.Identifier_expected);
+            case ParsingContext.ImportAttributes:
+                return parseErrorAtCurrentToken(Diagnostics.Identifier_or_string_literal_expected);
+            case ParsingContext.JSDocComment:
+                return parseErrorAtCurrentToken(Diagnostics.Identifier_expected);
+            case ParsingContext.Count:
+                return Debug.fail("ParsingContext.Count used as a context"); // Not a real context, only a marker.
+            default:
+                Debug.assertNever(context);
+        }
+    }
+
+    // Parses a comma-delimited list of elements
+    function parseDelimitedList<T extends Node>(kind: ParsingContext, parseElement: () => T, considerSemicolonAsDelimiter?: boolean): NodeArray<T>;
+    function parseDelimitedList<T extends Node | undefined>(kind: ParsingContext, parseElement: () => T, considerSemicolonAsDelimiter?: boolean): NodeArray<NonNullable<T>> | undefined;
+    function parseDelimitedList<T extends Node | undefined>(kind: ParsingContext, parseElement: () => T, considerSemicolonAsDelimiter?: boolean): NodeArray<NonNullable<T>> | undefined {
+        const saveParsingContext = parsingContext;
+        parsingContext |= 1 << kind;
+        const list: NonNullable<T>[] = [];
+        const listPos = getNodePos();
+
+        let commaStart = -1; // Meaning the previous token was not a comma
+        while (true) {
+            if (isListElement(kind, /*inErrorRecovery*/ false)) {
+                const startPos = scanner.getTokenFullStart();
+                const result = parseListElement(kind, parseElement);
+                if (!result) {
+                    parsingContext = saveParsingContext;
+                    return undefined;
+                }
+                list.push(result);
+                commaStart = scanner.getTokenStart();
+
+                if (parseOptional(SyntaxKind.CommaToken)) {
+                    // No need to check for a zero length node since we know we parsed a comma
+                    continue;
+                }
+
+                commaStart = -1; // Back to the state where the last token was not a comma
+                if (isListTerminator(kind)) {
+                    break;
+                }
+
+                // We didn't get a comma, and the list wasn't terminated, explicitly parse
+                // out a comma so we give a good error message.
+                parseExpected(SyntaxKind.CommaToken, getExpectedCommaDiagnostic(kind));
+
+                // If the token was a semicolon, and the caller allows that, then skip it and
+                // continue.  This ensures we get back on track and don't result in tons of
+                // parse errors.  For example, this can happen when people do things like use
+                // a semicolon to delimit object literal members.   Note: we'll have already
+                // reported an error when we called parseExpected above.
+                if (considerSemicolonAsDelimiter && token() === SyntaxKind.SemicolonToken && !scanner.hasPrecedingLineBreak()) {
+                    nextToken();
+                }
+                if (startPos === scanner.getTokenFullStart()) {
+                    // What we're parsing isn't actually remotely recognizable as a element and we've consumed no tokens whatsoever
+                    // Consume a token to advance the parser in some way and avoid an infinite loop
+                    // This can happen when we're speculatively parsing parenthesized expressions which we think may be arrow functions,
+                    // or when a modifier keyword which is disallowed as a parameter name (ie, `static` in strict mode) is supplied
+                    nextToken();
+                }
+                continue;
+            }
+
+            if (isListTerminator(kind)) {
+                break;
+            }
+
+            if (abortParsingListOrMoveToNextToken(kind)) {
+                break;
+            }
+        }
+
+        parsingContext = saveParsingContext;
+        // Recording the trailing comma is deliberately done after the previous
+        // loop, and not just if we see a list terminator. This is because the list
+        // may have ended incorrectly, but it is still important to know if there
+        // was a trailing comma.
+        // Check if the last token was a comma.
+        // Always preserve a trailing comma by marking it on the NodeArray
+        return createNodeArray(list, listPos, /*end*/ undefined, commaStart >= 0);
+    }
+
+    function getExpectedCommaDiagnostic(kind: ParsingContext) {
+        return kind === ParsingContext.EnumMembers ? Diagnostics.An_enum_member_name_must_be_followed_by_a_or : undefined;
+    }
+
+    interface MissingList<T extends Node> extends NodeArray<T> {
+        isMissingList: true;
+    }
+
+    function createMissingList<T extends Node>(): MissingList<T> {
+        const list = createNodeArray<T>([], getNodePos()) as MissingList<T>;
+        list.isMissingList = true;
+        return list;
+    }
+
+    function isMissingList(arr: NodeArray<Node>): boolean {
+        return !!(arr as MissingList<Node>).isMissingList;
+    }
+
+    function parseBracketedList<T extends Node>(kind: ParsingContext, parseElement: () => T, open: PunctuationSyntaxKind, close: PunctuationSyntaxKind): NodeArray<T> {
+        if (parseExpected(open)) {
+            const result = parseDelimitedList(kind, parseElement);
+            parseExpected(close);
+            return result;
+        }
+
+        return createMissingList<T>();
+    }
+
+    function parseEntityName(allowReservedWords: boolean, diagnosticMessage?: DiagnosticMessage): EntityName {
+        const pos = getNodePos();
+        let entity: EntityName = allowReservedWords ? parseIdentifierName(diagnosticMessage) : parseIdentifier(diagnosticMessage);
+        while (parseOptional(SyntaxKind.DotToken)) {
+            if (token() === SyntaxKind.LessThanToken) {
+                // The entity is part of a JSDoc-style generic. We will use the gap between `typeName` and
+                // `typeArguments` to report it as a grammar error in the checker.
+                break;
+            }
+            entity = finishNode(
+                factory.createQualifiedName(
+                    entity,
+                    parseRightSideOfDot(allowReservedWords, /*allowPrivateIdentifiers*/ false, /*allowUnicodeEscapeSequenceInIdentifierName*/ true) as Identifier,
+                ),
+                pos,
+            );
+        }
+        return entity;
+    }
+
+    function createQualifiedName(entity: EntityName, name: Identifier): QualifiedName {
+        return finishNode(factory.createQualifiedName(entity, name), entity.pos);
+    }
+
+    function parseRightSideOfDot(allowIdentifierNames: boolean, allowPrivateIdentifiers: boolean, allowUnicodeEscapeSequenceInIdentifierName: boolean): Identifier | PrivateIdentifier {
+        // Technically a keyword is valid here as all identifiers and keywords are identifier names.
+        // However, often we'll encounter this in error situations when the identifier or keyword
+        // is actually starting another valid construct.
+        //
+        // So, we check for the following specific case:
+        //
+        //      name.
+        //      identifierOrKeyword identifierNameOrKeyword
+        //
+        // Note: the newlines are important here.  For example, if that above code
+        // were rewritten into:
+        //
+        //      name.identifierOrKeyword
+        //      identifierNameOrKeyword
+        //
+        // Then we would consider it valid.  That's because ASI would take effect and
+        // the code would be implicitly: "name.identifierOrKeyword; identifierNameOrKeyword".
+        // In the first case though, ASI will not take effect because there is not a
+        // line terminator after the identifier or keyword.
+        if (scanner.hasPrecedingLineBreak() && tokenIsIdentifierOrKeyword(token())) {
+            const matchesPattern = lookAhead(nextTokenIsIdentifierOrKeywordOnSameLine);
+
+            if (matchesPattern) {
+                // Report that we need an identifier.  However, report it right after the dot,
+                // and not on the next token.  This is because the next token might actually
+                // be an identifier and the error would be quite confusing.
+                return createMissingNode<Identifier>(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ true, Diagnostics.Identifier_expected);
+            }
+        }
+
+        if (token() === SyntaxKind.PrivateIdentifier) {
+            const node = parsePrivateIdentifier();
+            return allowPrivateIdentifiers ? node : createMissingNode<Identifier>(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ true, Diagnostics.Identifier_expected);
+        }
+
+        if (allowIdentifierNames) {
+            return allowUnicodeEscapeSequenceInIdentifierName ? parseIdentifierName() : parseIdentifierNameErrorOnUnicodeEscapeSequence();
+        }
+
+        return parseIdentifier();
+    }
+
+    function parseTemplateSpans(isTaggedTemplate: boolean) {
+        const pos = getNodePos();
+        const list = [];
+        let node: TemplateSpan;
+        do {
+            node = parseTemplateSpan(isTaggedTemplate);
+            list.push(node);
+        }
+        while (node.literal.kind === SyntaxKind.TemplateMiddle);
+        return createNodeArray(list, pos);
+    }
+
+    function parseTemplateExpression(isTaggedTemplate: boolean): TemplateExpression {
+        const pos = getNodePos();
+        return finishNode(
+            factory.createTemplateExpression(
+                parseTemplateHead(isTaggedTemplate),
+                parseTemplateSpans(isTaggedTemplate),
+            ),
+            pos,
+        );
+    }
+
+    function parseTemplateType(): TemplateLiteralTypeNode {
+        const pos = getNodePos();
+        return finishNode(
+            factory.createTemplateLiteralType(
+                parseTemplateHead(/*isTaggedTemplate*/ false),
+                parseTemplateTypeSpans(),
+            ),
+            pos,
+        );
+    }
+
+    function parseTemplateTypeSpans() {
+        const pos = getNodePos();
+        const list = [];
+        let node: TemplateLiteralTypeSpan;
+        do {
+            node = parseTemplateTypeSpan();
+            list.push(node);
+        }
+        while (node.literal.kind === SyntaxKind.TemplateMiddle);
+        return createNodeArray(list, pos);
+    }
+
+    function parseTemplateTypeSpan(): TemplateLiteralTypeSpan {
+        const pos = getNodePos();
+        return finishNode(
+            factory.createTemplateLiteralTypeSpan(
+                parseType(),
+                parseLiteralOfTemplateSpan(/*isTaggedTemplate*/ false),
+            ),
+            pos,
+        );
+    }
+
+    function parseLiteralOfTemplateSpan(isTaggedTemplate: boolean) {
+        if (token() === SyntaxKind.CloseBraceToken) {
+            reScanTemplateToken(isTaggedTemplate);
+            return parseTemplateMiddleOrTemplateTail();
+        }
+        else {
+            // TODO(rbuckton): Do we need to call `parseExpectedToken` or can we just call `createMissingNode` directly?
+            return parseExpectedToken(SyntaxKind.TemplateTail, Diagnostics._0_expected, tokenToString(SyntaxKind.CloseBraceToken)) as TemplateTail;
+        }
+    }
+
+    function parseTemplateSpan(isTaggedTemplate: boolean): TemplateSpan {
+        const pos = getNodePos();
+        return finishNode(
+            factory.createTemplateSpan(
+                allowInAnd(parseExpression),
+                parseLiteralOfTemplateSpan(isTaggedTemplate),
+            ),
+            pos,
+        );
+    }
+
+    function parseLiteralNode(): LiteralExpression {
+        return parseLiteralLikeNode(token()) as LiteralExpression;
+    }
+
+    function parseTemplateHead(isTaggedTemplate: boolean): TemplateHead {
+        if (!isTaggedTemplate && scanner.getTokenFlags() & TokenFlags.IsInvalid) {
+            reScanTemplateToken(/*isTaggedTemplate*/ false);
+        }
+        const fragment = parseLiteralLikeNode(token());
+        Debug.assert(fragment.kind === SyntaxKind.TemplateHead, "Template head has wrong token kind");
+        return fragment as TemplateHead;
+    }
+
+    function parseTemplateMiddleOrTemplateTail(): TemplateMiddle | TemplateTail {
+        const fragment = parseLiteralLikeNode(token());
+        Debug.assert(fragment.kind === SyntaxKind.TemplateMiddle || fragment.kind === SyntaxKind.TemplateTail, "Template fragment has wrong token kind");
+        return fragment as TemplateMiddle | TemplateTail;
+    }
+
+    function getTemplateLiteralRawText(kind: TemplateLiteralToken["kind"]) {
+        const isLast = kind === SyntaxKind.NoSubstitutionTemplateLiteral || kind === SyntaxKind.TemplateTail;
+        const tokenText = scanner.getTokenText();
+        return tokenText.substring(1, tokenText.length - (scanner.isUnterminated() ? 0 : isLast ? 1 : 2));
+    }
+
+    function parseLiteralLikeNode(kind: SyntaxKind): LiteralLikeNode {
+        const pos = getNodePos();
+        const node = isTemplateLiteralKind(kind) ? factory.createTemplateLiteralLikeNode(kind, scanner.getTokenValue(), getTemplateLiteralRawText(kind), scanner.getTokenFlags() & TokenFlags.TemplateLiteralLikeFlags) :
+            // Note that theoretically the following condition would hold true literals like 009,
+            // which is not octal. But because of how the scanner separates the tokens, we would
+            // never get a token like this. Instead, we would get 00 and 9 as two separate tokens.
+            // We also do not need to check for negatives because any prefix operator would be part of a
+            // parent unary expression.
+            kind === SyntaxKind.NumericLiteral ? factoryCreateNumericLiteral(scanner.getTokenValue(), scanner.getNumericLiteralFlags()) :
+            kind === SyntaxKind.StringLiteral ? factoryCreateStringLiteral(scanner.getTokenValue(), /*isSingleQuote*/ undefined, scanner.hasExtendedUnicodeEscape()) :
+            isLiteralKind(kind) ? factoryCreateLiteralLikeNode(kind, scanner.getTokenValue()) :
+            Debug.fail();
+
+        if (scanner.hasExtendedUnicodeEscape()) {
+            node.hasExtendedUnicodeEscape = true;
+        }
+
+        if (scanner.isUnterminated()) {
+            node.isUnterminated = true;
+        }
+
+        nextToken();
+        return finishNode(node, pos);
+    }
+
+    // TYPES
+
+    function parseEntityNameOfTypeReference() {
+        return parseEntityName(/*allowReservedWords*/ true, Diagnostics.Type_expected);
+    }
+
+    function parseTypeArgumentsOfTypeReference() {
+        if (!scanner.hasPrecedingLineBreak() && reScanLessThanToken() === SyntaxKind.LessThanToken) {
+            return parseBracketedList(ParsingContext.TypeArguments, parseType, SyntaxKind.LessThanToken, SyntaxKind.GreaterThanToken);
+        }
+    }
+
+    function parseTypeReference(): TypeReferenceNode {
+        const pos = getNodePos();
+        return finishNode(
+            factory.createTypeReferenceNode(
+                parseEntityNameOfTypeReference(),
+                parseTypeArgumentsOfTypeReference(),
+            ),
+            pos,
+        );
+    }
+
+    // If true, we should abort parsing an error function.
+    function typeHasArrowFunctionBlockingParseError(node: TypeNode): boolean {
+        switch (node.kind) {
+            case SyntaxKind.TypeReference:
+                return nodeIsMissing((node as TypeReferenceNode).typeName);
+            case SyntaxKind.FunctionType:
+            case SyntaxKind.ConstructorType: {
+                const { parameters, type } = node as FunctionOrConstructorTypeNode;
+                return isMissingList(parameters) || typeHasArrowFunctionBlockingParseError(type);
+            }
+            case SyntaxKind.ParenthesizedType:
+                return typeHasArrowFunctionBlockingParseError((node as ParenthesizedTypeNode).type);
+            default:
+                return false;
+        }
+    }
+
+    function parseThisTypePredicate(lhs: ThisTypeNode): TypePredicateNode {
+        nextToken();
+        return finishNode(factory.createTypePredicateNode(/*assertsModifier*/ undefined, lhs, parseType()), lhs.pos);
+    }
+
+    function parseThisTypeNode(): ThisTypeNode {
+        const pos = getNodePos();
+        nextToken();
+        return finishNode(factory.createThisTypeNode(), pos);
+    }
+
+    function parseJSDocAllType(): JSDocAllType | JSDocOptionalType {
+        const pos = getNodePos();
+        nextToken();
+        return finishNode(factory.createJSDocAllType(), pos);
+    }
+
+    function parseJSDocNonNullableType(): TypeNode {
+        const pos = getNodePos();
+        nextToken();
+        return finishNode(factory.createJSDocNonNullableType(parseNonArrayType(), /*postfix*/ false), pos);
+    }
+
+    function parseJSDocUnknownOrNullableType(): JSDocUnknownType | JSDocNullableType {
+        const pos = getNodePos();
+        // skip the ?
+        nextToken();
+
+        // Need to lookahead to decide if this is a nullable or unknown type.
+
+        // Here are cases where we'll pick the unknown type:
+        //
+        //      Foo(?,
+        //      { a: ? }
+        //      Foo(?)
+        //      Foo<?>
+        //      Foo(?=
+        //      (?|
+        if (
+            token() === SyntaxKind.CommaToken ||
+            token() === SyntaxKind.CloseBraceToken ||
+            token() === SyntaxKind.CloseParenToken ||
+            token() === SyntaxKind.GreaterThanToken ||
+            token() === SyntaxKind.EqualsToken ||
+            token() === SyntaxKind.BarToken
+        ) {
+            return finishNode(factory.createJSDocUnknownType(), pos);
+        }
+        else {
+            return finishNode(factory.createJSDocNullableType(parseType(), /*postfix*/ false), pos);
+        }
+    }
+
+    function parseJSDocFunctionType(): JSDocFunctionType | TypeReferenceNode {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        if (lookAhead(nextTokenIsOpenParen)) {
+            nextToken();
+            const parameters = parseParameters(SignatureFlags.Type | SignatureFlags.JSDoc);
+            const type = parseReturnType(SyntaxKind.ColonToken, /*isType*/ false);
+            return withJSDoc(finishNode(factory.createJSDocFunctionType(parameters, type), pos), hasJSDoc);
+        }
+        return finishNode(factory.createTypeReferenceNode(parseIdentifierName(), /*typeArguments*/ undefined), pos);
+    }
+
+    function parseJSDocParameter(): ParameterDeclaration {
+        const pos = getNodePos();
+        let name: Identifier | undefined;
+        if (token() === SyntaxKind.ThisKeyword || token() === SyntaxKind.NewKeyword) {
+            name = parseIdentifierName();
+            parseExpected(SyntaxKind.ColonToken);
+        }
+        return finishNode(
+            factory.createParameterDeclaration(
+                /*modifiers*/ undefined,
+                /*dotDotDotToken*/ undefined,
+                // TODO(rbuckton): JSDoc parameters don't have names (except `this`/`new`), should we manufacture an empty identifier?
+                name!,
+                /*questionToken*/ undefined,
+                parseJSDocType(),
+                /*initializer*/ undefined,
+            ),
+            pos,
+        );
+    }
+
+    function parseJSDocType(): TypeNode {
+        scanner.setInJSDocType(true);
+        const pos = getNodePos();
+        if (parseOptional(SyntaxKind.ModuleKeyword)) {
+            // TODO(rbuckton): We never set the type for a JSDocNamepathType. What should we put here?
+            const moduleTag = factory.createJSDocNamepathType(/*type*/ undefined!);
+            terminate:
+            while (true) {
+                switch (token()) {
+                    case SyntaxKind.CloseBraceToken:
+                    case SyntaxKind.EndOfFileToken:
+                    case SyntaxKind.CommaToken:
+                    case SyntaxKind.WhitespaceTrivia:
+                        break terminate;
+                    default:
+                        nextTokenJSDoc();
+                }
+            }
+
+            scanner.setInJSDocType(false);
+            return finishNode(moduleTag, pos);
+        }
+
+        const hasDotDotDot = parseOptional(SyntaxKind.DotDotDotToken);
+        let type = parseTypeOrTypePredicate();
+        scanner.setInJSDocType(false);
+        if (hasDotDotDot) {
+            type = finishNode(factory.createJSDocVariadicType(type), pos);
+        }
+        if (token() === SyntaxKind.EqualsToken) {
+            nextToken();
+            return finishNode(factory.createJSDocOptionalType(type), pos);
+        }
+        return type;
+    }
+
+    function parseTypeQuery(): TypeQueryNode {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.TypeOfKeyword);
+        const entityName = parseEntityName(/*allowReservedWords*/ true);
+        // Make sure we perform ASI to prevent parsing the next line's type arguments as part of an instantiation expression.
+        const typeArguments = !scanner.hasPrecedingLineBreak() ? tryParseTypeArguments() : undefined;
+        return finishNode(factory.createTypeQueryNode(entityName, typeArguments), pos);
+    }
+
+    function parseTypeParameter(): TypeParameterDeclaration {
+        const pos = getNodePos();
+        const modifiers = parseModifiers(/*allowDecorators*/ false, /*permitConstAsModifier*/ true);
+        const name = parseIdentifier();
+        let constraint: TypeNode | undefined;
+        let expression: Expression | undefined;
+        if (parseOptional(SyntaxKind.ExtendsKeyword)) {
+            // It's not uncommon for people to write improper constraints to a generic.  If the
+            // user writes a constraint that is an expression and not an actual type, then parse
+            // it out as an expression (so we can recover well), but report that a type is needed
+            // instead.
+            if (isStartOfType() || !isStartOfExpression()) {
+                constraint = parseType();
+            }
+            else {
+                // It was not a type, and it looked like an expression.  Parse out an expression
+                // here so we recover well.  Note: it is important that we call parseUnaryExpression
+                // and not parseExpression here.  If the user has:
+                //
+                //      <T extends "">
+                //
+                // We do *not* want to consume the `>` as we're consuming the expression for "".
+                expression = parseUnaryExpressionOrHigher();
+            }
+        }
+
+        const defaultType = parseOptional(SyntaxKind.EqualsToken) ? parseType() : undefined;
+        const node = factory.createTypeParameterDeclaration(modifiers, name, constraint, defaultType);
+        node.expression = expression;
+        return finishNode(node, pos);
+    }
+
+    function parseTypeParameters(): NodeArray<TypeParameterDeclaration> | undefined {
+        if (token() === SyntaxKind.LessThanToken) {
+            return parseBracketedList(ParsingContext.TypeParameters, parseTypeParameter, SyntaxKind.LessThanToken, SyntaxKind.GreaterThanToken);
+        }
+    }
+
+    function isStartOfParameter(isJSDocParameter: boolean): boolean {
+        return token() === SyntaxKind.DotDotDotToken ||
+            isBindingIdentifierOrPrivateIdentifierOrPattern() ||
+            isModifierKind(token()) ||
+            token() === SyntaxKind.AtToken ||
+            isStartOfType(/*inStartOfParameter*/ !isJSDocParameter);
+    }
+
+    function parseNameOfParameter(modifiers: NodeArray<ModifierLike> | undefined) {
+        // FormalParameter [Yield,Await]:
+        //      BindingElement[?Yield,?Await]
+        const name = parseIdentifierOrPattern(Diagnostics.Private_identifiers_cannot_be_used_as_parameters);
+        if (getFullWidth(name) === 0 && !some(modifiers) && isModifierKind(token())) {
+            // in cases like
+            // 'use strict'
+            // function foo(static)
+            // isParameter('static') === true, because of isModifier('static')
+            // however 'static' is not a legal identifier in a strict mode.
+            // so result of this function will be ParameterDeclaration (flags = 0, name = missing, type = undefined, initializer = undefined)
+            // and current token will not change => parsing of the enclosing parameter list will last till the end of time (or OOM)
+            // to avoid this we'll advance cursor to the next token.
+            nextToken();
+        }
+        return name;
+    }
+
+    function isParameterNameStart() {
+        // Be permissive about await and yield by calling isBindingIdentifier instead of isIdentifier; disallowing
+        // them during a speculative parse leads to many more follow-on errors than allowing the function to parse then later
+        // complaining about the use of the keywords.
+        return isBindingIdentifier() || token() === SyntaxKind.OpenBracketToken || token() === SyntaxKind.OpenBraceToken;
+    }
+
+    function parseParameter(inOuterAwaitContext: boolean): ParameterDeclaration {
+        return parseParameterWorker(inOuterAwaitContext);
+    }
+
+    function parseParameterForSpeculation(inOuterAwaitContext: boolean): ParameterDeclaration | undefined {
+        return parseParameterWorker(inOuterAwaitContext, /*allowAmbiguity*/ false);
+    }
+
+    function parseParameterWorker(inOuterAwaitContext: boolean): ParameterDeclaration;
+    function parseParameterWorker(inOuterAwaitContext: boolean, allowAmbiguity: false): ParameterDeclaration | undefined;
+    function parseParameterWorker(inOuterAwaitContext: boolean, allowAmbiguity = true): ParameterDeclaration | undefined {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+
+        // FormalParameter [Yield,Await]:
+        //      BindingElement[?Yield,?Await]
+
+        // Decorators are parsed in the outer [Await] context, the rest of the parameter is parsed in the function's [Await] context.
+        const modifiers = inOuterAwaitContext ?
+            doInAwaitContext(() => parseModifiers(/*allowDecorators*/ true)) :
+            doOutsideOfAwaitContext(() => parseModifiers(/*allowDecorators*/ true));
+
+        if (token() === SyntaxKind.ThisKeyword) {
+            const node = factory.createParameterDeclaration(
+                modifiers,
+                /*dotDotDotToken*/ undefined,
+                createIdentifier(/*isIdentifier*/ true),
+                /*questionToken*/ undefined,
+                parseTypeAnnotation(),
+                /*initializer*/ undefined,
+            );
+
+            const modifier = firstOrUndefined(modifiers);
+            if (modifier) {
+                parseErrorAtRange(modifier, Diagnostics.Neither_decorators_nor_modifiers_may_be_applied_to_this_parameters);
+            }
+
+            return withJSDoc(finishNode(node, pos), hasJSDoc);
+        }
+
+        const savedTopLevel = topLevel;
+        topLevel = false;
+
+        const dotDotDotToken = parseOptionalToken(SyntaxKind.DotDotDotToken);
+
+        if (!allowAmbiguity && !isParameterNameStart()) {
+            return undefined;
+        }
+
+        const node = withJSDoc(
+            finishNode(
+                factory.createParameterDeclaration(
+                    modifiers,
+                    dotDotDotToken,
+                    parseNameOfParameter(modifiers),
+                    parseOptionalToken(SyntaxKind.QuestionToken),
+                    parseTypeAnnotation(),
+                    parseInitializer(),
+                ),
+                pos,
+            ),
+            hasJSDoc,
+        );
+        topLevel = savedTopLevel;
+        return node;
+    }
+
+    function parseReturnType(returnToken: SyntaxKind.EqualsGreaterThanToken, isType: boolean): TypeNode;
+    function parseReturnType(returnToken: SyntaxKind.ColonToken | SyntaxKind.EqualsGreaterThanToken, isType: boolean): TypeNode | undefined;
+    function parseReturnType(returnToken: SyntaxKind.ColonToken | SyntaxKind.EqualsGreaterThanToken, isType: boolean) {
+        if (shouldParseReturnType(returnToken, isType)) {
+            return allowConditionalTypesAnd(parseTypeOrTypePredicate);
+        }
+    }
+
+    function shouldParseReturnType(returnToken: SyntaxKind.ColonToken | SyntaxKind.EqualsGreaterThanToken, isType: boolean): boolean {
+        if (returnToken === SyntaxKind.EqualsGreaterThanToken) {
+            parseExpected(returnToken);
+            return true;
+        }
+        else if (parseOptional(SyntaxKind.ColonToken)) {
+            return true;
+        }
+        else if (isType && token() === SyntaxKind.EqualsGreaterThanToken) {
+            // This is easy to get backward, especially in type contexts, so parse the type anyway
+            parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(SyntaxKind.ColonToken));
+            nextToken();
+            return true;
+        }
+        return false;
+    }
+
+    function parseParametersWorker(flags: SignatureFlags, allowAmbiguity: true): NodeArray<ParameterDeclaration>;
+    function parseParametersWorker(flags: SignatureFlags, allowAmbiguity: false): NodeArray<ParameterDeclaration> | undefined;
+    function parseParametersWorker(flags: SignatureFlags, allowAmbiguity: boolean): NodeArray<ParameterDeclaration> | undefined {
+        // FormalParameters [Yield,Await]: (modified)
+        //      [empty]
+        //      FormalParameterList[?Yield,Await]
+        //
+        // FormalParameter[Yield,Await]: (modified)
+        //      BindingElement[?Yield,Await]
+        //
+        // BindingElement [Yield,Await]: (modified)
+        //      SingleNameBinding[?Yield,?Await]
+        //      BindingPattern[?Yield,?Await]Initializer [In, ?Yield,?Await] opt
+        //
+        // SingleNameBinding [Yield,Await]:
+        //      BindingIdentifier[?Yield,?Await]Initializer [In, ?Yield,?Await] opt
+        const savedYieldContext = inYieldContext();
+        const savedAwaitContext = inAwaitContext();
+
+        setYieldContext(!!(flags & SignatureFlags.Yield));
+        setAwaitContext(!!(flags & SignatureFlags.Await));
+
+        const parameters = flags & SignatureFlags.JSDoc ?
+            parseDelimitedList(ParsingContext.JSDocParameters, parseJSDocParameter) :
+            parseDelimitedList(ParsingContext.Parameters, () => allowAmbiguity ? parseParameter(savedAwaitContext) : parseParameterForSpeculation(savedAwaitContext));
+
+        setYieldContext(savedYieldContext);
+        setAwaitContext(savedAwaitContext);
+
+        return parameters;
+    }
+
+    function parseParameters(flags: SignatureFlags): NodeArray<ParameterDeclaration> {
+        // FormalParameters [Yield,Await]: (modified)
+        //      [empty]
+        //      FormalParameterList[?Yield,Await]
+        //
+        // FormalParameter[Yield,Await]: (modified)
+        //      BindingElement[?Yield,Await]
+        //
+        // BindingElement [Yield,Await]: (modified)
+        //      SingleNameBinding[?Yield,?Await]
+        //      BindingPattern[?Yield,?Await]Initializer [In, ?Yield,?Await] opt
+        //
+        // SingleNameBinding [Yield,Await]:
+        //      BindingIdentifier[?Yield,?Await]Initializer [In, ?Yield,?Await] opt
+        if (!parseExpected(SyntaxKind.OpenParenToken)) {
+            return createMissingList<ParameterDeclaration>();
+        }
+
+        const parameters = parseParametersWorker(flags, /*allowAmbiguity*/ true);
+        parseExpected(SyntaxKind.CloseParenToken);
+        return parameters;
+    }
+
+    function parseTypeMemberSemicolon() {
+        // We allow type members to be separated by commas or (possibly ASI) semicolons.
+        // First check if it was a comma.  If so, we're done with the member.
+        if (parseOptional(SyntaxKind.CommaToken)) {
+            return;
+        }
+
+        // Didn't have a comma.  We must have a (possible ASI) semicolon.
+        parseSemicolon();
+    }
+
+    function parseSignatureMember(kind: SyntaxKind.CallSignature | SyntaxKind.ConstructSignature): CallSignatureDeclaration | ConstructSignatureDeclaration {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        if (kind === SyntaxKind.ConstructSignature) {
+            parseExpected(SyntaxKind.NewKeyword);
+        }
+
+        const typeParameters = parseTypeParameters();
+        const parameters = parseParameters(SignatureFlags.Type);
+        const type = parseReturnType(SyntaxKind.ColonToken, /*isType*/ true);
+        parseTypeMemberSemicolon();
+        const node = kind === SyntaxKind.CallSignature
+            ? factory.createCallSignature(typeParameters, parameters, type)
+            : factory.createConstructSignature(typeParameters, parameters, type);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function isIndexSignature(): boolean {
+        return token() === SyntaxKind.OpenBracketToken && lookAhead(isUnambiguouslyIndexSignature);
+    }
+
+    function isUnambiguouslyIndexSignature() {
+        // The only allowed sequence is:
+        //
+        //   [id:
+        //
+        // However, for error recovery, we also check the following cases:
+        //
+        //   [...
+        //   [id,
+        //   [id?,
+        //   [id?:
+        //   [id?]
+        //   [public id
+        //   [private id
+        //   [protected id
+        //   []
+        //
+        nextToken();
+        if (token() === SyntaxKind.DotDotDotToken || token() === SyntaxKind.CloseBracketToken) {
+            return true;
+        }
+
+        if (isModifierKind(token())) {
+            nextToken();
+            if (isIdentifier()) {
+                return true;
+            }
+        }
+        else if (!isIdentifier()) {
+            return false;
+        }
+        else {
+            // Skip the identifier
+            nextToken();
+        }
+
+        // A colon signifies a well formed indexer
+        // A comma should be a badly formed indexer because comma expressions are not allowed
+        // in computed properties.
+        if (token() === SyntaxKind.ColonToken || token() === SyntaxKind.CommaToken) {
+            return true;
+        }
+
+        // Question mark could be an indexer with an optional property,
+        // or it could be a conditional expression in a computed property.
+        if (token() !== SyntaxKind.QuestionToken) {
+            return false;
+        }
+
+        // If any of the following tokens are after the question mark, it cannot
+        // be a conditional expression, so treat it as an indexer.
+        nextToken();
+        return token() === SyntaxKind.ColonToken || token() === SyntaxKind.CommaToken || token() === SyntaxKind.CloseBracketToken;
+    }
+
+    function parseIndexSignatureDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): IndexSignatureDeclaration {
+        const parameters = parseBracketedList<ParameterDeclaration>(ParsingContext.Parameters, () => parseParameter(/*inOuterAwaitContext*/ false), SyntaxKind.OpenBracketToken, SyntaxKind.CloseBracketToken);
+        const type = parseTypeAnnotation();
+        parseTypeMemberSemicolon();
+        const node = factory.createIndexSignature(modifiers, parameters, type);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parsePropertyOrMethodSignature(pos: number, hasJSDoc: boolean, modifiers: NodeArray<Modifier> | undefined): PropertySignature | MethodSignature {
+        const name = parsePropertyName();
+        const questionToken = parseOptionalToken(SyntaxKind.QuestionToken);
+        let node: PropertySignature | MethodSignature;
+        if (token() === SyntaxKind.OpenParenToken || token() === SyntaxKind.LessThanToken) {
+            // Method signatures don't exist in expression contexts.  So they have neither
+            // [Yield] nor [Await]
+            const typeParameters = parseTypeParameters();
+            const parameters = parseParameters(SignatureFlags.Type);
+            const type = parseReturnType(SyntaxKind.ColonToken, /*isType*/ true);
+            node = factory.createMethodSignature(modifiers, name, questionToken, typeParameters, parameters, type);
+        }
+        else {
+            const type = parseTypeAnnotation();
+            node = factory.createPropertySignature(modifiers, name, questionToken, type);
+            // Although type literal properties cannot not have initializers, we attempt
+            // to parse an initializer so we can report in the checker that an interface
+            // property or type literal property cannot have an initializer.
+            if (token() === SyntaxKind.EqualsToken) (node as Mutable<PropertySignature>).initializer = parseInitializer();
+        }
+        parseTypeMemberSemicolon();
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function isTypeMemberStart(): boolean {
+        // Return true if we have the start of a signature member
+        if (
+            token() === SyntaxKind.OpenParenToken ||
+            token() === SyntaxKind.LessThanToken ||
+            token() === SyntaxKind.GetKeyword ||
+            token() === SyntaxKind.SetKeyword
+        ) {
+            return true;
+        }
+        let idToken = false;
+        // Eat up all modifiers, but hold on to the last one in case it is actually an identifier
+        while (isModifierKind(token())) {
+            idToken = true;
+            nextToken();
+        }
+        // Index signatures and computed property names are type members
+        if (token() === SyntaxKind.OpenBracketToken) {
+            return true;
+        }
+        // Try to get the first property-like token following all modifiers
+        if (isLiteralPropertyName()) {
+            idToken = true;
+            nextToken();
+        }
+        // If we were able to get any potential identifier, check that it is
+        // the start of a member declaration
+        if (idToken) {
+            return token() === SyntaxKind.OpenParenToken ||
+                token() === SyntaxKind.LessThanToken ||
+                token() === SyntaxKind.QuestionToken ||
+                token() === SyntaxKind.ColonToken ||
+                token() === SyntaxKind.CommaToken ||
+                canParseSemicolon();
+        }
+        return false;
+    }
+
+    function parseTypeMember(): TypeElement {
+        if (token() === SyntaxKind.OpenParenToken || token() === SyntaxKind.LessThanToken) {
+            return parseSignatureMember(SyntaxKind.CallSignature);
+        }
+        if (token() === SyntaxKind.NewKeyword && lookAhead(nextTokenIsOpenParenOrLessThan)) {
+            return parseSignatureMember(SyntaxKind.ConstructSignature);
+        }
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        const modifiers = parseModifiers(/*allowDecorators*/ false);
+        if (parseContextualModifier(SyntaxKind.GetKeyword)) {
+            return parseAccessorDeclaration(pos, hasJSDoc, modifiers, SyntaxKind.GetAccessor, SignatureFlags.Type);
+        }
+
+        if (parseContextualModifier(SyntaxKind.SetKeyword)) {
+            return parseAccessorDeclaration(pos, hasJSDoc, modifiers, SyntaxKind.SetAccessor, SignatureFlags.Type);
+        }
+
+        if (isIndexSignature()) {
+            return parseIndexSignatureDeclaration(pos, hasJSDoc, modifiers);
+        }
+        return parsePropertyOrMethodSignature(pos, hasJSDoc, modifiers);
+    }
+
+    function nextTokenIsOpenParenOrLessThan() {
+        nextToken();
+        return token() === SyntaxKind.OpenParenToken || token() === SyntaxKind.LessThanToken;
+    }
+
+    function nextTokenIsDot() {
+        return nextToken() === SyntaxKind.DotToken;
+    }
+
+    function nextTokenIsOpenParenOrLessThanOrDot() {
+        switch (nextToken()) {
+            case SyntaxKind.OpenParenToken:
+            case SyntaxKind.LessThanToken:
+            case SyntaxKind.DotToken:
+                return true;
+        }
+        return false;
+    }
+
+    function parseTypeLiteral(): TypeLiteralNode {
+        const pos = getNodePos();
+        return finishNode(factory.createTypeLiteralNode(parseObjectTypeMembers()), pos);
+    }
+
+    function parseObjectTypeMembers(): NodeArray<TypeElement> {
+        let members: NodeArray<TypeElement>;
+        if (parseExpected(SyntaxKind.OpenBraceToken)) {
+            members = parseList(ParsingContext.TypeMembers, parseTypeMember);
+            parseExpected(SyntaxKind.CloseBraceToken);
+        }
+        else {
+            members = createMissingList<TypeElement>();
+        }
+
+        return members;
+    }
+
+    function isStartOfMappedType() {
+        nextToken();
+        if (token() === SyntaxKind.PlusToken || token() === SyntaxKind.MinusToken) {
+            return nextToken() === SyntaxKind.ReadonlyKeyword;
+        }
+        if (token() === SyntaxKind.ReadonlyKeyword) {
+            nextToken();
+        }
+        return token() === SyntaxKind.OpenBracketToken && nextTokenIsIdentifier() && nextToken() === SyntaxKind.InKeyword;
+    }
+
+    function parseMappedTypeParameter() {
+        const pos = getNodePos();
+        const name = parseIdentifierName();
+        parseExpected(SyntaxKind.InKeyword);
+        const type = parseType();
+        return finishNode(factory.createTypeParameterDeclaration(/*modifiers*/ undefined, name, type, /*defaultType*/ undefined), pos);
+    }
+
+    function parseMappedType() {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.OpenBraceToken);
+        let readonlyToken: ReadonlyKeyword | PlusToken | MinusToken | undefined;
+        if (token() === SyntaxKind.ReadonlyKeyword || token() === SyntaxKind.PlusToken || token() === SyntaxKind.MinusToken) {
+            readonlyToken = parseTokenNode<ReadonlyKeyword | PlusToken | MinusToken>();
+            if (readonlyToken.kind !== SyntaxKind.ReadonlyKeyword) {
+                parseExpected(SyntaxKind.ReadonlyKeyword);
+            }
+        }
+        parseExpected(SyntaxKind.OpenBracketToken);
+        const typeParameter = parseMappedTypeParameter();
+        const nameType = parseOptional(SyntaxKind.AsKeyword) ? parseType() : undefined;
+        parseExpected(SyntaxKind.CloseBracketToken);
+        let questionToken: QuestionToken | PlusToken | MinusToken | undefined;
+        if (token() === SyntaxKind.QuestionToken || token() === SyntaxKind.PlusToken || token() === SyntaxKind.MinusToken) {
+            questionToken = parseTokenNode<QuestionToken | PlusToken | MinusToken>();
+            if (questionToken.kind !== SyntaxKind.QuestionToken) {
+                parseExpected(SyntaxKind.QuestionToken);
+            }
+        }
+        const type = parseTypeAnnotation();
+        parseSemicolon();
+        const members = parseList(ParsingContext.TypeMembers, parseTypeMember);
+        parseExpected(SyntaxKind.CloseBraceToken);
+        return finishNode(factory.createMappedTypeNode(readonlyToken, typeParameter, nameType, questionToken, type, members), pos);
+    }
+
+    function parseTupleElementType() {
+        const pos = getNodePos();
+        if (parseOptional(SyntaxKind.DotDotDotToken)) {
+            return finishNode(factory.createRestTypeNode(parseType()), pos);
+        }
+        const type = parseType();
+        if (isJSDocNullableType(type) && type.pos === type.type.pos) {
+            const node = factory.createOptionalTypeNode(type.type);
+            setTextRange(node, type);
+            (node as Mutable<Node>).flags = type.flags;
+            return node;
+        }
+        return type;
+    }
+
+    function isNextTokenColonOrQuestionColon() {
+        return nextToken() === SyntaxKind.ColonToken || (token() === SyntaxKind.QuestionToken && nextToken() === SyntaxKind.ColonToken);
+    }
+
+    function isTupleElementName() {
+        if (token() === SyntaxKind.DotDotDotToken) {
+            return tokenIsIdentifierOrKeyword(nextToken()) && isNextTokenColonOrQuestionColon();
+        }
+        return tokenIsIdentifierOrKeyword(token()) && isNextTokenColonOrQuestionColon();
+    }
+
+    function parseTupleElementNameOrTupleElementType() {
+        if (lookAhead(isTupleElementName)) {
+            const pos = getNodePos();
+            const hasJSDoc = hasPrecedingJSDocComment();
+            const dotDotDotToken = parseOptionalToken(SyntaxKind.DotDotDotToken);
+            const name = parseIdentifierName();
+            const questionToken = parseOptionalToken(SyntaxKind.QuestionToken);
+            parseExpected(SyntaxKind.ColonToken);
+            const type = parseTupleElementType();
+            const node = factory.createNamedTupleMember(dotDotDotToken, name, questionToken, type);
+            return withJSDoc(finishNode(node, pos), hasJSDoc);
+        }
+        return parseTupleElementType();
+    }
+
+    function parseTupleType(): TupleTypeNode {
+        const pos = getNodePos();
+        return finishNode(
+            factory.createTupleTypeNode(
+                parseBracketedList(ParsingContext.TupleElementTypes, parseTupleElementNameOrTupleElementType, SyntaxKind.OpenBracketToken, SyntaxKind.CloseBracketToken),
+            ),
+            pos,
+        );
+    }
+
+    function parseParenthesizedType(): TypeNode {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.OpenParenToken);
+        const type = parseType();
+        parseExpected(SyntaxKind.CloseParenToken);
+        return finishNode(factory.createParenthesizedType(type), pos);
+    }
+
+    function parseModifiersForConstructorType(): NodeArray<Modifier> | undefined {
+        let modifiers: NodeArray<Modifier> | undefined;
+        if (token() === SyntaxKind.AbstractKeyword) {
+            const pos = getNodePos();
+            nextToken();
+            const modifier = finishNode(factoryCreateToken(SyntaxKind.AbstractKeyword), pos);
+            modifiers = createNodeArray<Modifier>([modifier], pos);
+        }
+        return modifiers;
+    }
+
+    function parseFunctionOrConstructorType(): TypeNode {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        const modifiers = parseModifiersForConstructorType();
+        const isConstructorType = parseOptional(SyntaxKind.NewKeyword);
+        Debug.assert(!modifiers || isConstructorType, "Per isStartOfFunctionOrConstructorType, a function type cannot have modifiers.");
+        const typeParameters = parseTypeParameters();
+        const parameters = parseParameters(SignatureFlags.Type);
+        const type = parseReturnType(SyntaxKind.EqualsGreaterThanToken, /*isType*/ false);
+        const node = isConstructorType
+            ? factory.createConstructorTypeNode(modifiers, typeParameters, parameters, type)
+            : factory.createFunctionTypeNode(typeParameters, parameters, type);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseKeywordAndNoDot(): TypeNode | undefined {
+        const node = parseTokenNode<TypeNode>();
+        return token() === SyntaxKind.DotToken ? undefined : node;
+    }
+
+    function parseLiteralTypeNode(negative?: boolean): LiteralTypeNode {
+        const pos = getNodePos();
+        if (negative) {
+            nextToken();
+        }
+        let expression: BooleanLiteral | NullLiteral | LiteralExpression | PrefixUnaryExpression = token() === SyntaxKind.TrueKeyword || token() === SyntaxKind.FalseKeyword || token() === SyntaxKind.NullKeyword ?
+            parseTokenNode<BooleanLiteral | NullLiteral>() :
+            parseLiteralLikeNode(token()) as LiteralExpression;
+        if (negative) {
+            expression = finishNode(factory.createPrefixUnaryExpression(SyntaxKind.MinusToken, expression), pos);
+        }
+        return finishNode(factory.createLiteralTypeNode(expression), pos);
+    }
+
+    function isStartOfTypeOfImportType() {
+        nextToken();
+        return token() === SyntaxKind.ImportKeyword;
+    }
+
+    function parseImportType(): ImportTypeNode {
+        sourceFlags |= NodeFlags.PossiblyContainsDynamicImport;
+        const pos = getNodePos();
+        const isTypeOf = parseOptional(SyntaxKind.TypeOfKeyword);
+        parseExpected(SyntaxKind.ImportKeyword);
+        parseExpected(SyntaxKind.OpenParenToken);
+        const type = parseType();
+        let attributes: ImportAttributes | undefined;
+        if (parseOptional(SyntaxKind.CommaToken)) {
+            const openBracePosition = scanner.getTokenStart();
+            parseExpected(SyntaxKind.OpenBraceToken);
+            const currentToken = token();
+            if (currentToken === SyntaxKind.WithKeyword || currentToken === SyntaxKind.AssertKeyword) {
+                nextToken();
+            }
+            else {
+                parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(SyntaxKind.WithKeyword));
+            }
+            parseExpected(SyntaxKind.ColonToken);
+            attributes = parseImportAttributes(currentToken as SyntaxKind.WithKeyword | SyntaxKind.AssertKeyword, /*skipKeyword*/ true);
+            if (!parseExpected(SyntaxKind.CloseBraceToken)) {
+                const lastError = lastOrUndefined(parseDiagnostics);
+                if (lastError && lastError.code === Diagnostics._0_expected.code) {
+                    addRelatedInfo(
+                        lastError,
+                        createDetachedDiagnostic(fileName, sourceText, openBracePosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, "{", "}"),
+                    );
+                }
+            }
+        }
+        parseExpected(SyntaxKind.CloseParenToken);
+        const qualifier = parseOptional(SyntaxKind.DotToken) ? parseEntityNameOfTypeReference() : undefined;
+        const typeArguments = parseTypeArgumentsOfTypeReference();
+        return finishNode(factory.createImportTypeNode(type, attributes, qualifier, typeArguments, isTypeOf), pos);
+    }
+
+    function nextTokenIsNumericOrBigIntLiteral() {
+        nextToken();
+        return token() === SyntaxKind.NumericLiteral || token() === SyntaxKind.BigIntLiteral;
+    }
+
+    function parseNonArrayType(): TypeNode {
+        switch (token()) {
+            case SyntaxKind.AnyKeyword:
+            case SyntaxKind.UnknownKeyword:
+            case SyntaxKind.StringKeyword:
+            case SyntaxKind.NumberKeyword:
+            case SyntaxKind.BigIntKeyword:
+            case SyntaxKind.SymbolKeyword:
+            case SyntaxKind.BooleanKeyword:
+            case SyntaxKind.UndefinedKeyword:
+            case SyntaxKind.NeverKeyword:
+            case SyntaxKind.ObjectKeyword:
+                // If these are followed by a dot, then parse these out as a dotted type reference instead.
+                return tryParse(parseKeywordAndNoDot) || parseTypeReference();
+            case SyntaxKind.AsteriskEqualsToken:
+                // If there is '*=', treat it as * followed by postfix =
+                scanner.reScanAsteriskEqualsToken();
+                // falls through
+            case SyntaxKind.AsteriskToken:
+                return parseJSDocAllType();
+            case SyntaxKind.QuestionQuestionToken:
+                // If there is '??', treat it as prefix-'?' in JSDoc type.
+                scanner.reScanQuestionToken();
+                // falls through
+            case SyntaxKind.QuestionToken:
+                return parseJSDocUnknownOrNullableType();
+            case SyntaxKind.FunctionKeyword:
+                return parseJSDocFunctionType();
+            case SyntaxKind.ExclamationToken:
+                return parseJSDocNonNullableType();
+            case SyntaxKind.NoSubstitutionTemplateLiteral:
+            case SyntaxKind.StringLiteral:
+            case SyntaxKind.NumericLiteral:
+            case SyntaxKind.BigIntLiteral:
+            case SyntaxKind.TrueKeyword:
+            case SyntaxKind.FalseKeyword:
+            case SyntaxKind.NullKeyword:
+                return parseLiteralTypeNode();
+            case SyntaxKind.MinusToken:
+                return lookAhead(nextTokenIsNumericOrBigIntLiteral) ? parseLiteralTypeNode(/*negative*/ true) : parseTypeReference();
+            case SyntaxKind.VoidKeyword:
+                return parseTokenNode<TypeNode>();
+            case SyntaxKind.ThisKeyword: {
+                const thisKeyword = parseThisTypeNode();
+                if (token() === SyntaxKind.IsKeyword && !scanner.hasPrecedingLineBreak()) {
+                    return parseThisTypePredicate(thisKeyword);
+                }
+                else {
+                    return thisKeyword;
+                }
+            }
+            case SyntaxKind.TypeOfKeyword:
+                return lookAhead(isStartOfTypeOfImportType) ? parseImportType() : parseTypeQuery();
+            case SyntaxKind.OpenBraceToken:
+                return lookAhead(isStartOfMappedType) ? parseMappedType() : parseTypeLiteral();
+            case SyntaxKind.OpenBracketToken:
+                return parseTupleType();
+            case SyntaxKind.OpenParenToken:
+                return parseParenthesizedType();
+            case SyntaxKind.ImportKeyword:
+                return parseImportType();
+            case SyntaxKind.AssertsKeyword:
+                return lookAhead(nextTokenIsIdentifierOrKeywordOnSameLine) ? parseAssertsTypePredicate() : parseTypeReference();
+            case SyntaxKind.TemplateHead:
+                return parseTemplateType();
+            default:
+                return parseTypeReference();
+        }
+    }
+
+    function isStartOfType(inStartOfParameter?: boolean): boolean {
+        switch (token()) {
+            case SyntaxKind.AnyKeyword:
+            case SyntaxKind.UnknownKeyword:
+            case SyntaxKind.StringKeyword:
+            case SyntaxKind.NumberKeyword:
+            case SyntaxKind.BigIntKeyword:
+            case SyntaxKind.BooleanKeyword:
+            case SyntaxKind.ReadonlyKeyword:
+            case SyntaxKind.SymbolKeyword:
+            case SyntaxKind.UniqueKeyword:
+            case SyntaxKind.VoidKeyword:
+            case SyntaxKind.UndefinedKeyword:
+            case SyntaxKind.NullKeyword:
+            case SyntaxKind.ThisKeyword:
+            case SyntaxKind.TypeOfKeyword:
+            case SyntaxKind.NeverKeyword:
+            case SyntaxKind.OpenBraceToken:
+            case SyntaxKind.OpenBracketToken:
+            case SyntaxKind.LessThanToken:
+            case SyntaxKind.BarToken:
+            case SyntaxKind.AmpersandToken:
+            case SyntaxKind.NewKeyword:
+            case SyntaxKind.StringLiteral:
+            case SyntaxKind.NumericLiteral:
+            case SyntaxKind.BigIntLiteral:
+            case SyntaxKind.TrueKeyword:
+            case SyntaxKind.FalseKeyword:
+            case SyntaxKind.ObjectKeyword:
+            case SyntaxKind.AsteriskToken:
+            case SyntaxKind.QuestionToken:
+            case SyntaxKind.ExclamationToken:
+            case SyntaxKind.DotDotDotToken:
+            case SyntaxKind.InferKeyword:
+            case SyntaxKind.ImportKeyword:
+            case SyntaxKind.AssertsKeyword:
+            case SyntaxKind.NoSubstitutionTemplateLiteral:
+            case SyntaxKind.TemplateHead:
+                return true;
+            case SyntaxKind.FunctionKeyword:
+                return !inStartOfParameter;
+            case SyntaxKind.MinusToken:
+                return !inStartOfParameter && lookAhead(nextTokenIsNumericOrBigIntLiteral);
+            case SyntaxKind.OpenParenToken:
+                // Only consider '(' the start of a type if followed by ')', '...', an identifier, a modifier,
+                // or something that starts a type. We don't want to consider things like '(1)' a type.
+                return !inStartOfParameter && lookAhead(isStartOfParenthesizedOrFunctionType);
+            default:
+                return isIdentifier();
+        }
+    }
+
+    function isStartOfParenthesizedOrFunctionType() {
+        nextToken();
+        return token() === SyntaxKind.CloseParenToken || isStartOfParameter(/*isJSDocParameter*/ false) || isStartOfType();
+    }
+
+    function parsePostfixTypeOrHigher(): TypeNode {
+        const pos = getNodePos();
+        let type = parseNonArrayType();
+        while (!scanner.hasPrecedingLineBreak()) {
+            switch (token()) {
+                case SyntaxKind.ExclamationToken:
+                    nextToken();
+                    type = finishNode(factory.createJSDocNonNullableType(type, /*postfix*/ true), pos);
+                    break;
+                case SyntaxKind.QuestionToken:
+                    // If next token is start of a type we have a conditional type
+                    if (lookAhead(nextTokenIsStartOfType)) {
+                        return type;
+                    }
+                    nextToken();
+                    type = finishNode(factory.createJSDocNullableType(type, /*postfix*/ true), pos);
+                    break;
+                case SyntaxKind.OpenBracketToken:
+                    parseExpected(SyntaxKind.OpenBracketToken);
+                    if (isStartOfType()) {
+                        const indexType = parseType();
+                        parseExpected(SyntaxKind.CloseBracketToken);
+                        type = finishNode(factory.createIndexedAccessTypeNode(type, indexType), pos);
+                    }
+                    else {
+                        parseExpected(SyntaxKind.CloseBracketToken);
+                        type = finishNode(factory.createArrayTypeNode(type), pos);
+                    }
+                    break;
+                default:
+                    return type;
+            }
+        }
+        return type;
+    }
+
+    function parseTypeOperator(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword) {
+        const pos = getNodePos();
+        parseExpected(operator);
+        return finishNode(factory.createTypeOperatorNode(operator, parseTypeOperatorOrHigher()), pos);
+    }
+
+    function tryParseConstraintOfInferType() {
+        if (parseOptional(SyntaxKind.ExtendsKeyword)) {
+            const constraint = disallowConditionalTypesAnd(parseType);
+            if (inDisallowConditionalTypesContext() || token() !== SyntaxKind.QuestionToken) {
+                return constraint;
+            }
+        }
+    }
+
+    function parseTypeParameterOfInferType(): TypeParameterDeclaration {
+        const pos = getNodePos();
+        const name = parseIdentifier();
+        const constraint = tryParse(tryParseConstraintOfInferType);
+        const node = factory.createTypeParameterDeclaration(/*modifiers*/ undefined, name, constraint);
+        return finishNode(node, pos);
+    }
+
+    function parseInferType(): InferTypeNode {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.InferKeyword);
+        return finishNode(factory.createInferTypeNode(parseTypeParameterOfInferType()), pos);
+    }
+
+    function parseTypeOperatorOrHigher(): TypeNode {
+        const operator = token();
+        switch (operator) {
+            case SyntaxKind.KeyOfKeyword:
+            case SyntaxKind.UniqueKeyword:
+            case SyntaxKind.ReadonlyKeyword:
+                return parseTypeOperator(operator);
+            case SyntaxKind.InferKeyword:
+                return parseInferType();
+        }
+        return allowConditionalTypesAnd(parsePostfixTypeOrHigher);
+    }
+
+    function parseFunctionOrConstructorTypeToError(
+        isInUnionType: boolean,
+    ): TypeNode | undefined {
+        // the function type and constructor type shorthand notation
+        // are not allowed directly in unions and intersections, but we'll
+        // try to parse them gracefully and issue a helpful message.
+        if (isStartOfFunctionTypeOrConstructorType()) {
+            const type = parseFunctionOrConstructorType();
+            let diagnostic: DiagnosticMessage;
+            if (isFunctionTypeNode(type)) {
+                diagnostic = isInUnionType
+                    ? Diagnostics.Function_type_notation_must_be_parenthesized_when_used_in_a_union_type
+                    : Diagnostics.Function_type_notation_must_be_parenthesized_when_used_in_an_intersection_type;
+            }
+            else {
+                diagnostic = isInUnionType
+                    ? Diagnostics.Constructor_type_notation_must_be_parenthesized_when_used_in_a_union_type
+                    : Diagnostics.Constructor_type_notation_must_be_parenthesized_when_used_in_an_intersection_type;
+            }
+            parseErrorAtRange(type, diagnostic);
+            return type;
+        }
+        return undefined;
+    }
+
+    function parseUnionOrIntersectionType(
+        operator: SyntaxKind.BarToken | SyntaxKind.AmpersandToken,
+        parseConstituentType: () => TypeNode,
+        createTypeNode: (types: NodeArray<TypeNode>) => UnionOrIntersectionTypeNode,
+    ): TypeNode {
+        const pos = getNodePos();
+        const isUnionType = operator === SyntaxKind.BarToken;
+        const hasLeadingOperator = parseOptional(operator);
+        let type = hasLeadingOperator && parseFunctionOrConstructorTypeToError(isUnionType)
+            || parseConstituentType();
+        if (token() === operator || hasLeadingOperator) {
+            const types = [type];
+            while (parseOptional(operator)) {
+                types.push(parseFunctionOrConstructorTypeToError(isUnionType) || parseConstituentType());
+            }
+            type = finishNode(createTypeNode(createNodeArray(types, pos)), pos);
+        }
+        return type;
+    }
+
+    function parseIntersectionTypeOrHigher(): TypeNode {
+        return parseUnionOrIntersectionType(SyntaxKind.AmpersandToken, parseTypeOperatorOrHigher, factory.createIntersectionTypeNode);
+    }
+
+    function parseUnionTypeOrHigher(): TypeNode {
+        return parseUnionOrIntersectionType(SyntaxKind.BarToken, parseIntersectionTypeOrHigher, factory.createUnionTypeNode);
+    }
+
+    function nextTokenIsNewKeyword(): boolean {
+        nextToken();
+        return token() === SyntaxKind.NewKeyword;
+    }
+
+    function isStartOfFunctionTypeOrConstructorType(): boolean {
+        if (token() === SyntaxKind.LessThanToken) {
+            return true;
+        }
+        if (token() === SyntaxKind.OpenParenToken && lookAhead(isUnambiguouslyStartOfFunctionType)) {
+            return true;
+        }
+        return token() === SyntaxKind.NewKeyword ||
+            token() === SyntaxKind.AbstractKeyword && lookAhead(nextTokenIsNewKeyword);
+    }
+
+    function skipParameterStart(): boolean {
+        if (isModifierKind(token())) {
+            // Skip modifiers
+            parseModifiers(/*allowDecorators*/ false);
+        }
+        if (isIdentifier() || token() === SyntaxKind.ThisKeyword) {
+            nextToken();
+            return true;
+        }
+        if (token() === SyntaxKind.OpenBracketToken || token() === SyntaxKind.OpenBraceToken) {
+            // Return true if we can parse an array or object binding pattern with no errors
+            const previousErrorCount = parseDiagnostics.length;
+            parseIdentifierOrPattern();
+            return previousErrorCount === parseDiagnostics.length;
+        }
+        return false;
+    }
+
+    function isUnambiguouslyStartOfFunctionType() {
+        nextToken();
+        if (token() === SyntaxKind.CloseParenToken || token() === SyntaxKind.DotDotDotToken) {
+            // ( )
+            // ( ...
+            return true;
+        }
+        if (skipParameterStart()) {
+            // We successfully skipped modifiers (if any) and an identifier or binding pattern,
+            // now see if we have something that indicates a parameter declaration
+            if (
+                token() === SyntaxKind.ColonToken || token() === SyntaxKind.CommaToken ||
+                token() === SyntaxKind.QuestionToken || token() === SyntaxKind.EqualsToken
+            ) {
+                // ( xxx :
+                // ( xxx ,
+                // ( xxx ?
+                // ( xxx =
+                return true;
+            }
+            if (token() === SyntaxKind.CloseParenToken) {
+                nextToken();
+                if (token() === SyntaxKind.EqualsGreaterThanToken) {
+                    // ( xxx ) =>
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    function parseTypeOrTypePredicate(): TypeNode {
+        const pos = getNodePos();
+        const typePredicateVariable = isIdentifier() && tryParse(parseTypePredicatePrefix);
+        const type = parseType();
+        if (typePredicateVariable) {
+            return finishNode(factory.createTypePredicateNode(/*assertsModifier*/ undefined, typePredicateVariable, type), pos);
+        }
+        else {
+            return type;
+        }
+    }
+
+    function parseTypePredicatePrefix() {
+        const id = parseIdentifier();
+        if (token() === SyntaxKind.IsKeyword && !scanner.hasPrecedingLineBreak()) {
+            nextToken();
+            return id;
+        }
+    }
+
+    function parseAssertsTypePredicate(): TypeNode {
+        const pos = getNodePos();
+        const assertsModifier = parseExpectedToken(SyntaxKind.AssertsKeyword);
+        const parameterName = token() === SyntaxKind.ThisKeyword ? parseThisTypeNode() : parseIdentifier();
+        const type = parseOptional(SyntaxKind.IsKeyword) ? parseType() : undefined;
+        return finishNode(factory.createTypePredicateNode(assertsModifier, parameterName, type), pos);
+    }
+
+    function parseType(): TypeNode {
+        if (contextFlags & NodeFlags.TypeExcludesFlags) {
+            return doOutsideOfContext(NodeFlags.TypeExcludesFlags, parseType);
+        }
+        if (isStartOfFunctionTypeOrConstructorType()) {
+            return parseFunctionOrConstructorType();
+        }
+        const pos = getNodePos();
+        const type = parseUnionTypeOrHigher();
+        if (!inDisallowConditionalTypesContext() && !scanner.hasPrecedingLineBreak() && parseOptional(SyntaxKind.ExtendsKeyword)) {
+            // The type following 'extends' is not permitted to be another conditional type
+            const extendsType = disallowConditionalTypesAnd(parseType);
+            parseExpected(SyntaxKind.QuestionToken);
+            const trueType = allowConditionalTypesAnd(parseType);
+            parseExpected(SyntaxKind.ColonToken);
+            const falseType = allowConditionalTypesAnd(parseType);
+            return finishNode(factory.createConditionalTypeNode(type, extendsType, trueType, falseType), pos);
+        }
+        return type;
+    }
+
+    function parseTypeAnnotation(): TypeNode | undefined {
+        return parseOptional(SyntaxKind.ColonToken) ? parseType() : undefined;
+    }
+
+    // EXPRESSIONS
+    function isStartOfLeftHandSideExpression(): boolean {
+        switch (token()) {
+            case SyntaxKind.ThisKeyword:
+            case SyntaxKind.SuperKeyword:
+            case SyntaxKind.NullKeyword:
+            case SyntaxKind.TrueKeyword:
+            case SyntaxKind.FalseKeyword:
+            case SyntaxKind.NumericLiteral:
+            case SyntaxKind.BigIntLiteral:
+            case SyntaxKind.StringLiteral:
+            case SyntaxKind.NoSubstitutionTemplateLiteral:
+            case SyntaxKind.TemplateHead:
+            case SyntaxKind.OpenParenToken:
+            case SyntaxKind.OpenBracketToken:
+            case SyntaxKind.OpenBraceToken:
+            case SyntaxKind.FunctionKeyword:
+            case SyntaxKind.ClassKeyword:
+            case SyntaxKind.NewKeyword:
+            case SyntaxKind.SlashToken:
+            case SyntaxKind.SlashEqualsToken:
+            case SyntaxKind.Identifier:
+                return true;
+            case SyntaxKind.ImportKeyword:
+                return lookAhead(nextTokenIsOpenParenOrLessThanOrDot);
+            default:
+                return isIdentifier();
+        }
+    }
+
+    function isStartOfExpression(): boolean {
+        if (isStartOfLeftHandSideExpression()) {
+            return true;
+        }
+
+        switch (token()) {
+            case SyntaxKind.PlusToken:
+            case SyntaxKind.MinusToken:
+            case SyntaxKind.TildeToken:
+            case SyntaxKind.ExclamationToken:
+            case SyntaxKind.DeleteKeyword:
+            case SyntaxKind.TypeOfKeyword:
+            case SyntaxKind.VoidKeyword:
+            case SyntaxKind.PlusPlusToken:
+            case SyntaxKind.MinusMinusToken:
+            case SyntaxKind.LessThanToken:
+            case SyntaxKind.AwaitKeyword:
+            case SyntaxKind.YieldKeyword:
+            case SyntaxKind.PrivateIdentifier:
+            case SyntaxKind.AtToken:
+                // Yield/await always starts an expression.  Either it is an identifier (in which case
+                // it is definitely an expression).  Or it's a keyword (either because we're in
+                // a generator or async function, or in strict mode (or both)) and it started a yield or await expression.
+                return true;
+            default:
+                // Error tolerance.  If we see the start of some binary operator, we consider
+                // that the start of an expression.  That way we'll parse out a missing identifier,
+                // give a good message about an identifier being missing, and then consume the
+                // rest of the binary expression.
+                if (isBinaryOperator()) {
+                    return true;
+                }
+
+                return isIdentifier();
+        }
+    }
+
+    function isStartOfExpressionStatement(): boolean {
+        // As per the grammar, none of '{' or 'function' or 'class' can start an expression statement.
+        return token() !== SyntaxKind.OpenBraceToken &&
+            token() !== SyntaxKind.FunctionKeyword &&
+            token() !== SyntaxKind.ClassKeyword &&
+            token() !== SyntaxKind.AtToken &&
+            isStartOfExpression();
+    }
+
+    function parseExpression(): Expression {
+        // Expression[in]:
+        //      AssignmentExpression[in]
+        //      Expression[in] , AssignmentExpression[in]
+
+        // clear the decorator context when parsing Expression, as it should be unambiguous when parsing a decorator
+        const saveDecoratorContext = inDecoratorContext();
+        if (saveDecoratorContext) {
+            setDecoratorContext(/*val*/ false);
+        }
+
+        const pos = getNodePos();
+        let expr = parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true);
+        let operatorToken: BinaryOperatorToken;
+        while ((operatorToken = parseOptionalToken(SyntaxKind.CommaToken))) {
+            expr = makeBinaryExpression(expr, operatorToken, parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true), pos);
+        }
+
+        if (saveDecoratorContext) {
+            setDecoratorContext(/*val*/ true);
+        }
+        return expr;
+    }
+
+    function parseInitializer(): Expression | undefined {
+        return parseOptional(SyntaxKind.EqualsToken) ? parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true) : undefined;
+    }
+
+    function parseAssignmentExpressionOrHigher(allowReturnTypeInArrowFunction: boolean): Expression {
+        //  AssignmentExpression[in,yield]:
+        //      1) ConditionalExpression[?in,?yield]
+        //      2) LeftHandSideExpression = AssignmentExpression[?in,?yield]
+        //      3) LeftHandSideExpression AssignmentOperator AssignmentExpression[?in,?yield]
+        //      4) ArrowFunctionExpression[?in,?yield]
+        //      5) AsyncArrowFunctionExpression[in,yield,await]
+        //      6) [+Yield] YieldExpression[?In]
+        //
+        // Note: for ease of implementation we treat productions '2' and '3' as the same thing.
+        // (i.e. they're both BinaryExpressions with an assignment operator in it).
+
+        // First, do the simple check if we have a YieldExpression (production '6').
+        if (isYieldExpression()) {
+            return parseYieldExpression();
+        }
+
+        // Then, check if we have an arrow function (production '4' and '5') that starts with a parenthesized
+        // parameter list or is an async arrow function.
+        // AsyncArrowFunctionExpression:
+        //      1) async[no LineTerminator here]AsyncArrowBindingIdentifier[?Yield][no LineTerminator here]=>AsyncConciseBody[?In]
+        //      2) CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await][no LineTerminator here]=>AsyncConciseBody[?In]
+        // Production (1) of AsyncArrowFunctionExpression is parsed in "tryParseAsyncSimpleArrowFunctionExpression".
+        // And production (2) is parsed in "tryParseParenthesizedArrowFunctionExpression".
+        //
+        // If we do successfully parse arrow-function, we must *not* recurse for productions 1, 2 or 3. An ArrowFunction is
+        // not a LeftHandSideExpression, nor does it start a ConditionalExpression.  So we are done
+        // with AssignmentExpression if we see one.
+        const arrowExpression = tryParseParenthesizedArrowFunctionExpression(allowReturnTypeInArrowFunction) || tryParseAsyncSimpleArrowFunctionExpression(allowReturnTypeInArrowFunction);
+        if (arrowExpression) {
+            return arrowExpression;
+        }
+
+        // Now try to see if we're in production '1', '2' or '3'.  A conditional expression can
+        // start with a LogicalOrExpression, while the assignment productions can only start with
+        // LeftHandSideExpressions.
+        //
+        // So, first, we try to just parse out a BinaryExpression.  If we get something that is a
+        // LeftHandSide or higher, then we can try to parse out the assignment expression part.
+        // Otherwise, we try to parse out the conditional expression bit.  We want to allow any
+        // binary expression here, so we pass in the 'lowest' precedence here so that it matches
+        // and consumes anything.
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        const expr = parseBinaryExpressionOrHigher(OperatorPrecedence.Lowest);
+
+        // To avoid a look-ahead, we did not handle the case of an arrow function with a single un-parenthesized
+        // parameter ('x => ...') above. We handle it here by checking if the parsed expression was a single
+        // identifier and the current token is an arrow.
+        if (expr.kind === SyntaxKind.Identifier && token() === SyntaxKind.EqualsGreaterThanToken) {
+            return parseSimpleArrowFunctionExpression(pos, expr as Identifier, allowReturnTypeInArrowFunction, hasJSDoc, /*asyncModifier*/ undefined);
+        }
+
+        // Now see if we might be in cases '2' or '3'.
+        // If the expression was a LHS expression, and we have an assignment operator, then
+        // we're in '2' or '3'. Consume the assignment and return.
+        //
+        // Note: we call reScanGreaterToken so that we get an appropriately merged token
+        // for cases like `> > =` becoming `>>=`
+        if (isLeftHandSideExpression(expr) && isAssignmentOperator(reScanGreaterToken())) {
+            return makeBinaryExpression(expr, parseTokenNode(), parseAssignmentExpressionOrHigher(allowReturnTypeInArrowFunction), pos);
+        }
+
+        // It wasn't an assignment or a lambda.  This is a conditional expression:
+        return parseConditionalExpressionRest(expr, pos, allowReturnTypeInArrowFunction);
+    }
+
+    function isYieldExpression(): boolean {
+        if (token() === SyntaxKind.YieldKeyword) {
+            // If we have a 'yield' keyword, and this is a context where yield expressions are
+            // allowed, then definitely parse out a yield expression.
+            if (inYieldContext()) {
+                return true;
+            }
+
+            // We're in a context where 'yield expr' is not allowed.  However, if we can
+            // definitely tell that the user was trying to parse a 'yield expr' and not
+            // just a normal expr that start with a 'yield' identifier, then parse out
+            // a 'yield expr'.  We can then report an error later that they are only
+            // allowed in generator expressions.
+            //
+            // for example, if we see 'yield(foo)', then we'll have to treat that as an
+            // invocation expression of something called 'yield'.  However, if we have
+            // 'yield foo' then that is not legal as a normal expression, so we can
+            // definitely recognize this as a yield expression.
+            //
+            // for now we just check if the next token is an identifier.  More heuristics
+            // can be added here later as necessary.  We just need to make sure that we
+            // don't accidentally consume something legal.
+            return lookAhead(nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine);
+        }
+
+        return false;
+    }
+
+    function nextTokenIsIdentifierOnSameLine() {
+        nextToken();
+        return !scanner.hasPrecedingLineBreak() && isIdentifier();
+    }
+
+    function parseYieldExpression(): YieldExpression {
+        const pos = getNodePos();
+
+        // YieldExpression[In] :
+        //      yield
+        //      yield [no LineTerminator here] [Lexical goal InputElementRegExp]AssignmentExpression[?In, Yield]
+        //      yield [no LineTerminator here] * [Lexical goal InputElementRegExp]AssignmentExpression[?In, Yield]
+        nextToken();
+
+        if (
+            !scanner.hasPrecedingLineBreak() &&
+            (token() === SyntaxKind.AsteriskToken || isStartOfExpression())
+        ) {
+            return finishNode(
+                factory.createYieldExpression(
+                    parseOptionalToken(SyntaxKind.AsteriskToken),
+                    parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true),
+                ),
+                pos,
+            );
+        }
+        else {
+            // if the next token is not on the same line as yield.  or we don't have an '*' or
+            // the start of an expression, then this is just a simple "yield" expression.
+            return finishNode(factory.createYieldExpression(/*asteriskToken*/ undefined, /*expression*/ undefined), pos);
+        }
+    }
+
+    function parseSimpleArrowFunctionExpression(pos: number, identifier: Identifier, allowReturnTypeInArrowFunction: boolean, hasJSDoc: boolean, asyncModifier?: NodeArray<Modifier> | undefined): ArrowFunction {
+        Debug.assert(token() === SyntaxKind.EqualsGreaterThanToken, "parseSimpleArrowFunctionExpression should only have been called if we had a =>");
+        const parameter = factory.createParameterDeclaration(
+            /*modifiers*/ undefined,
+            /*dotDotDotToken*/ undefined,
+            identifier,
+            /*questionToken*/ undefined,
+            /*type*/ undefined,
+            /*initializer*/ undefined,
+        );
+        finishNode(parameter, identifier.pos);
+
+        const parameters = createNodeArray<ParameterDeclaration>([parameter], parameter.pos, parameter.end);
+        const equalsGreaterThanToken = parseExpectedToken(SyntaxKind.EqualsGreaterThanToken);
+        const body = parseArrowFunctionExpressionBody(/*isAsync*/ !!asyncModifier, allowReturnTypeInArrowFunction);
+        const node = factory.createArrowFunction(asyncModifier, /*typeParameters*/ undefined, parameters, /*type*/ undefined, equalsGreaterThanToken, body);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function tryParseParenthesizedArrowFunctionExpression(allowReturnTypeInArrowFunction: boolean): Expression | undefined {
+        const triState = isParenthesizedArrowFunctionExpression();
+        if (triState === Tristate.False) {
+            // It's definitely not a parenthesized arrow function expression.
+            return undefined;
+        }
+
+        // If we definitely have an arrow function, then we can just parse one, not requiring a
+        // following => or { token. Otherwise, we *might* have an arrow function.  Try to parse
+        // it out, but don't allow any ambiguity, and return 'undefined' if this could be an
+        // expression instead.
+        return triState === Tristate.True ?
+            parseParenthesizedArrowFunctionExpression(/*allowAmbiguity*/ true, /*allowReturnTypeInArrowFunction*/ true) :
+            tryParse(() => parsePossibleParenthesizedArrowFunctionExpression(allowReturnTypeInArrowFunction));
+    }
+
+    //  True        -> We definitely expect a parenthesized arrow function here.
+    //  False       -> There *cannot* be a parenthesized arrow function here.
+    //  Unknown     -> There *might* be a parenthesized arrow function here.
+    //                 Speculatively look ahead to be sure, and rollback if not.
+    function isParenthesizedArrowFunctionExpression(): Tristate {
+        if (token() === SyntaxKind.OpenParenToken || token() === SyntaxKind.LessThanToken || token() === SyntaxKind.AsyncKeyword) {
+            return lookAhead(isParenthesizedArrowFunctionExpressionWorker);
+        }
+
+        if (token() === SyntaxKind.EqualsGreaterThanToken) {
+            // ERROR RECOVERY TWEAK:
+            // If we see a standalone => try to parse it as an arrow function expression as that's
+            // likely what the user intended to write.
+            return Tristate.True;
+        }
+        // Definitely not a parenthesized arrow function.
+        return Tristate.False;
+    }
+
+    function isParenthesizedArrowFunctionExpressionWorker() {
+        if (token() === SyntaxKind.AsyncKeyword) {
+            nextToken();
+            if (scanner.hasPrecedingLineBreak()) {
+                return Tristate.False;
+            }
+            if (token() !== SyntaxKind.OpenParenToken && token() !== SyntaxKind.LessThanToken) {
+                return Tristate.False;
+            }
+        }
+
+        const first = token();
+        const second = nextToken();
+
+        if (first === SyntaxKind.OpenParenToken) {
+            if (second === SyntaxKind.CloseParenToken) {
+                // Simple cases: "() =>", "(): ", and "() {".
+                // This is an arrow function with no parameters.
+                // The last one is not actually an arrow function,
+                // but this is probably what the user intended.
+                const third = nextToken();
+                switch (third) {
+                    case SyntaxKind.EqualsGreaterThanToken:
+                    case SyntaxKind.ColonToken:
+                    case SyntaxKind.OpenBraceToken:
+                        return Tristate.True;
+                    default:
+                        return Tristate.False;
+                }
+            }
+
+            // If encounter "([" or "({", this could be the start of a binding pattern.
+            // Examples:
+            //      ([ x ]) => { }
+            //      ({ x }) => { }
+            //      ([ x ])
+            //      ({ x })
+            if (second === SyntaxKind.OpenBracketToken || second === SyntaxKind.OpenBraceToken) {
+                return Tristate.Unknown;
+            }
+
+            // Simple case: "(..."
+            // This is an arrow function with a rest parameter.
+            if (second === SyntaxKind.DotDotDotToken) {
+                return Tristate.True;
+            }
+
+            // Check for "(xxx yyy", where xxx is a modifier and yyy is an identifier. This
+            // isn't actually allowed, but we want to treat it as a lambda so we can provide
+            // a good error message.
+            if (isModifierKind(second) && second !== SyntaxKind.AsyncKeyword && lookAhead(nextTokenIsIdentifier)) {
+                if (nextToken() === SyntaxKind.AsKeyword) {
+                    // https://github.com/microsoft/TypeScript/issues/44466
+                    return Tristate.False;
+                }
+                return Tristate.True;
+            }
+
+            // If we had "(" followed by something that's not an identifier,
+            // then this definitely doesn't look like a lambda.  "this" is not
+            // valid, but we want to parse it and then give a semantic error.
+            if (!isIdentifier() && second !== SyntaxKind.ThisKeyword) {
+                return Tristate.False;
+            }
+
+            switch (nextToken()) {
+                case SyntaxKind.ColonToken:
+                    // If we have something like "(a:", then we must have a
+                    // type-annotated parameter in an arrow function expression.
+                    return Tristate.True;
+                case SyntaxKind.QuestionToken:
+                    nextToken();
+                    // If we have "(a?:" or "(a?," or "(a?=" or "(a?)" then it is definitely a lambda.
+                    if (token() === SyntaxKind.ColonToken || token() === SyntaxKind.CommaToken || token() === SyntaxKind.EqualsToken || token() === SyntaxKind.CloseParenToken) {
+                        return Tristate.True;
+                    }
+                    // Otherwise it is definitely not a lambda.
+                    return Tristate.False;
+                case SyntaxKind.CommaToken:
+                case SyntaxKind.EqualsToken:
+                case SyntaxKind.CloseParenToken:
+                    // If we have "(a," or "(a=" or "(a)" this *could* be an arrow function
+                    return Tristate.Unknown;
+            }
+            // It is definitely not an arrow function
+            return Tristate.False;
+        }
+        else {
+            Debug.assert(first === SyntaxKind.LessThanToken);
+
+            // If we have "<" not followed by an identifier,
+            // then this definitely is not an arrow function.
+            if (!isIdentifier() && token() !== SyntaxKind.ConstKeyword) {
+                return Tristate.False;
+            }
+
+            // JSX overrides
+            if (languageVariant === LanguageVariant.JSX) {
+                const isArrowFunctionInJsx = lookAhead(() => {
+                    parseOptional(SyntaxKind.ConstKeyword);
+                    const third = nextToken();
+                    if (third === SyntaxKind.ExtendsKeyword) {
+                        const fourth = nextToken();
+                        switch (fourth) {
+                            case SyntaxKind.EqualsToken:
+                            case SyntaxKind.GreaterThanToken:
+                            case SyntaxKind.SlashToken:
+                                return false;
+                            default:
+                                return true;
+                        }
+                    }
+                    else if (third === SyntaxKind.CommaToken || third === SyntaxKind.EqualsToken) {
+                        return true;
+                    }
+                    return false;
+                });
+
+                if (isArrowFunctionInJsx) {
+                    return Tristate.True;
+                }
+
+                return Tristate.False;
+            }
+
+            // This *could* be a parenthesized arrow function.
+            return Tristate.Unknown;
+        }
+    }
+
+    function parsePossibleParenthesizedArrowFunctionExpression(allowReturnTypeInArrowFunction: boolean): ArrowFunction | undefined {
+        const tokenPos = scanner.getTokenStart();
+        if (notParenthesizedArrow?.has(tokenPos)) {
+            return undefined;
+        }
+
+        const result = parseParenthesizedArrowFunctionExpression(/*allowAmbiguity*/ false, allowReturnTypeInArrowFunction);
+        if (!result) {
+            (notParenthesizedArrow || (notParenthesizedArrow = new Set())).add(tokenPos);
+        }
+
+        return result;
+    }
+
+    function tryParseAsyncSimpleArrowFunctionExpression(allowReturnTypeInArrowFunction: boolean): ArrowFunction | undefined {
+        // We do a check here so that we won't be doing unnecessarily call to "lookAhead"
+        if (token() === SyntaxKind.AsyncKeyword) {
+            if (lookAhead(isUnParenthesizedAsyncArrowFunctionWorker) === Tristate.True) {
+                const pos = getNodePos();
+                const hasJSDoc = hasPrecedingJSDocComment();
+                const asyncModifier = parseModifiersForArrowFunction();
+                const expr = parseBinaryExpressionOrHigher(OperatorPrecedence.Lowest);
+                return parseSimpleArrowFunctionExpression(pos, expr as Identifier, allowReturnTypeInArrowFunction, hasJSDoc, asyncModifier);
+            }
+        }
+        return undefined;
+    }
+
+    function isUnParenthesizedAsyncArrowFunctionWorker(): Tristate {
+        // AsyncArrowFunctionExpression:
+        //      1) async[no LineTerminator here]AsyncArrowBindingIdentifier[?Yield][no LineTerminator here]=>AsyncConciseBody[?In]
+        //      2) CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await][no LineTerminator here]=>AsyncConciseBody[?In]
+        if (token() === SyntaxKind.AsyncKeyword) {
+            nextToken();
+            // If the "async" is followed by "=>" token then it is not a beginning of an async arrow-function
+            // but instead a simple arrow-function which will be parsed inside "parseAssignmentExpressionOrHigher"
+            if (scanner.hasPrecedingLineBreak() || token() === SyntaxKind.EqualsGreaterThanToken) {
+                return Tristate.False;
+            }
+            // Check for un-parenthesized AsyncArrowFunction
+            const expr = parseBinaryExpressionOrHigher(OperatorPrecedence.Lowest);
+            if (!scanner.hasPrecedingLineBreak() && expr.kind === SyntaxKind.Identifier && token() === SyntaxKind.EqualsGreaterThanToken) {
+                return Tristate.True;
+            }
+        }
+
+        return Tristate.False;
+    }
+
+    function parseParenthesizedArrowFunctionExpression(allowAmbiguity: boolean, allowReturnTypeInArrowFunction: boolean): ArrowFunction | undefined {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        const modifiers = parseModifiersForArrowFunction();
+        const isAsync = some(modifiers, isAsyncModifier) ? SignatureFlags.Await : SignatureFlags.None;
+        // Arrow functions are never generators.
+        //
+        // If we're speculatively parsing a signature for a parenthesized arrow function, then
+        // we have to have a complete parameter list.  Otherwise we might see something like
+        // a => (b => c)
+        // And think that "(b =>" was actually a parenthesized arrow function with a missing
+        // close paren.
+        const typeParameters = parseTypeParameters();
+
+        let parameters: NodeArray<ParameterDeclaration>;
+        if (!parseExpected(SyntaxKind.OpenParenToken)) {
+            if (!allowAmbiguity) {
+                return undefined;
+            }
+            parameters = createMissingList<ParameterDeclaration>();
+        }
+        else {
+            if (!allowAmbiguity) {
+                const maybeParameters = parseParametersWorker(isAsync, allowAmbiguity);
+                if (!maybeParameters) {
+                    return undefined;
+                }
+                parameters = maybeParameters;
+            }
+            else {
+                parameters = parseParametersWorker(isAsync, allowAmbiguity);
+            }
+            if (!parseExpected(SyntaxKind.CloseParenToken) && !allowAmbiguity) {
+                return undefined;
+            }
+        }
+
+        const hasReturnColon = token() === SyntaxKind.ColonToken;
+        const type = parseReturnType(SyntaxKind.ColonToken, /*isType*/ false);
+        if (type && !allowAmbiguity && typeHasArrowFunctionBlockingParseError(type)) {
+            return undefined;
+        }
+
+        // Parsing a signature isn't enough.
+        // Parenthesized arrow signatures often look like other valid expressions.
+        // For instance:
+        //  - "(x = 10)" is an assignment expression parsed as a signature with a default parameter value.
+        //  - "(x,y)" is a comma expression parsed as a signature with two parameters.
+        //  - "a ? (b): c" will have "(b):" parsed as a signature with a return type annotation.
+        //  - "a ? (b): function() {}" will too, since function() is a valid JSDoc function type.
+        //  - "a ? (b): (function() {})" as well, but inside of a parenthesized type with an arbitrary amount of nesting.
+        //
+        // So we need just a bit of lookahead to ensure that it can only be a signature.
+
+        let unwrappedType = type;
+        while (unwrappedType?.kind === SyntaxKind.ParenthesizedType) {
+            unwrappedType = (unwrappedType as ParenthesizedTypeNode).type; // Skip parens if need be
+        }
+
+        const hasJSDocFunctionType = unwrappedType && isJSDocFunctionType(unwrappedType);
+        if (!allowAmbiguity && token() !== SyntaxKind.EqualsGreaterThanToken && (hasJSDocFunctionType || token() !== SyntaxKind.OpenBraceToken)) {
+            // Returning undefined here will cause our caller to rewind to where we started from.
+            return undefined;
+        }
+
+        // If we have an arrow, then try to parse the body. Even if not, try to parse if we
+        // have an opening brace, just in case we're in an error state.
+        const lastToken = token();
+        const equalsGreaterThanToken = parseExpectedToken(SyntaxKind.EqualsGreaterThanToken);
+        const body = (lastToken === SyntaxKind.EqualsGreaterThanToken || lastToken === SyntaxKind.OpenBraceToken)
+            ? parseArrowFunctionExpressionBody(some(modifiers, isAsyncModifier), allowReturnTypeInArrowFunction)
+            : parseIdentifier();
+
+        // Given:
+        //     x ? y => ({ y }) : z => ({ z })
+        // We try to parse the body of the first arrow function by looking at:
+        //     ({ y }) : z => ({ z })
+        // This is a valid arrow function with "z" as the return type.
+        //
+        // But, if we're in the true side of a conditional expression, this colon
+        // terminates the expression, so we cannot allow a return type if we aren't
+        // certain whether or not the preceding text was parsed as a parameter list.
+        //
+        // For example,
+        //     a() ? (b: number, c?: string): void => d() : e
+        // is determined by isParenthesizedArrowFunctionExpression to unambiguously
+        // be an arrow expression, so we allow a return type.
+        if (!allowReturnTypeInArrowFunction && hasReturnColon) {
+            // However, if the arrow function we were able to parse is followed by another colon
+            // as in:
+            //     a ? (x): string => x : null
+            // Then allow the arrow function, and treat the second colon as terminating
+            // the conditional expression. It's okay to do this because this code would
+            // be a syntax error in JavaScript (as the second colon shouldn't be there).
+            if (token() !== SyntaxKind.ColonToken) {
+                return undefined;
+            }
+        }
+
+        const node = factory.createArrowFunction(modifiers, typeParameters, parameters, type, equalsGreaterThanToken, body);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseArrowFunctionExpressionBody(isAsync: boolean, allowReturnTypeInArrowFunction: boolean): Block | Expression {
+        if (token() === SyntaxKind.OpenBraceToken) {
+            return parseFunctionBlock(isAsync ? SignatureFlags.Await : SignatureFlags.None);
+        }
+
+        if (
+            token() !== SyntaxKind.SemicolonToken &&
+            token() !== SyntaxKind.FunctionKeyword &&
+            token() !== SyntaxKind.ClassKeyword &&
+            isStartOfStatement() &&
+            !isStartOfExpressionStatement()
+        ) {
+            // Check if we got a plain statement (i.e. no expression-statements, no function/class expressions/declarations)
+            //
+            // Here we try to recover from a potential error situation in the case where the
+            // user meant to supply a block. For example, if the user wrote:
+            //
+            //  a =>
+            //      let v = 0;
+            //  }
+            //
+            // they may be missing an open brace.  Check to see if that's the case so we can
+            // try to recover better.  If we don't do this, then the next close curly we see may end
+            // up preemptively closing the containing construct.
+            //
+            // Note: even when 'IgnoreMissingOpenBrace' is passed, parseBody will still error.
+            return parseFunctionBlock(SignatureFlags.IgnoreMissingOpenBrace | (isAsync ? SignatureFlags.Await : SignatureFlags.None));
+        }
+
+        const savedTopLevel = topLevel;
+        topLevel = false;
+        const node = isAsync
+            ? doInAwaitContext(() => parseAssignmentExpressionOrHigher(allowReturnTypeInArrowFunction))
+            : doOutsideOfAwaitContext(() => parseAssignmentExpressionOrHigher(allowReturnTypeInArrowFunction));
+        topLevel = savedTopLevel;
+        return node;
+    }
+
+    function parseConditionalExpressionRest(leftOperand: Expression, pos: number, allowReturnTypeInArrowFunction: boolean): Expression {
+        // Note: we are passed in an expression which was produced from parseBinaryExpressionOrHigher.
+        const questionToken = parseOptionalToken(SyntaxKind.QuestionToken);
+        if (!questionToken) {
+            return leftOperand;
+        }
+
+        // Note: we explicitly 'allowIn' in the whenTrue part of the condition expression, and
+        // we do not that for the 'whenFalse' part.
+        let colonToken;
+        return finishNode(
+            factory.createConditionalExpression(
+                leftOperand,
+                questionToken,
+                doOutsideOfContext(disallowInAndDecoratorContext, () => parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ false)),
+                colonToken = parseExpectedToken(SyntaxKind.ColonToken),
+                nodeIsPresent(colonToken)
+                    ? parseAssignmentExpressionOrHigher(allowReturnTypeInArrowFunction)
+                    : createMissingNode(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ false, Diagnostics._0_expected, tokenToString(SyntaxKind.ColonToken)),
+            ),
+            pos,
+        );
+    }
+
+    function parseBinaryExpressionOrHigher(precedence: OperatorPrecedence): Expression {
+        const pos = getNodePos();
+        const leftOperand = parseUnaryExpressionOrHigher();
+        return parseBinaryExpressionRest(precedence, leftOperand, pos);
+    }
+
+    function isInOrOfKeyword(t: SyntaxKind) {
+        return t === SyntaxKind.InKeyword || t === SyntaxKind.OfKeyword;
+    }
+
+    function parseBinaryExpressionRest(precedence: OperatorPrecedence, leftOperand: Expression, pos: number): Expression {
+        while (true) {
+            // We either have a binary operator here, or we're finished.  We call
+            // reScanGreaterToken so that we merge token sequences like > and = into >=
+
+            reScanGreaterToken();
+            const newPrecedence = getBinaryOperatorPrecedence(token());
+
+            // Check the precedence to see if we should "take" this operator
+            // - For left associative operator (all operator but **), consume the operator,
+            //   recursively call the function below, and parse binaryExpression as a rightOperand
+            //   of the caller if the new precedence of the operator is greater then or equal to the current precedence.
+            //   For example:
+            //      a - b - c;
+            //            ^token; leftOperand = b. Return b to the caller as a rightOperand
+            //      a * b - c
+            //            ^token; leftOperand = b. Return b to the caller as a rightOperand
+            //      a - b * c;
+            //            ^token; leftOperand = b. Return b * c to the caller as a rightOperand
+            // - For right associative operator (**), consume the operator, recursively call the function
+            //   and parse binaryExpression as a rightOperand of the caller if the new precedence of
+            //   the operator is strictly grater than the current precedence
+            //   For example:
+            //      a ** b ** c;
+            //             ^^token; leftOperand = b. Return b ** c to the caller as a rightOperand
+            //      a - b ** c;
+            //            ^^token; leftOperand = b. Return b ** c to the caller as a rightOperand
+            //      a ** b - c
+            //             ^token; leftOperand = b. Return b to the caller as a rightOperand
+            const consumeCurrentOperator = token() === SyntaxKind.AsteriskAsteriskToken ?
+                newPrecedence >= precedence :
+                newPrecedence > precedence;
+
+            if (!consumeCurrentOperator) {
+                break;
+            }
+
+            if (token() === SyntaxKind.InKeyword && inDisallowInContext()) {
+                break;
+            }
+
+            if (token() === SyntaxKind.AsKeyword || token() === SyntaxKind.SatisfiesKeyword) {
+                // Make sure we *do* perform ASI for constructs like this:
+                //    var x = foo
+                //    as (Bar)
+                // This should be parsed as an initialized variable, followed
+                // by a function call to 'as' with the argument 'Bar'
+                if (scanner.hasPrecedingLineBreak()) {
+                    break;
+                }
+                else {
+                    const keywordKind = token();
+                    nextToken();
+                    leftOperand = keywordKind === SyntaxKind.SatisfiesKeyword ? makeSatisfiesExpression(leftOperand, parseType()) :
+                        makeAsExpression(leftOperand, parseType());
+                }
+            }
+            else {
+                leftOperand = makeBinaryExpression(leftOperand, parseTokenNode(), parseBinaryExpressionOrHigher(newPrecedence), pos);
+            }
+        }
+
+        return leftOperand;
+    }
+
+    function isBinaryOperator() {
+        if (inDisallowInContext() && token() === SyntaxKind.InKeyword) {
+            return false;
+        }
+
+        return getBinaryOperatorPrecedence(token()) > 0;
+    }
+
+    function makeSatisfiesExpression(left: Expression, right: TypeNode): SatisfiesExpression {
+        return finishNode(factory.createSatisfiesExpression(left, right), left.pos);
+    }
+
+    function makeBinaryExpression(left: Expression, operatorToken: BinaryOperatorToken, right: Expression, pos: number): BinaryExpression {
+        return finishNode(factory.createBinaryExpression(left, operatorToken, right), pos);
+    }
+
+    function makeAsExpression(left: Expression, right: TypeNode): AsExpression {
+        return finishNode(factory.createAsExpression(left, right), left.pos);
+    }
+
+    function parsePrefixUnaryExpression() {
+        const pos = getNodePos();
+        return finishNode(factory.createPrefixUnaryExpression(token() as PrefixUnaryOperator, nextTokenAnd(parseSimpleUnaryExpression)), pos);
+    }
+
+    function parseDeleteExpression() {
+        const pos = getNodePos();
+        return finishNode(factory.createDeleteExpression(nextTokenAnd(parseSimpleUnaryExpression)), pos);
+    }
+
+    function parseTypeOfExpression() {
+        const pos = getNodePos();
+        return finishNode(factory.createTypeOfExpression(nextTokenAnd(parseSimpleUnaryExpression)), pos);
+    }
+
+    function parseVoidExpression() {
+        const pos = getNodePos();
+        return finishNode(factory.createVoidExpression(nextTokenAnd(parseSimpleUnaryExpression)), pos);
+    }
+
+    function isAwaitExpression(): boolean {
+        if (token() === SyntaxKind.AwaitKeyword) {
+            if (inAwaitContext()) {
+                return true;
+            }
+
+            // here we are using similar heuristics as 'isYieldExpression'
+            return lookAhead(nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine);
+        }
+
+        return false;
+    }
+
+    function parseAwaitExpression() {
+        const pos = getNodePos();
+        return finishNode(factory.createAwaitExpression(nextTokenAnd(parseSimpleUnaryExpression)), pos);
+    }
+
+    /**
+     * Parse ES7 exponential expression and await expression
+     *
+     * ES7 ExponentiationExpression:
+     *      1) UnaryExpression[?Yield]
+     *      2) UpdateExpression[?Yield] ** ExponentiationExpression[?Yield]
+     */
+    function parseUnaryExpressionOrHigher(): UnaryExpression | BinaryExpression {
+        /**
+         * ES7 UpdateExpression:
+         *      1) LeftHandSideExpression[?Yield]
+         *      2) LeftHandSideExpression[?Yield][no LineTerminator here]++
+         *      3) LeftHandSideExpression[?Yield][no LineTerminator here]--
+         *      4) ++UnaryExpression[?Yield]
+         *      5) --UnaryExpression[?Yield]
+         */
+        if (isUpdateExpression()) {
+            const pos = getNodePos();
+            const updateExpression = parseUpdateExpression();
+            return token() === SyntaxKind.AsteriskAsteriskToken ?
+                parseBinaryExpressionRest(getBinaryOperatorPrecedence(token()), updateExpression, pos) as BinaryExpression :
+                updateExpression;
+        }
+
+        /**
+         * ES7 UnaryExpression:
+         *      1) UpdateExpression[?yield]
+         *      2) delete UpdateExpression[?yield]
+         *      3) void UpdateExpression[?yield]
+         *      4) typeof UpdateExpression[?yield]
+         *      5) + UpdateExpression[?yield]
+         *      6) - UpdateExpression[?yield]
+         *      7) ~ UpdateExpression[?yield]
+         *      8) ! UpdateExpression[?yield]
+         */
+        const unaryOperator = token();
+        const simpleUnaryExpression = parseSimpleUnaryExpression();
+        if (token() === SyntaxKind.AsteriskAsteriskToken) {
+            const pos = skipTrivia(sourceText, simpleUnaryExpression.pos);
+            const { end } = simpleUnaryExpression;
+            if (simpleUnaryExpression.kind === SyntaxKind.TypeAssertionExpression) {
+                parseErrorAt(pos, end, Diagnostics.A_type_assertion_expression_is_not_allowed_in_the_left_hand_side_of_an_exponentiation_expression_Consider_enclosing_the_expression_in_parentheses);
+            }
+            else {
+                Debug.assert(isKeywordOrPunctuation(unaryOperator));
+                parseErrorAt(pos, end, Diagnostics.An_unary_expression_with_the_0_operator_is_not_allowed_in_the_left_hand_side_of_an_exponentiation_expression_Consider_enclosing_the_expression_in_parentheses, tokenToString(unaryOperator));
+            }
+        }
+        return simpleUnaryExpression;
+    }
+
+    /**
+     * Parse ES7 simple-unary expression or higher:
+     *
+     * ES7 UnaryExpression:
+     *      1) UpdateExpression[?yield]
+     *      2) delete UnaryExpression[?yield]
+     *      3) void UnaryExpression[?yield]
+     *      4) typeof UnaryExpression[?yield]
+     *      5) + UnaryExpression[?yield]
+     *      6) - UnaryExpression[?yield]
+     *      7) ~ UnaryExpression[?yield]
+     *      8) ! UnaryExpression[?yield]
+     *      9) [+Await] await UnaryExpression[?yield]
+     */
+    function parseSimpleUnaryExpression(): UnaryExpression {
+        switch (token()) {
+            case SyntaxKind.PlusToken:
+            case SyntaxKind.MinusToken:
+            case SyntaxKind.TildeToken:
+            case SyntaxKind.ExclamationToken:
+                return parsePrefixUnaryExpression();
+            case SyntaxKind.DeleteKeyword:
+                return parseDeleteExpression();
+            case SyntaxKind.TypeOfKeyword:
+                return parseTypeOfExpression();
+            case SyntaxKind.VoidKeyword:
+                return parseVoidExpression();
+            case SyntaxKind.LessThanToken:
+                // Just like in parseUpdateExpression, we need to avoid parsing type assertions when
+                // in JSX and we see an expression like "+ <foo> bar".
+                if (languageVariant === LanguageVariant.JSX) {
+                    return parseJsxElementOrSelfClosingElementOrFragment(/*inExpressionContext*/ true, /*topInvalidNodePosition*/ undefined, /*openingTag*/ undefined, /*mustBeUnary*/ true);
+                }
+                // This is modified UnaryExpression grammar in TypeScript
+                //  UnaryExpression (modified):
+                //      < type > UnaryExpression
+                return parseTypeAssertion();
+            case SyntaxKind.AwaitKeyword:
+                if (isAwaitExpression()) {
+                    return parseAwaitExpression();
+                }
+                // falls through
+            default:
+                return parseUpdateExpression();
+        }
+    }
+
+    /**
+     * Check if the current token can possibly be an ES7 increment expression.
+     *
+     * ES7 UpdateExpression:
+     *      LeftHandSideExpression[?Yield]
+     *      LeftHandSideExpression[?Yield][no LineTerminator here]++
+     *      LeftHandSideExpression[?Yield][no LineTerminator here]--
+     *      ++LeftHandSideExpression[?Yield]
+     *      --LeftHandSideExpression[?Yield]
+     */
+    function isUpdateExpression(): boolean {
+        // This function is called inside parseUnaryExpression to decide
+        // whether to call parseSimpleUnaryExpression or call parseUpdateExpression directly
+        switch (token()) {
+            case SyntaxKind.PlusToken:
+            case SyntaxKind.MinusToken:
+            case SyntaxKind.TildeToken:
+            case SyntaxKind.ExclamationToken:
+            case SyntaxKind.DeleteKeyword:
+            case SyntaxKind.TypeOfKeyword:
+            case SyntaxKind.VoidKeyword:
+            case SyntaxKind.AwaitKeyword:
+                return false;
+            case SyntaxKind.LessThanToken:
+                // If we are not in JSX context, we are parsing TypeAssertion which is an UnaryExpression
+                if (languageVariant !== LanguageVariant.JSX) {
+                    return false;
+                }
+                // We are in JSX context and the token is part of JSXElement.
+                // falls through
+            default:
+                return true;
+        }
+    }
+
+    /**
+     * Parse ES7 UpdateExpression. UpdateExpression is used instead of ES6's PostFixExpression.
+     *
+     * ES7 UpdateExpression[yield]:
+     *      1) LeftHandSideExpression[?yield]
+     *      2) LeftHandSideExpression[?yield] [[no LineTerminator here]]++
+     *      3) LeftHandSideExpression[?yield] [[no LineTerminator here]]--
+     *      4) ++LeftHandSideExpression[?yield]
+     *      5) --LeftHandSideExpression[?yield]
+     * In TypeScript (2), (3) are parsed as PostfixUnaryExpression. (4), (5) are parsed as PrefixUnaryExpression
+     */
+    function parseUpdateExpression(): UpdateExpression {
+        if (token() === SyntaxKind.PlusPlusToken || token() === SyntaxKind.MinusMinusToken) {
+            const pos = getNodePos();
+            return finishNode(factory.createPrefixUnaryExpression(token() as PrefixUnaryOperator, nextTokenAnd(parseLeftHandSideExpressionOrHigher)), pos);
+        }
+        else if (languageVariant === LanguageVariant.JSX && token() === SyntaxKind.LessThanToken && lookAhead(nextTokenIsIdentifierOrKeywordOrGreaterThan)) {
+            // JSXElement is part of primaryExpression
+            return parseJsxElementOrSelfClosingElementOrFragment(/*inExpressionContext*/ true);
+        }
+
+        const expression = parseLeftHandSideExpressionOrHigher();
+
+        Debug.assert(isLeftHandSideExpression(expression));
+        if ((token() === SyntaxKind.PlusPlusToken || token() === SyntaxKind.MinusMinusToken) && !scanner.hasPrecedingLineBreak()) {
+            const operator = token() as PostfixUnaryOperator;
+            nextToken();
+            return finishNode(factory.createPostfixUnaryExpression(expression, operator), expression.pos);
+        }
+
+        return expression;
+    }
+
+    function parseLeftHandSideExpressionOrHigher(): LeftHandSideExpression {
+        // Original Ecma:
+        // LeftHandSideExpression: See 11.2
+        //      NewExpression
+        //      CallExpression
+        //
+        // Our simplification:
+        //
+        // LeftHandSideExpression: See 11.2
+        //      MemberExpression
+        //      CallExpression
+        //
+        // See comment in parseMemberExpressionOrHigher on how we replaced NewExpression with
+        // MemberExpression to make our lives easier.
+        //
+        // to best understand the below code, it's important to see how CallExpression expands
+        // out into its own productions:
+        //
+        // CallExpression:
+        //      MemberExpression Arguments
+        //      CallExpression Arguments
+        //      CallExpression[Expression]
+        //      CallExpression.IdentifierName
+        //      import (AssignmentExpression)
+        //      super Arguments
+        //      super.IdentifierName
+        //
+        // Because of the recursion in these calls, we need to bottom out first. There are three
+        // bottom out states we can run into: 1) We see 'super' which must start either of
+        // the last two CallExpression productions. 2) We see 'import' which must start import call.
+        // 3)we have a MemberExpression which either completes the LeftHandSideExpression,
+        // or starts the beginning of the first four CallExpression productions.
+        const pos = getNodePos();
+        let expression: MemberExpression;
+        if (token() === SyntaxKind.ImportKeyword) {
+            if (lookAhead(nextTokenIsOpenParenOrLessThan)) {
+                // We don't want to eagerly consume all import keyword as import call expression so we look ahead to find "("
+                // For example:
+                //      var foo3 = require("subfolder
+                //      import * as foo1 from "module-from-node
+                // We want this import to be a statement rather than import call expression
+                sourceFlags |= NodeFlags.PossiblyContainsDynamicImport;
+                expression = parseTokenNode<PrimaryExpression>();
+            }
+            else if (lookAhead(nextTokenIsDot)) {
+                // This is an 'import.*' metaproperty (i.e. 'import.meta')
+                nextToken(); // advance past the 'import'
+                nextToken(); // advance past the dot
+                expression = finishNode(factory.createMetaProperty(SyntaxKind.ImportKeyword, parseIdentifierName()), pos);
+                sourceFlags |= NodeFlags.PossiblyContainsImportMeta;
+            }
+            else {
+                expression = parseMemberExpressionOrHigher();
+            }
+        }
+        else {
+            expression = token() === SyntaxKind.SuperKeyword ? parseSuperExpression() : parseMemberExpressionOrHigher();
+        }
+
+        // Now, we *may* be complete.  However, we might have consumed the start of a
+        // CallExpression or OptionalExpression.  As such, we need to consume the rest
+        // of it here to be complete.
+        return parseCallExpressionRest(pos, expression);
+    }
+
+    function parseMemberExpressionOrHigher(): MemberExpression {
+        // Note: to make our lives simpler, we decompose the NewExpression productions and
+        // place ObjectCreationExpression and FunctionExpression into PrimaryExpression.
+        // like so:
+        //
+        //   PrimaryExpression : See 11.1
+        //      this
+        //      Identifier
+        //      Literal
+        //      ArrayLiteral
+        //      ObjectLiteral
+        //      (Expression)
+        //      FunctionExpression
+        //      new MemberExpression Arguments?
+        //
+        //   MemberExpression : See 11.2
+        //      PrimaryExpression
+        //      MemberExpression[Expression]
+        //      MemberExpression.IdentifierName
+        //
+        //   CallExpression : See 11.2
+        //      MemberExpression
+        //      CallExpression Arguments
+        //      CallExpression[Expression]
+        //      CallExpression.IdentifierName
+        //
+        // Technically this is ambiguous.  i.e. CallExpression defines:
+        //
+        //   CallExpression:
+        //      CallExpression Arguments
+        //
+        // If you see: "new Foo()"
+        //
+        // Then that could be treated as a single ObjectCreationExpression, or it could be
+        // treated as the invocation of "new Foo".  We disambiguate that in code (to match
+        // the original grammar) by making sure that if we see an ObjectCreationExpression
+        // we always consume arguments if they are there. So we treat "new Foo()" as an
+        // object creation only, and not at all as an invocation.  Another way to think
+        // about this is that for every "new" that we see, we will consume an argument list if
+        // it is there as part of the *associated* object creation node.  Any additional
+        // argument lists we see, will become invocation expressions.
+        //
+        // Because there are no other places in the grammar now that refer to FunctionExpression
+        // or ObjectCreationExpression, it is safe to push down into the PrimaryExpression
+        // production.
+        //
+        // Because CallExpression and MemberExpression are left recursive, we need to bottom out
+        // of the recursion immediately.  So we parse out a primary expression to start with.
+        const pos = getNodePos();
+        const expression = parsePrimaryExpression();
+        return parseMemberExpressionRest(pos, expression, /*allowOptionalChain*/ true);
+    }
+
+    function parseSuperExpression(): MemberExpression {
+        const pos = getNodePos();
+        let expression = parseTokenNode<MemberExpression>();
+        if (token() === SyntaxKind.LessThanToken) {
+            const startPos = getNodePos();
+            const typeArguments = tryParse(parseTypeArgumentsInExpression);
+            if (typeArguments !== undefined) {
+                parseErrorAt(startPos, getNodePos(), Diagnostics.super_may_not_use_type_arguments);
+                if (!isTemplateStartOfTaggedTemplate()) {
+                    expression = factory.createExpressionWithTypeArguments(expression, typeArguments);
+                }
+            }
+        }
+
+        if (token() === SyntaxKind.OpenParenToken || token() === SyntaxKind.DotToken || token() === SyntaxKind.OpenBracketToken) {
+            return expression;
+        }
+
+        // If we have seen "super" it must be followed by '(' or '.'.
+        // If it wasn't then just try to parse out a '.' and report an error.
+        parseExpectedToken(SyntaxKind.DotToken, Diagnostics.super_must_be_followed_by_an_argument_list_or_member_access);
+        // private names will never work with `super` (`super.#foo`), but that's a semantic error, not syntactic
+        return finishNode(factoryCreatePropertyAccessExpression(expression, parseRightSideOfDot(/*allowIdentifierNames*/ true, /*allowPrivateIdentifiers*/ true, /*allowUnicodeEscapeSequenceInIdentifierName*/ true)), pos);
+    }
+
+    function parseJsxElementOrSelfClosingElementOrFragment(inExpressionContext: boolean, topInvalidNodePosition?: number, openingTag?: JsxOpeningElement | JsxOpeningFragment, mustBeUnary = false): JsxElement | JsxSelfClosingElement | JsxFragment {
+        const pos = getNodePos();
+        const opening = parseJsxOpeningOrSelfClosingElementOrOpeningFragment(inExpressionContext);
+        let result: JsxElement | JsxSelfClosingElement | JsxFragment;
+        if (opening.kind === SyntaxKind.JsxOpeningElement) {
+            let children = parseJsxChildren(opening);
+            let closingElement: JsxClosingElement;
+
+            const lastChild: JsxChild | undefined = children[children.length - 1];
+            if (
+                lastChild?.kind === SyntaxKind.JsxElement
+                && !tagNamesAreEquivalent(lastChild.openingElement.tagName, lastChild.closingElement.tagName)
+                && tagNamesAreEquivalent(opening.tagName, lastChild.closingElement.tagName)
+            ) {
+                // when an unclosed JsxOpeningElement incorrectly parses its parent's JsxClosingElement,
+                // restructure (<div>(...<span>...</div>)) --> (<div>(...<span>...</>)</div>)
+                // (no need to error; the parent will error)
+                const end = lastChild.children.end;
+                const newLast = finishNode(
+                    factory.createJsxElement(
+                        lastChild.openingElement,
+                        lastChild.children,
+                        finishNode(factory.createJsxClosingElement(finishNode(factoryCreateIdentifier(""), end, end)), end, end),
+                    ),
+                    lastChild.openingElement.pos,
+                    end,
+                );
+
+                children = createNodeArray([...children.slice(0, children.length - 1), newLast], children.pos, end);
+                closingElement = lastChild.closingElement;
+            }
+            else {
+                closingElement = parseJsxClosingElement(opening, inExpressionContext);
+                if (!tagNamesAreEquivalent(opening.tagName, closingElement.tagName)) {
+                    if (openingTag && isJsxOpeningElement(openingTag) && tagNamesAreEquivalent(closingElement.tagName, openingTag.tagName)) {
+                        // opening incorrectly matched with its parent's closing -- put error on opening
+                        parseErrorAtRange(opening.tagName, Diagnostics.JSX_element_0_has_no_corresponding_closing_tag, getTextOfNodeFromSourceText(sourceText, opening.tagName));
+                    }
+                    else {
+                        // other opening/closing mismatches -- put error on closing
+                        parseErrorAtRange(closingElement.tagName, Diagnostics.Expected_corresponding_JSX_closing_tag_for_0, getTextOfNodeFromSourceText(sourceText, opening.tagName));
+                    }
+                }
+            }
+            result = finishNode(factory.createJsxElement(opening, children, closingElement), pos);
+        }
+        else if (opening.kind === SyntaxKind.JsxOpeningFragment) {
+            result = finishNode(factory.createJsxFragment(opening, parseJsxChildren(opening), parseJsxClosingFragment(inExpressionContext)), pos);
+        }
+        else {
+            Debug.assert(opening.kind === SyntaxKind.JsxSelfClosingElement);
+            // Nothing else to do for self-closing elements
+            result = opening;
+        }
+
+        // If the user writes the invalid code '<div></div><div></div>' in an expression context (i.e. not wrapped in
+        // an enclosing tag), we'll naively try to parse   ^ this as a 'less than' operator and the remainder of the tag
+        // as garbage, which will cause the formatter to badly mangle the JSX. Perform a speculative parse of a JSX
+        // element if we see a < token so that we can wrap it in a synthetic binary expression so the formatter
+        // does less damage and we can report a better error.
+        // Since JSX elements are invalid < operands anyway, this lookahead parse will only occur in error scenarios
+        // of one sort or another.
+        // If we are in a unary context, we can't do this recovery; the binary expression we return here is not
+        // a valid UnaryExpression and will cause problems later.
+        if (!mustBeUnary && inExpressionContext && token() === SyntaxKind.LessThanToken) {
+            const topBadPos = typeof topInvalidNodePosition === "undefined" ? result.pos : topInvalidNodePosition;
+            const invalidElement = tryParse(() => parseJsxElementOrSelfClosingElementOrFragment(/*inExpressionContext*/ true, topBadPos));
+            if (invalidElement) {
+                const operatorToken = createMissingNode(SyntaxKind.CommaToken, /*reportAtCurrentPosition*/ false);
+                setTextRangePosWidth(operatorToken, invalidElement.pos, 0);
+                parseErrorAt(skipTrivia(sourceText, topBadPos), invalidElement.end, Diagnostics.JSX_expressions_must_have_one_parent_element);
+                return finishNode(factory.createBinaryExpression(result, operatorToken as Token<SyntaxKind.CommaToken>, invalidElement), pos) as Node as JsxElement;
+            }
+        }
+
+        return result;
+    }
+
+    function parseJsxText(): JsxText {
+        const pos = getNodePos();
+        const node = factory.createJsxText(scanner.getTokenValue(), currentToken === SyntaxKind.JsxTextAllWhiteSpaces);
+        currentToken = scanner.scanJsxToken();
+        return finishNode(node, pos);
+    }
+
+    function parseJsxChild(openingTag: JsxOpeningElement | JsxOpeningFragment, token: JsxTokenSyntaxKind): JsxChild | undefined {
+        switch (token) {
+            case SyntaxKind.EndOfFileToken:
+                // If we hit EOF, issue the error at the tag that lacks the closing element
+                // rather than at the end of the file (which is useless)
+                if (isJsxOpeningFragment(openingTag)) {
+                    parseErrorAtRange(openingTag, Diagnostics.JSX_fragment_has_no_corresponding_closing_tag);
+                }
+                else {
+                    // We want the error span to cover only 'Foo.Bar' in < Foo.Bar >
+                    // or to cover only 'Foo' in < Foo >
+                    const tag = openingTag.tagName;
+                    const start = Math.min(skipTrivia(sourceText, tag.pos), tag.end);
+                    parseErrorAt(start, tag.end, Diagnostics.JSX_element_0_has_no_corresponding_closing_tag, getTextOfNodeFromSourceText(sourceText, openingTag.tagName));
+                }
+                return undefined;
+            case SyntaxKind.LessThanSlashToken:
+            case SyntaxKind.ConflictMarkerTrivia:
+                return undefined;
+            case SyntaxKind.JsxText:
+            case SyntaxKind.JsxTextAllWhiteSpaces:
+                return parseJsxText();
+            case SyntaxKind.OpenBraceToken:
+                return parseJsxExpression(/*inExpressionContext*/ false);
+            case SyntaxKind.LessThanToken:
+                return parseJsxElementOrSelfClosingElementOrFragment(/*inExpressionContext*/ false, /*topInvalidNodePosition*/ undefined, openingTag);
+            default:
+                return Debug.assertNever(token);
+        }
+    }
+
+    function parseJsxChildren(openingTag: JsxOpeningElement | JsxOpeningFragment): NodeArray<JsxChild> {
+        const list = [];
+        const listPos = getNodePos();
+        const saveParsingContext = parsingContext;
+        parsingContext |= 1 << ParsingContext.JsxChildren;
+
+        while (true) {
+            const child = parseJsxChild(openingTag, currentToken = scanner.reScanJsxToken());
+            if (!child) break;
+            list.push(child);
+            if (
+                isJsxOpeningElement(openingTag)
+                && child?.kind === SyntaxKind.JsxElement
+                && !tagNamesAreEquivalent(child.openingElement.tagName, child.closingElement.tagName)
+                && tagNamesAreEquivalent(openingTag.tagName, child.closingElement.tagName)
+            ) {
+                // stop after parsing a mismatched child like <div>...(<span></div>) in order to reattach the </div> higher
+                break;
+            }
+        }
+
+        parsingContext = saveParsingContext;
+        return createNodeArray(list, listPos);
+    }
+
+    function parseJsxAttributes(): JsxAttributes {
+        const pos = getNodePos();
+        return finishNode(factory.createJsxAttributes(parseList(ParsingContext.JsxAttributes, parseJsxAttribute)), pos);
+    }
+
+    function parseJsxOpeningOrSelfClosingElementOrOpeningFragment(inExpressionContext: boolean): JsxOpeningElement | JsxSelfClosingElement | JsxOpeningFragment {
+        const pos = getNodePos();
+
+        parseExpected(SyntaxKind.LessThanToken);
+
+        if (token() === SyntaxKind.GreaterThanToken) {
+            // See below for explanation of scanJsxText
+            scanJsxText();
+            return finishNode(factory.createJsxOpeningFragment(), pos);
+        }
+        const tagName = parseJsxElementName();
+        const typeArguments = (contextFlags & NodeFlags.JavaScriptFile) === 0 ? tryParseTypeArguments() : undefined;
+        const attributes = parseJsxAttributes();
+
+        let node: JsxOpeningLikeElement;
+
+        if (token() === SyntaxKind.GreaterThanToken) {
+            // Closing tag, so scan the immediately-following text with the JSX scanning instead
+            // of regular scanning to avoid treating illegal characters (e.g. '#') as immediate
+            // scanning errors
+            scanJsxText();
+            node = factory.createJsxOpeningElement(tagName, typeArguments, attributes);
+        }
+        else {
+            parseExpected(SyntaxKind.SlashToken);
+            if (parseExpected(SyntaxKind.GreaterThanToken, /*diagnosticMessage*/ undefined, /*shouldAdvance*/ false)) {
+                // manually advance the scanner in order to look for jsx text inside jsx
+                if (inExpressionContext) {
+                    nextToken();
+                }
+                else {
+                    scanJsxText();
+                }
+            }
+            node = factory.createJsxSelfClosingElement(tagName, typeArguments, attributes);
+        }
+
+        return finishNode(node, pos);
+    }
+
+    function parseJsxElementName(): JsxTagNameExpression {
+        const pos = getNodePos();
+        // JsxElement can have name in the form of
+        //      propertyAccessExpression
+        //      primaryExpression in the form of an identifier and "this" keyword
+        // We can't just simply use parseLeftHandSideExpressionOrHigher because then we will start consider class,function etc as a keyword
+        // We only want to consider "this" as a primaryExpression
+        const initialExpression = parseJsxTagName();
+        if (isJsxNamespacedName(initialExpression)) {
+            return initialExpression; // `a:b.c` is invalid syntax, don't even look for the `.` if we parse `a:b`, and let `parseAttribute` report "unexpected :" instead.
+        }
+        let expression: PropertyAccessExpression | Identifier | ThisExpression = initialExpression;
+        while (parseOptional(SyntaxKind.DotToken)) {
+            expression = finishNode(factoryCreatePropertyAccessExpression(expression, parseRightSideOfDot(/*allowIdentifierNames*/ true, /*allowPrivateIdentifiers*/ false, /*allowUnicodeEscapeSequenceInIdentifierName*/ false)), pos);
+        }
+        return expression as JsxTagNameExpression;
+    }
+
+    function parseJsxTagName(): Identifier | JsxNamespacedName | ThisExpression {
+        const pos = getNodePos();
+        scanJsxIdentifier();
+
+        const isThis = token() === SyntaxKind.ThisKeyword;
+        const tagName = parseIdentifierNameErrorOnUnicodeEscapeSequence();
+        if (parseOptional(SyntaxKind.ColonToken)) {
+            scanJsxIdentifier();
+            return finishNode(factory.createJsxNamespacedName(tagName, parseIdentifierNameErrorOnUnicodeEscapeSequence()), pos);
+        }
+        return isThis ? finishNode(factory.createToken(SyntaxKind.ThisKeyword), pos) : tagName;
+    }
+
+    function parseJsxExpression(inExpressionContext: boolean): JsxExpression | undefined {
+        const pos = getNodePos();
+        if (!parseExpected(SyntaxKind.OpenBraceToken)) {
+            return undefined;
+        }
+
+        let dotDotDotToken: DotDotDotToken | undefined;
+        let expression: Expression | undefined;
+        if (token() !== SyntaxKind.CloseBraceToken) {
+            if (!inExpressionContext) {
+                dotDotDotToken = parseOptionalToken(SyntaxKind.DotDotDotToken);
+            }
+            // Only an AssignmentExpression is valid here per the JSX spec,
+            // but we can unambiguously parse a comma sequence and provide
+            // a better error message in grammar checking.
+            expression = parseExpression();
+        }
+        if (inExpressionContext) {
+            parseExpected(SyntaxKind.CloseBraceToken);
+        }
+        else {
+            if (parseExpected(SyntaxKind.CloseBraceToken, /*diagnosticMessage*/ undefined, /*shouldAdvance*/ false)) {
+                scanJsxText();
+            }
+        }
+
+        return finishNode(factory.createJsxExpression(dotDotDotToken, expression), pos);
+    }
+
+    function parseJsxAttribute(): JsxAttribute | JsxSpreadAttribute {
+        if (token() === SyntaxKind.OpenBraceToken) {
+            return parseJsxSpreadAttribute();
+        }
+
+        const pos = getNodePos();
+        return finishNode(factory.createJsxAttribute(parseJsxAttributeName(), parseJsxAttributeValue()), pos);
+    }
+
+    function parseJsxAttributeValue(): JsxAttributeValue | undefined {
+        if (token() === SyntaxKind.EqualsToken) {
+            if (scanJsxAttributeValue() === SyntaxKind.StringLiteral) {
+                return parseLiteralNode() as StringLiteral;
+            }
+            if (token() === SyntaxKind.OpenBraceToken) {
+                return parseJsxExpression(/*inExpressionContext*/ true);
+            }
+            if (token() === SyntaxKind.LessThanToken) {
+                return parseJsxElementOrSelfClosingElementOrFragment(/*inExpressionContext*/ true);
+            }
+            parseErrorAtCurrentToken(Diagnostics.or_JSX_element_expected);
+        }
+        return undefined;
+    }
+
+    function parseJsxAttributeName() {
+        const pos = getNodePos();
+        scanJsxIdentifier();
+
+        const attrName = parseIdentifierNameErrorOnUnicodeEscapeSequence();
+        if (parseOptional(SyntaxKind.ColonToken)) {
+            scanJsxIdentifier();
+            return finishNode(factory.createJsxNamespacedName(attrName, parseIdentifierNameErrorOnUnicodeEscapeSequence()), pos);
+        }
+        return attrName;
+    }
+
+    function parseJsxSpreadAttribute(): JsxSpreadAttribute {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.OpenBraceToken);
+        parseExpected(SyntaxKind.DotDotDotToken);
+        const expression = parseExpression();
+        parseExpected(SyntaxKind.CloseBraceToken);
+        return finishNode(factory.createJsxSpreadAttribute(expression), pos);
+    }
+
+    function parseJsxClosingElement(open: JsxOpeningElement, inExpressionContext: boolean): JsxClosingElement {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.LessThanSlashToken);
+        const tagName = parseJsxElementName();
+        if (parseExpected(SyntaxKind.GreaterThanToken, /*diagnosticMessage*/ undefined, /*shouldAdvance*/ false)) {
+            // manually advance the scanner in order to look for jsx text inside jsx
+            if (inExpressionContext || !tagNamesAreEquivalent(open.tagName, tagName)) {
+                nextToken();
+            }
+            else {
+                scanJsxText();
+            }
+        }
+        return finishNode(factory.createJsxClosingElement(tagName), pos);
+    }
+
+    function parseJsxClosingFragment(inExpressionContext: boolean): JsxClosingFragment {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.LessThanSlashToken);
+        if (parseExpected(SyntaxKind.GreaterThanToken, Diagnostics.Expected_corresponding_closing_tag_for_JSX_fragment, /*shouldAdvance*/ false)) {
+            // manually advance the scanner in order to look for jsx text inside jsx
+            if (inExpressionContext) {
+                nextToken();
+            }
+            else {
+                scanJsxText();
+            }
+        }
+        return finishNode(factory.createJsxJsxClosingFragment(), pos);
+    }
+
+    function parseTypeAssertion(): TypeAssertion {
+        Debug.assert(languageVariant !== LanguageVariant.JSX, "Type assertions should never be parsed in JSX; they should be parsed as comparisons or JSX elements/fragments.");
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.LessThanToken);
+        const type = parseType();
+        parseExpected(SyntaxKind.GreaterThanToken);
+        const expression = parseSimpleUnaryExpression();
+        return finishNode(factory.createTypeAssertion(type, expression), pos);
+    }
+
+    function nextTokenIsIdentifierOrKeywordOrOpenBracketOrTemplate() {
+        nextToken();
+        return tokenIsIdentifierOrKeyword(token())
+            || token() === SyntaxKind.OpenBracketToken
+            || isTemplateStartOfTaggedTemplate();
+    }
+
+    function isStartOfOptionalPropertyOrElementAccessChain() {
+        return token() === SyntaxKind.QuestionDotToken
+            && lookAhead(nextTokenIsIdentifierOrKeywordOrOpenBracketOrTemplate);
+    }
+
+    function tryReparseOptionalChain(node: Expression) {
+        if (node.flags & NodeFlags.OptionalChain) {
+            return true;
+        }
+        // check for an optional chain in a non-null expression
+        if (isNonNullExpression(node)) {
+            let expr = node.expression;
+            while (isNonNullExpression(expr) && !(expr.flags & NodeFlags.OptionalChain)) {
+                expr = expr.expression;
+            }
+            if (expr.flags & NodeFlags.OptionalChain) {
+                // this is part of an optional chain. Walk down from `node` to `expression` and set the flag.
+                while (isNonNullExpression(node)) {
+                    (node as Mutable<NonNullExpression>).flags |= NodeFlags.OptionalChain;
+                    node = node.expression;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function parsePropertyAccessExpressionRest(pos: number, expression: LeftHandSideExpression, questionDotToken: QuestionDotToken | undefined) {
+        const name = parseRightSideOfDot(/*allowIdentifierNames*/ true, /*allowPrivateIdentifiers*/ true, /*allowUnicodeEscapeSequenceInIdentifierName*/ true);
+        const isOptionalChain = questionDotToken || tryReparseOptionalChain(expression);
+        const propertyAccess = isOptionalChain ?
+            factoryCreatePropertyAccessChain(expression, questionDotToken, name) :
+            factoryCreatePropertyAccessExpression(expression, name);
+        if (isOptionalChain && isPrivateIdentifier(propertyAccess.name)) {
+            parseErrorAtRange(propertyAccess.name, Diagnostics.An_optional_chain_cannot_contain_private_identifiers);
+        }
+        if (isExpressionWithTypeArguments(expression) && expression.typeArguments) {
+            const pos = expression.typeArguments.pos - 1;
+            const end = skipTrivia(sourceText, expression.typeArguments.end) + 1;
+            parseErrorAt(pos, end, Diagnostics.An_instantiation_expression_cannot_be_followed_by_a_property_access);
+        }
+        return finishNode(propertyAccess, pos);
+    }
+
+    function parseElementAccessExpressionRest(pos: number, expression: LeftHandSideExpression, questionDotToken: QuestionDotToken | undefined) {
+        let argumentExpression: Expression;
+        if (token() === SyntaxKind.CloseBracketToken) {
+            argumentExpression = createMissingNode(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ true, Diagnostics.An_element_access_expression_should_take_an_argument);
+        }
+        else {
+            const argument = allowInAnd(parseExpression);
+            if (isStringOrNumericLiteralLike(argument)) {
+                argument.text = internIdentifier(argument.text);
+            }
+            argumentExpression = argument;
+        }
+
+        parseExpected(SyntaxKind.CloseBracketToken);
+
+        const indexedAccess = questionDotToken || tryReparseOptionalChain(expression) ?
+            factoryCreateElementAccessChain(expression, questionDotToken, argumentExpression) :
+            factoryCreateElementAccessExpression(expression, argumentExpression);
+        return finishNode(indexedAccess, pos);
+    }
+
+    function parseMemberExpressionRest(pos: number, expression: LeftHandSideExpression, allowOptionalChain: boolean): MemberExpression {
+        while (true) {
+            let questionDotToken: QuestionDotToken | undefined;
+            let isPropertyAccess = false;
+            if (allowOptionalChain && isStartOfOptionalPropertyOrElementAccessChain()) {
+                questionDotToken = parseExpectedToken(SyntaxKind.QuestionDotToken);
+                isPropertyAccess = tokenIsIdentifierOrKeyword(token());
+            }
+            else {
+                isPropertyAccess = parseOptional(SyntaxKind.DotToken);
+            }
+
+            if (isPropertyAccess) {
+                expression = parsePropertyAccessExpressionRest(pos, expression, questionDotToken);
+                continue;
+            }
+
+            // when in the [Decorator] context, we do not parse ElementAccess as it could be part of a ComputedPropertyName
+            if ((questionDotToken || !inDecoratorContext()) && parseOptional(SyntaxKind.OpenBracketToken)) {
+                expression = parseElementAccessExpressionRest(pos, expression, questionDotToken);
+                continue;
+            }
+
+            if (isTemplateStartOfTaggedTemplate()) {
+                // Absorb type arguments into TemplateExpression when preceding expression is ExpressionWithTypeArguments
+                expression = !questionDotToken && expression.kind === SyntaxKind.ExpressionWithTypeArguments ?
+                    parseTaggedTemplateRest(pos, (expression as ExpressionWithTypeArguments).expression, questionDotToken, (expression as ExpressionWithTypeArguments).typeArguments) :
+                    parseTaggedTemplateRest(pos, expression, questionDotToken, /*typeArguments*/ undefined);
+                continue;
+            }
+
+            if (!questionDotToken) {
+                if (token() === SyntaxKind.ExclamationToken && !scanner.hasPrecedingLineBreak()) {
+                    nextToken();
+                    expression = finishNode(factory.createNonNullExpression(expression), pos);
+                    continue;
+                }
+                const typeArguments = tryParse(parseTypeArgumentsInExpression);
+                if (typeArguments) {
+                    expression = finishNode(factory.createExpressionWithTypeArguments(expression, typeArguments), pos);
+                    continue;
+                }
+            }
+
+            return expression as MemberExpression;
+        }
+    }
+
+    function isTemplateStartOfTaggedTemplate() {
+        return token() === SyntaxKind.NoSubstitutionTemplateLiteral || token() === SyntaxKind.TemplateHead;
+    }
+
+    function parseTaggedTemplateRest(pos: number, tag: LeftHandSideExpression, questionDotToken: QuestionDotToken | undefined, typeArguments: NodeArray<TypeNode> | undefined) {
+        const tagExpression = factory.createTaggedTemplateExpression(
+            tag,
+            typeArguments,
+            token() === SyntaxKind.NoSubstitutionTemplateLiteral ?
+                (reScanTemplateToken(/*isTaggedTemplate*/ true), parseLiteralNode() as NoSubstitutionTemplateLiteral) :
+                parseTemplateExpression(/*isTaggedTemplate*/ true),
+        );
+        if (questionDotToken || tag.flags & NodeFlags.OptionalChain) {
+            (tagExpression as Mutable<Node>).flags |= NodeFlags.OptionalChain;
+        }
+        tagExpression.questionDotToken = questionDotToken;
+        return finishNode(tagExpression, pos);
+    }
+
+    function parseCallExpressionRest(pos: number, expression: LeftHandSideExpression): LeftHandSideExpression {
+        while (true) {
+            expression = parseMemberExpressionRest(pos, expression, /*allowOptionalChain*/ true);
+            let typeArguments: NodeArray<TypeNode> | undefined;
+            const questionDotToken = parseOptionalToken(SyntaxKind.QuestionDotToken);
+            if (questionDotToken) {
+                typeArguments = tryParse(parseTypeArgumentsInExpression);
+                if (isTemplateStartOfTaggedTemplate()) {
+                    expression = parseTaggedTemplateRest(pos, expression, questionDotToken, typeArguments);
+                    continue;
+                }
+            }
+            if (typeArguments || token() === SyntaxKind.OpenParenToken) {
+                // Absorb type arguments into CallExpression when preceding expression is ExpressionWithTypeArguments
+                if (!questionDotToken && expression.kind === SyntaxKind.ExpressionWithTypeArguments) {
+                    typeArguments = (expression as ExpressionWithTypeArguments).typeArguments;
+                    expression = (expression as ExpressionWithTypeArguments).expression;
+                }
+                const argumentList = parseArgumentList();
+                const callExpr = questionDotToken || tryReparseOptionalChain(expression) ?
+                    factoryCreateCallChain(expression, questionDotToken, typeArguments, argumentList) :
+                    factoryCreateCallExpression(expression, typeArguments, argumentList);
+                expression = finishNode(callExpr, pos);
+                continue;
+            }
+            if (questionDotToken) {
+                // We parsed `?.` but then failed to parse anything, so report a missing identifier here.
+                const name = createMissingNode<Identifier>(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ false, Diagnostics.Identifier_expected);
+                expression = finishNode(factoryCreatePropertyAccessChain(expression, questionDotToken, name), pos);
+            }
+            break;
+        }
+        return expression;
+    }
+
+    function parseArgumentList() {
+        parseExpected(SyntaxKind.OpenParenToken);
+        const result = parseDelimitedList(ParsingContext.ArgumentExpressions, parseArgumentExpression);
+        parseExpected(SyntaxKind.CloseParenToken);
+        return result;
+    }
+
+    function parseTypeArgumentsInExpression() {
+        if ((contextFlags & NodeFlags.JavaScriptFile) !== 0) {
+            // TypeArguments must not be parsed in JavaScript files to avoid ambiguity with binary operators.
+            return undefined;
+        }
+
+        if (reScanLessThanToken() !== SyntaxKind.LessThanToken) {
+            return undefined;
+        }
+        nextToken();
+
+        const typeArguments = parseDelimitedList(ParsingContext.TypeArguments, parseType);
+        if (reScanGreaterToken() !== SyntaxKind.GreaterThanToken) {
+            // If it doesn't have the closing `>` then it's definitely not an type argument list.
+            return undefined;
+        }
+        nextToken();
+
+        // We successfully parsed a type argument list. The next token determines whether we want to
+        // treat it as such. If the type argument list is followed by `(` or a template literal, as in
+        // `f<number>(42)`, we favor the type argument interpretation even though JavaScript would view
+        // it as a relational expression.
+        return typeArguments && canFollowTypeArgumentsInExpression() ? typeArguments : undefined;
+    }
+
+    function canFollowTypeArgumentsInExpression(): boolean {
+        switch (token()) {
+            // These tokens can follow a type argument list in a call expression.
+            case SyntaxKind.OpenParenToken: // foo<x>(
+            case SyntaxKind.NoSubstitutionTemplateLiteral: // foo<T> `...`
+            case SyntaxKind.TemplateHead: // foo<T> `...${100}...`
+                return true;
+            // A type argument list followed by `<` never makes sense, and a type argument list followed
+            // by `>` is ambiguous with a (re-scanned) `>>` operator, so we disqualify both. Also, in
+            // this context, `+` and `-` are unary operators, not binary operators.
+            case SyntaxKind.LessThanToken:
+            case SyntaxKind.GreaterThanToken:
+            case SyntaxKind.PlusToken:
+            case SyntaxKind.MinusToken:
+                return false;
+        }
+        // We favor the type argument list interpretation when it is immediately followed by
+        // a line break, a binary operator, or something that can't start an expression.
+        return scanner.hasPrecedingLineBreak() || isBinaryOperator() || !isStartOfExpression();
+    }
+
+    function parsePrimaryExpression(): PrimaryExpression {
+        switch (token()) {
+            case SyntaxKind.NoSubstitutionTemplateLiteral:
+                if (scanner.getTokenFlags() & TokenFlags.IsInvalid) {
+                    reScanTemplateToken(/*isTaggedTemplate*/ false);
+                }
+            // falls through
+            case SyntaxKind.NumericLiteral:
+            case SyntaxKind.BigIntLiteral:
+            case SyntaxKind.StringLiteral:
+                return parseLiteralNode();
+            case SyntaxKind.ThisKeyword:
+            case SyntaxKind.SuperKeyword:
+            case SyntaxKind.NullKeyword:
+            case SyntaxKind.TrueKeyword:
+            case SyntaxKind.FalseKeyword:
+                return parseTokenNode<PrimaryExpression>();
+            case SyntaxKind.OpenParenToken:
+                return parseParenthesizedExpression();
+            case SyntaxKind.OpenBracketToken:
+                return parseArrayLiteralExpression();
+            case SyntaxKind.OpenBraceToken:
+                return parseObjectLiteralExpression();
+            case SyntaxKind.AsyncKeyword:
+                // Async arrow functions are parsed earlier in parseAssignmentExpressionOrHigher.
+                // If we encounter `async [no LineTerminator here] function` then this is an async
+                // function; otherwise, its an identifier.
+                if (!lookAhead(nextTokenIsFunctionKeywordOnSameLine)) {
+                    break;
+                }
+
+                return parseFunctionExpression();
+            case SyntaxKind.AtToken:
+                return parseDecoratedExpression();
+            case SyntaxKind.ClassKeyword:
+                return parseClassExpression();
+            case SyntaxKind.FunctionKeyword:
+                return parseFunctionExpression();
+            case SyntaxKind.NewKeyword:
+                return parseNewExpressionOrNewDotTarget();
+            case SyntaxKind.SlashToken:
+            case SyntaxKind.SlashEqualsToken:
+                if (reScanSlashToken() === SyntaxKind.RegularExpressionLiteral) {
+                    return parseLiteralNode();
+                }
+                break;
+            case SyntaxKind.TemplateHead:
+                return parseTemplateExpression(/*isTaggedTemplate*/ false);
+            case SyntaxKind.PrivateIdentifier:
+                return parsePrivateIdentifier();
+        }
+
+        return parseIdentifier(Diagnostics.Expression_expected);
+    }
+
+    function parseParenthesizedExpression(): ParenthesizedExpression {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.OpenParenToken);
+        const expression = allowInAnd(parseExpression);
+        parseExpected(SyntaxKind.CloseParenToken);
+        return withJSDoc(finishNode(factoryCreateParenthesizedExpression(expression), pos), hasJSDoc);
+    }
+
+    function parseSpreadElement(): Expression {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.DotDotDotToken);
+        const expression = parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true);
+        return finishNode(factory.createSpreadElement(expression), pos);
+    }
+
+    function parseArgumentOrArrayLiteralElement(): Expression {
+        return token() === SyntaxKind.DotDotDotToken ? parseSpreadElement() :
+            token() === SyntaxKind.CommaToken ? finishNode(factory.createOmittedExpression(), getNodePos()) :
+            parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true);
+    }
+
+    function parseArgumentExpression(): Expression {
+        return doOutsideOfContext(disallowInAndDecoratorContext, parseArgumentOrArrayLiteralElement);
+    }
+
+    function parseArrayLiteralExpression(): ArrayLiteralExpression {
+        const pos = getNodePos();
+        const openBracketPosition = scanner.getTokenStart();
+        const openBracketParsed = parseExpected(SyntaxKind.OpenBracketToken);
+        const multiLine = scanner.hasPrecedingLineBreak();
+        const elements = parseDelimitedList(ParsingContext.ArrayLiteralMembers, parseArgumentOrArrayLiteralElement);
+        parseExpectedMatchingBrackets(SyntaxKind.OpenBracketToken, SyntaxKind.CloseBracketToken, openBracketParsed, openBracketPosition);
+        return finishNode(factoryCreateArrayLiteralExpression(elements, multiLine), pos);
+    }
+
+    function parseObjectLiteralElement(): ObjectLiteralElementLike {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+
+        if (parseOptionalToken(SyntaxKind.DotDotDotToken)) {
+            const expression = parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true);
+            return withJSDoc(finishNode(factory.createSpreadAssignment(expression), pos), hasJSDoc);
+        }
+
+        const modifiers = parseModifiers(/*allowDecorators*/ true);
+        if (parseContextualModifier(SyntaxKind.GetKeyword)) {
+            return parseAccessorDeclaration(pos, hasJSDoc, modifiers, SyntaxKind.GetAccessor, SignatureFlags.None);
+        }
+        if (parseContextualModifier(SyntaxKind.SetKeyword)) {
+            return parseAccessorDeclaration(pos, hasJSDoc, modifiers, SyntaxKind.SetAccessor, SignatureFlags.None);
+        }
+
+        const asteriskToken = parseOptionalToken(SyntaxKind.AsteriskToken);
+        const tokenIsIdentifier = isIdentifier();
+        const name = parsePropertyName();
+
+        // Disallowing of optional property assignments and definite assignment assertion happens in the grammar checker.
+        const questionToken = parseOptionalToken(SyntaxKind.QuestionToken);
+        const exclamationToken = parseOptionalToken(SyntaxKind.ExclamationToken);
+
+        if (asteriskToken || token() === SyntaxKind.OpenParenToken || token() === SyntaxKind.LessThanToken) {
+            return parseMethodDeclaration(pos, hasJSDoc, modifiers, asteriskToken, name, questionToken, exclamationToken);
+        }
+
+        // check if it is short-hand property assignment or normal property assignment
+        // NOTE: if token is EqualsToken it is interpreted as CoverInitializedName production
+        // CoverInitializedName[Yield] :
+        //     IdentifierReference[?Yield] Initializer[In, ?Yield]
+        // this is necessary because ObjectLiteral productions are also used to cover grammar for ObjectAssignmentPattern
+        let node: Mutable<ShorthandPropertyAssignment | PropertyAssignment>;
+        const isShorthandPropertyAssignment = tokenIsIdentifier && (token() !== SyntaxKind.ColonToken);
+        if (isShorthandPropertyAssignment) {
+            const equalsToken = parseOptionalToken(SyntaxKind.EqualsToken);
+            const objectAssignmentInitializer = equalsToken ? allowInAnd(() => parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true)) : undefined;
+            node = factory.createShorthandPropertyAssignment(name as Identifier, objectAssignmentInitializer);
+            // Save equals token for error reporting.
+            // TODO(rbuckton): Consider manufacturing this when we need to report an error as it is otherwise not useful.
+            node.equalsToken = equalsToken;
+        }
+        else {
+            parseExpected(SyntaxKind.ColonToken);
+            const initializer = allowInAnd(() => parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true));
+            node = factory.createPropertyAssignment(name, initializer);
+        }
+        // Decorators, Modifiers, questionToken, and exclamationToken are not supported by property assignments and are reported in the grammar checker
+        node.modifiers = modifiers;
+        node.questionToken = questionToken;
+        node.exclamationToken = exclamationToken;
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseObjectLiteralExpression(): ObjectLiteralExpression {
+        const pos = getNodePos();
+        const openBracePosition = scanner.getTokenStart();
+        const openBraceParsed = parseExpected(SyntaxKind.OpenBraceToken);
+        const multiLine = scanner.hasPrecedingLineBreak();
+        const properties = parseDelimitedList(ParsingContext.ObjectLiteralMembers, parseObjectLiteralElement, /*considerSemicolonAsDelimiter*/ true);
+        parseExpectedMatchingBrackets(SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken, openBraceParsed, openBracePosition);
+        return finishNode(factoryCreateObjectLiteralExpression(properties, multiLine), pos);
+    }
+
+    function parseFunctionExpression(): FunctionExpression {
+        // GeneratorExpression:
+        //      function* BindingIdentifier [Yield][opt](FormalParameters[Yield]){ GeneratorBody }
+        //
+        // FunctionExpression:
+        //      function BindingIdentifier[opt](FormalParameters){ FunctionBody }
+        const savedDecoratorContext = inDecoratorContext();
+        setDecoratorContext(/*val*/ false);
+
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        const modifiers = parseModifiers(/*allowDecorators*/ false);
+        parseExpected(SyntaxKind.FunctionKeyword);
+        const asteriskToken = parseOptionalToken(SyntaxKind.AsteriskToken);
+        const isGenerator = asteriskToken ? SignatureFlags.Yield : SignatureFlags.None;
+        const isAsync = some(modifiers, isAsyncModifier) ? SignatureFlags.Await : SignatureFlags.None;
+        const name = isGenerator && isAsync ? doInYieldAndAwaitContext(parseOptionalBindingIdentifier) :
+            isGenerator ? doInYieldContext(parseOptionalBindingIdentifier) :
+            isAsync ? doInAwaitContext(parseOptionalBindingIdentifier) :
+            parseOptionalBindingIdentifier();
+
+        const typeParameters = parseTypeParameters();
+        const parameters = parseParameters(isGenerator | isAsync);
+        const type = parseReturnType(SyntaxKind.ColonToken, /*isType*/ false);
+        const body = parseFunctionBlock(isGenerator | isAsync);
+
+        setDecoratorContext(savedDecoratorContext);
+
+        const node = factory.createFunctionExpression(modifiers, asteriskToken, name, typeParameters, parameters, type, body);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseOptionalBindingIdentifier(): Identifier | undefined {
+        return isBindingIdentifier() ? parseBindingIdentifier() : undefined;
+    }
+
+    function parseNewExpressionOrNewDotTarget(): NewExpression | MetaProperty {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.NewKeyword);
+        if (parseOptional(SyntaxKind.DotToken)) {
+            const name = parseIdentifierName();
+            return finishNode(factory.createMetaProperty(SyntaxKind.NewKeyword, name), pos);
+        }
+        const expressionPos = getNodePos();
+        let expression: LeftHandSideExpression = parseMemberExpressionRest(expressionPos, parsePrimaryExpression(), /*allowOptionalChain*/ false);
+        let typeArguments: NodeArray<TypeNode> | undefined;
+        // Absorb type arguments into NewExpression when preceding expression is ExpressionWithTypeArguments
+        if (expression.kind === SyntaxKind.ExpressionWithTypeArguments) {
+            typeArguments = (expression as ExpressionWithTypeArguments).typeArguments;
+            expression = (expression as ExpressionWithTypeArguments).expression;
+        }
+        if (token() === SyntaxKind.QuestionDotToken) {
+            parseErrorAtCurrentToken(Diagnostics.Invalid_optional_chain_from_new_expression_Did_you_mean_to_call_0, getTextOfNodeFromSourceText(sourceText, expression));
+        }
+        const argumentList = token() === SyntaxKind.OpenParenToken ? parseArgumentList() : undefined;
+        return finishNode(factoryCreateNewExpression(expression, typeArguments, argumentList), pos);
+    }
+
+    // STATEMENTS
+    function parseBlock(ignoreMissingOpenBrace: boolean, diagnosticMessage?: DiagnosticMessage): Block {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        const openBracePosition = scanner.getTokenStart();
+        const openBraceParsed = parseExpected(SyntaxKind.OpenBraceToken, diagnosticMessage);
+        if (openBraceParsed || ignoreMissingOpenBrace) {
+            const multiLine = scanner.hasPrecedingLineBreak();
+            const statements = parseList(ParsingContext.BlockStatements, parseStatement);
+            parseExpectedMatchingBrackets(SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken, openBraceParsed, openBracePosition);
+            const result = withJSDoc(finishNode(factoryCreateBlock(statements, multiLine), pos), hasJSDoc);
+            if (token() === SyntaxKind.EqualsToken) {
+                parseErrorAtCurrentToken(Diagnostics.Declaration_or_statement_expected_This_follows_a_block_of_statements_so_if_you_intended_to_write_a_destructuring_assignment_you_might_need_to_wrap_the_whole_assignment_in_parentheses);
+                nextToken();
+            }
+
+            return result;
+        }
+        else {
+            const statements = createMissingList<Statement>();
+            return withJSDoc(finishNode(factoryCreateBlock(statements, /*multiLine*/ undefined), pos), hasJSDoc);
+        }
+    }
+
+    function parseFunctionBlock(flags: SignatureFlags, diagnosticMessage?: DiagnosticMessage): Block {
+        const savedYieldContext = inYieldContext();
+        setYieldContext(!!(flags & SignatureFlags.Yield));
+
+        const savedAwaitContext = inAwaitContext();
+        setAwaitContext(!!(flags & SignatureFlags.Await));
+
+        const savedTopLevel = topLevel;
+        topLevel = false;
+
+        // We may be in a [Decorator] context when parsing a function expression or
+        // arrow function. The body of the function is not in [Decorator] context.
+        const saveDecoratorContext = inDecoratorContext();
+        if (saveDecoratorContext) {
+            setDecoratorContext(/*val*/ false);
+        }
+
+        const block = parseBlock(!!(flags & SignatureFlags.IgnoreMissingOpenBrace), diagnosticMessage);
+
+        if (saveDecoratorContext) {
+            setDecoratorContext(/*val*/ true);
+        }
+
+        topLevel = savedTopLevel;
+        setYieldContext(savedYieldContext);
+        setAwaitContext(savedAwaitContext);
+
+        return block;
+    }
+
+    function parseEmptyStatement(): Statement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.SemicolonToken);
+        return withJSDoc(finishNode(factory.createEmptyStatement(), pos), hasJSDoc);
+    }
+
+    function parseIfStatement(): IfStatement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.IfKeyword);
+        const openParenPosition = scanner.getTokenStart();
+        const openParenParsed = parseExpected(SyntaxKind.OpenParenToken);
+        const expression = allowInAnd(parseExpression);
+        parseExpectedMatchingBrackets(SyntaxKind.OpenParenToken, SyntaxKind.CloseParenToken, openParenParsed, openParenPosition);
+        const thenStatement = parseStatement();
+        const elseStatement = parseOptional(SyntaxKind.ElseKeyword) ? parseStatement() : undefined;
+        return withJSDoc(finishNode(factoryCreateIfStatement(expression, thenStatement, elseStatement), pos), hasJSDoc);
+    }
+
+    function parseDoStatement(): DoStatement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.DoKeyword);
+        const statement = parseStatement();
+        parseExpected(SyntaxKind.WhileKeyword);
+        const openParenPosition = scanner.getTokenStart();
+        const openParenParsed = parseExpected(SyntaxKind.OpenParenToken);
+        const expression = allowInAnd(parseExpression);
+        parseExpectedMatchingBrackets(SyntaxKind.OpenParenToken, SyntaxKind.CloseParenToken, openParenParsed, openParenPosition);
+
+        // From: https://mail.mozilla.org/pipermail/es-discuss/2011-August/016188.html
+        // 157 min --- All allen at wirfs-brock.com CONF --- "do{;}while(false)false" prohibited in
+        // spec but allowed in consensus reality. Approved -- this is the de-facto standard whereby
+        //  do;while(0)x will have a semicolon inserted before x.
+        parseOptional(SyntaxKind.SemicolonToken);
+        return withJSDoc(finishNode(factory.createDoStatement(statement, expression), pos), hasJSDoc);
+    }
+
+    function parseWhileStatement(): WhileStatement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.WhileKeyword);
+        const openParenPosition = scanner.getTokenStart();
+        const openParenParsed = parseExpected(SyntaxKind.OpenParenToken);
+        const expression = allowInAnd(parseExpression);
+        parseExpectedMatchingBrackets(SyntaxKind.OpenParenToken, SyntaxKind.CloseParenToken, openParenParsed, openParenPosition);
+        const statement = parseStatement();
+        return withJSDoc(finishNode(factoryCreateWhileStatement(expression, statement), pos), hasJSDoc);
+    }
+
+    function parseForOrForInOrForOfStatement(): Statement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.ForKeyword);
+        const awaitToken = parseOptionalToken(SyntaxKind.AwaitKeyword);
+        parseExpected(SyntaxKind.OpenParenToken);
+
+        let initializer!: VariableDeclarationList | Expression;
+        if (token() !== SyntaxKind.SemicolonToken) {
+            if (
+                token() === SyntaxKind.VarKeyword || token() === SyntaxKind.LetKeyword || token() === SyntaxKind.ConstKeyword ||
+                token() === SyntaxKind.UsingKeyword && lookAhead(nextTokenIsBindingIdentifierOrStartOfDestructuringOnSameLineDisallowOf) ||
+                token() === SyntaxKind.AwaitKeyword && lookAhead(nextTokenIsUsingKeywordThenBindingIdentifierOrStartOfObjectDestructuringOnSameLineDisallowOf)
+            ) {
+                initializer = parseVariableDeclarationList(/*inForStatementInitializer*/ true);
+            }
+            else {
+                initializer = disallowInAnd(parseExpression);
+            }
+        }
+
+        let node: IterationStatement;
+        if (awaitToken ? parseExpected(SyntaxKind.OfKeyword) : parseOptional(SyntaxKind.OfKeyword)) {
+            const expression = allowInAnd(() => parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true));
+            parseExpected(SyntaxKind.CloseParenToken);
+            node = factoryCreateForOfStatement(awaitToken, initializer, expression, parseStatement());
+        }
+        else if (parseOptional(SyntaxKind.InKeyword)) {
+            const expression = allowInAnd(parseExpression);
+            parseExpected(SyntaxKind.CloseParenToken);
+            node = factory.createForInStatement(initializer, expression, parseStatement());
+        }
+        else {
+            parseExpected(SyntaxKind.SemicolonToken);
+            const condition = token() !== SyntaxKind.SemicolonToken && token() !== SyntaxKind.CloseParenToken
+                ? allowInAnd(parseExpression)
+                : undefined;
+            parseExpected(SyntaxKind.SemicolonToken);
+            const incrementor = token() !== SyntaxKind.CloseParenToken
+                ? allowInAnd(parseExpression)
+                : undefined;
+            parseExpected(SyntaxKind.CloseParenToken);
+            node = factoryCreateForStatement(initializer, condition, incrementor, parseStatement());
+        }
+
+        return withJSDoc(finishNode(node, pos) as ForStatement | ForInOrOfStatement, hasJSDoc);
+    }
+
+    function parseBreakOrContinueStatement(kind: SyntaxKind): BreakOrContinueStatement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+
+        parseExpected(kind === SyntaxKind.BreakStatement ? SyntaxKind.BreakKeyword : SyntaxKind.ContinueKeyword);
+        const label = canParseSemicolon() ? undefined : parseIdentifier();
+
+        parseSemicolon();
+        const node = kind === SyntaxKind.BreakStatement
+            ? factory.createBreakStatement(label)
+            : factory.createContinueStatement(label);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseReturnStatement(): ReturnStatement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.ReturnKeyword);
+        const expression = canParseSemicolon() ? undefined : allowInAnd(parseExpression);
+        parseSemicolon();
+        return withJSDoc(finishNode(factory.createReturnStatement(expression), pos), hasJSDoc);
+    }
+
+    function parseWithStatement(): WithStatement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.WithKeyword);
+        const openParenPosition = scanner.getTokenStart();
+        const openParenParsed = parseExpected(SyntaxKind.OpenParenToken);
+        const expression = allowInAnd(parseExpression);
+        parseExpectedMatchingBrackets(SyntaxKind.OpenParenToken, SyntaxKind.CloseParenToken, openParenParsed, openParenPosition);
+        const statement = doInsideOfContext(NodeFlags.InWithStatement, parseStatement);
+        return withJSDoc(finishNode(factory.createWithStatement(expression, statement), pos), hasJSDoc);
+    }
+
+    function parseCaseClause(): CaseClause {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.CaseKeyword);
+        const expression = allowInAnd(parseExpression);
+        parseExpected(SyntaxKind.ColonToken);
+        const statements = parseList(ParsingContext.SwitchClauseStatements, parseStatement);
+        return withJSDoc(finishNode(factory.createCaseClause(expression, statements), pos), hasJSDoc);
+    }
+
+    function parseDefaultClause(): DefaultClause {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.DefaultKeyword);
+        parseExpected(SyntaxKind.ColonToken);
+        const statements = parseList(ParsingContext.SwitchClauseStatements, parseStatement);
+        return finishNode(factory.createDefaultClause(statements), pos);
+    }
+
+    function parseCaseOrDefaultClause(): CaseOrDefaultClause {
+        return token() === SyntaxKind.CaseKeyword ? parseCaseClause() : parseDefaultClause();
+    }
+
+    function parseCaseBlock(): CaseBlock {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.OpenBraceToken);
+        const clauses = parseList(ParsingContext.SwitchClauses, parseCaseOrDefaultClause);
+        parseExpected(SyntaxKind.CloseBraceToken);
+        return finishNode(factory.createCaseBlock(clauses), pos);
+    }
+
+    function parseSwitchStatement(): SwitchStatement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.SwitchKeyword);
+        parseExpected(SyntaxKind.OpenParenToken);
+        const expression = allowInAnd(parseExpression);
+        parseExpected(SyntaxKind.CloseParenToken);
+        const caseBlock = parseCaseBlock();
+        return withJSDoc(finishNode(factory.createSwitchStatement(expression, caseBlock), pos), hasJSDoc);
+    }
+
+    function parseThrowStatement(): ThrowStatement {
+        // ThrowStatement[Yield] :
+        //      throw [no LineTerminator here]Expression[In, ?Yield];
+
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.ThrowKeyword);
+
+        // Because of automatic semicolon insertion, we need to report error if this
+        // throw could be terminated with a semicolon.  Note: we can't call 'parseExpression'
+        // directly as that might consume an expression on the following line.
+        // Instead, we create a "missing" identifier, but don't report an error. The actual error
+        // will be reported in the grammar walker.
+        let expression = scanner.hasPrecedingLineBreak() ? undefined : allowInAnd(parseExpression);
+        if (expression === undefined) {
+            identifierCount++;
+            expression = finishNode(factoryCreateIdentifier(""), getNodePos());
+        }
+        if (!tryParseSemicolon()) {
+            parseErrorForMissingSemicolonAfter(expression);
+        }
+        return withJSDoc(finishNode(factory.createThrowStatement(expression), pos), hasJSDoc);
+    }
+
+    // TODO: Review for error recovery
+    function parseTryStatement(): TryStatement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+
+        parseExpected(SyntaxKind.TryKeyword);
+        const tryBlock = parseBlock(/*ignoreMissingOpenBrace*/ false);
+        const catchClause = token() === SyntaxKind.CatchKeyword ? parseCatchClause() : undefined;
+
+        // If we don't have a catch clause, then we must have a finally clause.  Try to parse
+        // one out no matter what.
+        let finallyBlock: Block | undefined;
+        if (!catchClause || token() === SyntaxKind.FinallyKeyword) {
+            parseExpected(SyntaxKind.FinallyKeyword, Diagnostics.catch_or_finally_expected);
+            finallyBlock = parseBlock(/*ignoreMissingOpenBrace*/ false);
+        }
+
+        return withJSDoc(finishNode(factory.createTryStatement(tryBlock, catchClause, finallyBlock), pos), hasJSDoc);
+    }
+
+    function parseCatchClause(): CatchClause {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.CatchKeyword);
+
+        let variableDeclaration;
+        if (parseOptional(SyntaxKind.OpenParenToken)) {
+            variableDeclaration = parseVariableDeclaration();
+            parseExpected(SyntaxKind.CloseParenToken);
+        }
+        else {
+            // Keep shape of node to avoid degrading performance.
+            variableDeclaration = undefined;
+        }
+
+        const block = parseBlock(/*ignoreMissingOpenBrace*/ false);
+        return finishNode(factory.createCatchClause(variableDeclaration, block), pos);
+    }
+
+    function parseDebuggerStatement(): Statement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        parseExpected(SyntaxKind.DebuggerKeyword);
+        parseSemicolon();
+        return withJSDoc(finishNode(factory.createDebuggerStatement(), pos), hasJSDoc);
+    }
+
+    function parseExpressionOrLabeledStatement(): ExpressionStatement | LabeledStatement {
+        // Avoiding having to do the lookahead for a labeled statement by just trying to parse
+        // out an expression, seeing if it is identifier and then seeing if it is followed by
+        // a colon.
+        const pos = getNodePos();
+        let hasJSDoc = hasPrecedingJSDocComment();
+        let node: ExpressionStatement | LabeledStatement;
+        const hasParen = token() === SyntaxKind.OpenParenToken;
+        const expression = allowInAnd(parseExpression);
+        if (isIdentifierNode(expression) && parseOptional(SyntaxKind.ColonToken)) {
+            node = factory.createLabeledStatement(expression, parseStatement());
+        }
+        else {
+            if (!tryParseSemicolon()) {
+                parseErrorForMissingSemicolonAfter(expression);
+            }
+            node = factoryCreateExpressionStatement(expression);
+            if (hasParen) {
+                // do not parse the same jsdoc twice
+                hasJSDoc = false;
+            }
+        }
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function nextTokenIsIdentifierOrKeywordOnSameLine() {
+        nextToken();
+        return tokenIsIdentifierOrKeyword(token()) && !scanner.hasPrecedingLineBreak();
+    }
+
+    function nextTokenIsClassKeywordOnSameLine() {
+        nextToken();
+        return token() === SyntaxKind.ClassKeyword && !scanner.hasPrecedingLineBreak();
+    }
+
+    function nextTokenIsFunctionKeywordOnSameLine() {
+        nextToken();
+        return token() === SyntaxKind.FunctionKeyword && !scanner.hasPrecedingLineBreak();
+    }
+
+    function nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine() {
+        nextToken();
+        return (tokenIsIdentifierOrKeyword(token()) || token() === SyntaxKind.NumericLiteral || token() === SyntaxKind.BigIntLiteral || token() === SyntaxKind.StringLiteral) && !scanner.hasPrecedingLineBreak();
+    }
+
+    function isDeclaration(): boolean {
+        while (true) {
+            switch (token()) {
+                case SyntaxKind.VarKeyword:
+                case SyntaxKind.LetKeyword:
+                case SyntaxKind.ConstKeyword:
+                case SyntaxKind.FunctionKeyword:
+                case SyntaxKind.ClassKeyword:
+                case SyntaxKind.EnumKeyword:
+                    return true;
+                case SyntaxKind.UsingKeyword:
+                    return isUsingDeclaration();
+                case SyntaxKind.AwaitKeyword:
+                    return isAwaitUsingDeclaration();
+
+                // 'declare', 'module', 'namespace', 'interface'* and 'type' are all legal JavaScript identifiers;
+                // however, an identifier cannot be followed by another identifier on the same line. This is what we
+                // count on to parse out the respective declarations. For instance, we exploit this to say that
+                //
+                //    namespace n
+                //
+                // can be none other than the beginning of a namespace declaration, but need to respect that JavaScript sees
+                //
+                //    namespace
+                //    n
+                //
+                // as the identifier 'namespace' on one line followed by the identifier 'n' on another.
+                // We need to look one token ahead to see if it permissible to try parsing a declaration.
+                //
+                // *Note*: 'interface' is actually a strict mode reserved word. So while
+                //
+                //   "use strict"
+                //   interface
+                //   I {}
+                //
+                // could be legal, it would add complexity for very little gain.
+                case SyntaxKind.InterfaceKeyword:
+                case SyntaxKind.TypeKeyword:
+                    return nextTokenIsIdentifierOnSameLine();
+                case SyntaxKind.ModuleKeyword:
+                case SyntaxKind.NamespaceKeyword:
+                    return nextTokenIsIdentifierOrStringLiteralOnSameLine();
+                case SyntaxKind.AbstractKeyword:
+                case SyntaxKind.AccessorKeyword:
+                case SyntaxKind.AsyncKeyword:
+                case SyntaxKind.DeclareKeyword:
+                case SyntaxKind.PrivateKeyword:
+                case SyntaxKind.ProtectedKeyword:
+                case SyntaxKind.PublicKeyword:
+                case SyntaxKind.ReadonlyKeyword:
+                    const previousToken = token();
+                    nextToken();
+                    // ASI takes effect for this modifier.
+                    if (scanner.hasPrecedingLineBreak()) {
+                        return false;
+                    }
+                    if (previousToken === SyntaxKind.DeclareKeyword && token() === SyntaxKind.TypeKeyword) {
+                        // If we see 'declare type', then commit to parsing a type alias. parseTypeAliasDeclaration will
+                        // report Line_break_not_permitted_here if needed.
+                        return true;
+                    }
+                    continue;
+
+                case SyntaxKind.GlobalKeyword:
+                    nextToken();
+                    return token() === SyntaxKind.OpenBraceToken || token() === SyntaxKind.Identifier || token() === SyntaxKind.ExportKeyword;
+
+                case SyntaxKind.ImportKeyword:
+                    nextToken();
+                    return token() === SyntaxKind.StringLiteral || token() === SyntaxKind.AsteriskToken ||
+                        token() === SyntaxKind.OpenBraceToken || tokenIsIdentifierOrKeyword(token());
+                case SyntaxKind.ExportKeyword:
+                    let currentToken = nextToken();
+                    if (currentToken === SyntaxKind.TypeKeyword) {
+                        currentToken = lookAhead(nextToken);
+                    }
+                    if (
+                        currentToken === SyntaxKind.EqualsToken || currentToken === SyntaxKind.AsteriskToken ||
+                        currentToken === SyntaxKind.OpenBraceToken || currentToken === SyntaxKind.DefaultKeyword ||
+                        currentToken === SyntaxKind.AsKeyword || currentToken === SyntaxKind.AtToken
+                    ) {
+                        return true;
+                    }
+                    continue;
+
+                case SyntaxKind.StaticKeyword:
+                    nextToken();
+                    continue;
+
+                default:
+                    return false;
+            }
+        }
+    }
+
+    function isStartOfDeclaration(): boolean {
+        return lookAhead(isDeclaration);
+    }
+
+    function isStartOfStatement(): boolean {
+        switch (token()) {
+            case SyntaxKind.AtToken:
+            case SyntaxKind.SemicolonToken:
+            case SyntaxKind.OpenBraceToken:
+            case SyntaxKind.VarKeyword:
+            case SyntaxKind.LetKeyword:
+            case SyntaxKind.UsingKeyword:
+            case SyntaxKind.FunctionKeyword:
+            case SyntaxKind.ClassKeyword:
+            case SyntaxKind.EnumKeyword:
+            case SyntaxKind.IfKeyword:
+            case SyntaxKind.DoKeyword:
+            case SyntaxKind.WhileKeyword:
+            case SyntaxKind.ForKeyword:
+            case SyntaxKind.ContinueKeyword:
+            case SyntaxKind.BreakKeyword:
+            case SyntaxKind.ReturnKeyword:
+            case SyntaxKind.WithKeyword:
+            case SyntaxKind.SwitchKeyword:
+            case SyntaxKind.ThrowKeyword:
+            case SyntaxKind.TryKeyword:
+            case SyntaxKind.DebuggerKeyword:
+            // 'catch' and 'finally' do not actually indicate that the code is part of a statement,
+            // however, we say they are here so that we may gracefully parse them and error later.
+            // falls through
+            case SyntaxKind.CatchKeyword:
+            case SyntaxKind.FinallyKeyword:
+                return true;
+
+            case SyntaxKind.ImportKeyword:
+                return isStartOfDeclaration() || lookAhead(nextTokenIsOpenParenOrLessThanOrDot);
+
+            case SyntaxKind.ConstKeyword:
+            case SyntaxKind.ExportKeyword:
+                return isStartOfDeclaration();
+
+            case SyntaxKind.AsyncKeyword:
+            case SyntaxKind.DeclareKeyword:
+            case SyntaxKind.InterfaceKeyword:
+            case SyntaxKind.ModuleKeyword:
+            case SyntaxKind.NamespaceKeyword:
+            case SyntaxKind.TypeKeyword:
+            case SyntaxKind.GlobalKeyword:
+                // When these don't start a declaration, they're an identifier in an expression statement
+                return true;
+
+            case SyntaxKind.AccessorKeyword:
+            case SyntaxKind.PublicKeyword:
+            case SyntaxKind.PrivateKeyword:
+            case SyntaxKind.ProtectedKeyword:
+            case SyntaxKind.StaticKeyword:
+            case SyntaxKind.ReadonlyKeyword:
+                // When these don't start a declaration, they may be the start of a class member if an identifier
+                // immediately follows. Otherwise they're an identifier in an expression statement.
+                return isStartOfDeclaration() || !lookAhead(nextTokenIsIdentifierOrKeywordOnSameLine);
+
+            default:
+                return isStartOfExpression();
+        }
+    }
+
+    function nextTokenIsBindingIdentifierOrStartOfDestructuring() {
+        nextToken();
+        return isBindingIdentifier() || token() === SyntaxKind.OpenBraceToken || token() === SyntaxKind.OpenBracketToken;
+    }
+
+    function isLetDeclaration() {
+        // In ES6 'let' always starts a lexical declaration if followed by an identifier or {
+        // or [.
+        return lookAhead(nextTokenIsBindingIdentifierOrStartOfDestructuring);
+    }
+
+    function nextTokenIsBindingIdentifierOrStartOfDestructuringOnSameLineDisallowOf() {
+        return nextTokenIsBindingIdentifierOrStartOfDestructuringOnSameLine(/*disallowOf*/ true);
+    }
+
+    function nextTokenIsBindingIdentifierOrStartOfDestructuringOnSameLine(disallowOf?: boolean) {
+        nextToken();
+        if (disallowOf && token() === SyntaxKind.OfKeyword) return false;
+        return (isBindingIdentifier() || token() === SyntaxKind.OpenBraceToken) && !scanner.hasPrecedingLineBreak();
+    }
+
+    function isUsingDeclaration() {
+        // 'using' always starts a lexical declaration if followed by an identifier. We also eagerly parse
+        // |ObjectBindingPattern| so that we can report a grammar error during check. We don't parse out
+        // |ArrayBindingPattern| since it potentially conflicts with element access (i.e., `using[x]`).
+        return lookAhead(nextTokenIsBindingIdentifierOrStartOfDestructuringOnSameLine);
+    }
+
+    function nextTokenIsUsingKeywordThenBindingIdentifierOrStartOfObjectDestructuringOnSameLineDisallowOf() {
+        return nextTokenIsUsingKeywordThenBindingIdentifierOrStartOfObjectDestructuringOnSameLine(/*disallowOf*/ true);
+    }
+
+    function nextTokenIsUsingKeywordThenBindingIdentifierOrStartOfObjectDestructuringOnSameLine(disallowOf?: boolean) {
+        if (nextToken() === SyntaxKind.UsingKeyword) {
+            return nextTokenIsBindingIdentifierOrStartOfDestructuringOnSameLine(disallowOf);
+        }
+        return false;
+    }
+
+    function isAwaitUsingDeclaration() {
+        // 'await using' always starts a lexical declaration if followed by an identifier. We also eagerly parse
+        // |ObjectBindingPattern| so that we can report a grammar error during check. We don't parse out
+        // |ArrayBindingPattern| since it potentially conflicts with element access (i.e., `await using[x]`).
+        return lookAhead(nextTokenIsUsingKeywordThenBindingIdentifierOrStartOfObjectDestructuringOnSameLine);
+    }
+
+    function parseStatement(): Statement {
+        switch (token()) {
+            case SyntaxKind.SemicolonToken:
+                return parseEmptyStatement();
+            case SyntaxKind.OpenBraceToken:
+                return parseBlock(/*ignoreMissingOpenBrace*/ false);
+            case SyntaxKind.VarKeyword:
+                return parseVariableStatement(getNodePos(), hasPrecedingJSDocComment(), /*modifiers*/ undefined);
+            case SyntaxKind.LetKeyword:
+                if (isLetDeclaration()) {
+                    return parseVariableStatement(getNodePos(), hasPrecedingJSDocComment(), /*modifiers*/ undefined);
+                }
+                break;
+            case SyntaxKind.AwaitKeyword:
+                if (isAwaitUsingDeclaration()) {
+                    return parseVariableStatement(getNodePos(), hasPrecedingJSDocComment(), /*modifiers*/ undefined);
+                }
+                break;
+            case SyntaxKind.UsingKeyword:
+                if (isUsingDeclaration()) {
+                    return parseVariableStatement(getNodePos(), hasPrecedingJSDocComment(), /*modifiers*/ undefined);
+                }
+                break;
+            case SyntaxKind.FunctionKeyword:
+                return parseFunctionDeclaration(getNodePos(), hasPrecedingJSDocComment(), /*modifiers*/ undefined);
+            case SyntaxKind.ClassKeyword:
+                return parseClassDeclaration(getNodePos(), hasPrecedingJSDocComment(), /*modifiers*/ undefined);
+            case SyntaxKind.IfKeyword:
+                return parseIfStatement();
+            case SyntaxKind.DoKeyword:
+                return parseDoStatement();
+            case SyntaxKind.WhileKeyword:
+                return parseWhileStatement();
+            case SyntaxKind.ForKeyword:
+                return parseForOrForInOrForOfStatement();
+            case SyntaxKind.ContinueKeyword:
+                return parseBreakOrContinueStatement(SyntaxKind.ContinueStatement);
+            case SyntaxKind.BreakKeyword:
+                return parseBreakOrContinueStatement(SyntaxKind.BreakStatement);
+            case SyntaxKind.ReturnKeyword:
+                return parseReturnStatement();
+            case SyntaxKind.WithKeyword:
+                return parseWithStatement();
+            case SyntaxKind.SwitchKeyword:
+                return parseSwitchStatement();
+            case SyntaxKind.ThrowKeyword:
+                return parseThrowStatement();
+            case SyntaxKind.TryKeyword:
+            // Include 'catch' and 'finally' for error recovery.
+            // falls through
+            case SyntaxKind.CatchKeyword:
+            case SyntaxKind.FinallyKeyword:
+                return parseTryStatement();
+            case SyntaxKind.DebuggerKeyword:
+                return parseDebuggerStatement();
+            case SyntaxKind.AtToken:
+                return parseDeclaration();
+            case SyntaxKind.AsyncKeyword:
+            case SyntaxKind.InterfaceKeyword:
+            case SyntaxKind.TypeKeyword:
+            case SyntaxKind.ModuleKeyword:
+            case SyntaxKind.NamespaceKeyword:
+            case SyntaxKind.DeclareKeyword:
+            case SyntaxKind.ConstKeyword:
+            case SyntaxKind.EnumKeyword:
+            case SyntaxKind.ExportKeyword:
+            case SyntaxKind.ImportKeyword:
+            case SyntaxKind.PrivateKeyword:
+            case SyntaxKind.ProtectedKeyword:
+            case SyntaxKind.PublicKeyword:
+            case SyntaxKind.AbstractKeyword:
+            case SyntaxKind.AccessorKeyword:
+            case SyntaxKind.StaticKeyword:
+            case SyntaxKind.ReadonlyKeyword:
+            case SyntaxKind.GlobalKeyword:
+                if (isStartOfDeclaration()) {
+                    return parseDeclaration();
+                }
+                break;
+        }
+        return parseExpressionOrLabeledStatement();
+    }
+
+    function isDeclareModifier(modifier: ModifierLike) {
+        return modifier.kind === SyntaxKind.DeclareKeyword;
+    }
+
+    function parseDeclaration(): Statement {
+        // `parseListElement` attempted to get the reused node at this position,
+        // but the ambient context flag was not yet set, so the node appeared
+        // not reusable in that context.
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        const modifiers = parseModifiers(/*allowDecorators*/ true);
+        const isAmbient = some(modifiers, isDeclareModifier);
+        if (isAmbient) {
+            const node = tryReuseAmbientDeclaration(pos);
+            if (node) {
+                return node;
+            }
+
+            for (const m of modifiers!) {
+                (m as Mutable<Node>).flags |= NodeFlags.Ambient;
+            }
+            return doInsideOfContext(NodeFlags.Ambient, () => parseDeclarationWorker(pos, hasJSDoc, modifiers));
+        }
+        else {
+            return parseDeclarationWorker(pos, hasJSDoc, modifiers);
+        }
+    }
+
+    function tryReuseAmbientDeclaration(pos: number): Statement | undefined {
+        return doInsideOfContext(NodeFlags.Ambient, () => {
+            // TODO(jakebailey): this is totally wrong; `parsingContext` is the result of ORing a bunch of `1 << ParsingContext.XYZ`.
+            // The enum should really be a bunch of flags.
+            const node = currentNode(parsingContext, pos);
+            if (node) {
+                return consumeNode(node) as Statement;
+            }
+        });
+    }
+
+    function parseDeclarationWorker(pos: number, hasJSDoc: boolean, modifiersIn: NodeArray<ModifierLike> | undefined): Statement {
+        switch (token()) {
+            case SyntaxKind.VarKeyword:
+            case SyntaxKind.LetKeyword:
+            case SyntaxKind.ConstKeyword:
+            case SyntaxKind.UsingKeyword:
+            case SyntaxKind.AwaitKeyword:
+                return parseVariableStatement(pos, hasJSDoc, modifiersIn);
+            case SyntaxKind.FunctionKeyword:
+                return parseFunctionDeclaration(pos, hasJSDoc, modifiersIn);
+            case SyntaxKind.ClassKeyword:
+                return parseClassDeclaration(pos, hasJSDoc, modifiersIn);
+            case SyntaxKind.InterfaceKeyword:
+                return parseInterfaceDeclaration(pos, hasJSDoc, modifiersIn);
+            case SyntaxKind.TypeKeyword:
+                return parseTypeAliasDeclaration(pos, hasJSDoc, modifiersIn);
+            case SyntaxKind.EnumKeyword:
+                return parseEnumDeclaration(pos, hasJSDoc, modifiersIn);
+            case SyntaxKind.GlobalKeyword:
+            case SyntaxKind.ModuleKeyword:
+            case SyntaxKind.NamespaceKeyword:
+                return parseModuleDeclaration(pos, hasJSDoc, modifiersIn);
+            case SyntaxKind.ImportKeyword:
+                return parseImportDeclarationOrImportEqualsDeclaration(pos, hasJSDoc, modifiersIn);
+            case SyntaxKind.ExportKeyword:
+                nextToken();
+                switch (token()) {
+                    case SyntaxKind.DefaultKeyword:
+                    case SyntaxKind.EqualsToken:
+                        return parseExportAssignment(pos, hasJSDoc, modifiersIn);
+                    case SyntaxKind.AsKeyword:
+                        return parseNamespaceExportDeclaration(pos, hasJSDoc, modifiersIn);
+                    default:
+                        return parseExportDeclaration(pos, hasJSDoc, modifiersIn);
+                }
+            default:
+                if (modifiersIn) {
+                    // We reached this point because we encountered decorators and/or modifiers and assumed a declaration
+                    // would follow. For recovery and error reporting purposes, return an incomplete declaration.
+                    const missing = createMissingNode<MissingDeclaration>(SyntaxKind.MissingDeclaration, /*reportAtCurrentPosition*/ true, Diagnostics.Declaration_expected);
+                    setTextRangePos(missing, pos);
+                    (missing as Mutable<MissingDeclaration>).modifiers = modifiersIn;
+                    return missing;
+                }
+                return undefined!; // TODO: GH#18217
+        }
+    }
+
+    function nextTokenIsStringLiteral() {
+        return nextToken() === SyntaxKind.StringLiteral;
+    }
+    function nextTokenIsIdentifierOrStringLiteralOnSameLine() {
+        nextToken();
+        return !scanner.hasPrecedingLineBreak() && (isIdentifier() || token() === SyntaxKind.StringLiteral);
+    }
+
+    function parseFunctionBlockOrSemicolon(flags: SignatureFlags, diagnosticMessage?: DiagnosticMessage): Block | undefined {
+        if (token() !== SyntaxKind.OpenBraceToken) {
+            if (flags & SignatureFlags.Type) {
+                parseTypeMemberSemicolon();
+                return;
+            }
+            if (canParseSemicolon()) {
+                parseSemicolon();
+                return;
+            }
+        }
+        return parseFunctionBlock(flags, diagnosticMessage);
+    }
+
+    // DECLARATIONS
+
+    function parseArrayBindingElement(): ArrayBindingElement {
+        const pos = getNodePos();
+        if (token() === SyntaxKind.CommaToken) {
+            return finishNode(factory.createOmittedExpression(), pos);
+        }
+        const dotDotDotToken = parseOptionalToken(SyntaxKind.DotDotDotToken);
+        const name = parseIdentifierOrPattern();
+        const initializer = parseInitializer();
+        return finishNode(factory.createBindingElement(dotDotDotToken, /*propertyName*/ undefined, name, initializer), pos);
+    }
+
+    function parseObjectBindingElement(): BindingElement {
+        const pos = getNodePos();
+        const dotDotDotToken = parseOptionalToken(SyntaxKind.DotDotDotToken);
+        const tokenIsIdentifier = isBindingIdentifier();
+        let propertyName: PropertyName | undefined = parsePropertyName();
+        let name: BindingName;
+        if (tokenIsIdentifier && token() !== SyntaxKind.ColonToken) {
+            name = propertyName as Identifier;
+            propertyName = undefined;
+        }
+        else {
+            parseExpected(SyntaxKind.ColonToken);
+            name = parseIdentifierOrPattern();
+        }
+        const initializer = parseInitializer();
+        return finishNode(factory.createBindingElement(dotDotDotToken, propertyName, name, initializer), pos);
+    }
+
+    function parseObjectBindingPattern(): ObjectBindingPattern {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.OpenBraceToken);
+        const elements = allowInAnd(() => parseDelimitedList(ParsingContext.ObjectBindingElements, parseObjectBindingElement));
+        parseExpected(SyntaxKind.CloseBraceToken);
+        return finishNode(factory.createObjectBindingPattern(elements), pos);
+    }
+
+    function parseArrayBindingPattern(): ArrayBindingPattern {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.OpenBracketToken);
+        const elements = allowInAnd(() => parseDelimitedList(ParsingContext.ArrayBindingElements, parseArrayBindingElement));
+        parseExpected(SyntaxKind.CloseBracketToken);
+        return finishNode(factory.createArrayBindingPattern(elements), pos);
+    }
+
+    function isBindingIdentifierOrPrivateIdentifierOrPattern() {
+        return token() === SyntaxKind.OpenBraceToken
+            || token() === SyntaxKind.OpenBracketToken
+            || token() === SyntaxKind.PrivateIdentifier
+            || isBindingIdentifier();
+    }
+
+    function parseIdentifierOrPattern(privateIdentifierDiagnosticMessage?: DiagnosticMessage): Identifier | BindingPattern {
+        if (token() === SyntaxKind.OpenBracketToken) {
+            return parseArrayBindingPattern();
+        }
+        if (token() === SyntaxKind.OpenBraceToken) {
+            return parseObjectBindingPattern();
+        }
+        return parseBindingIdentifier(privateIdentifierDiagnosticMessage);
+    }
+
+    function parseVariableDeclarationAllowExclamation() {
+        return parseVariableDeclaration(/*allowExclamation*/ true);
+    }
+
+    function parseVariableDeclaration(allowExclamation?: boolean): VariableDeclaration {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        const name = parseIdentifierOrPattern(Diagnostics.Private_identifiers_are_not_allowed_in_variable_declarations);
+        let exclamationToken: ExclamationToken | undefined;
+        if (
+            allowExclamation && name.kind === SyntaxKind.Identifier &&
+            token() === SyntaxKind.ExclamationToken && !scanner.hasPrecedingLineBreak()
+        ) {
+            exclamationToken = parseTokenNode<Token<SyntaxKind.ExclamationToken>>();
+        }
+        const type = parseTypeAnnotation();
+        const initializer = isInOrOfKeyword(token()) ? undefined : parseInitializer();
+        const node = factoryCreateVariableDeclaration(name, exclamationToken, type, initializer);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseVariableDeclarationList(inForStatementInitializer: boolean): VariableDeclarationList {
+        const pos = getNodePos();
+
+        let flags: NodeFlags = 0;
+        switch (token()) {
+            case SyntaxKind.VarKeyword:
+                break;
+            case SyntaxKind.LetKeyword:
+                flags |= NodeFlags.Let;
+                break;
+            case SyntaxKind.ConstKeyword:
+                flags |= NodeFlags.Const;
+                break;
+            case SyntaxKind.UsingKeyword:
+                flags |= NodeFlags.Using;
+                break;
+            case SyntaxKind.AwaitKeyword:
+                Debug.assert(isAwaitUsingDeclaration());
+                flags |= NodeFlags.AwaitUsing;
+                nextToken();
+                break;
+            default:
+                Debug.fail();
+        }
+
+        nextToken();
+
+        // The user may have written the following:
+        //
+        //    for (let of X) { }
+        //
+        // In this case, we want to parse an empty declaration list, and then parse 'of'
+        // as a keyword. The reason this is not automatic is that 'of' is a valid identifier.
+        // So we need to look ahead to determine if 'of' should be treated as a keyword in
+        // this context.
+        // The checker will then give an error that there is an empty declaration list.
+        let declarations: readonly VariableDeclaration[];
+        if (token() === SyntaxKind.OfKeyword && lookAhead(canFollowContextualOfKeyword)) {
+            declarations = createMissingList<VariableDeclaration>();
+        }
+        else {
+            const savedDisallowIn = inDisallowInContext();
+            setDisallowInContext(inForStatementInitializer);
+
+            declarations = parseDelimitedList(
+                ParsingContext.VariableDeclarations,
+                inForStatementInitializer ? parseVariableDeclaration : parseVariableDeclarationAllowExclamation,
+            );
+
+            setDisallowInContext(savedDisallowIn);
+        }
+
+        return finishNode(factoryCreateVariableDeclarationList(declarations, flags), pos);
+    }
+
+    function canFollowContextualOfKeyword(): boolean {
+        return nextTokenIsIdentifier() && nextToken() === SyntaxKind.CloseParenToken;
+    }
+
+    function parseVariableStatement(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): VariableStatement {
+        const declarationList = parseVariableDeclarationList(/*inForStatementInitializer*/ false);
+        parseSemicolon();
+        const node = factoryCreateVariableStatement(modifiers, declarationList);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseFunctionDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): FunctionDeclaration {
+        const savedAwaitContext = inAwaitContext();
+        const modifierFlags = modifiersToFlags(modifiers);
+        parseExpected(SyntaxKind.FunctionKeyword);
+        const asteriskToken = parseOptionalToken(SyntaxKind.AsteriskToken);
+        // We don't parse the name here in await context, instead we will report a grammar error in the checker.
+        const name = modifierFlags & ModifierFlags.Default ? parseOptionalBindingIdentifier() : parseBindingIdentifier();
+        const isGenerator = asteriskToken ? SignatureFlags.Yield : SignatureFlags.None;
+        const isAsync = modifierFlags & ModifierFlags.Async ? SignatureFlags.Await : SignatureFlags.None;
+        const typeParameters = parseTypeParameters();
+        if (modifierFlags & ModifierFlags.Export) setAwaitContext(/*value*/ true);
+        const parameters = parseParameters(isGenerator | isAsync);
+        const type = parseReturnType(SyntaxKind.ColonToken, /*isType*/ false);
+        const body = parseFunctionBlockOrSemicolon(isGenerator | isAsync, Diagnostics.or_expected);
+        setAwaitContext(savedAwaitContext);
+        const node = factory.createFunctionDeclaration(modifiers, asteriskToken, name, typeParameters, parameters, type, body);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseConstructorName() {
+        if (token() === SyntaxKind.ConstructorKeyword) {
+            return parseExpected(SyntaxKind.ConstructorKeyword);
+        }
+        if (token() === SyntaxKind.StringLiteral && lookAhead(nextToken) === SyntaxKind.OpenParenToken) {
+            return tryParse(() => {
+                const literalNode = parseLiteralNode();
+                return literalNode.text === "constructor" ? literalNode : undefined;
+            });
+        }
+    }
+
+    function tryParseConstructorDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): ConstructorDeclaration | undefined {
+        return tryParse(() => {
+            if (parseConstructorName()) {
+                const typeParameters = parseTypeParameters();
+                const parameters = parseParameters(SignatureFlags.None);
+                const type = parseReturnType(SyntaxKind.ColonToken, /*isType*/ false);
+                const body = parseFunctionBlockOrSemicolon(SignatureFlags.None, Diagnostics.or_expected);
+                const node = factory.createConstructorDeclaration(modifiers, parameters, body);
+
+                // Attach invalid nodes if they exist so that we can report them in the grammar checker.
+                (node as Mutable<ConstructorDeclaration>).typeParameters = typeParameters;
+                (node as Mutable<ConstructorDeclaration>).type = type;
+                return withJSDoc(finishNode(node, pos), hasJSDoc);
+            }
+        });
+    }
+
+    function parseMethodDeclaration(
+        pos: number,
+        hasJSDoc: boolean,
+        modifiers: NodeArray<ModifierLike> | undefined,
+        asteriskToken: AsteriskToken | undefined,
+        name: PropertyName,
+        questionToken: QuestionToken | undefined,
+        exclamationToken: ExclamationToken | undefined,
+        diagnosticMessage?: DiagnosticMessage,
+    ): MethodDeclaration {
+        const isGenerator = asteriskToken ? SignatureFlags.Yield : SignatureFlags.None;
+        const isAsync = some(modifiers, isAsyncModifier) ? SignatureFlags.Await : SignatureFlags.None;
+        const typeParameters = parseTypeParameters();
+        const parameters = parseParameters(isGenerator | isAsync);
+        const type = parseReturnType(SyntaxKind.ColonToken, /*isType*/ false);
+        const body = parseFunctionBlockOrSemicolon(isGenerator | isAsync, diagnosticMessage);
+        const node = factory.createMethodDeclaration(
+            modifiers,
+            asteriskToken,
+            name,
+            questionToken,
+            typeParameters,
+            parameters,
+            type,
+            body,
+        );
+
+        // An exclamation token on a method is invalid syntax and will be handled by the grammar checker
+        (node as Mutable<MethodDeclaration>).exclamationToken = exclamationToken;
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parsePropertyDeclaration(
+        pos: number,
+        hasJSDoc: boolean,
+        modifiers: NodeArray<ModifierLike> | undefined,
+        name: PropertyName,
+        questionToken: QuestionToken | undefined,
+    ): PropertyDeclaration {
+        const exclamationToken = !questionToken && !scanner.hasPrecedingLineBreak() ? parseOptionalToken(SyntaxKind.ExclamationToken) : undefined;
+        const type = parseTypeAnnotation();
+        const initializer = doOutsideOfContext(NodeFlags.YieldContext | NodeFlags.AwaitContext | NodeFlags.DisallowInContext, parseInitializer);
+        parseSemicolonAfterPropertyName(name, type, initializer);
+        const node = factory.createPropertyDeclaration(
+            modifiers,
+            name,
+            questionToken || exclamationToken,
+            type,
+            initializer,
+        );
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parsePropertyOrMethodDeclaration(
+        pos: number,
+        hasJSDoc: boolean,
+        modifiers: NodeArray<ModifierLike> | undefined,
+    ): PropertyDeclaration | MethodDeclaration {
+        const asteriskToken = parseOptionalToken(SyntaxKind.AsteriskToken);
+        const name = parsePropertyName();
+        // Note: this is not legal as per the grammar.  But we allow it in the parser and
+        // report an error in the grammar checker.
+        const questionToken = parseOptionalToken(SyntaxKind.QuestionToken);
+        if (asteriskToken || token() === SyntaxKind.OpenParenToken || token() === SyntaxKind.LessThanToken) {
+            return parseMethodDeclaration(pos, hasJSDoc, modifiers, asteriskToken, name, questionToken, /*exclamationToken*/ undefined, Diagnostics.or_expected);
+        }
+        return parsePropertyDeclaration(pos, hasJSDoc, modifiers, name, questionToken);
+    }
+
+    function parseAccessorDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined, kind: AccessorDeclaration["kind"], flags: SignatureFlags): AccessorDeclaration {
+        const name = parsePropertyName();
+        const typeParameters = parseTypeParameters();
+        const parameters = parseParameters(SignatureFlags.None);
+        const type = parseReturnType(SyntaxKind.ColonToken, /*isType*/ false);
+        const body = parseFunctionBlockOrSemicolon(flags);
+        const node = kind === SyntaxKind.GetAccessor
+            ? factory.createGetAccessorDeclaration(modifiers, name, parameters, type, body)
+            : factory.createSetAccessorDeclaration(modifiers, name, parameters, body);
+        // Keep track of `typeParameters` (for both) and `type` (for setters) if they were parsed those indicate grammar errors
+        (node as Mutable<AccessorDeclaration>).typeParameters = typeParameters;
+        if (isSetAccessorDeclaration(node)) (node as Mutable<SetAccessorDeclaration>).type = type;
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function isClassMemberStart(): boolean {
+        let idToken: SyntaxKind | undefined;
+
+        if (token() === SyntaxKind.AtToken) {
+            return true;
+        }
+
+        // Eat up all modifiers, but hold on to the last one in case it is actually an identifier.
+        while (isModifierKind(token())) {
+            idToken = token();
+            // If the idToken is a class modifier (protected, private, public, and static), it is
+            // certain that we are starting to parse class member. This allows better error recovery
+            // Example:
+            //      public foo() ...     // true
+            //      public @dec blah ... // true; we will then report an error later
+            //      export public ...    // true; we will then report an error later
+            if (isClassMemberModifier(idToken)) {
+                return true;
+            }
+
+            nextToken();
+        }
+
+        if (token() === SyntaxKind.AsteriskToken) {
+            return true;
+        }
+
+        // Try to get the first property-like token following all modifiers.
+        // This can either be an identifier or the 'get' or 'set' keywords.
+        if (isLiteralPropertyName()) {
+            idToken = token();
+            nextToken();
+        }
+
+        // Index signatures and computed properties are class members; we can parse.
+        if (token() === SyntaxKind.OpenBracketToken) {
+            return true;
+        }
+
+        // If we were able to get any potential identifier...
+        if (idToken !== undefined) {
+            // If we have a non-keyword identifier, or if we have an accessor, then it's safe to parse.
+            if (!isKeyword(idToken) || idToken === SyntaxKind.SetKeyword || idToken === SyntaxKind.GetKeyword) {
+                return true;
+            }
+
+            // If it *is* a keyword, but not an accessor, check a little farther along
+            // to see if it should actually be parsed as a class member.
+            switch (token()) {
+                case SyntaxKind.OpenParenToken: // Method declaration
+                case SyntaxKind.LessThanToken: // Generic Method declaration
+                case SyntaxKind.ExclamationToken: // Non-null assertion on property name
+                case SyntaxKind.ColonToken: // Type Annotation for declaration
+                case SyntaxKind.EqualsToken: // Initializer for declaration
+                case SyntaxKind.QuestionToken: // Not valid, but permitted so that it gets caught later on.
+                    return true;
+                default:
+                    // Covers
+                    //  - Semicolons     (declaration termination)
+                    //  - Closing braces (end-of-class, must be declaration)
+                    //  - End-of-files   (not valid, but permitted so that it gets caught later on)
+                    //  - Line-breaks    (enabling *automatic semicolon insertion*)
+                    return canParseSemicolon();
+            }
+        }
+
+        return false;
+    }
+
+    function parseClassStaticBlockDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): ClassStaticBlockDeclaration {
+        parseExpectedToken(SyntaxKind.StaticKeyword);
+        const body = parseClassStaticBlockBody();
+        const node = withJSDoc(finishNode(factory.createClassStaticBlockDeclaration(body), pos), hasJSDoc);
+        (node as Mutable<ClassStaticBlockDeclaration>).modifiers = modifiers;
+        return node;
+    }
+
+    function parseClassStaticBlockBody() {
+        const savedYieldContext = inYieldContext();
+        const savedAwaitContext = inAwaitContext();
+
+        setYieldContext(false);
+        setAwaitContext(true);
+
+        const body = parseBlock(/*ignoreMissingOpenBrace*/ false);
+
+        setYieldContext(savedYieldContext);
+        setAwaitContext(savedAwaitContext);
+
+        return body;
+    }
+
+    function parseDecoratorExpression() {
+        if (inAwaitContext() && token() === SyntaxKind.AwaitKeyword) {
+            // `@await` is is disallowed in an [Await] context, but can cause parsing to go off the rails
+            // This simply parses the missing identifier and moves on.
+            const pos = getNodePos();
+            const awaitExpression = parseIdentifier(Diagnostics.Expression_expected);
+            nextToken();
+            const memberExpression = parseMemberExpressionRest(pos, awaitExpression, /*allowOptionalChain*/ true);
+            return parseCallExpressionRest(pos, memberExpression);
+        }
+        return parseLeftHandSideExpressionOrHigher();
+    }
+
+    function tryParseDecorator(): Decorator | undefined {
+        const pos = getNodePos();
+        if (!parseOptional(SyntaxKind.AtToken)) {
+            return undefined;
+        }
+        const expression = doInDecoratorContext(parseDecoratorExpression);
+        return finishNode(factory.createDecorator(expression), pos);
+    }
+
+    function tryParseModifier(hasSeenStaticModifier: boolean, permitConstAsModifier?: boolean, stopOnStartOfClassStaticBlock?: boolean): Modifier | undefined {
+        const pos = getNodePos();
+        const kind = token();
+
+        if (token() === SyntaxKind.ConstKeyword && permitConstAsModifier) {
+            // We need to ensure that any subsequent modifiers appear on the same line
+            // so that when 'const' is a standalone declaration, we don't issue an error.
+            if (!tryParse(nextTokenIsOnSameLineAndCanFollowModifier)) {
+                return undefined;
+            }
+        }
+        else if (stopOnStartOfClassStaticBlock && token() === SyntaxKind.StaticKeyword && lookAhead(nextTokenIsOpenBrace)) {
+            return undefined;
+        }
+        else if (hasSeenStaticModifier && token() === SyntaxKind.StaticKeyword) {
+            return undefined;
+        }
+        else {
+            if (!parseAnyContextualModifier()) {
+                return undefined;
+            }
+        }
+
+        return finishNode(factoryCreateToken(kind as Modifier["kind"]), pos);
+    }
+
+    /*
+     * There are situations in which a modifier like 'const' will appear unexpectedly, such as on a class member.
+     * In those situations, if we are entirely sure that 'const' is not valid on its own (such as when ASI takes effect
+     * and turns it into a standalone declaration), then it is better to parse it and report an error later.
+     *
+     * In such situations, 'permitConstAsModifier' should be set to true.
+     */
+    function parseModifiers(allowDecorators: false, permitConstAsModifier?: boolean, stopOnStartOfClassStaticBlock?: boolean): NodeArray<Modifier> | undefined;
+    function parseModifiers(allowDecorators: true, permitConstAsModifier?: boolean, stopOnStartOfClassStaticBlock?: boolean): NodeArray<ModifierLike> | undefined;
+    function parseModifiers(allowDecorators: boolean, permitConstAsModifier?: boolean, stopOnStartOfClassStaticBlock?: boolean): NodeArray<ModifierLike> | undefined {
+        const pos = getNodePos();
+        let list: ModifierLike[] | undefined;
+        let decorator, modifier, hasSeenStaticModifier = false, hasLeadingModifier = false, hasTrailingDecorator = false;
+
+        // Decorators should be contiguous in a list of modifiers but can potentially appear in two places (i.e., `[...leadingDecorators, ...leadingModifiers, ...trailingDecorators, ...trailingModifiers]`).
+        // The leading modifiers *should* only contain `export` and `default` when trailingDecorators are present, but we'll handle errors for any other leading modifiers in the checker.
+        // It is illegal to have both leadingDecorators and trailingDecorators, but we will report that as a grammar check in the checker.
+
+        // parse leading decorators
+        if (allowDecorators && token() === SyntaxKind.AtToken) {
+            while (decorator = tryParseDecorator()) {
+                list = append(list, decorator);
+            }
+        }
+
+        // parse leading modifiers
+        while (modifier = tryParseModifier(hasSeenStaticModifier, permitConstAsModifier, stopOnStartOfClassStaticBlock)) {
+            if (modifier.kind === SyntaxKind.StaticKeyword) hasSeenStaticModifier = true;
+            list = append(list, modifier);
+            hasLeadingModifier = true;
+        }
+
+        // parse trailing decorators, but only if we parsed any leading modifiers
+        if (hasLeadingModifier && allowDecorators && token() === SyntaxKind.AtToken) {
+            while (decorator = tryParseDecorator()) {
+                list = append(list, decorator);
+                hasTrailingDecorator = true;
+            }
+        }
+
+        // parse trailing modifiers, but only if we parsed any trailing decorators
+        if (hasTrailingDecorator) {
+            while (modifier = tryParseModifier(hasSeenStaticModifier, permitConstAsModifier, stopOnStartOfClassStaticBlock)) {
+                if (modifier.kind === SyntaxKind.StaticKeyword) hasSeenStaticModifier = true;
+                list = append(list, modifier);
+            }
+        }
+
+        return list && createNodeArray(list, pos);
+    }
+
+    function parseModifiersForArrowFunction(): NodeArray<Modifier> | undefined {
+        let modifiers: NodeArray<Modifier> | undefined;
+        if (token() === SyntaxKind.AsyncKeyword) {
+            const pos = getNodePos();
+            nextToken();
+            const modifier = finishNode(factoryCreateToken(SyntaxKind.AsyncKeyword), pos);
+            modifiers = createNodeArray<Modifier>([modifier], pos);
+        }
+        return modifiers;
+    }
+
+    function parseClassElement(): ClassElement {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        if (token() === SyntaxKind.SemicolonToken) {
+            nextToken();
+            return withJSDoc(finishNode(factory.createSemicolonClassElement(), pos), hasJSDoc);
+        }
+
+        const modifiers = parseModifiers(/*allowDecorators*/ true, /*permitConstAsModifier*/ true, /*stopOnStartOfClassStaticBlock*/ true);
+        if (token() === SyntaxKind.StaticKeyword && lookAhead(nextTokenIsOpenBrace)) {
+            return parseClassStaticBlockDeclaration(pos, hasJSDoc, modifiers);
+        }
+
+        if (parseContextualModifier(SyntaxKind.GetKeyword)) {
+            return parseAccessorDeclaration(pos, hasJSDoc, modifiers, SyntaxKind.GetAccessor, SignatureFlags.None);
+        }
+
+        if (parseContextualModifier(SyntaxKind.SetKeyword)) {
+            return parseAccessorDeclaration(pos, hasJSDoc, modifiers, SyntaxKind.SetAccessor, SignatureFlags.None);
+        }
+
+        if (token() === SyntaxKind.ConstructorKeyword || token() === SyntaxKind.StringLiteral) {
+            const constructorDeclaration = tryParseConstructorDeclaration(pos, hasJSDoc, modifiers);
+            if (constructorDeclaration) {
+                return constructorDeclaration;
+            }
+        }
+
+        if (isIndexSignature()) {
+            return parseIndexSignatureDeclaration(pos, hasJSDoc, modifiers);
+        }
+
+        // It is very important that we check this *after* checking indexers because
+        // the [ token can start an index signature or a computed property name
+        if (
+            tokenIsIdentifierOrKeyword(token()) ||
+            token() === SyntaxKind.StringLiteral ||
+            token() === SyntaxKind.NumericLiteral ||
+            token() === SyntaxKind.AsteriskToken ||
+            token() === SyntaxKind.OpenBracketToken
+        ) {
+            const isAmbient = some(modifiers, isDeclareModifier);
+            if (isAmbient) {
+                for (const m of modifiers!) {
+                    (m as Mutable<Node>).flags |= NodeFlags.Ambient;
+                }
+                return doInsideOfContext(NodeFlags.Ambient, () => parsePropertyOrMethodDeclaration(pos, hasJSDoc, modifiers));
+            }
+            else {
+                return parsePropertyOrMethodDeclaration(pos, hasJSDoc, modifiers);
+            }
+        }
+
+        if (modifiers) {
+            // treat this as a property declaration with a missing name.
+            const name = createMissingNode<Identifier>(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ true, Diagnostics.Declaration_expected);
+            return parsePropertyDeclaration(pos, hasJSDoc, modifiers, name, /*questionToken*/ undefined);
+        }
+
+        // 'isClassMemberStart' should have hinted not to attempt parsing.
+        return Debug.fail("Should not have attempted to parse class member declaration.");
+    }
+
+    function parseDecoratedExpression(): PrimaryExpression {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        const modifiers = parseModifiers(/*allowDecorators*/ true);
+        if (token() === SyntaxKind.ClassKeyword) {
+            return parseClassDeclarationOrExpression(pos, hasJSDoc, modifiers, SyntaxKind.ClassExpression) as ClassExpression;
+        }
+
+        const missing = createMissingNode<MissingDeclaration>(SyntaxKind.MissingDeclaration, /*reportAtCurrentPosition*/ true, Diagnostics.Expression_expected);
+        setTextRangePos(missing, pos);
+        (missing as Mutable<MissingDeclaration>).modifiers = modifiers;
+        return missing;
+    }
+
+    function parseClassExpression(): ClassExpression {
+        return parseClassDeclarationOrExpression(getNodePos(), hasPrecedingJSDocComment(), /*modifiers*/ undefined, SyntaxKind.ClassExpression) as ClassExpression;
+    }
+
+    function parseClassDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): ClassDeclaration {
+        return parseClassDeclarationOrExpression(pos, hasJSDoc, modifiers, SyntaxKind.ClassDeclaration) as ClassDeclaration;
+    }
+
+    function parseClassDeclarationOrExpression(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined, kind: ClassLikeDeclaration["kind"]): ClassLikeDeclaration {
+        const savedAwaitContext = inAwaitContext();
+        parseExpected(SyntaxKind.ClassKeyword);
+
+        // We don't parse the name here in await context, instead we will report a grammar error in the checker.
+        const name = parseNameOfClassDeclarationOrExpression();
+        const typeParameters = parseTypeParameters();
+        if (some(modifiers, isExportModifier)) setAwaitContext(/*value*/ true);
+        const heritageClauses = parseHeritageClauses();
+
+        let members;
+        if (parseExpected(SyntaxKind.OpenBraceToken)) {
+            // ClassTail[Yield,Await] : (Modified) See 14.5
+            //      ClassHeritage[?Yield,?Await]opt { ClassBody[?Yield,?Await]opt }
+            members = parseClassMembers();
+            parseExpected(SyntaxKind.CloseBraceToken);
+        }
+        else {
+            members = createMissingList<ClassElement>();
+        }
+        setAwaitContext(savedAwaitContext);
+        const node = kind === SyntaxKind.ClassDeclaration
+            ? factory.createClassDeclaration(modifiers, name, typeParameters, heritageClauses, members)
+            : factory.createClassExpression(modifiers, name, typeParameters, heritageClauses, members);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseNameOfClassDeclarationOrExpression(): Identifier | undefined {
+        // implements is a future reserved word so
+        // 'class implements' might mean either
+        // - class expression with omitted name, 'implements' starts heritage clause
+        // - class with name 'implements'
+        // 'isImplementsClause' helps to disambiguate between these two cases
+        return isBindingIdentifier() && !isImplementsClause()
+            ? createIdentifier(isBindingIdentifier())
+            : undefined;
+    }
+
+    function isImplementsClause() {
+        return token() === SyntaxKind.ImplementsKeyword && lookAhead(nextTokenIsIdentifierOrKeyword);
+    }
+
+    function parseHeritageClauses(): NodeArray<HeritageClause> | undefined {
+        // ClassTail[Yield,Await] : (Modified) See 14.5
+        //      ClassHeritage[?Yield,?Await]opt { ClassBody[?Yield,?Await]opt }
+
+        if (isHeritageClause()) {
+            return parseList(ParsingContext.HeritageClauses, parseHeritageClause);
+        }
+
+        return undefined;
+    }
+
+    function parseHeritageClause(): HeritageClause {
+        const pos = getNodePos();
+        const tok = token();
+        Debug.assert(tok === SyntaxKind.ExtendsKeyword || tok === SyntaxKind.ImplementsKeyword); // isListElement() should ensure this.
+        nextToken();
+        const types = parseDelimitedList(ParsingContext.HeritageClauseElement, parseExpressionWithTypeArguments);
+        return finishNode(factory.createHeritageClause(tok, types), pos);
+    }
+
+    function parseExpressionWithTypeArguments(): ExpressionWithTypeArguments {
+        const pos = getNodePos();
+        const expression = parseLeftHandSideExpressionOrHigher();
+        if (expression.kind === SyntaxKind.ExpressionWithTypeArguments) {
+            return expression as ExpressionWithTypeArguments;
+        }
+        const typeArguments = tryParseTypeArguments();
+        return finishNode(factory.createExpressionWithTypeArguments(expression, typeArguments), pos);
+    }
+
+    function tryParseTypeArguments(): NodeArray<TypeNode> | undefined {
+        return token() === SyntaxKind.LessThanToken ?
+            parseBracketedList(ParsingContext.TypeArguments, parseType, SyntaxKind.LessThanToken, SyntaxKind.GreaterThanToken) : undefined;
+    }
+
+    function isHeritageClause(): boolean {
+        return token() === SyntaxKind.ExtendsKeyword || token() === SyntaxKind.ImplementsKeyword;
+    }
+
+    function parseClassMembers(): NodeArray<ClassElement> {
+        return parseList(ParsingContext.ClassMembers, parseClassElement);
+    }
+
+    function parseInterfaceDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): InterfaceDeclaration {
+        parseExpected(SyntaxKind.InterfaceKeyword);
+        const name = parseIdentifier();
+        const typeParameters = parseTypeParameters();
+        const heritageClauses = parseHeritageClauses();
+        const members = parseObjectTypeMembers();
+        const node = factory.createInterfaceDeclaration(modifiers, name, typeParameters, heritageClauses, members);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseTypeAliasDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): TypeAliasDeclaration {
+        parseExpected(SyntaxKind.TypeKeyword);
+        if (scanner.hasPrecedingLineBreak()) {
+            parseErrorAtCurrentToken(Diagnostics.Line_break_not_permitted_here);
+        }
+        const name = parseIdentifier();
+        const typeParameters = parseTypeParameters();
+        parseExpected(SyntaxKind.EqualsToken);
+        const type = token() === SyntaxKind.IntrinsicKeyword && tryParse(parseKeywordAndNoDot) || parseType();
+        parseSemicolon();
+        const node = factory.createTypeAliasDeclaration(modifiers, name, typeParameters, type);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    // In an ambient declaration, the grammar only allows integer literals as initializers.
+    // In a non-ambient declaration, the grammar allows uninitialized members only in a
+    // ConstantEnumMemberSection, which starts at the beginning of an enum declaration
+    // or any time an integer literal initializer is encountered.
+    function parseEnumMember(): EnumMember {
+        const pos = getNodePos();
+        const hasJSDoc = hasPrecedingJSDocComment();
+        const name = parsePropertyName();
+        const initializer = allowInAnd(parseInitializer);
+        return withJSDoc(finishNode(factory.createEnumMember(name, initializer), pos), hasJSDoc);
+    }
+
+    function parseEnumDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): EnumDeclaration {
+        parseExpected(SyntaxKind.EnumKeyword);
+        const name = parseIdentifier();
+        let members;
+        if (parseExpected(SyntaxKind.OpenBraceToken)) {
+            members = doOutsideOfYieldAndAwaitContext(() => parseDelimitedList(ParsingContext.EnumMembers, parseEnumMember));
+            parseExpected(SyntaxKind.CloseBraceToken);
+        }
+        else {
+            members = createMissingList<EnumMember>();
+        }
+        const node = factory.createEnumDeclaration(modifiers, name, members);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseModuleBlock(): ModuleBlock {
+        const pos = getNodePos();
+        let statements;
+        if (parseExpected(SyntaxKind.OpenBraceToken)) {
+            statements = parseList(ParsingContext.BlockStatements, parseStatement);
+            parseExpected(SyntaxKind.CloseBraceToken);
+        }
+        else {
+            statements = createMissingList<Statement>();
+        }
+        return finishNode(factory.createModuleBlock(statements), pos);
+    }
+
+    function parseModuleOrNamespaceDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined, flags: NodeFlags): ModuleDeclaration {
+        // If we are parsing a dotted namespace name, we want to
+        // propagate the 'Namespace' flag across the names if set.
+        const namespaceFlag = flags & NodeFlags.Namespace;
+        const name = flags & NodeFlags.NestedNamespace ? parseIdentifierName() : parseIdentifier();
+        const body = parseOptional(SyntaxKind.DotToken)
+            ? parseModuleOrNamespaceDeclaration(getNodePos(), /*hasJSDoc*/ false, /*modifiers*/ undefined, NodeFlags.NestedNamespace | namespaceFlag) as NamespaceDeclaration
+            : parseModuleBlock();
+        const node = factory.createModuleDeclaration(modifiers, name, body, flags);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseAmbientExternalModuleDeclaration(pos: number, hasJSDoc: boolean, modifiersIn: NodeArray<ModifierLike> | undefined): ModuleDeclaration {
+        let flags: NodeFlags = 0;
+        let name;
+        if (token() === SyntaxKind.GlobalKeyword) {
+            // parse 'global' as name of global scope augmentation
+            name = parseIdentifier();
+            flags |= NodeFlags.GlobalAugmentation;
+        }
+        else {
+            name = parseLiteralNode() as StringLiteral;
+            name.text = internIdentifier(name.text);
+        }
+        let body: ModuleBlock | undefined;
+        if (token() === SyntaxKind.OpenBraceToken) {
+            body = parseModuleBlock();
+        }
+        else {
+            parseSemicolon();
+        }
+        const node = factory.createModuleDeclaration(modifiersIn, name, body, flags);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseModuleDeclaration(pos: number, hasJSDoc: boolean, modifiersIn: NodeArray<ModifierLike> | undefined): ModuleDeclaration {
+        let flags: NodeFlags = 0;
+        if (token() === SyntaxKind.GlobalKeyword) {
+            // global augmentation
+            return parseAmbientExternalModuleDeclaration(pos, hasJSDoc, modifiersIn);
+        }
+        else if (parseOptional(SyntaxKind.NamespaceKeyword)) {
+            flags |= NodeFlags.Namespace;
+        }
+        else {
+            parseExpected(SyntaxKind.ModuleKeyword);
+            if (token() === SyntaxKind.StringLiteral) {
+                return parseAmbientExternalModuleDeclaration(pos, hasJSDoc, modifiersIn);
+            }
+        }
+        return parseModuleOrNamespaceDeclaration(pos, hasJSDoc, modifiersIn, flags);
+    }
+
+    function isExternalModuleReference() {
+        return token() === SyntaxKind.RequireKeyword &&
+            lookAhead(nextTokenIsOpenParen);
+    }
+
+    function nextTokenIsOpenParen() {
+        return nextToken() === SyntaxKind.OpenParenToken;
+    }
+
+    function nextTokenIsOpenBrace() {
+        return nextToken() === SyntaxKind.OpenBraceToken;
+    }
+
+    function nextTokenIsSlash() {
+        return nextToken() === SyntaxKind.SlashToken;
+    }
+
+    function parseNamespaceExportDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): NamespaceExportDeclaration {
+        parseExpected(SyntaxKind.AsKeyword);
+        parseExpected(SyntaxKind.NamespaceKeyword);
+        const name = parseIdentifier();
+        parseSemicolon();
+        const node = factory.createNamespaceExportDeclaration(name);
+        // NamespaceExportDeclaration nodes cannot have decorators or modifiers, so we attach them here so we can report them in the grammar checker
+        (node as Mutable<NamespaceExportDeclaration>).modifiers = modifiers;
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseImportDeclarationOrImportEqualsDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): ImportEqualsDeclaration | ImportDeclaration {
+        parseExpected(SyntaxKind.ImportKeyword);
+
+        const afterImportPos = scanner.getTokenFullStart();
+
+        // We don't parse the identifier here in await context, instead we will report a grammar error in the checker.
+        let identifier: Identifier | undefined;
+        if (isIdentifier()) {
+            identifier = parseIdentifier();
+        }
+
+        let isTypeOnly = false;
+        if (
+            token() !== SyntaxKind.FromKeyword &&
+            identifier?.escapedText === "type" &&
+            (isIdentifier() || tokenAfterImportDefinitelyProducesImportDeclaration())
+        ) {
+            isTypeOnly = true;
+            identifier = isIdentifier() ? parseIdentifier() : undefined;
+        }
+
+        if (identifier && !tokenAfterImportedIdentifierDefinitelyProducesImportDeclaration()) {
+            return parseImportEqualsDeclaration(pos, hasJSDoc, modifiers, identifier, isTypeOnly);
+        }
+
+        // ImportDeclaration:
+        //  import ImportClause from ModuleSpecifier ;
+        //  import ModuleSpecifier;
+        let importClause: ImportClause | undefined;
+        if (
+            identifier || // import id
+            token() === SyntaxKind.AsteriskToken || // import *
+            token() === SyntaxKind.OpenBraceToken // import {
+        ) {
+            importClause = parseImportClause(identifier, afterImportPos, isTypeOnly);
+            parseExpected(SyntaxKind.FromKeyword);
+        }
+        const moduleSpecifier = parseModuleSpecifier();
+        const currentToken = token();
+        let attributes: ImportAttributes | undefined;
+        if ((currentToken === SyntaxKind.WithKeyword || currentToken === SyntaxKind.AssertKeyword) && !scanner.hasPrecedingLineBreak()) {
+            attributes = parseImportAttributes(currentToken);
+        }
+        parseSemicolon();
+        const node = factory.createImportDeclaration(modifiers, importClause, moduleSpecifier, attributes);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseImportAttribute() {
+        const pos = getNodePos();
+        const name = tokenIsIdentifierOrKeyword(token()) ? parseIdentifierName() : parseLiteralLikeNode(SyntaxKind.StringLiteral) as StringLiteral;
+        parseExpected(SyntaxKind.ColonToken);
+        const value = parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true);
+        return finishNode(factory.createImportAttribute(name, value), pos);
+    }
+
+    function parseImportAttributes(token: SyntaxKind.AssertKeyword | SyntaxKind.WithKeyword, skipKeyword?: true) {
+        const pos = getNodePos();
+        if (!skipKeyword) {
+            parseExpected(token);
+        }
+        const openBracePosition = scanner.getTokenStart();
+        if (parseExpected(SyntaxKind.OpenBraceToken)) {
+            const multiLine = scanner.hasPrecedingLineBreak();
+            const elements = parseDelimitedList(ParsingContext.ImportAttributes, parseImportAttribute, /*considerSemicolonAsDelimiter*/ true);
+            if (!parseExpected(SyntaxKind.CloseBraceToken)) {
+                const lastError = lastOrUndefined(parseDiagnostics);
+                if (lastError && lastError.code === Diagnostics._0_expected.code) {
+                    addRelatedInfo(
+                        lastError,
+                        createDetachedDiagnostic(fileName, sourceText, openBracePosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, "{", "}"),
+                    );
+                }
+            }
+            return finishNode(factory.createImportAttributes(elements, multiLine, token), pos);
+        }
+        else {
+            const elements = createNodeArray([], getNodePos(), /*end*/ undefined, /*hasTrailingComma*/ false);
+            return finishNode(factory.createImportAttributes(elements, /*multiLine*/ false, token), pos);
+        }
+    }
+
+    function tokenAfterImportDefinitelyProducesImportDeclaration() {
+        return token() === SyntaxKind.AsteriskToken || token() === SyntaxKind.OpenBraceToken;
+    }
+
+    function tokenAfterImportedIdentifierDefinitelyProducesImportDeclaration() {
+        // In `import id ___`, the current token decides whether to produce
+        // an ImportDeclaration or ImportEqualsDeclaration.
+        return token() === SyntaxKind.CommaToken || token() === SyntaxKind.FromKeyword;
+    }
+
+    function parseImportEqualsDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined, identifier: Identifier, isTypeOnly: boolean): ImportEqualsDeclaration {
+        parseExpected(SyntaxKind.EqualsToken);
+        const moduleReference = parseModuleReference();
+        parseSemicolon();
+        const node = factory.createImportEqualsDeclaration(modifiers, isTypeOnly, identifier, moduleReference);
+        const finished = withJSDoc(finishNode(node, pos), hasJSDoc);
+        return finished;
+    }
+
+    function parseImportClause(identifier: Identifier | undefined, pos: number, isTypeOnly: boolean) {
+        // ImportClause:
+        //  ImportedDefaultBinding
+        //  NameSpaceImport
+        //  NamedImports
+        //  ImportedDefaultBinding, NameSpaceImport
+        //  ImportedDefaultBinding, NamedImports
+
+        // If there was no default import or if there is comma token after default import
+        // parse namespace or named imports
+        let namedBindings: NamespaceImport | NamedImports | undefined;
+        if (
+            !identifier ||
+            parseOptional(SyntaxKind.CommaToken)
+        ) {
+            namedBindings = token() === SyntaxKind.AsteriskToken ? parseNamespaceImport() : parseNamedImportsOrExports(SyntaxKind.NamedImports);
+        }
+
+        return finishNode(factory.createImportClause(isTypeOnly, identifier, namedBindings), pos);
+    }
+
+    function parseModuleReference() {
+        return isExternalModuleReference()
+            ? parseExternalModuleReference()
+            : parseEntityName(/*allowReservedWords*/ false);
+    }
+
+    function parseExternalModuleReference() {
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.RequireKeyword);
+        parseExpected(SyntaxKind.OpenParenToken);
+        const expression = parseModuleSpecifier();
+        parseExpected(SyntaxKind.CloseParenToken);
+        return finishNode(factory.createExternalModuleReference(expression), pos);
+    }
+
+    function parseModuleSpecifier(): Expression {
+        if (token() === SyntaxKind.StringLiteral) {
+            const result = parseLiteralNode();
+            result.text = internIdentifier(result.text);
+            return result;
+        }
+        else {
+            // We allow arbitrary expressions here, even though the grammar only allows string
+            // literals.  We check to ensure that it is only a string literal later in the grammar
+            // check pass.
+            return parseExpression();
+        }
+    }
+
+    function parseNamespaceImport(): NamespaceImport {
+        // NameSpaceImport:
+        //  * as ImportedBinding
+        const pos = getNodePos();
+        parseExpected(SyntaxKind.AsteriskToken);
+        parseExpected(SyntaxKind.AsKeyword);
+        const name = parseIdentifier();
+        return finishNode(factory.createNamespaceImport(name), pos);
+    }
+
+    function parseNamedImportsOrExports(kind: SyntaxKind.NamedImports): NamedImports;
+    function parseNamedImportsOrExports(kind: SyntaxKind.NamedExports): NamedExports;
+    function parseNamedImportsOrExports(kind: SyntaxKind): NamedImportsOrExports {
+        const pos = getNodePos();
+
+        // NamedImports:
+        //  { }
+        //  { ImportsList }
+        //  { ImportsList, }
+
+        // ImportsList:
+        //  ImportSpecifier
+        //  ImportsList, ImportSpecifier
+        const node = kind === SyntaxKind.NamedImports
+            ? factory.createNamedImports(parseBracketedList(ParsingContext.ImportOrExportSpecifiers, parseImportSpecifier, SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken))
+            : factory.createNamedExports(parseBracketedList(ParsingContext.ImportOrExportSpecifiers, parseExportSpecifier, SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken));
+        return finishNode(node, pos);
+    }
+
+    function parseExportSpecifier() {
+        const hasJSDoc = hasPrecedingJSDocComment();
+        return withJSDoc(parseImportOrExportSpecifier(SyntaxKind.ExportSpecifier) as ExportSpecifier, hasJSDoc);
+    }
+
+    function parseImportSpecifier() {
+        return parseImportOrExportSpecifier(SyntaxKind.ImportSpecifier) as ImportSpecifier;
+    }
+
+    function parseImportOrExportSpecifier(kind: SyntaxKind): ImportOrExportSpecifier {
+        const pos = getNodePos();
+        // ImportSpecifier:
+        //   BindingIdentifier
+        //   IdentifierName as BindingIdentifier
+        // ExportSpecifier:
+        //   IdentifierName
+        //   IdentifierName as IdentifierName
+        let checkIdentifierIsKeyword = isKeyword(token()) && !isIdentifier();
+        let checkIdentifierStart = scanner.getTokenStart();
+        let checkIdentifierEnd = scanner.getTokenEnd();
+        let isTypeOnly = false;
+        let propertyName: Identifier | undefined;
+        let canParseAsKeyword = true;
+        let name = parseIdentifierName();
+        if (name.escapedText === "type") {
+            // If the first token of an import specifier is 'type', there are a lot of possibilities,
+            // especially if we see 'as' afterwards:
+            //
+            // import { type } from "mod";          - isTypeOnly: false,   name: type
+            // import { type as } from "mod";       - isTypeOnly: true,    name: as
+            // import { type as as } from "mod";    - isTypeOnly: false,   name: as,    propertyName: type
+            // import { type as as as } from "mod"; - isTypeOnly: true,    name: as,    propertyName: as
+            if (token() === SyntaxKind.AsKeyword) {
+                // { type as ...? }
+                const firstAs = parseIdentifierName();
+                if (token() === SyntaxKind.AsKeyword) {
+                    // { type as as ...? }
+                    const secondAs = parseIdentifierName();
+                    if (tokenIsIdentifierOrKeyword(token())) {
+                        // { type as as something }
+                        isTypeOnly = true;
+                        propertyName = firstAs;
+                        name = parseNameWithKeywordCheck();
+                        canParseAsKeyword = false;
+                    }
+                    else {
+                        // { type as as }
+                        propertyName = name;
+                        name = secondAs;
+                        canParseAsKeyword = false;
+                    }
+                }
+                else if (tokenIsIdentifierOrKeyword(token())) {
+                    // { type as something }
+                    propertyName = name;
+                    canParseAsKeyword = false;
+                    name = parseNameWithKeywordCheck();
+                }
+                else {
+                    // { type as }
+                    isTypeOnly = true;
+                    name = firstAs;
+                }
+            }
+            else if (tokenIsIdentifierOrKeyword(token())) {
+                // { type something ...? }
+                isTypeOnly = true;
+                name = parseNameWithKeywordCheck();
+            }
+        }
+
+        if (canParseAsKeyword && token() === SyntaxKind.AsKeyword) {
+            propertyName = name;
+            parseExpected(SyntaxKind.AsKeyword);
+            name = parseNameWithKeywordCheck();
+        }
+        if (kind === SyntaxKind.ImportSpecifier && checkIdentifierIsKeyword) {
+            parseErrorAt(checkIdentifierStart, checkIdentifierEnd, Diagnostics.Identifier_expected);
+        }
+        const node = kind === SyntaxKind.ImportSpecifier
+            ? factory.createImportSpecifier(isTypeOnly, propertyName, name)
+            : factory.createExportSpecifier(isTypeOnly, propertyName, name);
+        return finishNode(node, pos);
+
+        function parseNameWithKeywordCheck() {
+            checkIdentifierIsKeyword = isKeyword(token()) && !isIdentifier();
+            checkIdentifierStart = scanner.getTokenStart();
+            checkIdentifierEnd = scanner.getTokenEnd();
+            return parseIdentifierName();
+        }
+    }
+
+    function parseNamespaceExport(pos: number): NamespaceExport {
+        return finishNode(factory.createNamespaceExport(parseIdentifierName()), pos);
+    }
+
+    function parseExportDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): ExportDeclaration {
+        const savedAwaitContext = inAwaitContext();
+        setAwaitContext(/*value*/ true);
+        let exportClause: NamedExportBindings | undefined;
+        let moduleSpecifier: Expression | undefined;
+        let attributes: ImportAttributes | undefined;
+        const isTypeOnly = parseOptional(SyntaxKind.TypeKeyword);
+        const namespaceExportPos = getNodePos();
+        if (parseOptional(SyntaxKind.AsteriskToken)) {
+            if (parseOptional(SyntaxKind.AsKeyword)) {
+                exportClause = parseNamespaceExport(namespaceExportPos);
+            }
+            parseExpected(SyntaxKind.FromKeyword);
+            moduleSpecifier = parseModuleSpecifier();
+        }
+        else {
+            exportClause = parseNamedImportsOrExports(SyntaxKind.NamedExports);
+            // It is not uncommon to accidentally omit the 'from' keyword. Additionally, in editing scenarios,
+            // the 'from' keyword can be parsed as a named export when the export clause is unterminated (i.e. `export { from "moduleName";`)
+            // If we don't have a 'from' keyword, see if we have a string literal such that ASI won't take effect.
+            if (token() === SyntaxKind.FromKeyword || (token() === SyntaxKind.StringLiteral && !scanner.hasPrecedingLineBreak())) {
+                parseExpected(SyntaxKind.FromKeyword);
+                moduleSpecifier = parseModuleSpecifier();
+            }
+        }
+        const currentToken = token();
+        if (moduleSpecifier && (currentToken === SyntaxKind.WithKeyword || currentToken === SyntaxKind.AssertKeyword) && !scanner.hasPrecedingLineBreak()) {
+            attributes = parseImportAttributes(currentToken);
+        }
+        parseSemicolon();
+        setAwaitContext(savedAwaitContext);
+        const node = factory.createExportDeclaration(modifiers, isTypeOnly, exportClause, moduleSpecifier, attributes);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    function parseExportAssignment(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): ExportAssignment {
+        const savedAwaitContext = inAwaitContext();
+        setAwaitContext(/*value*/ true);
+        let isExportEquals: boolean | undefined;
+        if (parseOptional(SyntaxKind.EqualsToken)) {
+            isExportEquals = true;
+        }
+        else {
+            parseExpected(SyntaxKind.DefaultKeyword);
+        }
+        const expression = parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true);
+        parseSemicolon();
+        setAwaitContext(savedAwaitContext);
+        const node = factory.createExportAssignment(modifiers, isExportEquals, expression);
+        return withJSDoc(finishNode(node, pos), hasJSDoc);
+    }
+
+    // dprint-ignore
+    const enum ParsingContext {
+        SourceElements,            // Elements in source file
+        BlockStatements,           // Statements in block
+        SwitchClauses,             // Clauses in switch statement
+        SwitchClauseStatements,    // Statements in switch clause
+        TypeMembers,               // Members in interface or type literal
+        ClassMembers,              // Members in class declaration
+        EnumMembers,               // Members in enum declaration
+        HeritageClauseElement,     // Elements in a heritage clause
+        VariableDeclarations,      // Variable declarations in variable statement
+        ObjectBindingElements,     // Binding elements in object binding list
+        ArrayBindingElements,      // Binding elements in array binding list
+        ArgumentExpressions,       // Expressions in argument list
+        ObjectLiteralMembers,      // Members in object literal
+        JsxAttributes,             // Attributes in jsx element
+        JsxChildren,               // Things between opening and closing JSX tags
+        ArrayLiteralMembers,       // Members in array literal
+        Parameters,                // Parameters in parameter list
+        JSDocParameters,           // JSDoc parameters in parameter list of JSDoc function type
+        RestProperties,            // Property names in a rest type list
+        TypeParameters,            // Type parameters in type parameter list
+        TypeArguments,             // Type arguments in type argument list
+        TupleElementTypes,         // Element types in tuple element type list
+        HeritageClauses,           // Heritage clauses for a class or interface declaration.
+        ImportOrExportSpecifiers,  // Named import clause's import specifier list,
+        ImportAttributes,          // Import attributes
+        JSDocComment,              // Parsing via JSDocParser
+        Count,                     // Number of parsing contexts
+    }
+
+    const enum Tristate {
+        False,
+        True,
+        Unknown,
+    }
+
+    export namespace JSDocParser {
+        export function parseJSDocTypeExpressionForTests(content: string, start: number | undefined, length: number | undefined): { jsDocTypeExpression: JSDocTypeExpression; diagnostics: Diagnostic[]; } | undefined {
+            initializeState("file.js", content, ScriptTarget.Latest, /*syntaxCursor*/ undefined, ScriptKind.JS, JSDocParsingMode.ParseAll);
+            scanner.setText(content, start, length);
+            currentToken = scanner.scan();
+            const jsDocTypeExpression = parseJSDocTypeExpression();
+
+            const sourceFile = createSourceFile("file.js", ScriptTarget.Latest, ScriptKind.JS, /*isDeclarationFile*/ false, [], factoryCreateToken(SyntaxKind.EndOfFileToken), NodeFlags.None, noop);
+            const diagnostics = attachFileToDiagnostics(parseDiagnostics, sourceFile);
+            if (jsDocDiagnostics) {
+                sourceFile.jsDocDiagnostics = attachFileToDiagnostics(jsDocDiagnostics, sourceFile);
+            }
+
+            clearState();
+
+            return jsDocTypeExpression ? { jsDocTypeExpression, diagnostics } : undefined;
+        }
+
+        // Parses out a JSDoc type expression.
+        export function parseJSDocTypeExpression(mayOmitBraces?: boolean): JSDocTypeExpression {
+            const pos = getNodePos();
+            const hasBrace = (mayOmitBraces ? parseOptional : parseExpected)(SyntaxKind.OpenBraceToken);
+            const type = doInsideOfContext(NodeFlags.JSDoc, parseJSDocType);
+            if (!mayOmitBraces || hasBrace) {
+                parseExpectedJSDoc(SyntaxKind.CloseBraceToken);
+            }
+
+            const result = factory.createJSDocTypeExpression(type);
+            fixupParentReferences(result);
+            return finishNode(result, pos);
+        }
+
+        export function parseJSDocNameReference(): JSDocNameReference {
+            const pos = getNodePos();
+            const hasBrace = parseOptional(SyntaxKind.OpenBraceToken);
+            const p2 = getNodePos();
+            let entityName: EntityName | JSDocMemberName = parseEntityName(/*allowReservedWords*/ false);
+            while (token() === SyntaxKind.PrivateIdentifier) {
+                reScanHashToken(); // rescan #id as # id
+                nextTokenJSDoc(); // then skip the #
+                entityName = finishNode(factory.createJSDocMemberName(entityName, parseIdentifier()), p2);
+            }
+            if (hasBrace) {
+                parseExpectedJSDoc(SyntaxKind.CloseBraceToken);
+            }
+
+            const result = factory.createJSDocNameReference(entityName);
+            fixupParentReferences(result);
+            return finishNode(result, pos);
+        }
+
+        export function parseIsolatedJSDocComment(content: string, start: number | undefined, length: number | undefined): { jsDoc: JSDoc; diagnostics: Diagnostic[]; } | undefined {
+            initializeState("", content, ScriptTarget.Latest, /*syntaxCursor*/ undefined, ScriptKind.JS, JSDocParsingMode.ParseAll);
+            const jsDoc = doInsideOfContext(NodeFlags.JSDoc, () => parseJSDocCommentWorker(start, length));
+
+            const sourceFile = { languageVariant: LanguageVariant.Standard, text: content } as SourceFile;
+            const diagnostics = attachFileToDiagnostics(parseDiagnostics, sourceFile);
+            clearState();
+
+            return jsDoc ? { jsDoc, diagnostics } : undefined;
+        }
+
+        export function parseJSDocComment(parent: HasJSDoc, start: number, length: number): JSDoc | undefined {
+            const saveToken = currentToken;
+            const saveParseDiagnosticsLength = parseDiagnostics.length;
+            const saveParseErrorBeforeNextFinishedNode = parseErrorBeforeNextFinishedNode;
+
+            const comment = doInsideOfContext(NodeFlags.JSDoc, () => parseJSDocCommentWorker(start, length));
+            setParent(comment, parent);
+
+            if (contextFlags & NodeFlags.JavaScriptFile) {
+                if (!jsDocDiagnostics) {
+                    jsDocDiagnostics = [];
+                }
+                jsDocDiagnostics.push(...parseDiagnostics);
+            }
+            currentToken = saveToken;
+            parseDiagnostics.length = saveParseDiagnosticsLength;
+            parseErrorBeforeNextFinishedNode = saveParseErrorBeforeNextFinishedNode;
+            return comment;
+        }
+
+        const enum JSDocState {
+            BeginningOfLine,
+            SawAsterisk,
+            SavingComments,
+            SavingBackticks, // NOTE: Only used when parsing tag comments
+        }
+
+        const enum PropertyLikeParse {
+            Property = 1 << 0,
+            Parameter = 1 << 1,
+            CallbackParameter = 1 << 2,
+        }
+
+        function parseJSDocCommentWorker(start = 0, length: number | undefined): JSDoc | undefined {
+            const content = sourceText;
+            const end = length === undefined ? content.length : start + length;
+            length = end - start;
+
+            Debug.assert(start >= 0);
+            Debug.assert(start <= end);
+            Debug.assert(end <= content.length);
+
+            // Check for /** (JSDoc opening part)
+            if (!isJSDocLikeText(content, start)) {
+                return undefined;
+            }
+
+            let tags: JSDocTag[];
+            let tagsPos: number;
+            let tagsEnd: number;
+            let linkEnd: number;
+            let commentsPos: number | undefined;
+            let comments: string[] = [];
+            const parts: JSDocComment[] = [];
+
+            const saveParsingContext = parsingContext;
+            parsingContext |= 1 << ParsingContext.JSDocComment;
+
+            // + 3 for leading /**, - 5 in total for /** */
+            const result = scanner.scanRange(start + 3, length - 5, doJSDocScan);
+            parsingContext = saveParsingContext;
+            return result;
+
+            function doJSDocScan() {
+                // Initially we can parse out a tag.  We also have seen a starting asterisk.
+                // This is so that /** * @type */ doesn't parse.
+                let state = JSDocState.SawAsterisk;
+                let margin: number | undefined;
+                // + 4 for leading '/** '
+                // + 1 because the last index of \n is always one index before the first character in the line and coincidentally, if there is no \n before start, it is -1, which is also one index before the first character
+                let indent = start - (content.lastIndexOf("\n", start) + 1) + 4;
+                function pushComment(text: string) {
+                    if (!margin) {
+                        margin = indent;
+                    }
+                    comments.push(text);
+                    indent += text.length;
+                }
+
+                nextTokenJSDoc();
+                while (parseOptionalJsdoc(SyntaxKind.WhitespaceTrivia));
+                if (parseOptionalJsdoc(SyntaxKind.NewLineTrivia)) {
+                    state = JSDocState.BeginningOfLine;
+                    indent = 0;
+                }
+                loop:
+                while (true) {
+                    switch (token()) {
+                        case SyntaxKind.AtToken:
+                            removeTrailingWhitespace(comments);
+                            if (!commentsPos) commentsPos = getNodePos();
+                            addTag(parseTag(indent));
+                            // NOTE: According to usejsdoc.org, a tag goes to end of line, except the last tag.
+                            // Real-world comments may break this rule, so "BeginningOfLine" will not be a real line beginning
+                            // for malformed examples like `/** @param {string} x @returns {number} the length */`
+                            state = JSDocState.BeginningOfLine;
+                            margin = undefined;
+                            break;
+                        case SyntaxKind.NewLineTrivia:
+                            comments.push(scanner.getTokenText());
+                            state = JSDocState.BeginningOfLine;
+                            indent = 0;
+                            break;
+                        case SyntaxKind.AsteriskToken:
+                            const asterisk = scanner.getTokenText();
+                            if (state === JSDocState.SawAsterisk) {
+                                // If we've already seen an asterisk, then we can no longer parse a tag on this line
+                                state = JSDocState.SavingComments;
+                                pushComment(asterisk);
+                            }
+                            else {
+                                Debug.assert(state === JSDocState.BeginningOfLine);
+                                // Ignore the first asterisk on a line
+                                state = JSDocState.SawAsterisk;
+                                indent += asterisk.length;
+                            }
+                            break;
+                        case SyntaxKind.WhitespaceTrivia:
+                            Debug.assert(state !== JSDocState.SavingComments, "whitespace shouldn't come from the scanner while saving top-level comment text");
+                            // only collect whitespace if we're already saving comments or have just crossed the comment indent margin
+                            const whitespace = scanner.getTokenText();
+                            if (margin !== undefined && indent + whitespace.length > margin) {
+                                comments.push(whitespace.slice(margin - indent));
+                            }
+                            indent += whitespace.length;
+                            break;
+                        case SyntaxKind.EndOfFileToken:
+                            break loop;
+                        case SyntaxKind.JSDocCommentTextToken:
+                            state = JSDocState.SavingComments;
+                            pushComment(scanner.getTokenValue());
+                            break;
+                        case SyntaxKind.OpenBraceToken:
+                            state = JSDocState.SavingComments;
+                            const commentEnd = scanner.getTokenFullStart();
+                            const linkStart = scanner.getTokenEnd() - 1;
+                            const link = parseJSDocLink(linkStart);
+                            if (link) {
+                                if (!linkEnd) {
+                                    removeLeadingNewlines(comments);
+                                }
+                                parts.push(finishNode(factory.createJSDocText(comments.join("")), linkEnd ?? start, commentEnd));
+                                parts.push(link);
+                                comments = [];
+                                linkEnd = scanner.getTokenEnd();
+                                break;
+                            }
+                            // fallthrough if it's not a {@link sequence
+                        default:
+                            // Anything else is doc comment text. We just save it. Because it
+                            // wasn't a tag, we can no longer parse a tag on this line until we hit the next
+                            // line break.
+                            state = JSDocState.SavingComments;
+                            pushComment(scanner.getTokenText());
+                            break;
+                    }
+                    if (state === JSDocState.SavingComments) {
+                        nextJSDocCommentTextToken(/*inBackticks*/ false);
+                    }
+                    else {
+                        nextTokenJSDoc();
+                    }
+                }
+                const trimmedComments = comments.join("").trimEnd();
+                if (parts.length && trimmedComments.length) {
+                    parts.push(finishNode(factory.createJSDocText(trimmedComments), linkEnd ?? start, commentsPos));
+                }
+                if (parts.length && tags) Debug.assertIsDefined(commentsPos, "having parsed tags implies that the end of the comment span should be set");
+                const tagsArray = tags && createNodeArray(tags, tagsPos, tagsEnd);
+                return finishNode(factory.createJSDocComment(parts.length ? createNodeArray(parts, start, commentsPos) : trimmedComments.length ? trimmedComments : undefined, tagsArray), start, end);
+            }
+
+            function removeLeadingNewlines(comments: string[]) {
+                while (comments.length && (comments[0] === "\n" || comments[0] === "\r")) {
+                    comments.shift();
+                }
+            }
+
+            function removeTrailingWhitespace(comments: string[]) {
+                while (comments.length) {
+                    const trimmed = comments[comments.length - 1].trimEnd();
+                    if (trimmed === "") {
+                        comments.pop();
+                    }
+                    else if (trimmed.length < comments[comments.length - 1].length) {
+                        comments[comments.length - 1] = trimmed;
+                        break;
+                    }
+                    else {
+                        break;
+                    }
+                }
+            }
+
+            function isNextNonwhitespaceTokenEndOfFile(): boolean {
+                // We must use infinite lookahead, as there could be any number of newlines :(
+                while (true) {
+                    nextTokenJSDoc();
+                    if (token() === SyntaxKind.EndOfFileToken) {
+                        return true;
+                    }
+                    if (!(token() === SyntaxKind.WhitespaceTrivia || token() === SyntaxKind.NewLineTrivia)) {
+                        return false;
+                    }
+                }
+            }
+
+            function skipWhitespace(): void {
+                if (token() === SyntaxKind.WhitespaceTrivia || token() === SyntaxKind.NewLineTrivia) {
+                    if (lookAhead(isNextNonwhitespaceTokenEndOfFile)) {
+                        return; // Don't skip whitespace prior to EoF (or end of comment) - that shouldn't be included in any node's range
+                    }
+                }
+                while (token() === SyntaxKind.WhitespaceTrivia || token() === SyntaxKind.NewLineTrivia) {
+                    nextTokenJSDoc();
+                }
+            }
+
+            function skipWhitespaceOrAsterisk(): string {
+                if (token() === SyntaxKind.WhitespaceTrivia || token() === SyntaxKind.NewLineTrivia) {
+                    if (lookAhead(isNextNonwhitespaceTokenEndOfFile)) {
+                        return ""; // Don't skip whitespace prior to EoF (or end of comment) - that shouldn't be included in any node's range
+                    }
+                }
+
+                let precedingLineBreak = scanner.hasPrecedingLineBreak();
+                let seenLineBreak = false;
+                let indentText = "";
+                while ((precedingLineBreak && token() === SyntaxKind.AsteriskToken) || token() === SyntaxKind.WhitespaceTrivia || token() === SyntaxKind.NewLineTrivia) {
+                    indentText += scanner.getTokenText();
+                    if (token() === SyntaxKind.NewLineTrivia) {
+                        precedingLineBreak = true;
+                        seenLineBreak = true;
+                        indentText = "";
+                    }
+                    else if (token() === SyntaxKind.AsteriskToken) {
+                        precedingLineBreak = false;
+                    }
+                    nextTokenJSDoc();
+                }
+                return seenLineBreak ? indentText : "";
+            }
+
+            function parseTag(margin: number) {
+                Debug.assert(token() === SyntaxKind.AtToken);
+                const start = scanner.getTokenStart();
+                nextTokenJSDoc();
+
+                const tagName = parseJSDocIdentifierName(/*message*/ undefined);
+                const indentText = skipWhitespaceOrAsterisk();
+
+                let tag: JSDocTag | undefined;
+                switch (tagName.escapedText) {
+                    case "author":
+                        tag = parseAuthorTag(start, tagName, margin, indentText);
+                        break;
+                    case "implements":
+                        tag = parseImplementsTag(start, tagName, margin, indentText);
+                        break;
+                    case "augments":
+                    case "extends":
+                        tag = parseAugmentsTag(start, tagName, margin, indentText);
+                        break;
+                    case "class":
+                    case "constructor":
+                        tag = parseSimpleTag(start, factory.createJSDocClassTag, tagName, margin, indentText);
+                        break;
+                    case "public":
+                        tag = parseSimpleTag(start, factory.createJSDocPublicTag, tagName, margin, indentText);
+                        break;
+                    case "private":
+                        tag = parseSimpleTag(start, factory.createJSDocPrivateTag, tagName, margin, indentText);
+                        break;
+                    case "protected":
+                        tag = parseSimpleTag(start, factory.createJSDocProtectedTag, tagName, margin, indentText);
+                        break;
+                    case "readonly":
+                        tag = parseSimpleTag(start, factory.createJSDocReadonlyTag, tagName, margin, indentText);
+                        break;
+                    case "override":
+                        tag = parseSimpleTag(start, factory.createJSDocOverrideTag, tagName, margin, indentText);
+                        break;
+                    case "deprecated":
+                        hasDeprecatedTag = true;
+                        tag = parseSimpleTag(start, factory.createJSDocDeprecatedTag, tagName, margin, indentText);
+                        break;
+                    case "this":
+                        tag = parseThisTag(start, tagName, margin, indentText);
+                        break;
+                    case "enum":
+                        tag = parseEnumTag(start, tagName, margin, indentText);
+                        break;
+                    case "arg":
+                    case "argument":
+                    case "param":
+                        return parseParameterOrPropertyTag(start, tagName, PropertyLikeParse.Parameter, margin);
+                    case "return":
+                    case "returns":
+                        tag = parseReturnTag(start, tagName, margin, indentText);
+                        break;
+                    case "template":
+                        tag = parseTemplateTag(start, tagName, margin, indentText);
+                        break;
+                    case "type":
+                        tag = parseTypeTag(start, tagName, margin, indentText);
+                        break;
+                    case "typedef":
+                        tag = parseTypedefTag(start, tagName, margin, indentText);
+                        break;
+                    case "callback":
+                        tag = parseCallbackTag(start, tagName, margin, indentText);
+                        break;
+                    case "overload":
+                        tag = parseOverloadTag(start, tagName, margin, indentText);
+                        break;
+                    case "satisfies":
+                        tag = parseSatisfiesTag(start, tagName, margin, indentText);
+                        break;
+                    case "see":
+                        tag = parseSeeTag(start, tagName, margin, indentText);
+                        break;
+                    case "exception":
+                    case "throws":
+                        tag = parseThrowsTag(start, tagName, margin, indentText);
+                        break;
+                    default:
+                        tag = parseUnknownTag(start, tagName, margin, indentText);
+                        break;
+                }
+                return tag;
+            }
+
+            function parseTrailingTagComments(pos: number, end: number, margin: number, indentText: string) {
+                // some tags, like typedef and callback, have already parsed their comments earlier
+                if (!indentText) {
+                    margin += end - pos;
+                }
+                return parseTagComments(margin, indentText.slice(margin));
+            }
+
+            function parseTagComments(indent: number, initialMargin?: string): string | NodeArray<JSDocComment> | undefined {
+                const commentsPos = getNodePos();
+                let comments: string[] = [];
+                const parts: JSDocComment[] = [];
+                let linkEnd;
+                let state = JSDocState.BeginningOfLine;
+                let margin: number | undefined;
+                function pushComment(text: string) {
+                    if (!margin) {
+                        margin = indent;
+                    }
+                    comments.push(text);
+                    indent += text.length;
+                }
+                if (initialMargin !== undefined) {
+                    // jump straight to saving comments if there is some initial indentation
+                    if (initialMargin !== "") {
+                        pushComment(initialMargin);
+                    }
+                    state = JSDocState.SawAsterisk;
+                }
+                let tok = token() as JSDocSyntaxKind | SyntaxKind.JSDocCommentTextToken;
+                loop:
+                while (true) {
+                    switch (tok) {
+                        case SyntaxKind.NewLineTrivia:
+                            state = JSDocState.BeginningOfLine;
+                            // don't use pushComment here because we want to keep the margin unchanged
+                            comments.push(scanner.getTokenText());
+                            indent = 0;
+                            break;
+                        case SyntaxKind.AtToken:
+                            scanner.resetTokenState(scanner.getTokenEnd() - 1);
+                            break loop;
+                        case SyntaxKind.EndOfFileToken:
+                            // Done
+                            break loop;
+                        case SyntaxKind.WhitespaceTrivia:
+                            Debug.assert(state !== JSDocState.SavingComments && state !== JSDocState.SavingBackticks, "whitespace shouldn't come from the scanner while saving comment text");
+                            const whitespace = scanner.getTokenText();
+                            // if the whitespace crosses the margin, take only the whitespace that passes the margin
+                            if (margin !== undefined && indent + whitespace.length > margin) {
+                                comments.push(whitespace.slice(margin - indent));
+                                state = JSDocState.SavingComments;
+                            }
+                            indent += whitespace.length;
+                            break;
+                        case SyntaxKind.OpenBraceToken:
+                            state = JSDocState.SavingComments;
+                            const commentEnd = scanner.getTokenFullStart();
+                            const linkStart = scanner.getTokenEnd() - 1;
+                            const link = parseJSDocLink(linkStart);
+                            if (link) {
+                                parts.push(finishNode(factory.createJSDocText(comments.join("")), linkEnd ?? commentsPos, commentEnd));
+                                parts.push(link);
+                                comments = [];
+                                linkEnd = scanner.getTokenEnd();
+                            }
+                            else {
+                                pushComment(scanner.getTokenText());
+                            }
+                            break;
+                        case SyntaxKind.BacktickToken:
+                            if (state === JSDocState.SavingBackticks) {
+                                state = JSDocState.SavingComments;
+                            }
+                            else {
+                                state = JSDocState.SavingBackticks;
+                            }
+                            pushComment(scanner.getTokenText());
+                            break;
+                        case SyntaxKind.JSDocCommentTextToken:
+                            if (state !== JSDocState.SavingBackticks) {
+                                state = JSDocState.SavingComments; // leading identifiers start recording as well
+                            }
+                            pushComment(scanner.getTokenValue());
+                            break;
+                        case SyntaxKind.AsteriskToken:
+                            if (state === JSDocState.BeginningOfLine) {
+                                // leading asterisks start recording on the *next* (non-whitespace) token
+                                state = JSDocState.SawAsterisk;
+                                indent += 1;
+                                break;
+                            }
+                            // record the * as a comment
+                            // falls through
+                        default:
+                            if (state !== JSDocState.SavingBackticks) {
+                                state = JSDocState.SavingComments; // leading identifiers start recording as well
+                            }
+                            pushComment(scanner.getTokenText());
+                            break;
+                    }
+                    if (state === JSDocState.SavingComments || state === JSDocState.SavingBackticks) {
+                        tok = nextJSDocCommentTextToken(state === JSDocState.SavingBackticks);
+                    }
+                    else {
+                        tok = nextTokenJSDoc();
+                    }
+                }
+
+                removeLeadingNewlines(comments);
+                const trimmedComments = comments.join("").trimEnd();
+                if (parts.length) {
+                    if (trimmedComments.length) {
+                        parts.push(finishNode(factory.createJSDocText(trimmedComments), linkEnd ?? commentsPos));
+                    }
+                    return createNodeArray(parts, commentsPos, scanner.getTokenEnd());
+                }
+                else if (trimmedComments.length) {
+                    return trimmedComments;
+                }
+            }
+
+            function parseJSDocLink(start: number) {
+                const linkType = tryParse(parseJSDocLinkPrefix);
+                if (!linkType) {
+                    return undefined;
+                }
+                nextTokenJSDoc(); // start at token after link, then skip any whitespace
+                skipWhitespace();
+                // parseEntityName logs an error for non-identifier, so create a MissingNode ourselves to avoid the error
+                const p2 = getNodePos();
+                let name: EntityName | JSDocMemberName | undefined = tokenIsIdentifierOrKeyword(token())
+                    ? parseEntityName(/*allowReservedWords*/ true)
+                    : undefined;
+                if (name) {
+                    while (token() === SyntaxKind.PrivateIdentifier) {
+                        reScanHashToken(); // rescan #id as # id
+                        nextTokenJSDoc(); // then skip the #
+                        name = finishNode(factory.createJSDocMemberName(name, parseIdentifier()), p2);
+                    }
+                }
+                const text = [];
+                while (token() !== SyntaxKind.CloseBraceToken && token() !== SyntaxKind.NewLineTrivia && token() !== SyntaxKind.EndOfFileToken) {
+                    text.push(scanner.getTokenText());
+                    nextTokenJSDoc();
+                }
+                const create = linkType === "link" ? factory.createJSDocLink
+                    : linkType === "linkcode" ? factory.createJSDocLinkCode
+                    : factory.createJSDocLinkPlain;
+                return finishNode(create(name, text.join("")), start, scanner.getTokenEnd());
+            }
+
+            function parseJSDocLinkPrefix() {
+                skipWhitespaceOrAsterisk();
+                if (
+                    token() === SyntaxKind.OpenBraceToken
+                    && nextTokenJSDoc() === SyntaxKind.AtToken
+                    && tokenIsIdentifierOrKeyword(nextTokenJSDoc())
+                ) {
+                    const kind = scanner.getTokenValue();
+                    if (isJSDocLinkTag(kind)) return kind;
+                }
+            }
+
+            function isJSDocLinkTag(kind: string) {
+                return kind === "link" || kind === "linkcode" || kind === "linkplain";
+            }
+
+            function parseUnknownTag(start: number, tagName: Identifier, indent: number, indentText: string) {
+                return finishNode(factory.createJSDocUnknownTag(tagName, parseTrailingTagComments(start, getNodePos(), indent, indentText)), start);
+            }
+
+            function addTag(tag: JSDocTag | undefined): void {
+                if (!tag) {
+                    return;
+                }
+                if (!tags) {
+                    tags = [tag];
+                    tagsPos = tag.pos;
+                }
+                else {
+                    tags.push(tag);
+                }
+                tagsEnd = tag.end;
+            }
+
+            function tryParseTypeExpression(): JSDocTypeExpression | undefined {
+                skipWhitespaceOrAsterisk();
+                return token() === SyntaxKind.OpenBraceToken ? parseJSDocTypeExpression() : undefined;
+            }
+
+            function parseBracketNameInPropertyAndParamTag(): { name: EntityName; isBracketed: boolean; } {
+                // Looking for something like '[foo]', 'foo', '[foo.bar]' or 'foo.bar'
+                const isBracketed = parseOptionalJsdoc(SyntaxKind.OpenBracketToken);
+                if (isBracketed) {
+                    skipWhitespace();
+                }
+                // a markdown-quoted name: `arg` is not legal jsdoc, but occurs in the wild
+                const isBackquoted = parseOptionalJsdoc(SyntaxKind.BacktickToken);
+                const name = parseJSDocEntityName();
+                if (isBackquoted) {
+                    parseExpectedTokenJSDoc(SyntaxKind.BacktickToken);
+                }
+                if (isBracketed) {
+                    skipWhitespace();
+                    // May have an optional default, e.g. '[foo = 42]'
+                    if (parseOptionalToken(SyntaxKind.EqualsToken)) {
+                        parseExpression();
+                    }
+
+                    parseExpected(SyntaxKind.CloseBracketToken);
+                }
+
+                return { name, isBracketed };
+            }
+
+            function isObjectOrObjectArrayTypeReference(node: TypeNode): boolean {
+                switch (node.kind) {
+                    case SyntaxKind.ObjectKeyword:
+                        return true;
+                    case SyntaxKind.ArrayType:
+                        return isObjectOrObjectArrayTypeReference((node as ArrayTypeNode).elementType);
+                    default:
+                        return isTypeReferenceNode(node) && isIdentifierNode(node.typeName) && node.typeName.escapedText === "Object" && !node.typeArguments;
+                }
+            }
+
+            function parseParameterOrPropertyTag(start: number, tagName: Identifier, target: PropertyLikeParse, indent: number): JSDocParameterTag | JSDocPropertyTag {
+                let typeExpression = tryParseTypeExpression();
+                let isNameFirst = !typeExpression;
+                skipWhitespaceOrAsterisk();
+
+                const { name, isBracketed } = parseBracketNameInPropertyAndParamTag();
+                const indentText = skipWhitespaceOrAsterisk();
+
+                if (isNameFirst && !lookAhead(parseJSDocLinkPrefix)) {
+                    typeExpression = tryParseTypeExpression();
+                }
+
+                const comment = parseTrailingTagComments(start, getNodePos(), indent, indentText);
+
+                const nestedTypeLiteral = parseNestedTypeLiteral(typeExpression, name, target, indent);
+                if (nestedTypeLiteral) {
+                    typeExpression = nestedTypeLiteral;
+                    isNameFirst = true;
+                }
+                const result = target === PropertyLikeParse.Property
+                    ? factory.createJSDocPropertyTag(tagName, name, isBracketed, typeExpression, isNameFirst, comment)
+                    : factory.createJSDocParameterTag(tagName, name, isBracketed, typeExpression, isNameFirst, comment);
+                return finishNode(result, start);
+            }
+
+            function parseNestedTypeLiteral(typeExpression: JSDocTypeExpression | undefined, name: EntityName, target: PropertyLikeParse, indent: number) {
+                if (typeExpression && isObjectOrObjectArrayTypeReference(typeExpression.type)) {
+                    const pos = getNodePos();
+                    let child: JSDocPropertyLikeTag | JSDocTypeTag | JSDocTemplateTag | false;
+                    let children: JSDocPropertyLikeTag[] | undefined;
+                    while (child = tryParse(() => parseChildParameterOrPropertyTag(target, indent, name))) {
+                        if (child.kind === SyntaxKind.JSDocParameterTag || child.kind === SyntaxKind.JSDocPropertyTag) {
+                            children = append(children, child);
+                        }
+                        else if (child.kind === SyntaxKind.JSDocTemplateTag) {
+                            parseErrorAtRange(child.tagName, Diagnostics.A_JSDoc_template_tag_may_not_follow_a_typedef_callback_or_overload_tag);
+                        }
+                    }
+                    if (children) {
+                        const literal = finishNode(factory.createJSDocTypeLiteral(children, typeExpression.type.kind === SyntaxKind.ArrayType), pos);
+                        return finishNode(factory.createJSDocTypeExpression(literal), pos);
+                    }
+                }
+            }
+
+            function parseReturnTag(start: number, tagName: Identifier, indent: number, indentText: string): JSDocReturnTag {
+                if (some(tags, isJSDocReturnTag)) {
+                    parseErrorAt(tagName.pos, scanner.getTokenStart(), Diagnostics._0_tag_already_specified, unescapeLeadingUnderscores(tagName.escapedText));
+                }
+
+                const typeExpression = tryParseTypeExpression();
+                return finishNode(factory.createJSDocReturnTag(tagName, typeExpression, parseTrailingTagComments(start, getNodePos(), indent, indentText)), start);
+            }
+
+            function parseTypeTag(start: number, tagName: Identifier, indent?: number, indentText?: string): JSDocTypeTag {
+                if (some(tags, isJSDocTypeTag)) {
+                    parseErrorAt(tagName.pos, scanner.getTokenStart(), Diagnostics._0_tag_already_specified, unescapeLeadingUnderscores(tagName.escapedText));
+                }
+
+                const typeExpression = parseJSDocTypeExpression(/*mayOmitBraces*/ true);
+                const comments = indent !== undefined && indentText !== undefined ? parseTrailingTagComments(start, getNodePos(), indent, indentText) : undefined;
+                return finishNode(factory.createJSDocTypeTag(tagName, typeExpression, comments), start);
+            }
+
+            function parseSeeTag(start: number, tagName: Identifier, indent?: number, indentText?: string): JSDocSeeTag {
+                const isMarkdownOrJSDocLink = token() === SyntaxKind.OpenBracketToken
+                    || lookAhead(() => nextTokenJSDoc() === SyntaxKind.AtToken && tokenIsIdentifierOrKeyword(nextTokenJSDoc()) && isJSDocLinkTag(scanner.getTokenValue()));
+                const nameExpression = isMarkdownOrJSDocLink ? undefined : parseJSDocNameReference();
+                const comments = indent !== undefined && indentText !== undefined ? parseTrailingTagComments(start, getNodePos(), indent, indentText) : undefined;
+                return finishNode(factory.createJSDocSeeTag(tagName, nameExpression, comments), start);
+            }
+
+            function parseThrowsTag(start: number, tagName: Identifier, indent: number, indentText: string): JSDocThrowsTag {
+                const typeExpression = tryParseTypeExpression();
+                const comment = parseTrailingTagComments(start, getNodePos(), indent, indentText);
+                return finishNode(factory.createJSDocThrowsTag(tagName, typeExpression, comment), start);
+            }
+
+            function parseAuthorTag(start: number, tagName: Identifier, indent: number, indentText: string): JSDocAuthorTag {
+                const commentStart = getNodePos();
+                const textOnly = parseAuthorNameAndEmail();
+                let commentEnd = scanner.getTokenFullStart();
+                const comments = parseTrailingTagComments(start, commentEnd, indent, indentText);
+                if (!comments) {
+                    commentEnd = scanner.getTokenFullStart();
+                }
+                const allParts = typeof comments !== "string"
+                    ? createNodeArray(concatenate([finishNode(textOnly, commentStart, commentEnd)], comments) as JSDocComment[], commentStart) // cast away readonly
+                    : textOnly.text + comments;
+                return finishNode(factory.createJSDocAuthorTag(tagName, allParts), start);
+            }
+
+            function parseAuthorNameAndEmail(): JSDocText {
+                const comments: string[] = [];
+                let inEmail = false;
+                let token = scanner.getToken();
+                while (token !== SyntaxKind.EndOfFileToken && token !== SyntaxKind.NewLineTrivia) {
+                    if (token === SyntaxKind.LessThanToken) {
+                        inEmail = true;
+                    }
+                    else if (token === SyntaxKind.AtToken && !inEmail) {
+                        break;
+                    }
+                    else if (token === SyntaxKind.GreaterThanToken && inEmail) {
+                        comments.push(scanner.getTokenText());
+                        scanner.resetTokenState(scanner.getTokenEnd());
+                        break;
+                    }
+                    comments.push(scanner.getTokenText());
+                    token = nextTokenJSDoc();
+                }
+
+                return factory.createJSDocText(comments.join(""));
+            }
+
+            function parseImplementsTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocImplementsTag {
+                const className = parseExpressionWithTypeArgumentsForAugments();
+                return finishNode(factory.createJSDocImplementsTag(tagName, className, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
+            }
+
+            function parseAugmentsTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocAugmentsTag {
+                const className = parseExpressionWithTypeArgumentsForAugments();
+                return finishNode(factory.createJSDocAugmentsTag(tagName, className, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
+            }
+
+            function parseSatisfiesTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocSatisfiesTag {
+                const typeExpression = parseJSDocTypeExpression(/*mayOmitBraces*/ false);
+                const comments = margin !== undefined && indentText !== undefined ? parseTrailingTagComments(start, getNodePos(), margin, indentText) : undefined;
+                return finishNode(factory.createJSDocSatisfiesTag(tagName, typeExpression, comments), start);
+            }
+
+            function parseExpressionWithTypeArgumentsForAugments(): ExpressionWithTypeArguments & { expression: Identifier | PropertyAccessEntityNameExpression; } {
+                const usedBrace = parseOptional(SyntaxKind.OpenBraceToken);
+                const pos = getNodePos();
+                const expression = parsePropertyAccessEntityNameExpression();
+                scanner.setInJSDocType(true);
+                const typeArguments = tryParseTypeArguments();
+                scanner.setInJSDocType(false);
+                const node = factory.createExpressionWithTypeArguments(expression, typeArguments) as ExpressionWithTypeArguments & { expression: Identifier | PropertyAccessEntityNameExpression; };
+                const res = finishNode(node, pos);
+                if (usedBrace) {
+                    parseExpected(SyntaxKind.CloseBraceToken);
+                }
+                return res;
+            }
+
+            function parsePropertyAccessEntityNameExpression() {
+                const pos = getNodePos();
+                let node: Identifier | PropertyAccessEntityNameExpression = parseJSDocIdentifierName();
+                while (parseOptional(SyntaxKind.DotToken)) {
+                    const name = parseJSDocIdentifierName();
+                    node = finishNode(factoryCreatePropertyAccessExpression(node, name), pos) as PropertyAccessEntityNameExpression;
+                }
+                return node;
+            }
+
+            function parseSimpleTag(start: number, createTag: (tagName: Identifier | undefined, comment?: string | NodeArray<JSDocComment>) => JSDocTag, tagName: Identifier, margin: number, indentText: string): JSDocTag {
+                return finishNode(createTag(tagName, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
+            }
+
+            function parseThisTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocThisTag {
+                const typeExpression = parseJSDocTypeExpression(/*mayOmitBraces*/ true);
+                skipWhitespace();
+                return finishNode(factory.createJSDocThisTag(tagName, typeExpression, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
+            }
+
+            function parseEnumTag(start: number, tagName: Identifier, margin: number, indentText: string): JSDocEnumTag {
+                const typeExpression = parseJSDocTypeExpression(/*mayOmitBraces*/ true);
+                skipWhitespace();
+                return finishNode(factory.createJSDocEnumTag(tagName, typeExpression, parseTrailingTagComments(start, getNodePos(), margin, indentText)), start);
+            }
+
+            function parseTypedefTag(start: number, tagName: Identifier, indent: number, indentText: string): JSDocTypedefTag {
+                let typeExpression: JSDocTypeExpression | JSDocTypeLiteral | undefined = tryParseTypeExpression();
+                skipWhitespaceOrAsterisk();
+
+                const fullName = parseJSDocTypeNameWithNamespace();
+                skipWhitespace();
+                let comment = parseTagComments(indent);
+
+                let end: number | undefined;
+                if (!typeExpression || isObjectOrObjectArrayTypeReference(typeExpression.type)) {
+                    let child: JSDocTypeTag | JSDocPropertyTag | JSDocTemplateTag | false;
+                    let childTypeTag: JSDocTypeTag | undefined;
+                    let jsDocPropertyTags: JSDocPropertyTag[] | undefined;
+                    let hasChildren = false;
+                    while (child = tryParse(() => parseChildPropertyTag(indent))) {
+                        if (child.kind === SyntaxKind.JSDocTemplateTag) {
+                            break;
+                        }
+                        hasChildren = true;
+                        if (child.kind === SyntaxKind.JSDocTypeTag) {
+                            if (childTypeTag) {
+                                const lastError = parseErrorAtCurrentToken(Diagnostics.A_JSDoc_typedef_comment_may_not_contain_multiple_type_tags);
+                                if (lastError) {
+                                    addRelatedInfo(lastError, createDetachedDiagnostic(fileName, sourceText, 0, 0, Diagnostics.The_tag_was_first_specified_here));
+                                }
+                                break;
+                            }
+                            else {
+                                childTypeTag = child;
+                            }
+                        }
+                        else {
+                            jsDocPropertyTags = append(jsDocPropertyTags, child);
+                        }
+                    }
+                    if (hasChildren) {
+                        const isArrayType = typeExpression && typeExpression.type.kind === SyntaxKind.ArrayType;
+                        const jsdocTypeLiteral = factory.createJSDocTypeLiteral(jsDocPropertyTags, isArrayType);
+                        typeExpression = childTypeTag && childTypeTag.typeExpression && !isObjectOrObjectArrayTypeReference(childTypeTag.typeExpression.type) ?
+                            childTypeTag.typeExpression :
+                            finishNode(jsdocTypeLiteral, start);
+                        end = typeExpression.end;
+                    }
+                }
+
+                // Only include the characters between the name end and the next token if a comment was actually parsed out - otherwise it's just whitespace
+                end = end || comment !== undefined ?
+                    getNodePos() :
+                    (fullName ?? typeExpression ?? tagName).end;
+
+                if (!comment) {
+                    comment = parseTrailingTagComments(start, end, indent, indentText);
+                }
+
+                const typedefTag = factory.createJSDocTypedefTag(tagName, typeExpression, fullName, comment);
+                return finishNode(typedefTag, start, end);
+            }
+
+            function parseJSDocTypeNameWithNamespace(nested?: boolean) {
+                const start = scanner.getTokenStart();
+                if (!tokenIsIdentifierOrKeyword(token())) {
+                    return undefined;
+                }
+                const typeNameOrNamespaceName = parseJSDocIdentifierName();
+                if (parseOptional(SyntaxKind.DotToken)) {
+                    const body = parseJSDocTypeNameWithNamespace(/*nested*/ true);
+                    const jsDocNamespaceNode = factory.createModuleDeclaration(
+                        /*modifiers*/ undefined,
+                        typeNameOrNamespaceName,
+                        body,
+                        nested ? NodeFlags.NestedNamespace : undefined,
+                    ) as JSDocNamespaceDeclaration;
+                    return finishNode(jsDocNamespaceNode, start);
+                }
+
+                if (nested) {
+                    (typeNameOrNamespaceName as Mutable<Identifier>).flags |= NodeFlags.IdentifierIsInJSDocNamespace;
+                }
+                return typeNameOrNamespaceName;
+            }
+
+            function parseCallbackTagParameters(indent: number) {
+                const pos = getNodePos();
+                let child: JSDocParameterTag | JSDocTemplateTag | false;
+                let parameters;
+                while (child = tryParse(() => parseChildParameterOrPropertyTag(PropertyLikeParse.CallbackParameter, indent) as JSDocParameterTag | JSDocTemplateTag)) {
+                    if (child.kind === SyntaxKind.JSDocTemplateTag) {
+                        parseErrorAtRange(child.tagName, Diagnostics.A_JSDoc_template_tag_may_not_follow_a_typedef_callback_or_overload_tag);
+                        break;
+                    }
+                    parameters = append(parameters, child);
+                }
+                return createNodeArray(parameters || [], pos);
+            }
+
+            function parseJSDocSignature(start: number, indent: number): JSDocSignature {
+                const parameters = parseCallbackTagParameters(indent);
+                const returnTag = tryParse(() => {
+                    if (parseOptionalJsdoc(SyntaxKind.AtToken)) {
+                        const tag = parseTag(indent);
+                        if (tag && tag.kind === SyntaxKind.JSDocReturnTag) {
+                            return tag as JSDocReturnTag;
+                        }
+                    }
+                });
+                return finishNode(factory.createJSDocSignature(/*typeParameters*/ undefined, parameters, returnTag), start);
+            }
+
+            function parseCallbackTag(start: number, tagName: Identifier, indent: number, indentText: string): JSDocCallbackTag {
+                const fullName = parseJSDocTypeNameWithNamespace();
+                skipWhitespace();
+                let comment = parseTagComments(indent);
+                const typeExpression = parseJSDocSignature(start, indent);
+                if (!comment) {
+                    comment = parseTrailingTagComments(start, getNodePos(), indent, indentText);
+                }
+                const end = comment !== undefined ? getNodePos() : typeExpression.end;
+                return finishNode(factory.createJSDocCallbackTag(tagName, typeExpression, fullName, comment), start, end);
+            }
+
+            function parseOverloadTag(start: number, tagName: Identifier, indent: number, indentText: string): JSDocOverloadTag {
+                skipWhitespace();
+                let comment = parseTagComments(indent);
+                const typeExpression = parseJSDocSignature(start, indent);
+                if (!comment) {
+                    comment = parseTrailingTagComments(start, getNodePos(), indent, indentText);
+                }
+                const end = comment !== undefined ? getNodePos() : typeExpression.end;
+                return finishNode(factory.createJSDocOverloadTag(tagName, typeExpression, comment), start, end);
+            }
+
+            function escapedTextsEqual(a: EntityName, b: EntityName): boolean {
+                while (!isIdentifierNode(a) || !isIdentifierNode(b)) {
+                    if (!isIdentifierNode(a) && !isIdentifierNode(b) && a.right.escapedText === b.right.escapedText) {
+                        a = a.left;
+                        b = b.left;
+                    }
+                    else {
+                        return false;
+                    }
+                }
+                return a.escapedText === b.escapedText;
+            }
+
+            function parseChildPropertyTag(indent: number) {
+                return parseChildParameterOrPropertyTag(PropertyLikeParse.Property, indent) as JSDocTypeTag | JSDocPropertyTag | JSDocTemplateTag | false;
+            }
+
+            function parseChildParameterOrPropertyTag(target: PropertyLikeParse, indent: number, name?: EntityName): JSDocTypeTag | JSDocPropertyTag | JSDocParameterTag | JSDocTemplateTag | false {
+                let canParseTag = true;
+                let seenAsterisk = false;
+                while (true) {
+                    switch (nextTokenJSDoc()) {
+                        case SyntaxKind.AtToken:
+                            if (canParseTag) {
+                                const child = tryParseChildTag(target, indent);
+                                if (
+                                    child && (child.kind === SyntaxKind.JSDocParameterTag || child.kind === SyntaxKind.JSDocPropertyTag) &&
+                                    name && (isIdentifierNode(child.name) || !escapedTextsEqual(name, child.name.left))
+                                ) {
+                                    return false;
+                                }
+                                return child;
+                            }
+                            seenAsterisk = false;
+                            break;
+                        case SyntaxKind.NewLineTrivia:
+                            canParseTag = true;
+                            seenAsterisk = false;
+                            break;
+                        case SyntaxKind.AsteriskToken:
+                            if (seenAsterisk) {
+                                canParseTag = false;
+                            }
+                            seenAsterisk = true;
+                            break;
+                        case SyntaxKind.Identifier:
+                            canParseTag = false;
+                            break;
+                        case SyntaxKind.EndOfFileToken:
+                            return false;
+                    }
+                }
+            }
+
+            function tryParseChildTag(target: PropertyLikeParse, indent: number): JSDocTypeTag | JSDocPropertyTag | JSDocParameterTag | JSDocTemplateTag | false {
+                Debug.assert(token() === SyntaxKind.AtToken);
+                const start = scanner.getTokenFullStart();
+                nextTokenJSDoc();
+
+                const tagName = parseJSDocIdentifierName();
+                const indentText = skipWhitespaceOrAsterisk();
+                let t: PropertyLikeParse;
+                switch (tagName.escapedText) {
+                    case "type":
+                        return target === PropertyLikeParse.Property && parseTypeTag(start, tagName);
+                    case "prop":
+                    case "property":
+                        t = PropertyLikeParse.Property;
+                        break;
+                    case "arg":
+                    case "argument":
+                    case "param":
+                        t = PropertyLikeParse.Parameter | PropertyLikeParse.CallbackParameter;
+                        break;
+                    case "template":
+                        return parseTemplateTag(start, tagName, indent, indentText);
+                    default:
+                        return false;
+                }
+                if (!(target & t)) {
+                    return false;
+                }
+                return parseParameterOrPropertyTag(start, tagName, target, indent);
+            }
+
+            function parseTemplateTagTypeParameter() {
+                const typeParameterPos = getNodePos();
+                const isBracketed = parseOptionalJsdoc(SyntaxKind.OpenBracketToken);
+                if (isBracketed) {
+                    skipWhitespace();
+                }
+                const name = parseJSDocIdentifierName(Diagnostics.Unexpected_token_A_type_parameter_name_was_expected_without_curly_braces);
+
+                let defaultType: TypeNode | undefined;
+                if (isBracketed) {
+                    skipWhitespace();
+                    parseExpected(SyntaxKind.EqualsToken);
+                    defaultType = doInsideOfContext(NodeFlags.JSDoc, parseJSDocType);
+                    parseExpected(SyntaxKind.CloseBracketToken);
+                }
+
+                if (nodeIsMissing(name)) {
+                    return undefined;
+                }
+                return finishNode(factory.createTypeParameterDeclaration(/*modifiers*/ undefined, name, /*constraint*/ undefined, defaultType), typeParameterPos);
+            }
+
+            function parseTemplateTagTypeParameters() {
+                const pos = getNodePos();
+                const typeParameters = [];
+                do {
+                    skipWhitespace();
+                    const node = parseTemplateTagTypeParameter();
+                    if (node !== undefined) {
+                        typeParameters.push(node);
+                    }
+                    skipWhitespaceOrAsterisk();
+                }
+                while (parseOptionalJsdoc(SyntaxKind.CommaToken));
+                return createNodeArray(typeParameters, pos);
+            }
+
+            function parseTemplateTag(start: number, tagName: Identifier, indent: number, indentText: string): JSDocTemplateTag {
+                // The template tag looks like one of the following:
+                //   @template T,U,V
+                //   @template {Constraint} T
+                //
+                // According to the [closure docs](https://github.com/google/closure-compiler/wiki/Generic-Types#multiple-bounded-template-types):
+                //   > Multiple bounded generics cannot be declared on the same line. For the sake of clarity, if multiple templates share the same
+                //   > type bound they must be declared on separate lines.
+                //
+                // TODO: Determine whether we should enforce this in the checker.
+                // TODO: Consider moving the `constraint` to the first type parameter as we could then remove `getEffectiveConstraintOfTypeParameter`.
+                // TODO: Consider only parsing a single type parameter if there is a constraint.
+                const constraint = token() === SyntaxKind.OpenBraceToken ? parseJSDocTypeExpression() : undefined;
+                const typeParameters = parseTemplateTagTypeParameters();
+                return finishNode(factory.createJSDocTemplateTag(tagName, constraint, typeParameters, parseTrailingTagComments(start, getNodePos(), indent, indentText)), start);
+            }
+
+            function parseOptionalJsdoc(t: JSDocSyntaxKind): boolean {
+                if (token() === t) {
+                    nextTokenJSDoc();
+                    return true;
+                }
+                return false;
+            }
+
+            function parseJSDocEntityName(): EntityName {
+                let entity: EntityName = parseJSDocIdentifierName();
+                if (parseOptional(SyntaxKind.OpenBracketToken)) {
+                    parseExpected(SyntaxKind.CloseBracketToken);
+                    // Note that y[] is accepted as an entity name, but the postfix brackets are not saved for checking.
+                    // Technically usejsdoc.org requires them for specifying a property of a type equivalent to Array<{ x: ...}>
+                    // but it's not worth it to enforce that restriction.
+                }
+                while (parseOptional(SyntaxKind.DotToken)) {
+                    const name = parseJSDocIdentifierName();
+                    if (parseOptional(SyntaxKind.OpenBracketToken)) {
+                        parseExpected(SyntaxKind.CloseBracketToken);
+                    }
+                    entity = createQualifiedName(entity, name);
+                }
+                return entity;
+            }
+
+            function parseJSDocIdentifierName(message?: DiagnosticMessage): Identifier {
+                if (!tokenIsIdentifierOrKeyword(token())) {
+                    return createMissingNode<Identifier>(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ !message, message || Diagnostics.Identifier_expected);
+                }
+
+                identifierCount++;
+                const start = scanner.getTokenStart();
+                const end = scanner.getTokenEnd();
+                const originalKeywordKind = token();
+                const text = internIdentifier(scanner.getTokenValue());
+                const result = finishNode(factoryCreateIdentifier(text, originalKeywordKind), start, end);
+                nextTokenJSDoc();
+                return result;
+            }
+        }
+    }
+}
+
+namespace IncrementalParser {
+    export function updateSourceFile(sourceFile: SourceFile, newText: string, textChangeRange: TextChangeRange, aggressiveChecks: boolean): SourceFile {
+        aggressiveChecks = aggressiveChecks || Debug.shouldAssert(AssertionLevel.Aggressive);
+
+        checkChangeRange(sourceFile, newText, textChangeRange, aggressiveChecks);
+        if (textChangeRangeIsUnchanged(textChangeRange)) {
+            // if the text didn't change, then we can just return our current source file as-is.
+            return sourceFile;
+        }
+
+        if (sourceFile.statements.length === 0) {
+            // If we don't have any statements in the current source file, then there's no real
+            // way to incrementally parse.  So just do a full parse instead.
+            return Parser.parseSourceFile(sourceFile.fileName, newText, sourceFile.languageVersion, /*syntaxCursor*/ undefined, /*setParentNodes*/ true, sourceFile.scriptKind, sourceFile.setExternalModuleIndicator, sourceFile.jsDocParsingMode);
+        }
+
+        // Make sure we're not trying to incrementally update a source file more than once.  Once
+        // we do an update the original source file is considered unusable from that point onwards.
+        //
+        // This is because we do incremental parsing in-place.  i.e. we take nodes from the old
+        // tree and give them new positions and parents.  From that point on, trusting the old
+        // tree at all is not possible as far too much of it may violate invariants.
+        const incrementalSourceFile = sourceFile as Node as IncrementalNode;
+        Debug.assert(!incrementalSourceFile.hasBeenIncrementallyParsed);
+        incrementalSourceFile.hasBeenIncrementallyParsed = true;
+        Parser.fixupParentReferences(incrementalSourceFile);
+        const oldText = sourceFile.text;
+        const syntaxCursor = createSyntaxCursor(sourceFile);
+
+        // Make the actual change larger so that we know to reparse anything whose lookahead
+        // might have intersected the change.
+        const changeRange = extendToAffectedRange(sourceFile, textChangeRange);
+        checkChangeRange(sourceFile, newText, changeRange, aggressiveChecks);
+
+        // Ensure that extending the affected range only moved the start of the change range
+        // earlier in the file.
+        Debug.assert(changeRange.span.start <= textChangeRange.span.start);
+        Debug.assert(textSpanEnd(changeRange.span) === textSpanEnd(textChangeRange.span));
+        Debug.assert(textSpanEnd(textChangeRangeNewSpan(changeRange)) === textSpanEnd(textChangeRangeNewSpan(textChangeRange)));
+
+        // The is the amount the nodes after the edit range need to be adjusted.  It can be
+        // positive (if the edit added characters), negative (if the edit deleted characters)
+        // or zero (if this was a pure overwrite with nothing added/removed).
+        const delta = textChangeRangeNewSpan(changeRange).length - changeRange.span.length;
+
+        // If we added or removed characters during the edit, then we need to go and adjust all
+        // the nodes after the edit.  Those nodes may move forward (if we inserted chars) or they
+        // may move backward (if we deleted chars).
+        //
+        // Doing this helps us out in two ways.  First, it means that any nodes/tokens we want
+        // to reuse are already at the appropriate position in the new text.  That way when we
+        // reuse them, we don't have to figure out if they need to be adjusted.  Second, it makes
+        // it very easy to determine if we can reuse a node.  If the node's position is at where
+        // we are in the text, then we can reuse it.  Otherwise we can't.  If the node's position
+        // is ahead of us, then we'll need to rescan tokens.  If the node's position is behind
+        // us, then we'll need to skip it or crumble it as appropriate
+        //
+        // We will also adjust the positions of nodes that intersect the change range as well.
+        // By doing this, we ensure that all the positions in the old tree are consistent, not
+        // just the positions of nodes entirely before/after the change range.  By being
+        // consistent, we can then easily map from positions to nodes in the old tree easily.
+        //
+        // Also, mark any syntax elements that intersect the changed span.  We know, up front,
+        // that we cannot reuse these elements.
+        updateTokenPositionsAndMarkElements(incrementalSourceFile, changeRange.span.start, textSpanEnd(changeRange.span), textSpanEnd(textChangeRangeNewSpan(changeRange)), delta, oldText, newText, aggressiveChecks);
+
+        // Now that we've set up our internal incremental state just proceed and parse the
+        // source file in the normal fashion.  When possible the parser will retrieve and
+        // reuse nodes from the old tree.
+        //
+        // Note: passing in 'true' for setNodeParents is very important.  When incrementally
+        // parsing, we will be reusing nodes from the old tree, and placing it into new
+        // parents.  If we don't set the parents now, we'll end up with an observably
+        // inconsistent tree.  Setting the parents on the new tree should be very fast.  We
+        // will immediately bail out of walking any subtrees when we can see that their parents
+        // are already correct.
+        const result = Parser.parseSourceFile(sourceFile.fileName, newText, sourceFile.languageVersion, syntaxCursor, /*setParentNodes*/ true, sourceFile.scriptKind, sourceFile.setExternalModuleIndicator, sourceFile.jsDocParsingMode);
+        result.commentDirectives = getNewCommentDirectives(
+            sourceFile.commentDirectives,
+            result.commentDirectives,
+            changeRange.span.start,
+            textSpanEnd(changeRange.span),
+            delta,
+            oldText,
+            newText,
+            aggressiveChecks,
+        );
+        result.impliedNodeFormat = sourceFile.impliedNodeFormat;
+        return result;
+    }
+
+    function getNewCommentDirectives(
+        oldDirectives: CommentDirective[] | undefined,
+        newDirectives: CommentDirective[] | undefined,
+        changeStart: number,
+        changeRangeOldEnd: number,
+        delta: number,
+        oldText: string,
+        newText: string,
+        aggressiveChecks: boolean,
+    ): CommentDirective[] | undefined {
+        if (!oldDirectives) return newDirectives;
+        let commentDirectives: CommentDirective[] | undefined;
+        let addedNewlyScannedDirectives = false;
+        for (const directive of oldDirectives) {
+            const { range, type } = directive;
+            // Range before the change
+            if (range.end < changeStart) {
+                commentDirectives = append(commentDirectives, directive);
+            }
+            else if (range.pos > changeRangeOldEnd) {
+                addNewlyScannedDirectives();
+                // Node is entirely past the change range.  We need to move both its pos and
+                // end, forward or backward appropriately.
+                const updatedDirective: CommentDirective = {
+                    range: { pos: range.pos + delta, end: range.end + delta },
+                    type,
+                };
+                commentDirectives = append(commentDirectives, updatedDirective);
+                if (aggressiveChecks) {
+                    Debug.assert(oldText.substring(range.pos, range.end) === newText.substring(updatedDirective.range.pos, updatedDirective.range.end));
+                }
+            }
+            // Ignore ranges that fall in change range
+        }
+        addNewlyScannedDirectives();
+        return commentDirectives;
+
+        function addNewlyScannedDirectives() {
+            if (addedNewlyScannedDirectives) return;
+            addedNewlyScannedDirectives = true;
+            if (!commentDirectives) {
+                commentDirectives = newDirectives;
+            }
+            else if (newDirectives) {
+                commentDirectives.push(...newDirectives);
+            }
+        }
+    }
+
+    function moveElementEntirelyPastChangeRange(element: IncrementalNode, isArray: false, delta: number, oldText: string, newText: string, aggressiveChecks: boolean): void;
+    function moveElementEntirelyPastChangeRange(element: IncrementalNodeArray, isArray: true, delta: number, oldText: string, newText: string, aggressiveChecks: boolean): void;
+    function moveElementEntirelyPastChangeRange(element: IncrementalNode | IncrementalNodeArray, isArray: boolean, delta: number, oldText: string, newText: string, aggressiveChecks: boolean) {
+        if (isArray) {
+            visitArray(element as IncrementalNodeArray);
+        }
+        else {
+            visitNode(element as IncrementalNode);
+        }
+        return;
+
+        function visitNode(node: IncrementalNode) {
+            let text = "";
+            if (aggressiveChecks && shouldCheckNode(node)) {
+                text = oldText.substring(node.pos, node.end);
+            }
+
+            // Ditch any existing LS children we may have created.  This way we can avoid
+            // moving them forward.
+            if (node._children) {
+                node._children = undefined;
+            }
+
+            setTextRangePosEnd(node, node.pos + delta, node.end + delta);
+
+            if (aggressiveChecks && shouldCheckNode(node)) {
+                Debug.assert(text === newText.substring(node.pos, node.end));
+            }
+
+            forEachChild(node, visitNode as (node: Node) => void, visitArray as (nodes: NodeArray<Node>) => void);
+            if (hasJSDocNodes(node)) {
+                for (const jsDocComment of node.jsDoc!) {
+                    visitNode(jsDocComment as Node as IncrementalNode);
+                }
+            }
+            checkNodePositions(node, aggressiveChecks);
+        }
+
+        function visitArray(array: IncrementalNodeArray) {
+            array._children = undefined;
+            setTextRangePosEnd(array, array.pos + delta, array.end + delta);
+
+            for (const node of array) {
+                visitNode(node);
+            }
+        }
+    }
+
+    function shouldCheckNode(node: Node) {
+        switch (node.kind) {
+            case SyntaxKind.StringLiteral:
+            case SyntaxKind.NumericLiteral:
+            case SyntaxKind.Identifier:
+                return true;
+        }
+
+        return false;
+    }
+
+    function adjustIntersectingElement(element: IncrementalElement, changeStart: number, changeRangeOldEnd: number, changeRangeNewEnd: number, delta: number) {
+        Debug.assert(element.end >= changeStart, "Adjusting an element that was entirely before the change range");
+        Debug.assert(element.pos <= changeRangeOldEnd, "Adjusting an element that was entirely after the change range");
+        Debug.assert(element.pos <= element.end);
+
+        // We have an element that intersects the change range in some way.  It may have its
+        // start, or its end (or both) in the changed range.  We want to adjust any part
+        // that intersects such that the final tree is in a consistent state.  i.e. all
+        // children have spans within the span of their parent, and all siblings are ordered
+        // properly.
+
+        // We may need to update both the 'pos' and the 'end' of the element.
+
+        // If the 'pos' is before the start of the change, then we don't need to touch it.
+        // If it isn't, then the 'pos' must be inside the change.  How we update it will
+        // depend if delta is positive or negative. If delta is positive then we have
+        // something like:
+        //
+        //  -------------------AAA-----------------
+        //  -------------------BBBCCCCCCC-----------------
+        //
+        // In this case, we consider any node that started in the change range to still be
+        // starting at the same position.
+        //
+        // however, if the delta is negative, then we instead have something like this:
+        //
+        //  -------------------XXXYYYYYYY-----------------
+        //  -------------------ZZZ-----------------
+        //
+        // In this case, any element that started in the 'X' range will keep its position.
+        // However any element that started after that will have their pos adjusted to be
+        // at the end of the new range.  i.e. any node that started in the 'Y' range will
+        // be adjusted to have their start at the end of the 'Z' range.
+        //
+        // The element will keep its position if possible.  Or Move backward to the new-end
+        // if it's in the 'Y' range.
+        const pos = Math.min(element.pos, changeRangeNewEnd);
+
+        // If the 'end' is after the change range, then we always adjust it by the delta
+        // amount.  However, if the end is in the change range, then how we adjust it
+        // will depend on if delta is positive or negative.  If delta is positive then we
+        // have something like:
+        //
+        //  -------------------AAA-----------------
+        //  -------------------BBBCCCCCCC-----------------
+        //
+        // In this case, we consider any node that ended inside the change range to keep its
+        // end position.
+        //
+        // however, if the delta is negative, then we instead have something like this:
+        //
+        //  -------------------XXXYYYYYYY-----------------
+        //  -------------------ZZZ-----------------
+        //
+        // In this case, any element that ended in the 'X' range will keep its position.
+        // However any element that ended after that will have their pos adjusted to be
+        // at the end of the new range.  i.e. any node that ended in the 'Y' range will
+        // be adjusted to have their end at the end of the 'Z' range.
+        const end = element.end >= changeRangeOldEnd ?
+            // Element ends after the change range.  Always adjust the end pos.
+            element.end + delta :
+            // Element ends in the change range.  The element will keep its position if
+            // possible. Or Move backward to the new-end if it's in the 'Y' range.
+            Math.min(element.end, changeRangeNewEnd);
+
+        Debug.assert(pos <= end);
+        if (element.parent) {
+            Debug.assertGreaterThanOrEqual(pos, element.parent.pos);
+            Debug.assertLessThanOrEqual(end, element.parent.end);
+        }
+
+        setTextRangePosEnd(element, pos, end);
+    }
+
+    function checkNodePositions(node: Node, aggressiveChecks: boolean) {
+        if (aggressiveChecks) {
+            let pos = node.pos;
+            const visitNode = (child: Node) => {
+                Debug.assert(child.pos >= pos);
+                pos = child.end;
+            };
+            if (hasJSDocNodes(node)) {
+                for (const jsDocComment of node.jsDoc!) {
+                    visitNode(jsDocComment);
+                }
+            }
+            forEachChild(node, visitNode);
+            Debug.assert(pos <= node.end);
+        }
+    }
+
+    function updateTokenPositionsAndMarkElements(
+        sourceFile: IncrementalNode,
+        changeStart: number,
+        changeRangeOldEnd: number,
+        changeRangeNewEnd: number,
+        delta: number,
+        oldText: string,
+        newText: string,
+        aggressiveChecks: boolean,
+    ): void {
+        visitNode(sourceFile);
+        return;
+
+        function visitNode(child: IncrementalNode) {
+            Debug.assert(child.pos <= child.end);
+            if (child.pos > changeRangeOldEnd) {
+                // Node is entirely past the change range.  We need to move both its pos and
+                // end, forward or backward appropriately.
+                moveElementEntirelyPastChangeRange(child, /*isArray*/ false, delta, oldText, newText, aggressiveChecks);
+                return;
+            }
+
+            // Check if the element intersects the change range.  If it does, then it is not
+            // reusable.  Also, we'll need to recurse to see what constituent portions we may
+            // be able to use.
+            const fullEnd = child.end;
+            if (fullEnd >= changeStart) {
+                child.intersectsChange = true;
+                child._children = undefined;
+
+                // Adjust the pos or end (or both) of the intersecting element accordingly.
+                adjustIntersectingElement(child, changeStart, changeRangeOldEnd, changeRangeNewEnd, delta);
+                forEachChild(child, visitNode as (node: Node) => void, visitArray as (nodes: NodeArray<Node>) => void);
+                if (hasJSDocNodes(child)) {
+                    for (const jsDocComment of child.jsDoc!) {
+                        visitNode(jsDocComment as Node as IncrementalNode);
+                    }
+                }
+                checkNodePositions(child, aggressiveChecks);
+                return;
+            }
+
+            // Otherwise, the node is entirely before the change range.  No need to do anything with it.
+            Debug.assert(fullEnd < changeStart);
+        }
+
+        function visitArray(array: IncrementalNodeArray) {
+            Debug.assert(array.pos <= array.end);
+            if (array.pos > changeRangeOldEnd) {
+                // Array is entirely after the change range.  We need to move it, and move any of
+                // its children.
+                moveElementEntirelyPastChangeRange(array, /*isArray*/ true, delta, oldText, newText, aggressiveChecks);
+                return;
+            }
+
+            // Check if the element intersects the change range.  If it does, then it is not
+            // reusable.  Also, we'll need to recurse to see what constituent portions we may
+            // be able to use.
+            const fullEnd = array.end;
+            if (fullEnd >= changeStart) {
+                array.intersectsChange = true;
+                array._children = undefined;
+
+                // Adjust the pos or end (or both) of the intersecting array accordingly.
+                adjustIntersectingElement(array, changeStart, changeRangeOldEnd, changeRangeNewEnd, delta);
+                for (const node of array) {
+                    visitNode(node);
+                }
+                return;
+            }
+
+            // Otherwise, the array is entirely before the change range.  No need to do anything with it.
+            Debug.assert(fullEnd < changeStart);
+        }
+    }
+
+    function extendToAffectedRange(sourceFile: SourceFile, changeRange: TextChangeRange): TextChangeRange {
+        // Consider the following code:
+        //      void foo() { /; }
+        //
+        // If the text changes with an insertion of / just before the semicolon then we end up with:
+        //      void foo() { //; }
+        //
+        // If we were to just use the changeRange a is, then we would not rescan the { token
+        // (as it does not intersect the actual original change range).  Because an edit may
+        // change the token touching it, we actually need to look back *at least* one token so
+        // that the prior token sees that change.
+        const maxLookahead = 1;
+
+        let start = changeRange.span.start;
+
+        // the first iteration aligns us with the change start. subsequent iteration move us to
+        // the left by maxLookahead tokens.  We only need to do this as long as we're not at the
+        // start of the tree.
+        for (let i = 0; start > 0 && i <= maxLookahead; i++) {
+            const nearestNode = findNearestNodeStartingBeforeOrAtPosition(sourceFile, start);
+            Debug.assert(nearestNode.pos <= start);
+            const position = nearestNode.pos;
+
+            start = Math.max(0, position - 1);
+        }
+
+        const finalSpan = createTextSpanFromBounds(start, textSpanEnd(changeRange.span));
+        const finalLength = changeRange.newLength + (changeRange.span.start - start);
+
+        return createTextChangeRange(finalSpan, finalLength);
+    }
+
+    function findNearestNodeStartingBeforeOrAtPosition(sourceFile: SourceFile, position: number): Node {
+        let bestResult: Node = sourceFile;
+        let lastNodeEntirelyBeforePosition: Node | undefined;
+
+        forEachChild(sourceFile, visit);
+
+        if (lastNodeEntirelyBeforePosition) {
+            const lastChildOfLastEntireNodeBeforePosition = getLastDescendant(lastNodeEntirelyBeforePosition);
+            if (lastChildOfLastEntireNodeBeforePosition.pos > bestResult.pos) {
+                bestResult = lastChildOfLastEntireNodeBeforePosition;
+            }
+        }
+
+        return bestResult;
+
+        function getLastDescendant(node: Node): Node {
+            while (true) {
+                const lastChild = getLastChild(node);
+                if (lastChild) {
+                    node = lastChild;
+                }
+                else {
+                    return node;
+                }
+            }
+        }
+
+        function visit(child: Node) {
+            if (nodeIsMissing(child)) {
+                // Missing nodes are effectively invisible to us.  We never even consider them
+                // When trying to find the nearest node before us.
+                return;
+            }
+
+            // If the child intersects this position, then this node is currently the nearest
+            // node that starts before the position.
+            if (child.pos <= position) {
+                if (child.pos >= bestResult.pos) {
+                    // This node starts before the position, and is closer to the position than
+                    // the previous best node we found.  It is now the new best node.
+                    bestResult = child;
+                }
+
+                // Now, the node may overlap the position, or it may end entirely before the
+                // position.  If it overlaps with the position, then either it, or one of its
+                // children must be the nearest node before the position.  So we can just
+                // recurse into this child to see if we can find something better.
+                if (position < child.end) {
+                    // The nearest node is either this child, or one of the children inside
+                    // of it.  We've already marked this child as the best so far.  Recurse
+                    // in case one of the children is better.
+                    forEachChild(child, visit);
+
+                    // Once we look at the children of this node, then there's no need to
+                    // continue any further.
+                    return true;
+                }
+                else {
+                    Debug.assert(child.end <= position);
+                    // The child ends entirely before this position.  Say you have the following
+                    // (where $ is the position)
+                    //
+                    //      <complex expr 1> ? <complex expr 2> $ : <...> <...>
+                    //
+                    // We would want to find the nearest preceding node in "complex expr 2".
+                    // To support that, we keep track of this node, and once we're done searching
+                    // for a best node, we recurse down this node to see if we can find a good
+                    // result in it.
+                    //
+                    // This approach allows us to quickly skip over nodes that are entirely
+                    // before the position, while still allowing us to find any nodes in the
+                    // last one that might be what we want.
+                    lastNodeEntirelyBeforePosition = child;
+                }
+            }
+            else {
+                Debug.assert(child.pos > position);
+                // We're now at a node that is entirely past the position we're searching for.
+                // This node (and all following nodes) could never contribute to the result,
+                // so just skip them by returning 'true' here.
+                return true;
+            }
+        }
+    }
+
+    function checkChangeRange(sourceFile: SourceFile, newText: string, textChangeRange: TextChangeRange, aggressiveChecks: boolean) {
+        const oldText = sourceFile.text;
+        if (textChangeRange) {
+            Debug.assert((oldText.length - textChangeRange.span.length + textChangeRange.newLength) === newText.length);
+
+            if (aggressiveChecks || Debug.shouldAssert(AssertionLevel.VeryAggressive)) {
+                const oldTextPrefix = oldText.substr(0, textChangeRange.span.start);
+                const newTextPrefix = newText.substr(0, textChangeRange.span.start);
+                Debug.assert(oldTextPrefix === newTextPrefix);
+
+                const oldTextSuffix = oldText.substring(textSpanEnd(textChangeRange.span), oldText.length);
+                const newTextSuffix = newText.substring(textSpanEnd(textChangeRangeNewSpan(textChangeRange)), newText.length);
+                Debug.assert(oldTextSuffix === newTextSuffix);
+            }
+        }
+    }
+
+    interface IncrementalElement extends ReadonlyTextRange {
+        readonly parent: Node;
+        intersectsChange: boolean;
+        length?: number;
+        _children: Node[] | undefined;
+    }
+
+    export interface IncrementalNode extends Node, IncrementalElement {
+        hasBeenIncrementallyParsed: boolean;
+    }
+
+    interface IncrementalNodeArray extends NodeArray<IncrementalNode>, IncrementalElement {
+        length: number;
+    }
+
+    // Allows finding nodes in the source file at a certain position in an efficient manner.
+    // The implementation takes advantage of the calling pattern it knows the parser will
+    // make in order to optimize finding nodes as quickly as possible.
+    export interface SyntaxCursor {
+        currentNode(position: number): IncrementalNode;
+    }
+
+    export function createSyntaxCursor(sourceFile: SourceFile): SyntaxCursor {
+        let currentArray: NodeArray<Node> = sourceFile.statements;
+        let currentArrayIndex = 0;
+
+        Debug.assert(currentArrayIndex < currentArray.length);
+        let current = currentArray[currentArrayIndex];
+        let lastQueriedPosition = InvalidPosition.Value;
+
+        return {
+            currentNode(position: number) {
+                // Only compute the current node if the position is different than the last time
+                // we were asked.  The parser commonly asks for the node at the same position
+                // twice.  Once to know if can read an appropriate list element at a certain point,
+                // and then to actually read and consume the node.
+                if (position !== lastQueriedPosition) {
+                    // Much of the time the parser will need the very next node in the array that
+                    // we just returned a node from.So just simply check for that case and move
+                    // forward in the array instead of searching for the node again.
+                    if (current && current.end === position && currentArrayIndex < (currentArray.length - 1)) {
+                        currentArrayIndex++;
+                        current = currentArray[currentArrayIndex];
+                    }
+
+                    // If we don't have a node, or the node we have isn't in the right position,
+                    // then try to find a viable node at the position requested.
+                    if (!current || current.pos !== position) {
+                        findHighestListElementThatStartsAtPosition(position);
+                    }
+                }
+
+                // Cache this query so that we don't do any extra work if the parser calls back
+                // into us.  Note: this is very common as the parser will make pairs of calls like
+                // 'isListElement -> parseListElement'.  If we were unable to find a node when
+                // called with 'isListElement', we don't want to redo the work when parseListElement
+                // is called immediately after.
+                lastQueriedPosition = position;
+
+                // Either we don'd have a node, or we have a node at the position being asked for.
+                Debug.assert(!current || current.pos === position);
+                return current as IncrementalNode;
+            },
+        };
+
+        // Finds the highest element in the tree we can find that starts at the provided position.
+        // The element must be a direct child of some node list in the tree.  This way after we
+        // return it, we can easily return its next sibling in the list.
+        function findHighestListElementThatStartsAtPosition(position: number) {
+            // Clear out any cached state about the last node we found.
+            currentArray = undefined!;
+            currentArrayIndex = InvalidPosition.Value;
+            current = undefined!;
+
+            // Recurse into the source file to find the highest node at this position.
+            forEachChild(sourceFile, visitNode, visitArray);
+            return;
+
+            function visitNode(node: Node) {
+                if (position >= node.pos && position < node.end) {
+                    // Position was within this node.  Keep searching deeper to find the node.
+                    forEachChild(node, visitNode, visitArray);
+
+                    // don't proceed any further in the search.
+                    return true;
+                }
+
+                // position wasn't in this node, have to keep searching.
+                return false;
+            }
+
+            function visitArray(array: NodeArray<Node>) {
+                if (position >= array.pos && position < array.end) {
+                    // position was in this array.  Search through this array to see if we find a
+                    // viable element.
+                    for (let i = 0; i < array.length; i++) {
+                        const child = array[i];
+                        if (child) {
+                            if (child.pos === position) {
+                                // Found the right node.  We're done.
+                                currentArray = array;
+                                currentArrayIndex = i;
+                                current = child;
+                                return true;
+                            }
+                            else {
+                                if (child.pos < position && position < child.end) {
+                                    // Position in somewhere within this child.  Search in it and
+                                    // stop searching in this array.
+                                    forEachChild(child, visitNode, visitArray);
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // position wasn't in this array, have to keep searching.
+                return false;
+            }
+        }
+    }
+
+    const enum InvalidPosition {
+        Value = -1,
+    }
+}
+
+/** @internal */
+export function isDeclarationFileName(fileName: string): boolean {
+    return fileExtensionIsOneOf(fileName, supportedDeclarationExtensions) || (fileExtensionIs(fileName, Extension.Ts) && getBaseFileName(fileName).includes(".d."));
+}
+
+function parseResolutionMode(mode: string | undefined, pos: number, end: number, reportDiagnostic: PragmaDiagnosticReporter): ResolutionMode {
+    if (!mode) {
+        return undefined;
+    }
+    if (mode === "import") {
+        return ModuleKind.ESNext;
+    }
+    if (mode === "require") {
+        return ModuleKind.CommonJS;
+    }
+    reportDiagnostic(pos, end - pos, Diagnostics.resolution_mode_should_be_either_require_or_import);
+    return undefined;
+}
+
+/** @internal */
+export function processCommentPragmas(context: PragmaContext, sourceText: string): void {
+    const pragmas: PragmaPseudoMapEntry[] = [];
+
+    for (const range of getLeadingCommentRanges(sourceText, 0) || emptyArray) {
+        const comment = sourceText.substring(range.pos, range.end);
+        extractPragmas(pragmas, range, comment);
+    }
+
+    context.pragmas = new Map() as PragmaMap;
+    for (const pragma of pragmas) {
+        if (context.pragmas.has(pragma.name)) {
+            const currentValue = context.pragmas.get(pragma.name);
+            if (currentValue instanceof Array) {
+                currentValue.push(pragma.args);
+            }
+            else {
+                context.pragmas.set(pragma.name, [currentValue, pragma.args]);
+            }
+            continue;
+        }
+        context.pragmas.set(pragma.name, pragma.args);
+    }
+}
+
+/** @internal */
+export type PragmaDiagnosticReporter = (pos: number, length: number, message: DiagnosticMessage) => void;
+
+/** @internal */
+export function processPragmasIntoFields(context: PragmaContext, reportDiagnostic: PragmaDiagnosticReporter): void {
+    context.checkJsDirective = undefined;
+    context.referencedFiles = [];
+    context.typeReferenceDirectives = [];
+    context.libReferenceDirectives = [];
+    context.amdDependencies = [];
+    context.hasNoDefaultLib = false;
+    context.pragmas!.forEach((entryOrList, key) => { // TODO: GH#18217
+        // TODO: The below should be strongly type-guarded and not need casts/explicit annotations, since entryOrList is related to
+        // key and key is constrained to a union; but it's not (see GH#21483 for at least partial fix) :(
+        switch (key) {
+            case "reference": {
+                const referencedFiles = context.referencedFiles;
+                const typeReferenceDirectives = context.typeReferenceDirectives;
+                const libReferenceDirectives = context.libReferenceDirectives;
+                forEach(toArray(entryOrList) as PragmaPseudoMap["reference"][], arg => {
+                    const { types, lib, path, ["resolution-mode"]: res } = arg.arguments;
+                    if (arg.arguments["no-default-lib"]) {
+                        context.hasNoDefaultLib = true;
+                    }
+                    else if (types) {
+                        const parsed = parseResolutionMode(res, types.pos, types.end, reportDiagnostic);
+                        typeReferenceDirectives.push({ pos: types.pos, end: types.end, fileName: types.value, ...(parsed ? { resolutionMode: parsed } : {}) });
+                    }
+                    else if (lib) {
+                        libReferenceDirectives.push({ pos: lib.pos, end: lib.end, fileName: lib.value });
+                    }
+                    else if (path) {
+                        referencedFiles.push({ pos: path.pos, end: path.end, fileName: path.value });
+                    }
+                    else {
+                        reportDiagnostic(arg.range.pos, arg.range.end - arg.range.pos, Diagnostics.Invalid_reference_directive_syntax);
+                    }
+                });
+                break;
+            }
+            case "amd-dependency": {
+                context.amdDependencies = map(
+                    toArray(entryOrList) as PragmaPseudoMap["amd-dependency"][],
+                    x => ({ name: x.arguments.name, path: x.arguments.path }),
+                );
+                break;
+            }
+            case "amd-module": {
+                if (entryOrList instanceof Array) {
+                    for (const entry of entryOrList) {
+                        if (context.moduleName) {
+                            // TODO: It's probably fine to issue this diagnostic on all instances of the pragma
+                            reportDiagnostic(entry.range.pos, entry.range.end - entry.range.pos, Diagnostics.An_AMD_module_cannot_have_multiple_name_assignments);
+                        }
+                        context.moduleName = (entry as PragmaPseudoMap["amd-module"]).arguments.name;
+                    }
+                }
+                else {
+                    context.moduleName = (entryOrList as PragmaPseudoMap["amd-module"]).arguments.name;
+                }
+                break;
+            }
+            case "ts-nocheck":
+            case "ts-check": {
+                // _last_ of either nocheck or check in a file is the "winner"
+                forEach(toArray(entryOrList), entry => {
+                    if (!context.checkJsDirective || entry.range.pos > context.checkJsDirective.pos) {
+                        context.checkJsDirective = {
+                            enabled: key === "ts-check",
+                            end: entry.range.end,
+                            pos: entry.range.pos,
+                        };
+                    }
+                });
+                break;
+            }
+            case "jsx":
+            case "jsxfrag":
+            case "jsximportsource":
+            case "jsxruntime":
+                return; // Accessed directly
+            default:
+                Debug.fail("Unhandled pragma kind"); // Can this be made into an assertNever in the future?
+        }
+    });
+}
+
+const namedArgRegExCache = new Map<string, RegExp>();
+function getNamedArgRegEx(name: string): RegExp {
+    if (namedArgRegExCache.has(name)) {
+        return namedArgRegExCache.get(name)!;
+    }
+    const result = new RegExp(`(\\s${name}\\s*=\\s*)(?:(?:'([^']*)')|(?:"([^"]*)"))`, "im");
+    namedArgRegExCache.set(name, result);
+    return result;
+}
+
+const tripleSlashXMLCommentStartRegEx = /^\/\/\/\s*<(\S+)\s.*?\/>/im;
+const singleLinePragmaRegEx = /^\/\/\/?\s*@([^\s:]+)(.*)\s*$/im;
+function extractPragmas(pragmas: PragmaPseudoMapEntry[], range: CommentRange, text: string) {
+    const tripleSlash = range.kind === SyntaxKind.SingleLineCommentTrivia && tripleSlashXMLCommentStartRegEx.exec(text);
+    if (tripleSlash) {
+        const name = tripleSlash[1].toLowerCase() as keyof PragmaPseudoMap; // Technically unsafe cast, but we do it so the below check to make it safe typechecks
+        const pragma = commentPragmas[name] as PragmaDefinition;
+        if (!pragma || !(pragma.kind! & PragmaKindFlags.TripleSlashXML)) {
+            return;
+        }
+        if (pragma.args) {
+            const argument: { [index: string]: string | { value: string; pos: number; end: number; }; } = {};
+            for (const arg of pragma.args) {
+                const matcher = getNamedArgRegEx(arg.name);
+                const matchResult = matcher.exec(text);
+                if (!matchResult && !arg.optional) {
+                    return; // Missing required argument, don't parse
+                }
+                else if (matchResult) {
+                    const value = matchResult[2] || matchResult[3];
+                    if (arg.captureSpan) {
+                        const startPos = range.pos + matchResult.index + matchResult[1].length + 1;
+                        argument[arg.name] = {
+                            value,
+                            pos: startPos,
+                            end: startPos + value.length,
+                        };
+                    }
+                    else {
+                        argument[arg.name] = value;
+                    }
+                }
+            }
+            pragmas.push({ name, args: { arguments: argument, range } } as PragmaPseudoMapEntry);
+        }
+        else {
+            pragmas.push({ name, args: { arguments: {}, range } } as PragmaPseudoMapEntry);
+        }
+        return;
+    }
+
+    const singleLine = range.kind === SyntaxKind.SingleLineCommentTrivia && singleLinePragmaRegEx.exec(text);
+    if (singleLine) {
+        return addPragmaForMatch(pragmas, range, PragmaKindFlags.SingleLine, singleLine);
+    }
+
+    if (range.kind === SyntaxKind.MultiLineCommentTrivia) {
+        const multiLinePragmaRegEx = /@(\S+)(\s+.*)?$/gim; // Defined inline since it uses the "g" flag, which keeps a persistent index (for iterating)
+        let multiLineMatch: RegExpExecArray | null;
+        while (multiLineMatch = multiLinePragmaRegEx.exec(text)) {
+            addPragmaForMatch(pragmas, range, PragmaKindFlags.MultiLine, multiLineMatch);
+        }
+    }
+}
+
+function addPragmaForMatch(pragmas: PragmaPseudoMapEntry[], range: CommentRange, kind: PragmaKindFlags, match: RegExpExecArray) {
+    if (!match) return;
+    const name = match[1].toLowerCase() as keyof PragmaPseudoMap; // Technically unsafe cast, but we do it so they below check to make it safe typechecks
+    const pragma = commentPragmas[name] as PragmaDefinition;
+    if (!pragma || !(pragma.kind! & kind)) {
+        return;
+    }
+    const args = match[2]; // Split on spaces and match up positionally with definition
+    const argument = getNamedPragmaArguments(pragma, args);
+    if (argument === "fail") return; // Missing required argument, fail to parse it
+    pragmas.push({ name, args: { arguments: argument, range } } as PragmaPseudoMapEntry);
+    return;
+}
+
+function getNamedPragmaArguments(pragma: PragmaDefinition, text: string | undefined): { [index: string]: string; } | "fail" {
+    if (!text) return {};
+    if (!pragma.args) return {};
+    const args = text.trim().split(/\s+/);
+    const argMap: { [index: string]: string; } = {};
+    for (let i = 0; i < pragma.args.length; i++) {
+        const argument = pragma.args[i];
+        if (!args[i] && !argument.optional) {
+            return "fail";
+        }
+        if (argument.captureSpan) {
+            return Debug.fail("Capture spans not yet implemented for non-xml pragmas");
+        }
+        argMap[argument.name] = args[i];
+    }
+    return argMap;
+}
+
+/** @internal */
+export function tagNamesAreEquivalent(lhs: JsxTagNameExpression, rhs: JsxTagNameExpression): boolean {
+    if (lhs.kind !== rhs.kind) {
+        return false;
+    }
+
+    if (lhs.kind === SyntaxKind.Identifier) {
+        return lhs.escapedText === (rhs as Identifier).escapedText;
+    }
+
+    if (lhs.kind === SyntaxKind.ThisKeyword) {
+        return true;
+    }
+
+    if (lhs.kind === SyntaxKind.JsxNamespacedName) {
+        return lhs.namespace.escapedText === (rhs as JsxNamespacedName).namespace.escapedText &&
+            lhs.name.escapedText === (rhs as JsxNamespacedName).name.escapedText;
+    }
+
+    // If we are at this statement then we must have PropertyAccessExpression and because tag name in Jsx element can only
+    // take forms of JsxTagNameExpression which includes an identifier, "this" expression, or another propertyAccessExpression
+    // it is safe to case the expression property as such. See parseJsxElementName for how we parse tag name in Jsx element
+    return (lhs as PropertyAccessExpression).name.escapedText === (rhs as PropertyAccessExpression).name.escapedText &&
+        tagNamesAreEquivalent((lhs as PropertyAccessExpression).expression as JsxTagNameExpression, (rhs as PropertyAccessExpression).expression as JsxTagNameExpression);
+}

--- a/benchmark/babel-parser/real-case/bench.mjs
+++ b/benchmark/babel-parser/real-case/bench.mjs
@@ -1,0 +1,33 @@
+import Benchmark from "benchmark";
+import baseline from "@babel-baseline/parser";
+import current from "@babel/parser";
+import { report } from "../../util.mjs";
+import { readFileSync } from "fs";
+
+const suite = new Benchmark.Suite();
+
+function createInput(length) {
+  return readFileSync(new URL("./jquery-3.6.txt", import.meta.url), {
+    encoding: "utf-8",
+  }).repeat(length);
+}
+
+const inputs = [4].map(length => ({
+  tag: length,
+  body: createInput(length),
+}));
+
+function benchCases(name, implementation, options) {
+  for (const input of inputs) {
+    suite.add(`${name} ${input.tag} jquery 3.6`, () => {
+      implementation(input.body, options);
+    });
+  }
+}
+
+benchCases("current", current.parse);
+benchCases("baseline", baseline.parse);
+benchCases("current", current.parse);
+benchCases("baseline", baseline.parse);
+
+suite.on("cycle", report).run();

--- a/benchmark/babel-parser/real-case/jquery-3.6.txt
+++ b/benchmark/babel-parser/real-case/jquery-3.6.txt
@@ -1,0 +1,11193 @@
+/*!
+ * jQuery JavaScript Library v3.6.0
+ * https://jquery.com/
+ *
+ * Includes Sizzle.js
+ * https://sizzlejs.com/
+ *
+ * Copyright OpenJS Foundation and other contributors
+ * Released under the MIT license
+ * https://jquery.org/license
+ *
+ * Date: 2021-03-02T17:08Z
+ */
+(function (global, factory) {
+  "use strict";
+
+  if (typeof module === "object" && typeof module.exports === "object") {
+    // For CommonJS and CommonJS-like environments where a proper `window`
+    // is present, execute the factory and get jQuery.
+    // For environments that do not have a `window` with a `document`
+    // (such as Node.js), expose a factory as module.exports.
+    // This accentuates the need for the creation of a real `window`.
+    // e.g. var jQuery = require("jquery")(window);
+    // See ticket #14549 for more info.
+    module.exports = global.document
+      ? factory(global, true)
+      : function (w) {
+          if (!w.document) {
+            throw new Error("jQuery requires a window with a document");
+          }
+          return factory(w);
+        };
+  } else {
+    factory(global);
+  }
+
+  // Pass this if window is not defined yet
+})(typeof window !== "undefined" ? window : this, function (window, noGlobal) {
+  // Edge <= 12 - 13+, Firefox <=18 - 45+, IE 10 - 11, Safari 5.1 - 9+, iOS 6 - 9.1
+  // throw exceptions when non-strict code (e.g., ASP.NET 4.5) accesses strict mode
+  // arguments.callee.caller (trac-13335). But as of jQuery 3.0 (2016), strict mode should be common
+  // enough that all such attempts are guarded in a try block.
+  "use strict";
+
+  var arr = [];
+
+  var getProto = Object.getPrototypeOf;
+
+  var slice = arr.slice;
+
+  var flat = arr.flat
+    ? function (array) {
+        return arr.flat.call(array);
+      }
+    : function (array) {
+        return arr.concat.apply([], array);
+      };
+
+  var push = arr.push;
+
+  var indexOf = arr.indexOf;
+
+  var class2type = {};
+
+  var toString = class2type.toString;
+
+  var hasOwn = class2type.hasOwnProperty;
+
+  var fnToString = hasOwn.toString;
+
+  var ObjectFunctionString = fnToString.call(Object);
+
+  var support = {};
+
+  var isFunction = function isFunction(obj) {
+    // Support: Chrome <=57, Firefox <=52
+    // In some browsers, typeof returns "function" for HTML <object> elements
+    // (i.e., `typeof document.createElement( "object" ) === "function"`).
+    // We don't want to classify *any* DOM node as a function.
+    // Support: QtWeb <=3.8.5, WebKit <=534.34, wkhtmltopdf tool <=0.12.5
+    // Plus for old WebKit, typeof returns "function" for HTML collections
+    // (e.g., `typeof document.getElementsByTagName("div") === "function"`). (gh-4756)
+    return (
+      typeof obj === "function" &&
+      typeof obj.nodeType !== "number" &&
+      typeof obj.item !== "function"
+    );
+  };
+
+  var isWindow = function isWindow(obj) {
+    return obj != null && obj === obj.window;
+  };
+
+  var document = window.document;
+
+  var preservedScriptAttributes = {
+    type: true,
+    src: true,
+    nonce: true,
+    noModule: true,
+  };
+
+  function DOMEval(code, node, doc) {
+    doc = doc || document;
+
+    var i,
+      val,
+      script = doc.createElement("script");
+
+    script.text = code;
+    if (node) {
+      for (i in preservedScriptAttributes) {
+        // Support: Firefox 64+, Edge 18+
+        // Some browsers don't support the "nonce" property on scripts.
+        // On the other hand, just using `getAttribute` is not enough as
+        // the `nonce` attribute is reset to an empty string whenever it
+        // becomes browsing-context connected.
+        // See https://github.com/whatwg/html/issues/2369
+        // See https://html.spec.whatwg.org/#nonce-attributes
+        // The `node.getAttribute` check was added for the sake of
+        // `jQuery.globalEval` so that it can fake a nonce-containing node
+        // via an object.
+        val = node[i] || (node.getAttribute && node.getAttribute(i));
+        if (val) {
+          script.setAttribute(i, val);
+        }
+      }
+    }
+    doc.head.appendChild(script).parentNode.removeChild(script);
+  }
+
+  function toType(obj) {
+    if (obj == null) {
+      return obj + "";
+    }
+
+    // Support: Android <=2.3 only (functionish RegExp)
+    return typeof obj === "object" || typeof obj === "function"
+      ? class2type[toString.call(obj)] || "object"
+      : typeof obj;
+  }
+  /* global Symbol */
+  // Defining this global in .eslintrc.json would create a danger of using the global
+  // unguarded in another place, it seems safer to define global only for this module
+
+  var version = "3.6.0",
+    // Define a local copy of jQuery
+    jQuery = function (selector, context) {
+      // The jQuery object is actually just the init constructor 'enhanced'
+      // Need init if jQuery is called (just allow error to be thrown if not included)
+      return new jQuery.fn.init(selector, context);
+    };
+
+  jQuery.fn = jQuery.prototype = {
+    // The current version of jQuery being used
+    jquery: version,
+
+    constructor: jQuery,
+
+    // The default length of a jQuery object is 0
+    length: 0,
+
+    toArray: function () {
+      return slice.call(this);
+    },
+
+    // Get the Nth element in the matched element set OR
+    // Get the whole matched element set as a clean array
+    get: function (num) {
+      // Return all the elements in a clean array
+      if (num == null) {
+        return slice.call(this);
+      }
+
+      // Return just the one element from the set
+      return num < 0 ? this[num + this.length] : this[num];
+    },
+
+    // Take an array of elements and push it onto the stack
+    // (returning the new matched element set)
+    pushStack: function (elems) {
+      // Build a new jQuery matched element set
+      var ret = jQuery.merge(this.constructor(), elems);
+
+      // Add the old object onto the stack (as a reference)
+      ret.prevObject = this;
+
+      // Return the newly-formed element set
+      return ret;
+    },
+
+    // Execute a callback for every element in the matched set.
+    each: function (callback) {
+      return jQuery.each(this, callback);
+    },
+
+    map: function (callback) {
+      return this.pushStack(
+        jQuery.map(this, function (elem, i) {
+          return callback.call(elem, i, elem);
+        })
+      );
+    },
+
+    slice: function () {
+      return this.pushStack(slice.apply(this, arguments));
+    },
+
+    first: function () {
+      return this.eq(0);
+    },
+
+    last: function () {
+      return this.eq(-1);
+    },
+
+    even: function () {
+      return this.pushStack(
+        jQuery.grep(this, function (_elem, i) {
+          return (i + 1) % 2;
+        })
+      );
+    },
+
+    odd: function () {
+      return this.pushStack(
+        jQuery.grep(this, function (_elem, i) {
+          return i % 2;
+        })
+      );
+    },
+
+    eq: function (i) {
+      var len = this.length,
+        j = +i + (i < 0 ? len : 0);
+      return this.pushStack(j >= 0 && j < len ? [this[j]] : []);
+    },
+
+    end: function () {
+      return this.prevObject || this.constructor();
+    },
+
+    // For internal use only.
+    // Behaves like an Array's method, not like a jQuery method.
+    push: push,
+    sort: arr.sort,
+    splice: arr.splice,
+  };
+
+  jQuery.extend = jQuery.fn.extend = function () {
+    var options,
+      name,
+      src,
+      copy,
+      copyIsArray,
+      clone,
+      target = arguments[0] || {},
+      i = 1,
+      length = arguments.length,
+      deep = false;
+
+    // Handle a deep copy situation
+    if (typeof target === "boolean") {
+      deep = target;
+
+      // Skip the boolean and the target
+      target = arguments[i] || {};
+      i++;
+    }
+
+    // Handle case when target is a string or something (possible in deep copy)
+    if (typeof target !== "object" && !isFunction(target)) {
+      target = {};
+    }
+
+    // Extend jQuery itself if only one argument is passed
+    if (i === length) {
+      target = this;
+      i--;
+    }
+
+    for (; i < length; i++) {
+      // Only deal with non-null/undefined values
+      if ((options = arguments[i]) != null) {
+        // Extend the base object
+        for (name in options) {
+          copy = options[name];
+
+          // Prevent Object.prototype pollution
+          // Prevent never-ending loop
+          if (name === "__proto__" || target === copy) {
+            continue;
+          }
+
+          // Recurse if we're merging plain objects or arrays
+          if (
+            deep &&
+            copy &&
+            (jQuery.isPlainObject(copy) || (copyIsArray = Array.isArray(copy)))
+          ) {
+            src = target[name];
+
+            // Ensure proper type for the source value
+            if (copyIsArray && !Array.isArray(src)) {
+              clone = [];
+            } else if (!copyIsArray && !jQuery.isPlainObject(src)) {
+              clone = {};
+            } else {
+              clone = src;
+            }
+            copyIsArray = false;
+
+            // Never move original objects, clone them
+            target[name] = jQuery.extend(deep, clone, copy);
+
+            // Don't bring in undefined values
+          } else if (copy !== undefined) {
+            target[name] = copy;
+          }
+        }
+      }
+    }
+
+    // Return the modified object
+    return target;
+  };
+
+  jQuery.extend({
+    // Unique for each copy of jQuery on the page
+    expando: "jQuery" + (version + Math.random()).replace(/\D/g, ""),
+
+    // Assume jQuery is ready without the ready module
+    isReady: true,
+
+    error: function (msg) {
+      throw new Error(msg);
+    },
+
+    noop: function () {},
+
+    isPlainObject: function (obj) {
+      var proto, Ctor;
+
+      // Detect obvious negatives
+      // Use toString instead of jQuery.type to catch host objects
+      if (!obj || toString.call(obj) !== "[object Object]") {
+        return false;
+      }
+
+      proto = getProto(obj);
+
+      // Objects with no prototype (e.g., `Object.create( null )`) are plain
+      if (!proto) {
+        return true;
+      }
+
+      // Objects with prototype are plain iff they were constructed by a global Object function
+      Ctor = hasOwn.call(proto, "constructor") && proto.constructor;
+      return (
+        typeof Ctor === "function" &&
+        fnToString.call(Ctor) === ObjectFunctionString
+      );
+    },
+
+    isEmptyObject: function (obj) {
+      var name;
+
+      for (name in obj) {
+        return false;
+      }
+      return true;
+    },
+
+    // Evaluates a script in a provided context; falls back to the global one
+    // if not specified.
+    globalEval: function (code, options, doc) {
+      DOMEval(code, { nonce: options && options.nonce }, doc);
+    },
+
+    each: function (obj, callback) {
+      var length,
+        i = 0;
+
+      if (isArrayLike(obj)) {
+        length = obj.length;
+        for (; i < length; i++) {
+          if (callback.call(obj[i], i, obj[i]) === false) {
+            break;
+          }
+        }
+      } else {
+        for (i in obj) {
+          if (callback.call(obj[i], i, obj[i]) === false) {
+            break;
+          }
+        }
+      }
+
+      return obj;
+    },
+
+    // results is for internal usage only
+    makeArray: function (arr, results) {
+      var ret = results || [];
+
+      if (arr != null) {
+        if (isArrayLike(Object(arr))) {
+          jQuery.merge(ret, typeof arr === "string" ? [arr] : arr);
+        } else {
+          push.call(ret, arr);
+        }
+      }
+
+      return ret;
+    },
+
+    inArray: function (elem, arr, i) {
+      return arr == null ? -1 : indexOf.call(arr, elem, i);
+    },
+
+    // Support: Android <=4.0 only, PhantomJS 1 only
+    // push.apply(_, arraylike) throws on ancient WebKit
+    merge: function (first, second) {
+      var len = +second.length,
+        j = 0,
+        i = first.length;
+
+      for (; j < len; j++) {
+        first[i++] = second[j];
+      }
+
+      first.length = i;
+
+      return first;
+    },
+
+    grep: function (elems, callback, invert) {
+      var callbackInverse,
+        matches = [],
+        i = 0,
+        length = elems.length,
+        callbackExpect = !invert;
+
+      // Go through the array, only saving the items
+      // that pass the validator function
+      for (; i < length; i++) {
+        callbackInverse = !callback(elems[i], i);
+        if (callbackInverse !== callbackExpect) {
+          matches.push(elems[i]);
+        }
+      }
+
+      return matches;
+    },
+
+    // arg is for internal usage only
+    map: function (elems, callback, arg) {
+      var length,
+        value,
+        i = 0,
+        ret = [];
+
+      // Go through the array, translating each of the items to their new values
+      if (isArrayLike(elems)) {
+        length = elems.length;
+        for (; i < length; i++) {
+          value = callback(elems[i], i, arg);
+
+          if (value != null) {
+            ret.push(value);
+          }
+        }
+
+        // Go through every key on the object,
+      } else {
+        for (i in elems) {
+          value = callback(elems[i], i, arg);
+
+          if (value != null) {
+            ret.push(value);
+          }
+        }
+      }
+
+      // Flatten any nested arrays
+      return flat(ret);
+    },
+
+    // A global GUID counter for objects
+    guid: 1,
+
+    // jQuery.support is not used in Core but other projects attach their
+    // properties to it so it needs to exist.
+    support: support,
+  });
+
+  if (typeof Symbol === "function") {
+    jQuery.fn[Symbol.iterator] = arr[Symbol.iterator];
+  }
+
+  // Populate the class2type map
+  jQuery.each(
+    "Boolean Number String Function Array Date RegExp Object Error Symbol".split(
+      " "
+    ),
+    function (_i, name) {
+      class2type["[object " + name + "]"] = name.toLowerCase();
+    }
+  );
+
+  function isArrayLike(obj) {
+    // Support: real iOS 8.2 only (not reproducible in simulator)
+    // `in` check used to prevent JIT error (gh-2145)
+    // hasOwn isn't used here due to false negatives
+    // regarding Nodelist length in IE
+    var length = !!obj && "length" in obj && obj.length,
+      type = toType(obj);
+
+    if (isFunction(obj) || isWindow(obj)) {
+      return false;
+    }
+
+    return (
+      type === "array" ||
+      length === 0 ||
+      (typeof length === "number" && length > 0 && length - 1 in obj)
+    );
+  }
+  var Sizzle =
+    /*!
+     * Sizzle CSS Selector Engine v2.3.6
+     * https://sizzlejs.com/
+     *
+     * Copyright JS Foundation and other contributors
+     * Released under the MIT license
+     * https://js.foundation/
+     *
+     * Date: 2021-02-16
+     */
+    (function (window) {
+      var i,
+        support,
+        Expr,
+        getText,
+        isXML,
+        tokenize,
+        compile,
+        select,
+        outermostContext,
+        sortInput,
+        hasDuplicate,
+        // Local document vars
+        setDocument,
+        document,
+        docElem,
+        documentIsHTML,
+        rbuggyQSA,
+        rbuggyMatches,
+        matches,
+        contains,
+        // Instance-specific data
+        expando = "sizzle" + 1 * new Date(),
+        preferredDoc = window.document,
+        dirruns = 0,
+        done = 0,
+        classCache = createCache(),
+        tokenCache = createCache(),
+        compilerCache = createCache(),
+        nonnativeSelectorCache = createCache(),
+        sortOrder = function (a, b) {
+          if (a === b) {
+            hasDuplicate = true;
+          }
+          return 0;
+        },
+        // Instance methods
+        hasOwn = {}.hasOwnProperty,
+        arr = [],
+        pop = arr.pop,
+        pushNative = arr.push,
+        push = arr.push,
+        slice = arr.slice,
+        // Use a stripped-down indexOf as it's faster than native
+        // https://jsperf.com/thor-indexof-vs-for/5
+        indexOf = function (list, elem) {
+          var i = 0,
+            len = list.length;
+          for (; i < len; i++) {
+            if (list[i] === elem) {
+              return i;
+            }
+          }
+          return -1;
+        },
+        booleans =
+          "checked|selected|async|autofocus|autoplay|controls|defer|disabled|hidden|" +
+          "ismap|loop|multiple|open|readonly|required|scoped",
+        // Regular expressions
+
+        // http://www.w3.org/TR/css3-selectors/#whitespace
+        whitespace = "[\\x20\\t\\r\\n\\f]",
+        // https://www.w3.org/TR/css-syntax-3/#ident-token-diagram
+        identifier =
+          "(?:\\\\[\\da-fA-F]{1,6}" +
+          whitespace +
+          "?|\\\\[^\\r\\n\\f]|[\\w-]|[^\0-\\x7f])+",
+        // Attribute selectors: http://www.w3.org/TR/selectors/#attribute-selectors
+        attributes =
+          "\\[" +
+          whitespace +
+          "*(" +
+          identifier +
+          ")(?:" +
+          whitespace +
+          // Operator (capture 2)
+          "*([*^$|!~]?=)" +
+          whitespace +
+          // "Attribute values must be CSS identifiers [capture 5]
+          // or strings [capture 3 or capture 4]"
+          "*(?:'((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\"|(" +
+          identifier +
+          "))|)" +
+          whitespace +
+          "*\\]",
+        pseudos =
+          ":(" +
+          identifier +
+          ")(?:\\((" +
+          // To reduce the number of selectors needing tokenize in the preFilter, prefer arguments:
+          // 1. quoted (capture 3; capture 4 or capture 5)
+          "('((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\")|" +
+          // 2. simple (capture 6)
+          "((?:\\\\.|[^\\\\()[\\]]|" +
+          attributes +
+          ")*)|" +
+          // 3. anything else (capture 2)
+          ".*" +
+          ")\\)|)",
+        // Leading and non-escaped trailing whitespace, capturing some non-whitespace characters preceding the latter
+        rwhitespace = new RegExp(whitespace + "+", "g"),
+        rtrim = new RegExp(
+          "^" + whitespace + "+|((?:^|[^\\\\])(?:\\\\.)*)" + whitespace + "+$",
+          "g"
+        ),
+        rcomma = new RegExp("^" + whitespace + "*," + whitespace + "*"),
+        rcombinators = new RegExp(
+          "^" + whitespace + "*([>+~]|" + whitespace + ")" + whitespace + "*"
+        ),
+        rdescend = new RegExp(whitespace + "|>"),
+        rpseudo = new RegExp(pseudos),
+        ridentifier = new RegExp("^" + identifier + "$"),
+        matchExpr = {
+          ID: new RegExp("^#(" + identifier + ")"),
+          CLASS: new RegExp("^\\.(" + identifier + ")"),
+          TAG: new RegExp("^(" + identifier + "|[*])"),
+          ATTR: new RegExp("^" + attributes),
+          PSEUDO: new RegExp("^" + pseudos),
+          CHILD: new RegExp(
+            "^:(only|first|last|nth|nth-last)-(child|of-type)(?:\\(" +
+              whitespace +
+              "*(even|odd|(([+-]|)(\\d*)n|)" +
+              whitespace +
+              "*(?:([+-]|)" +
+              whitespace +
+              "*(\\d+)|))" +
+              whitespace +
+              "*\\)|)",
+            "i"
+          ),
+          bool: new RegExp("^(?:" + booleans + ")$", "i"),
+
+          // For use in libraries implementing .is()
+          // We use this for POS matching in `select`
+          needsContext: new RegExp(
+            "^" +
+              whitespace +
+              "*[>+~]|:(even|odd|eq|gt|lt|nth|first|last)(?:\\(" +
+              whitespace +
+              "*((?:-\\d)?\\d*)" +
+              whitespace +
+              "*\\)|)(?=[^-]|$)",
+            "i"
+          ),
+        },
+        rhtml = /HTML$/i,
+        rinputs = /^(?:input|select|textarea|button)$/i,
+        rheader = /^h\d$/i,
+        rnative = /^[^{]+\{\s*\[native \w/,
+        // Easily-parseable/retrievable ID or TAG or CLASS selectors
+        rquickExpr = /^(?:#([\w-]+)|(\w+)|\.([\w-]+))$/,
+        rsibling = /[+~]/,
+        // CSS escapes
+        // http://www.w3.org/TR/CSS21/syndata.html#escaped-characters
+        runescape = new RegExp(
+          "\\\\[\\da-fA-F]{1,6}" + whitespace + "?|\\\\([^\\r\\n\\f])",
+          "g"
+        ),
+        funescape = function (escape, nonHex) {
+          var high = "0x" + escape.slice(1) - 0x10000;
+
+          return nonHex
+            ? // Strip the backslash prefix from a non-hex escape sequence
+              nonHex
+            : // Replace a hexadecimal escape sequence with the encoded Unicode code point
+            // Support: IE <=11+
+            // For values outside the Basic Multilingual Plane (BMP), manually construct a
+            // surrogate pair
+            high < 0
+            ? String.fromCharCode(high + 0x10000)
+            : String.fromCharCode(
+                (high >> 10) | 0xd800,
+                (high & 0x3ff) | 0xdc00
+              );
+        },
+        // CSS string/identifier serialization
+        // https://drafts.csswg.org/cssom/#common-serializing-idioms
+        rcssescape = /([\0-\x1f\x7f]|^-?\d)|^-$|[^\0-\x1f\x7f-\uFFFF\w-]/g,
+        fcssescape = function (ch, asCodePoint) {
+          if (asCodePoint) {
+            // U+0000 NULL becomes U+FFFD REPLACEMENT CHARACTER
+            if (ch === "\0") {
+              return "\uFFFD";
+            }
+
+            // Control characters and (dependent upon position) numbers get escaped as code points
+            return (
+              ch.slice(0, -1) +
+              "\\" +
+              ch.charCodeAt(ch.length - 1).toString(16) +
+              " "
+            );
+          }
+
+          // Other potentially-special ASCII characters get backslash-escaped
+          return "\\" + ch;
+        },
+        // Used for iframes
+        // See setDocument()
+        // Removing the function wrapper causes a "Permission Denied"
+        // error in IE
+        unloadHandler = function () {
+          setDocument();
+        },
+        inDisabledFieldset = addCombinator(
+          function (elem) {
+            return (
+              elem.disabled === true &&
+              elem.nodeName.toLowerCase() === "fieldset"
+            );
+          },
+          { dir: "parentNode", next: "legend" }
+        );
+
+      // Optimize for push.apply( _, NodeList )
+      try {
+        push.apply(
+          (arr = slice.call(preferredDoc.childNodes)),
+          preferredDoc.childNodes
+        );
+
+        // Support: Android<4.0
+        // Detect silently failing push.apply
+        // eslint-disable-next-line no-unused-expressions
+        arr[preferredDoc.childNodes.length].nodeType;
+      } catch (e) {
+        push = {
+          apply: arr.length
+            ? // Leverage slice if possible
+              function (target, els) {
+                pushNative.apply(target, slice.call(els));
+              }
+            : // Support: IE<9
+              // Otherwise append directly
+              function (target, els) {
+                var j = target.length,
+                  i = 0;
+
+                // Can't trust NodeList.length
+                while ((target[j++] = els[i++])) {}
+                target.length = j - 1;
+              },
+        };
+      }
+
+      function Sizzle(selector, context, results, seed) {
+        var m,
+          i,
+          elem,
+          nid,
+          match,
+          groups,
+          newSelector,
+          newContext = context && context.ownerDocument,
+          // nodeType defaults to 9, since context defaults to document
+          nodeType = context ? context.nodeType : 9;
+
+        results = results || [];
+
+        // Return early from calls with invalid selector or context
+        if (
+          typeof selector !== "string" ||
+          !selector ||
+          (nodeType !== 1 && nodeType !== 9 && nodeType !== 11)
+        ) {
+          return results;
+        }
+
+        // Try to shortcut find operations (as opposed to filters) in HTML documents
+        if (!seed) {
+          setDocument(context);
+          context = context || document;
+
+          if (documentIsHTML) {
+            // If the selector is sufficiently simple, try using a "get*By*" DOM method
+            // (excepting DocumentFragment context, where the methods don't exist)
+            if (nodeType !== 11 && (match = rquickExpr.exec(selector))) {
+              // ID selector
+              if ((m = match[1])) {
+                // Document context
+                if (nodeType === 9) {
+                  if ((elem = context.getElementById(m))) {
+                    // Support: IE, Opera, Webkit
+                    // TODO: identify versions
+                    // getElementById can match elements by name instead of ID
+                    if (elem.id === m) {
+                      results.push(elem);
+                      return results;
+                    }
+                  } else {
+                    return results;
+                  }
+
+                  // Element context
+                } else {
+                  // Support: IE, Opera, Webkit
+                  // TODO: identify versions
+                  // getElementById can match elements by name instead of ID
+                  if (
+                    newContext &&
+                    (elem = newContext.getElementById(m)) &&
+                    contains(context, elem) &&
+                    elem.id === m
+                  ) {
+                    results.push(elem);
+                    return results;
+                  }
+                }
+
+                // Type selector
+              } else if (match[2]) {
+                push.apply(results, context.getElementsByTagName(selector));
+                return results;
+
+                // Class selector
+              } else if (
+                (m = match[3]) &&
+                support.getElementsByClassName &&
+                context.getElementsByClassName
+              ) {
+                push.apply(results, context.getElementsByClassName(m));
+                return results;
+              }
+            }
+
+            // Take advantage of querySelectorAll
+            if (
+              support.qsa &&
+              !nonnativeSelectorCache[selector + " "] &&
+              (!rbuggyQSA || !rbuggyQSA.test(selector)) &&
+              // Support: IE 8 only
+              // Exclude object elements
+              (nodeType !== 1 || context.nodeName.toLowerCase() !== "object")
+            ) {
+              newSelector = selector;
+              newContext = context;
+
+              // qSA considers elements outside a scoping root when evaluating child or
+              // descendant combinators, which is not what we want.
+              // In such cases, we work around the behavior by prefixing every selector in the
+              // list with an ID selector referencing the scope context.
+              // The technique has to be used as well when a leading combinator is used
+              // as such selectors are not recognized by querySelectorAll.
+              // Thanks to Andrew Dupont for this technique.
+              if (
+                nodeType === 1 &&
+                (rdescend.test(selector) || rcombinators.test(selector))
+              ) {
+                // Expand context for sibling selectors
+                newContext =
+                  (rsibling.test(selector) &&
+                    testContext(context.parentNode)) ||
+                  context;
+
+                // We can use :scope instead of the ID hack if the browser
+                // supports it & if we're not changing the context.
+                if (newContext !== context || !support.scope) {
+                  // Capture the context ID, setting it first if necessary
+                  if ((nid = context.getAttribute("id"))) {
+                    nid = nid.replace(rcssescape, fcssescape);
+                  } else {
+                    context.setAttribute("id", (nid = expando));
+                  }
+                }
+
+                // Prefix every selector in the list
+                groups = tokenize(selector);
+                i = groups.length;
+                while (i--) {
+                  groups[i] =
+                    (nid ? "#" + nid : ":scope") + " " + toSelector(groups[i]);
+                }
+                newSelector = groups.join(",");
+              }
+
+              try {
+                push.apply(results, newContext.querySelectorAll(newSelector));
+                return results;
+              } catch (qsaError) {
+                nonnativeSelectorCache(selector, true);
+              } finally {
+                if (nid === expando) {
+                  context.removeAttribute("id");
+                }
+              }
+            }
+          }
+        }
+
+        // All others
+        return select(selector.replace(rtrim, "$1"), context, results, seed);
+      }
+
+      /**
+       * Create key-value caches of limited size
+       * @returns {function(string, object)} Returns the Object data after storing it on itself with
+       *	property name the (space-suffixed) string and (if the cache is larger than Expr.cacheLength)
+       *	deleting the oldest entry
+       */
+      function createCache() {
+        var keys = [];
+
+        function cache(key, value) {
+          // Use (key + " ") to avoid collision with native prototype properties (see Issue #157)
+          if (keys.push(key + " ") > Expr.cacheLength) {
+            // Only keep the most recent entries
+            delete cache[keys.shift()];
+          }
+          return (cache[key + " "] = value);
+        }
+        return cache;
+      }
+
+      /**
+       * Mark a function for special use by Sizzle
+       * @param {Function} fn The function to mark
+       */
+      function markFunction(fn) {
+        fn[expando] = true;
+        return fn;
+      }
+
+      /**
+       * Support testing using an element
+       * @param {Function} fn Passed the created element and returns a boolean result
+       */
+      function assert(fn) {
+        var el = document.createElement("fieldset");
+
+        try {
+          return !!fn(el);
+        } catch (e) {
+          return false;
+        } finally {
+          // Remove from its parent by default
+          if (el.parentNode) {
+            el.parentNode.removeChild(el);
+          }
+
+          // release memory in IE
+          el = null;
+        }
+      }
+
+      /**
+       * Adds the same handler for all of the specified attrs
+       * @param {String} attrs Pipe-separated list of attributes
+       * @param {Function} handler The method that will be applied
+       */
+      function addHandle(attrs, handler) {
+        var arr = attrs.split("|"),
+          i = arr.length;
+
+        while (i--) {
+          Expr.attrHandle[arr[i]] = handler;
+        }
+      }
+
+      /**
+       * Checks document order of two siblings
+       * @param {Element} a
+       * @param {Element} b
+       * @returns {Number} Returns less than 0 if a precedes b, greater than 0 if a follows b
+       */
+      function siblingCheck(a, b) {
+        var cur = b && a,
+          diff =
+            cur &&
+            a.nodeType === 1 &&
+            b.nodeType === 1 &&
+            a.sourceIndex - b.sourceIndex;
+
+        // Use IE sourceIndex if available on both nodes
+        if (diff) {
+          return diff;
+        }
+
+        // Check if b follows a
+        if (cur) {
+          while ((cur = cur.nextSibling)) {
+            if (cur === b) {
+              return -1;
+            }
+          }
+        }
+
+        return a ? 1 : -1;
+      }
+
+      /**
+       * Returns a function to use in pseudos for input types
+       * @param {String} type
+       */
+      function createInputPseudo(type) {
+        return function (elem) {
+          var name = elem.nodeName.toLowerCase();
+          return name === "input" && elem.type === type;
+        };
+      }
+
+      /**
+       * Returns a function to use in pseudos for buttons
+       * @param {String} type
+       */
+      function createButtonPseudo(type) {
+        return function (elem) {
+          var name = elem.nodeName.toLowerCase();
+          return (name === "input" || name === "button") && elem.type === type;
+        };
+      }
+
+      /**
+       * Returns a function to use in pseudos for :enabled/:disabled
+       * @param {Boolean} disabled true for :disabled; false for :enabled
+       */
+      function createDisabledPseudo(disabled) {
+        // Known :disabled false positives: fieldset[disabled] > legend:nth-of-type(n+2) :can-disable
+        return function (elem) {
+          // Only certain elements can match :enabled or :disabled
+          // https://html.spec.whatwg.org/multipage/scripting.html#selector-enabled
+          // https://html.spec.whatwg.org/multipage/scripting.html#selector-disabled
+          if ("form" in elem) {
+            // Check for inherited disabledness on relevant non-disabled elements:
+            // * listed form-associated elements in a disabled fieldset
+            //   https://html.spec.whatwg.org/multipage/forms.html#category-listed
+            //   https://html.spec.whatwg.org/multipage/forms.html#concept-fe-disabled
+            // * option elements in a disabled optgroup
+            //   https://html.spec.whatwg.org/multipage/forms.html#concept-option-disabled
+            // All such elements have a "form" property.
+            if (elem.parentNode && elem.disabled === false) {
+              // Option elements defer to a parent optgroup if present
+              if ("label" in elem) {
+                if ("label" in elem.parentNode) {
+                  return elem.parentNode.disabled === disabled;
+                } else {
+                  return elem.disabled === disabled;
+                }
+              }
+
+              // Support: IE 6 - 11
+              // Use the isDisabled shortcut property to check for disabled fieldset ancestors
+              return (
+                elem.isDisabled === disabled ||
+                // Where there is no isDisabled, check manually
+                /* jshint -W018 */
+                (elem.isDisabled !== !disabled &&
+                  inDisabledFieldset(elem) === disabled)
+              );
+            }
+
+            return elem.disabled === disabled;
+
+            // Try to winnow out elements that can't be disabled before trusting the disabled property.
+            // Some victims get caught in our net (label, legend, menu, track), but it shouldn't
+            // even exist on them, let alone have a boolean value.
+          } else if ("label" in elem) {
+            return elem.disabled === disabled;
+          }
+
+          // Remaining elements are neither :enabled nor :disabled
+          return false;
+        };
+      }
+
+      /**
+       * Returns a function to use in pseudos for positionals
+       * @param {Function} fn
+       */
+      function createPositionalPseudo(fn) {
+        return markFunction(function (argument) {
+          argument = +argument;
+          return markFunction(function (seed, matches) {
+            var j,
+              matchIndexes = fn([], seed.length, argument),
+              i = matchIndexes.length;
+
+            // Match elements found at the specified indexes
+            while (i--) {
+              if (seed[(j = matchIndexes[i])]) {
+                seed[j] = !(matches[j] = seed[j]);
+              }
+            }
+          });
+        });
+      }
+
+      /**
+       * Checks a node for validity as a Sizzle context
+       * @param {Element|Object=} context
+       * @returns {Element|Object|Boolean} The input node if acceptable, otherwise a falsy value
+       */
+      function testContext(context) {
+        return (
+          context &&
+          typeof context.getElementsByTagName !== "undefined" &&
+          context
+        );
+      }
+
+      // Expose support vars for convenience
+      support = Sizzle.support = {};
+
+      /**
+       * Detects XML nodes
+       * @param {Element|Object} elem An element or a document
+       * @returns {Boolean} True iff elem is a non-HTML XML node
+       */
+      isXML = Sizzle.isXML = function (elem) {
+        var namespace = elem && elem.namespaceURI,
+          docElem = elem && (elem.ownerDocument || elem).documentElement;
+
+        // Support: IE <=8
+        // Assume HTML when documentElement doesn't yet exist, such as inside loading iframes
+        // https://bugs.jquery.com/ticket/4833
+        return !rhtml.test(
+          namespace || (docElem && docElem.nodeName) || "HTML"
+        );
+      };
+
+      /**
+       * Sets document-related variables once based on the current document
+       * @param {Element|Object} [doc] An element or document object to use to set the document
+       * @returns {Object} Returns the current document
+       */
+      setDocument = Sizzle.setDocument = function (node) {
+        var hasCompare,
+          subWindow,
+          doc = node ? node.ownerDocument || node : preferredDoc;
+
+        // Return early if doc is invalid or already selected
+        // Support: IE 11+, Edge 17 - 18+
+        // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+        // two documents; shallow comparisons work.
+        // eslint-disable-next-line eqeqeq
+        if (doc == document || doc.nodeType !== 9 || !doc.documentElement) {
+          return document;
+        }
+
+        // Update global variables
+        document = doc;
+        docElem = document.documentElement;
+        documentIsHTML = !isXML(document);
+
+        // Support: IE 9 - 11+, Edge 12 - 18+
+        // Accessing iframe documents after unload throws "permission denied" errors (jQuery #13936)
+        // Support: IE 11+, Edge 17 - 18+
+        // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+        // two documents; shallow comparisons work.
+        // eslint-disable-next-line eqeqeq
+        if (
+          preferredDoc != document &&
+          (subWindow = document.defaultView) &&
+          subWindow.top !== subWindow
+        ) {
+          // Support: IE 11, Edge
+          if (subWindow.addEventListener) {
+            subWindow.addEventListener("unload", unloadHandler, false);
+
+            // Support: IE 9 - 10 only
+          } else if (subWindow.attachEvent) {
+            subWindow.attachEvent("onunload", unloadHandler);
+          }
+        }
+
+        // Support: IE 8 - 11+, Edge 12 - 18+, Chrome <=16 - 25 only, Firefox <=3.6 - 31 only,
+        // Safari 4 - 5 only, Opera <=11.6 - 12.x only
+        // IE/Edge & older browsers don't support the :scope pseudo-class.
+        // Support: Safari 6.0 only
+        // Safari 6.0 supports :scope but it's an alias of :root there.
+        support.scope = assert(function (el) {
+          docElem.appendChild(el).appendChild(document.createElement("div"));
+          return (
+            typeof el.querySelectorAll !== "undefined" &&
+            !el.querySelectorAll(":scope fieldset div").length
+          );
+        });
+
+        /* Attributes
+	---------------------------------------------------------------------- */
+
+        // Support: IE<8
+        // Verify that getAttribute really returns attributes and not properties
+        // (excepting IE8 booleans)
+        support.attributes = assert(function (el) {
+          el.className = "i";
+          return !el.getAttribute("className");
+        });
+
+        /* getElement(s)By*
+	---------------------------------------------------------------------- */
+
+        // Check if getElementsByTagName("*") returns only elements
+        support.getElementsByTagName = assert(function (el) {
+          el.appendChild(document.createComment(""));
+          return !el.getElementsByTagName("*").length;
+        });
+
+        // Support: IE<9
+        support.getElementsByClassName = rnative.test(
+          document.getElementsByClassName
+        );
+
+        // Support: IE<10
+        // Check if getElementById returns elements by name
+        // The broken getElementById methods don't pick up programmatically-set names,
+        // so use a roundabout getElementsByName test
+        support.getById = assert(function (el) {
+          docElem.appendChild(el).id = expando;
+          return (
+            !document.getElementsByName ||
+            !document.getElementsByName(expando).length
+          );
+        });
+
+        // ID filter and find
+        if (support.getById) {
+          Expr.filter["ID"] = function (id) {
+            var attrId = id.replace(runescape, funescape);
+            return function (elem) {
+              return elem.getAttribute("id") === attrId;
+            };
+          };
+          Expr.find["ID"] = function (id, context) {
+            if (
+              typeof context.getElementById !== "undefined" &&
+              documentIsHTML
+            ) {
+              var elem = context.getElementById(id);
+              return elem ? [elem] : [];
+            }
+          };
+        } else {
+          Expr.filter["ID"] = function (id) {
+            var attrId = id.replace(runescape, funescape);
+            return function (elem) {
+              var node =
+                typeof elem.getAttributeNode !== "undefined" &&
+                elem.getAttributeNode("id");
+              return node && node.value === attrId;
+            };
+          };
+
+          // Support: IE 6 - 7 only
+          // getElementById is not reliable as a find shortcut
+          Expr.find["ID"] = function (id, context) {
+            if (
+              typeof context.getElementById !== "undefined" &&
+              documentIsHTML
+            ) {
+              var node,
+                i,
+                elems,
+                elem = context.getElementById(id);
+
+              if (elem) {
+                // Verify the id attribute
+                node = elem.getAttributeNode("id");
+                if (node && node.value === id) {
+                  return [elem];
+                }
+
+                // Fall back on getElementsByName
+                elems = context.getElementsByName(id);
+                i = 0;
+                while ((elem = elems[i++])) {
+                  node = elem.getAttributeNode("id");
+                  if (node && node.value === id) {
+                    return [elem];
+                  }
+                }
+              }
+
+              return [];
+            }
+          };
+        }
+
+        // Tag
+        Expr.find["TAG"] = support.getElementsByTagName
+          ? function (tag, context) {
+              if (typeof context.getElementsByTagName !== "undefined") {
+                return context.getElementsByTagName(tag);
+
+                // DocumentFragment nodes don't have gEBTN
+              } else if (support.qsa) {
+                return context.querySelectorAll(tag);
+              }
+            }
+          : function (tag, context) {
+              var elem,
+                tmp = [],
+                i = 0,
+                // By happy coincidence, a (broken) gEBTN appears on DocumentFragment nodes too
+                results = context.getElementsByTagName(tag);
+
+              // Filter out possible comments
+              if (tag === "*") {
+                while ((elem = results[i++])) {
+                  if (elem.nodeType === 1) {
+                    tmp.push(elem);
+                  }
+                }
+
+                return tmp;
+              }
+              return results;
+            };
+
+        // Class
+        Expr.find["CLASS"] =
+          support.getElementsByClassName &&
+          function (className, context) {
+            if (
+              typeof context.getElementsByClassName !== "undefined" &&
+              documentIsHTML
+            ) {
+              return context.getElementsByClassName(className);
+            }
+          };
+
+        /* QSA/matchesSelector
+	---------------------------------------------------------------------- */
+
+        // QSA and matchesSelector support
+
+        // matchesSelector(:active) reports false when true (IE9/Opera 11.5)
+        rbuggyMatches = [];
+
+        // qSa(:focus) reports false when true (Chrome 21)
+        // We allow this because of a bug in IE8/9 that throws an error
+        // whenever `document.activeElement` is accessed on an iframe
+        // So, we allow :focus to pass through QSA all the time to avoid the IE error
+        // See https://bugs.jquery.com/ticket/13378
+        rbuggyQSA = [];
+
+        if ((support.qsa = rnative.test(document.querySelectorAll))) {
+          // Build QSA regex
+          // Regex strategy adopted from Diego Perini
+          assert(function (el) {
+            var input;
+
+            // Select is set to empty string on purpose
+            // This is to test IE's treatment of not explicitly
+            // setting a boolean content attribute,
+            // since its presence should be enough
+            // https://bugs.jquery.com/ticket/12359
+            docElem.appendChild(el).innerHTML =
+              "<a id='" +
+              expando +
+              "'></a>" +
+              "<select id='" +
+              expando +
+              "-\r\\' msallowcapture=''>" +
+              "<option selected=''></option></select>";
+
+            // Support: IE8, Opera 11-12.16
+            // Nothing should be selected when empty strings follow ^= or $= or *=
+            // The test attribute must be unknown in Opera but "safe" for WinRT
+            // https://msdn.microsoft.com/en-us/library/ie/hh465388.aspx#attribute_section
+            if (el.querySelectorAll("[msallowcapture^='']").length) {
+              rbuggyQSA.push("[*^$]=" + whitespace + "*(?:''|\"\")");
+            }
+
+            // Support: IE8
+            // Boolean attributes and "value" are not treated correctly
+            if (!el.querySelectorAll("[selected]").length) {
+              rbuggyQSA.push(
+                "\\[" + whitespace + "*(?:value|" + booleans + ")"
+              );
+            }
+
+            // Support: Chrome<29, Android<4.4, Safari<7.0+, iOS<7.0+, PhantomJS<1.9.8+
+            if (!el.querySelectorAll("[id~=" + expando + "-]").length) {
+              rbuggyQSA.push("~=");
+            }
+
+            // Support: IE 11+, Edge 15 - 18+
+            // IE 11/Edge don't find elements on a `[name='']` query in some cases.
+            // Adding a temporary attribute to the document before the selection works
+            // around the issue.
+            // Interestingly, IE 10 & older don't seem to have the issue.
+            input = document.createElement("input");
+            input.setAttribute("name", "");
+            el.appendChild(input);
+            if (!el.querySelectorAll("[name='']").length) {
+              rbuggyQSA.push(
+                "\\[" +
+                  whitespace +
+                  "*name" +
+                  whitespace +
+                  "*=" +
+                  whitespace +
+                  "*(?:''|\"\")"
+              );
+            }
+
+            // Webkit/Opera - :checked should return selected option elements
+            // http://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
+            // IE8 throws error here and will not see later tests
+            if (!el.querySelectorAll(":checked").length) {
+              rbuggyQSA.push(":checked");
+            }
+
+            // Support: Safari 8+, iOS 8+
+            // https://bugs.webkit.org/show_bug.cgi?id=136851
+            // In-page `selector#id sibling-combinator selector` fails
+            if (!el.querySelectorAll("a#" + expando + "+*").length) {
+              rbuggyQSA.push(".#.+[+~]");
+            }
+
+            // Support: Firefox <=3.6 - 5 only
+            // Old Firefox doesn't throw on a badly-escaped identifier.
+            el.querySelectorAll("\\\f");
+            rbuggyQSA.push("[\\r\\n\\f]");
+          });
+
+          assert(function (el) {
+            el.innerHTML =
+              "<a href='' disabled='disabled'></a>" +
+              "<select disabled='disabled'><option/></select>";
+
+            // Support: Windows 8 Native Apps
+            // The type and name attributes are restricted during .innerHTML assignment
+            var input = document.createElement("input");
+            input.setAttribute("type", "hidden");
+            el.appendChild(input).setAttribute("name", "D");
+
+            // Support: IE8
+            // Enforce case-sensitivity of name attribute
+            if (el.querySelectorAll("[name=d]").length) {
+              rbuggyQSA.push("name" + whitespace + "*[*^$|!~]?=");
+            }
+
+            // FF 3.5 - :enabled/:disabled and hidden elements (hidden elements are still enabled)
+            // IE8 throws error here and will not see later tests
+            if (el.querySelectorAll(":enabled").length !== 2) {
+              rbuggyQSA.push(":enabled", ":disabled");
+            }
+
+            // Support: IE9-11+
+            // IE's :disabled selector does not pick up the children of disabled fieldsets
+            docElem.appendChild(el).disabled = true;
+            if (el.querySelectorAll(":disabled").length !== 2) {
+              rbuggyQSA.push(":enabled", ":disabled");
+            }
+
+            // Support: Opera 10 - 11 only
+            // Opera 10-11 does not throw on post-comma invalid pseudos
+            el.querySelectorAll("*,:x");
+            rbuggyQSA.push(",.*:");
+          });
+        }
+
+        if (
+          (support.matchesSelector = rnative.test(
+            (matches =
+              docElem.matches ||
+              docElem.webkitMatchesSelector ||
+              docElem.mozMatchesSelector ||
+              docElem.oMatchesSelector ||
+              docElem.msMatchesSelector)
+          ))
+        ) {
+          assert(function (el) {
+            // Check to see if it's possible to do matchesSelector
+            // on a disconnected node (IE 9)
+            support.disconnectedMatch = matches.call(el, "*");
+
+            // This should fail with an exception
+            // Gecko does not error, returns false instead
+            matches.call(el, "[s!='']:x");
+            rbuggyMatches.push("!=", pseudos);
+          });
+        }
+
+        rbuggyQSA = rbuggyQSA.length && new RegExp(rbuggyQSA.join("|"));
+        rbuggyMatches =
+          rbuggyMatches.length && new RegExp(rbuggyMatches.join("|"));
+
+        /* Contains
+	---------------------------------------------------------------------- */
+        hasCompare = rnative.test(docElem.compareDocumentPosition);
+
+        // Element contains another
+        // Purposefully self-exclusive
+        // As in, an element does not contain itself
+        contains =
+          hasCompare || rnative.test(docElem.contains)
+            ? function (a, b) {
+                var adown = a.nodeType === 9 ? a.documentElement : a,
+                  bup = b && b.parentNode;
+                return (
+                  a === bup ||
+                  !!(
+                    bup &&
+                    bup.nodeType === 1 &&
+                    (adown.contains
+                      ? adown.contains(bup)
+                      : a.compareDocumentPosition &&
+                        a.compareDocumentPosition(bup) & 16)
+                  )
+                );
+              }
+            : function (a, b) {
+                if (b) {
+                  while ((b = b.parentNode)) {
+                    if (b === a) {
+                      return true;
+                    }
+                  }
+                }
+                return false;
+              };
+
+        /* Sorting
+	---------------------------------------------------------------------- */
+
+        // Document order sorting
+        sortOrder = hasCompare
+          ? function (a, b) {
+              // Flag for duplicate removal
+              if (a === b) {
+                hasDuplicate = true;
+                return 0;
+              }
+
+              // Sort on method existence if only one input has compareDocumentPosition
+              var compare =
+                !a.compareDocumentPosition - !b.compareDocumentPosition;
+              if (compare) {
+                return compare;
+              }
+
+              // Calculate position if both inputs belong to the same document
+              // Support: IE 11+, Edge 17 - 18+
+              // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+              // two documents; shallow comparisons work.
+              // eslint-disable-next-line eqeqeq
+              compare =
+                (a.ownerDocument || a) == (b.ownerDocument || b)
+                  ? a.compareDocumentPosition(b)
+                  : // Otherwise we know they are disconnected
+                    1;
+
+              // Disconnected nodes
+              if (
+                compare & 1 ||
+                (!support.sortDetached &&
+                  b.compareDocumentPosition(a) === compare)
+              ) {
+                // Choose the first element that is related to our preferred document
+                // Support: IE 11+, Edge 17 - 18+
+                // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+                // two documents; shallow comparisons work.
+                // eslint-disable-next-line eqeqeq
+                if (
+                  a == document ||
+                  (a.ownerDocument == preferredDoc && contains(preferredDoc, a))
+                ) {
+                  return -1;
+                }
+
+                // Support: IE 11+, Edge 17 - 18+
+                // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+                // two documents; shallow comparisons work.
+                // eslint-disable-next-line eqeqeq
+                if (
+                  b == document ||
+                  (b.ownerDocument == preferredDoc && contains(preferredDoc, b))
+                ) {
+                  return 1;
+                }
+
+                // Maintain original order
+                return sortInput
+                  ? indexOf(sortInput, a) - indexOf(sortInput, b)
+                  : 0;
+              }
+
+              return compare & 4 ? -1 : 1;
+            }
+          : function (a, b) {
+              // Exit early if the nodes are identical
+              if (a === b) {
+                hasDuplicate = true;
+                return 0;
+              }
+
+              var cur,
+                i = 0,
+                aup = a.parentNode,
+                bup = b.parentNode,
+                ap = [a],
+                bp = [b];
+
+              // Parentless nodes are either documents or disconnected
+              if (!aup || !bup) {
+                // Support: IE 11+, Edge 17 - 18+
+                // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+                // two documents; shallow comparisons work.
+                /* eslint-disable eqeqeq */
+                return a == document
+                  ? -1
+                  : b == document
+                  ? 1
+                  : /* eslint-enable eqeqeq */
+                  aup
+                  ? -1
+                  : bup
+                  ? 1
+                  : sortInput
+                  ? indexOf(sortInput, a) - indexOf(sortInput, b)
+                  : 0;
+
+                // If the nodes are siblings, we can do a quick check
+              } else if (aup === bup) {
+                return siblingCheck(a, b);
+              }
+
+              // Otherwise we need full lists of their ancestors for comparison
+              cur = a;
+              while ((cur = cur.parentNode)) {
+                ap.unshift(cur);
+              }
+              cur = b;
+              while ((cur = cur.parentNode)) {
+                bp.unshift(cur);
+              }
+
+              // Walk down the tree looking for a discrepancy
+              while (ap[i] === bp[i]) {
+                i++;
+              }
+
+              return i
+                ? // Do a sibling check if the nodes have a common ancestor
+                  siblingCheck(ap[i], bp[i])
+                : // Otherwise nodes in our document sort first
+                // Support: IE 11+, Edge 17 - 18+
+                // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+                // two documents; shallow comparisons work.
+                /* eslint-disable eqeqeq */
+                ap[i] == preferredDoc
+                ? -1
+                : bp[i] == preferredDoc
+                ? 1
+                : /* eslint-enable eqeqeq */
+                  0;
+            };
+
+        return document;
+      };
+
+      Sizzle.matches = function (expr, elements) {
+        return Sizzle(expr, null, null, elements);
+      };
+
+      Sizzle.matchesSelector = function (elem, expr) {
+        setDocument(elem);
+
+        if (
+          support.matchesSelector &&
+          documentIsHTML &&
+          !nonnativeSelectorCache[expr + " "] &&
+          (!rbuggyMatches || !rbuggyMatches.test(expr)) &&
+          (!rbuggyQSA || !rbuggyQSA.test(expr))
+        ) {
+          try {
+            var ret = matches.call(elem, expr);
+
+            // IE 9's matchesSelector returns false on disconnected nodes
+            if (
+              ret ||
+              support.disconnectedMatch ||
+              // As well, disconnected nodes are said to be in a document
+              // fragment in IE 9
+              (elem.document && elem.document.nodeType !== 11)
+            ) {
+              return ret;
+            }
+          } catch (e) {
+            nonnativeSelectorCache(expr, true);
+          }
+        }
+
+        return Sizzle(expr, document, null, [elem]).length > 0;
+      };
+
+      Sizzle.contains = function (context, elem) {
+        // Set document vars if needed
+        // Support: IE 11+, Edge 17 - 18+
+        // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+        // two documents; shallow comparisons work.
+        // eslint-disable-next-line eqeqeq
+        if ((context.ownerDocument || context) != document) {
+          setDocument(context);
+        }
+        return contains(context, elem);
+      };
+
+      Sizzle.attr = function (elem, name) {
+        // Set document vars if needed
+        // Support: IE 11+, Edge 17 - 18+
+        // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+        // two documents; shallow comparisons work.
+        // eslint-disable-next-line eqeqeq
+        if ((elem.ownerDocument || elem) != document) {
+          setDocument(elem);
+        }
+
+        var fn = Expr.attrHandle[name.toLowerCase()],
+          // Don't get fooled by Object.prototype properties (jQuery #13807)
+          val =
+            fn && hasOwn.call(Expr.attrHandle, name.toLowerCase())
+              ? fn(elem, name, !documentIsHTML)
+              : undefined;
+
+        return val !== undefined
+          ? val
+          : support.attributes || !documentIsHTML
+          ? elem.getAttribute(name)
+          : (val = elem.getAttributeNode(name)) && val.specified
+          ? val.value
+          : null;
+      };
+
+      Sizzle.escape = function (sel) {
+        return (sel + "").replace(rcssescape, fcssescape);
+      };
+
+      Sizzle.error = function (msg) {
+        throw new Error("Syntax error, unrecognized expression: " + msg);
+      };
+
+      /**
+       * Document sorting and removing duplicates
+       * @param {ArrayLike} results
+       */
+      Sizzle.uniqueSort = function (results) {
+        var elem,
+          duplicates = [],
+          j = 0,
+          i = 0;
+
+        // Unless we *know* we can detect duplicates, assume their presence
+        hasDuplicate = !support.detectDuplicates;
+        sortInput = !support.sortStable && results.slice(0);
+        results.sort(sortOrder);
+
+        if (hasDuplicate) {
+          while ((elem = results[i++])) {
+            if (elem === results[i]) {
+              j = duplicates.push(i);
+            }
+          }
+          while (j--) {
+            results.splice(duplicates[j], 1);
+          }
+        }
+
+        // Clear input after sorting to release objects
+        // See https://github.com/jquery/sizzle/pull/225
+        sortInput = null;
+
+        return results;
+      };
+
+      /**
+       * Utility function for retrieving the text value of an array of DOM nodes
+       * @param {Array|Element} elem
+       */
+      getText = Sizzle.getText = function (elem) {
+        var node,
+          ret = "",
+          i = 0,
+          nodeType = elem.nodeType;
+
+        if (!nodeType) {
+          // If no nodeType, this is expected to be an array
+          while ((node = elem[i++])) {
+            // Do not traverse comment nodes
+            ret += getText(node);
+          }
+        } else if (nodeType === 1 || nodeType === 9 || nodeType === 11) {
+          // Use textContent for elements
+          // innerText usage removed for consistency of new lines (jQuery #11153)
+          if (typeof elem.textContent === "string") {
+            return elem.textContent;
+          } else {
+            // Traverse its children
+            for (elem = elem.firstChild; elem; elem = elem.nextSibling) {
+              ret += getText(elem);
+            }
+          }
+        } else if (nodeType === 3 || nodeType === 4) {
+          return elem.nodeValue;
+        }
+
+        // Do not include comment or processing instruction nodes
+
+        return ret;
+      };
+
+      Expr = Sizzle.selectors = {
+        // Can be adjusted by the user
+        cacheLength: 50,
+
+        createPseudo: markFunction,
+
+        match: matchExpr,
+
+        attrHandle: {},
+
+        find: {},
+
+        relative: {
+          ">": { dir: "parentNode", first: true },
+          " ": { dir: "parentNode" },
+          "+": { dir: "previousSibling", first: true },
+          "~": { dir: "previousSibling" },
+        },
+
+        preFilter: {
+          ATTR: function (match) {
+            match[1] = match[1].replace(runescape, funescape);
+
+            // Move the given value to match[3] whether quoted or unquoted
+            match[3] = (match[3] || match[4] || match[5] || "").replace(
+              runescape,
+              funescape
+            );
+
+            if (match[2] === "~=") {
+              match[3] = " " + match[3] + " ";
+            }
+
+            return match.slice(0, 4);
+          },
+
+          CHILD: function (match) {
+            /* matches from matchExpr["CHILD"]
+				1 type (only|nth|...)
+				2 what (child|of-type)
+				3 argument (even|odd|\d*|\d*n([+-]\d+)?|...)
+				4 xn-component of xn+y argument ([+-]?\d*n|)
+				5 sign of xn-component
+				6 x of xn-component
+				7 sign of y-component
+				8 y of y-component
+			*/
+            match[1] = match[1].toLowerCase();
+
+            if (match[1].slice(0, 3) === "nth") {
+              // nth-* requires argument
+              if (!match[3]) {
+                Sizzle.error(match[0]);
+              }
+
+              // numeric x and y parameters for Expr.filter.CHILD
+              // remember that false/true cast respectively to 0/1
+              match[4] = +(match[4]
+                ? match[5] + (match[6] || 1)
+                : 2 * (match[3] === "even" || match[3] === "odd"));
+              match[5] = +(match[7] + match[8] || match[3] === "odd");
+
+              // other types prohibit arguments
+            } else if (match[3]) {
+              Sizzle.error(match[0]);
+            }
+
+            return match;
+          },
+
+          PSEUDO: function (match) {
+            var excess,
+              unquoted = !match[6] && match[2];
+
+            if (matchExpr["CHILD"].test(match[0])) {
+              return null;
+            }
+
+            // Accept quoted arguments as-is
+            if (match[3]) {
+              match[2] = match[4] || match[5] || "";
+
+              // Strip excess characters from unquoted arguments
+            } else if (
+              unquoted &&
+              rpseudo.test(unquoted) &&
+              // Get excess from tokenize (recursively)
+              (excess = tokenize(unquoted, true)) &&
+              // advance to the next closing parenthesis
+              (excess =
+                unquoted.indexOf(")", unquoted.length - excess) -
+                unquoted.length)
+            ) {
+              // excess is a negative index
+              match[0] = match[0].slice(0, excess);
+              match[2] = unquoted.slice(0, excess);
+            }
+
+            // Return only captures needed by the pseudo filter method (type and argument)
+            return match.slice(0, 3);
+          },
+        },
+
+        filter: {
+          TAG: function (nodeNameSelector) {
+            var nodeName = nodeNameSelector
+              .replace(runescape, funescape)
+              .toLowerCase();
+            return nodeNameSelector === "*"
+              ? function () {
+                  return true;
+                }
+              : function (elem) {
+                  return (
+                    elem.nodeName && elem.nodeName.toLowerCase() === nodeName
+                  );
+                };
+          },
+
+          CLASS: function (className) {
+            var pattern = classCache[className + " "];
+
+            return (
+              pattern ||
+              ((pattern = new RegExp(
+                "(^|" + whitespace + ")" + className + "(" + whitespace + "|$)"
+              )) &&
+                classCache(className, function (elem) {
+                  return pattern.test(
+                    (typeof elem.className === "string" && elem.className) ||
+                      (typeof elem.getAttribute !== "undefined" &&
+                        elem.getAttribute("class")) ||
+                      ""
+                  );
+                }))
+            );
+          },
+
+          ATTR: function (name, operator, check) {
+            return function (elem) {
+              var result = Sizzle.attr(elem, name);
+
+              if (result == null) {
+                return operator === "!=";
+              }
+              if (!operator) {
+                return true;
+              }
+
+              result += "";
+
+              /* eslint-disable max-len */
+
+              return operator === "="
+                ? result === check
+                : operator === "!="
+                ? result !== check
+                : operator === "^="
+                ? check && result.indexOf(check) === 0
+                : operator === "*="
+                ? check && result.indexOf(check) > -1
+                : operator === "$="
+                ? check && result.slice(-check.length) === check
+                : operator === "~="
+                ? (" " + result.replace(rwhitespace, " ") + " ").indexOf(
+                    check
+                  ) > -1
+                : operator === "|="
+                ? result === check ||
+                  result.slice(0, check.length + 1) === check + "-"
+                : false;
+              /* eslint-enable max-len */
+            };
+          },
+
+          CHILD: function (type, what, _argument, first, last) {
+            var simple = type.slice(0, 3) !== "nth",
+              forward = type.slice(-4) !== "last",
+              ofType = what === "of-type";
+
+            return first === 1 && last === 0
+              ? // Shortcut for :nth-*(n)
+                function (elem) {
+                  return !!elem.parentNode;
+                }
+              : function (elem, _context, xml) {
+                  var cache,
+                    uniqueCache,
+                    outerCache,
+                    node,
+                    nodeIndex,
+                    start,
+                    dir =
+                      simple !== forward ? "nextSibling" : "previousSibling",
+                    parent = elem.parentNode,
+                    name = ofType && elem.nodeName.toLowerCase(),
+                    useCache = !xml && !ofType,
+                    diff = false;
+
+                  if (parent) {
+                    // :(first|last|only)-(child|of-type)
+                    if (simple) {
+                      while (dir) {
+                        node = elem;
+                        while ((node = node[dir])) {
+                          if (
+                            ofType
+                              ? node.nodeName.toLowerCase() === name
+                              : node.nodeType === 1
+                          ) {
+                            return false;
+                          }
+                        }
+
+                        // Reverse direction for :only-* (if we haven't yet done so)
+                        start = dir =
+                          type === "only" && !start && "nextSibling";
+                      }
+                      return true;
+                    }
+
+                    start = [forward ? parent.firstChild : parent.lastChild];
+
+                    // non-xml :nth-child(...) stores cache data on `parent`
+                    if (forward && useCache) {
+                      // Seek `elem` from a previously-cached index
+
+                      // ...in a gzip-friendly way
+                      node = parent;
+                      outerCache = node[expando] || (node[expando] = {});
+
+                      // Support: IE <9 only
+                      // Defend against cloned attroperties (jQuery gh-1709)
+                      uniqueCache =
+                        outerCache[node.uniqueID] ||
+                        (outerCache[node.uniqueID] = {});
+
+                      cache = uniqueCache[type] || [];
+                      nodeIndex = cache[0] === dirruns && cache[1];
+                      diff = nodeIndex && cache[2];
+                      node = nodeIndex && parent.childNodes[nodeIndex];
+
+                      while (
+                        (node =
+                          (++nodeIndex && node && node[dir]) ||
+                          // Fallback to seeking `elem` from the start
+                          (diff = nodeIndex = 0) ||
+                          start.pop())
+                      ) {
+                        // When found, cache indexes on `parent` and break
+                        if (node.nodeType === 1 && ++diff && node === elem) {
+                          uniqueCache[type] = [dirruns, nodeIndex, diff];
+                          break;
+                        }
+                      }
+                    } else {
+                      // Use previously-cached element index if available
+                      if (useCache) {
+                        // ...in a gzip-friendly way
+                        node = elem;
+                        outerCache = node[expando] || (node[expando] = {});
+
+                        // Support: IE <9 only
+                        // Defend against cloned attroperties (jQuery gh-1709)
+                        uniqueCache =
+                          outerCache[node.uniqueID] ||
+                          (outerCache[node.uniqueID] = {});
+
+                        cache = uniqueCache[type] || [];
+                        nodeIndex = cache[0] === dirruns && cache[1];
+                        diff = nodeIndex;
+                      }
+
+                      // xml :nth-child(...)
+                      // or :nth-last-child(...) or :nth(-last)?-of-type(...)
+                      if (diff === false) {
+                        // Use the same loop as above to seek `elem` from the start
+                        while (
+                          (node =
+                            (++nodeIndex && node && node[dir]) ||
+                            (diff = nodeIndex = 0) ||
+                            start.pop())
+                        ) {
+                          if (
+                            (ofType
+                              ? node.nodeName.toLowerCase() === name
+                              : node.nodeType === 1) &&
+                            ++diff
+                          ) {
+                            // Cache the index of each encountered element
+                            if (useCache) {
+                              outerCache =
+                                node[expando] || (node[expando] = {});
+
+                              // Support: IE <9 only
+                              // Defend against cloned attroperties (jQuery gh-1709)
+                              uniqueCache =
+                                outerCache[node.uniqueID] ||
+                                (outerCache[node.uniqueID] = {});
+
+                              uniqueCache[type] = [dirruns, diff];
+                            }
+
+                            if (node === elem) {
+                              break;
+                            }
+                          }
+                        }
+                      }
+                    }
+
+                    // Incorporate the offset, then check against cycle size
+                    diff -= last;
+                    return (
+                      diff === first ||
+                      (diff % first === 0 && diff / first >= 0)
+                    );
+                  }
+                };
+          },
+
+          PSEUDO: function (pseudo, argument) {
+            // pseudo-class names are case-insensitive
+            // http://www.w3.org/TR/selectors/#pseudo-classes
+            // Prioritize by case sensitivity in case custom pseudos are added with uppercase letters
+            // Remember that setFilters inherits from pseudos
+            var args,
+              fn =
+                Expr.pseudos[pseudo] ||
+                Expr.setFilters[pseudo.toLowerCase()] ||
+                Sizzle.error("unsupported pseudo: " + pseudo);
+
+            // The user may use createPseudo to indicate that
+            // arguments are needed to create the filter function
+            // just as Sizzle does
+            if (fn[expando]) {
+              return fn(argument);
+            }
+
+            // But maintain support for old signatures
+            if (fn.length > 1) {
+              args = [pseudo, pseudo, "", argument];
+              return Expr.setFilters.hasOwnProperty(pseudo.toLowerCase())
+                ? markFunction(function (seed, matches) {
+                    var idx,
+                      matched = fn(seed, argument),
+                      i = matched.length;
+                    while (i--) {
+                      idx = indexOf(seed, matched[i]);
+                      seed[idx] = !(matches[idx] = matched[i]);
+                    }
+                  })
+                : function (elem) {
+                    return fn(elem, 0, args);
+                  };
+            }
+
+            return fn;
+          },
+        },
+
+        pseudos: {
+          // Potentially complex pseudos
+          not: markFunction(function (selector) {
+            // Trim the selector passed to compile
+            // to avoid treating leading and trailing
+            // spaces as combinators
+            var input = [],
+              results = [],
+              matcher = compile(selector.replace(rtrim, "$1"));
+
+            return matcher[expando]
+              ? markFunction(function (seed, matches, _context, xml) {
+                  var elem,
+                    unmatched = matcher(seed, null, xml, []),
+                    i = seed.length;
+
+                  // Match elements unmatched by `matcher`
+                  while (i--) {
+                    if ((elem = unmatched[i])) {
+                      seed[i] = !(matches[i] = elem);
+                    }
+                  }
+                })
+              : function (elem, _context, xml) {
+                  input[0] = elem;
+                  matcher(input, null, xml, results);
+
+                  // Don't keep the element (issue #299)
+                  input[0] = null;
+                  return !results.pop();
+                };
+          }),
+
+          has: markFunction(function (selector) {
+            return function (elem) {
+              return Sizzle(selector, elem).length > 0;
+            };
+          }),
+
+          contains: markFunction(function (text) {
+            text = text.replace(runescape, funescape);
+            return function (elem) {
+              return (elem.textContent || getText(elem)).indexOf(text) > -1;
+            };
+          }),
+
+          // "Whether an element is represented by a :lang() selector
+          // is based solely on the element's language value
+          // being equal to the identifier C,
+          // or beginning with the identifier C immediately followed by "-".
+          // The matching of C against the element's language value is performed case-insensitively.
+          // The identifier C does not have to be a valid language name."
+          // http://www.w3.org/TR/selectors/#lang-pseudo
+          lang: markFunction(function (lang) {
+            // lang value must be a valid identifier
+            if (!ridentifier.test(lang || "")) {
+              Sizzle.error("unsupported lang: " + lang);
+            }
+            lang = lang.replace(runescape, funescape).toLowerCase();
+            return function (elem) {
+              var elemLang;
+              do {
+                if (
+                  (elemLang = documentIsHTML
+                    ? elem.lang
+                    : elem.getAttribute("xml:lang") ||
+                      elem.getAttribute("lang"))
+                ) {
+                  elemLang = elemLang.toLowerCase();
+                  return (
+                    elemLang === lang || elemLang.indexOf(lang + "-") === 0
+                  );
+                }
+              } while ((elem = elem.parentNode) && elem.nodeType === 1);
+              return false;
+            };
+          }),
+
+          // Miscellaneous
+          target: function (elem) {
+            var hash = window.location && window.location.hash;
+            return hash && hash.slice(1) === elem.id;
+          },
+
+          root: function (elem) {
+            return elem === docElem;
+          },
+
+          focus: function (elem) {
+            return (
+              elem === document.activeElement &&
+              (!document.hasFocus || document.hasFocus()) &&
+              !!(elem.type || elem.href || ~elem.tabIndex)
+            );
+          },
+
+          // Boolean properties
+          enabled: createDisabledPseudo(false),
+          disabled: createDisabledPseudo(true),
+
+          checked: function (elem) {
+            // In CSS3, :checked should return both checked and selected elements
+            // http://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
+            var nodeName = elem.nodeName.toLowerCase();
+            return (
+              (nodeName === "input" && !!elem.checked) ||
+              (nodeName === "option" && !!elem.selected)
+            );
+          },
+
+          selected: function (elem) {
+            // Accessing this property makes selected-by-default
+            // options in Safari work properly
+            if (elem.parentNode) {
+              // eslint-disable-next-line no-unused-expressions
+              elem.parentNode.selectedIndex;
+            }
+
+            return elem.selected === true;
+          },
+
+          // Contents
+          empty: function (elem) {
+            // http://www.w3.org/TR/selectors/#empty-pseudo
+            // :empty is negated by element (1) or content nodes (text: 3; cdata: 4; entity ref: 5),
+            //   but not by others (comment: 8; processing instruction: 7; etc.)
+            // nodeType < 6 works because attributes (2) do not appear as children
+            for (elem = elem.firstChild; elem; elem = elem.nextSibling) {
+              if (elem.nodeType < 6) {
+                return false;
+              }
+            }
+            return true;
+          },
+
+          parent: function (elem) {
+            return !Expr.pseudos["empty"](elem);
+          },
+
+          // Element/input types
+          header: function (elem) {
+            return rheader.test(elem.nodeName);
+          },
+
+          input: function (elem) {
+            return rinputs.test(elem.nodeName);
+          },
+
+          button: function (elem) {
+            var name = elem.nodeName.toLowerCase();
+            return (
+              (name === "input" && elem.type === "button") || name === "button"
+            );
+          },
+
+          text: function (elem) {
+            var attr;
+            return (
+              elem.nodeName.toLowerCase() === "input" &&
+              elem.type === "text" &&
+              // Support: IE<8
+              // New HTML5 attribute values (e.g., "search") appear with elem.type === "text"
+              ((attr = elem.getAttribute("type")) == null ||
+                attr.toLowerCase() === "text")
+            );
+          },
+
+          // Position-in-collection
+          first: createPositionalPseudo(function () {
+            return [0];
+          }),
+
+          last: createPositionalPseudo(function (_matchIndexes, length) {
+            return [length - 1];
+          }),
+
+          eq: createPositionalPseudo(function (
+            _matchIndexes,
+            length,
+            argument
+          ) {
+            return [argument < 0 ? argument + length : argument];
+          }),
+
+          even: createPositionalPseudo(function (matchIndexes, length) {
+            var i = 0;
+            for (; i < length; i += 2) {
+              matchIndexes.push(i);
+            }
+            return matchIndexes;
+          }),
+
+          odd: createPositionalPseudo(function (matchIndexes, length) {
+            var i = 1;
+            for (; i < length; i += 2) {
+              matchIndexes.push(i);
+            }
+            return matchIndexes;
+          }),
+
+          lt: createPositionalPseudo(function (matchIndexes, length, argument) {
+            var i =
+              argument < 0
+                ? argument + length
+                : argument > length
+                ? length
+                : argument;
+            for (; --i >= 0; ) {
+              matchIndexes.push(i);
+            }
+            return matchIndexes;
+          }),
+
+          gt: createPositionalPseudo(function (matchIndexes, length, argument) {
+            var i = argument < 0 ? argument + length : argument;
+            for (; ++i < length; ) {
+              matchIndexes.push(i);
+            }
+            return matchIndexes;
+          }),
+        },
+      };
+
+      Expr.pseudos["nth"] = Expr.pseudos["eq"];
+
+      // Add button/input type pseudos
+      for (i in {
+        radio: true,
+        checkbox: true,
+        file: true,
+        password: true,
+        image: true,
+      }) {
+        Expr.pseudos[i] = createInputPseudo(i);
+      }
+      for (i in { submit: true, reset: true }) {
+        Expr.pseudos[i] = createButtonPseudo(i);
+      }
+
+      // Easy API for creating new setFilters
+      function setFilters() {}
+      setFilters.prototype = Expr.filters = Expr.pseudos;
+      Expr.setFilters = new setFilters();
+
+      tokenize = Sizzle.tokenize = function (selector, parseOnly) {
+        var matched,
+          match,
+          tokens,
+          type,
+          soFar,
+          groups,
+          preFilters,
+          cached = tokenCache[selector + " "];
+
+        if (cached) {
+          return parseOnly ? 0 : cached.slice(0);
+        }
+
+        soFar = selector;
+        groups = [];
+        preFilters = Expr.preFilter;
+
+        while (soFar) {
+          // Comma and first run
+          if (!matched || (match = rcomma.exec(soFar))) {
+            if (match) {
+              // Don't consume trailing commas as valid
+              soFar = soFar.slice(match[0].length) || soFar;
+            }
+            groups.push((tokens = []));
+          }
+
+          matched = false;
+
+          // Combinators
+          if ((match = rcombinators.exec(soFar))) {
+            matched = match.shift();
+            tokens.push({
+              value: matched,
+
+              // Cast descendant combinators to space
+              type: match[0].replace(rtrim, " "),
+            });
+            soFar = soFar.slice(matched.length);
+          }
+
+          // Filters
+          for (type in Expr.filter) {
+            if (
+              (match = matchExpr[type].exec(soFar)) &&
+              (!preFilters[type] || (match = preFilters[type](match)))
+            ) {
+              matched = match.shift();
+              tokens.push({
+                value: matched,
+                type: type,
+                matches: match,
+              });
+              soFar = soFar.slice(matched.length);
+            }
+          }
+
+          if (!matched) {
+            break;
+          }
+        }
+
+        // Return the length of the invalid excess
+        // if we're just parsing
+        // Otherwise, throw an error or return tokens
+        return parseOnly
+          ? soFar.length
+          : soFar
+          ? Sizzle.error(selector)
+          : // Cache the tokens
+            tokenCache(selector, groups).slice(0);
+      };
+
+      function toSelector(tokens) {
+        var i = 0,
+          len = tokens.length,
+          selector = "";
+        for (; i < len; i++) {
+          selector += tokens[i].value;
+        }
+        return selector;
+      }
+
+      function addCombinator(matcher, combinator, base) {
+        var dir = combinator.dir,
+          skip = combinator.next,
+          key = skip || dir,
+          checkNonElements = base && key === "parentNode",
+          doneName = done++;
+
+        return combinator.first
+          ? // Check against closest ancestor/preceding element
+            function (elem, context, xml) {
+              while ((elem = elem[dir])) {
+                if (elem.nodeType === 1 || checkNonElements) {
+                  return matcher(elem, context, xml);
+                }
+              }
+              return false;
+            }
+          : // Check against all ancestor/preceding elements
+            function (elem, context, xml) {
+              var oldCache,
+                uniqueCache,
+                outerCache,
+                newCache = [dirruns, doneName];
+
+              // We can't set arbitrary data on XML nodes, so they don't benefit from combinator caching
+              if (xml) {
+                while ((elem = elem[dir])) {
+                  if (elem.nodeType === 1 || checkNonElements) {
+                    if (matcher(elem, context, xml)) {
+                      return true;
+                    }
+                  }
+                }
+              } else {
+                while ((elem = elem[dir])) {
+                  if (elem.nodeType === 1 || checkNonElements) {
+                    outerCache = elem[expando] || (elem[expando] = {});
+
+                    // Support: IE <9 only
+                    // Defend against cloned attroperties (jQuery gh-1709)
+                    uniqueCache =
+                      outerCache[elem.uniqueID] ||
+                      (outerCache[elem.uniqueID] = {});
+
+                    if (skip && skip === elem.nodeName.toLowerCase()) {
+                      elem = elem[dir] || elem;
+                    } else if (
+                      (oldCache = uniqueCache[key]) &&
+                      oldCache[0] === dirruns &&
+                      oldCache[1] === doneName
+                    ) {
+                      // Assign to newCache so results back-propagate to previous elements
+                      return (newCache[2] = oldCache[2]);
+                    } else {
+                      // Reuse newcache so results back-propagate to previous elements
+                      uniqueCache[key] = newCache;
+
+                      // A match means we're done; a fail means we have to keep checking
+                      if ((newCache[2] = matcher(elem, context, xml))) {
+                        return true;
+                      }
+                    }
+                  }
+                }
+              }
+              return false;
+            };
+      }
+
+      function elementMatcher(matchers) {
+        return matchers.length > 1
+          ? function (elem, context, xml) {
+              var i = matchers.length;
+              while (i--) {
+                if (!matchers[i](elem, context, xml)) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          : matchers[0];
+      }
+
+      function multipleContexts(selector, contexts, results) {
+        var i = 0,
+          len = contexts.length;
+        for (; i < len; i++) {
+          Sizzle(selector, contexts[i], results);
+        }
+        return results;
+      }
+
+      function condense(unmatched, map, filter, context, xml) {
+        var elem,
+          newUnmatched = [],
+          i = 0,
+          len = unmatched.length,
+          mapped = map != null;
+
+        for (; i < len; i++) {
+          if ((elem = unmatched[i])) {
+            if (!filter || filter(elem, context, xml)) {
+              newUnmatched.push(elem);
+              if (mapped) {
+                map.push(i);
+              }
+            }
+          }
+        }
+
+        return newUnmatched;
+      }
+
+      function setMatcher(
+        preFilter,
+        selector,
+        matcher,
+        postFilter,
+        postFinder,
+        postSelector
+      ) {
+        if (postFilter && !postFilter[expando]) {
+          postFilter = setMatcher(postFilter);
+        }
+        if (postFinder && !postFinder[expando]) {
+          postFinder = setMatcher(postFinder, postSelector);
+        }
+        return markFunction(function (seed, results, context, xml) {
+          var temp,
+            i,
+            elem,
+            preMap = [],
+            postMap = [],
+            preexisting = results.length,
+            // Get initial elements from seed or context
+            elems =
+              seed ||
+              multipleContexts(
+                selector || "*",
+                context.nodeType ? [context] : context,
+                []
+              ),
+            // Prefilter to get matcher input, preserving a map for seed-results synchronization
+            matcherIn =
+              preFilter && (seed || !selector)
+                ? condense(elems, preMap, preFilter, context, xml)
+                : elems,
+            matcherOut = matcher
+              ? // If we have a postFinder, or filtered seed, or non-seed postFilter or preexisting results,
+                postFinder || (seed ? preFilter : preexisting || postFilter)
+                ? // ...intermediate processing is necessary
+                  []
+                : // ...otherwise use results directly
+                  results
+              : matcherIn;
+
+          // Find primary matches
+          if (matcher) {
+            matcher(matcherIn, matcherOut, context, xml);
+          }
+
+          // Apply postFilter
+          if (postFilter) {
+            temp = condense(matcherOut, postMap);
+            postFilter(temp, [], context, xml);
+
+            // Un-match failing elements by moving them back to matcherIn
+            i = temp.length;
+            while (i--) {
+              if ((elem = temp[i])) {
+                matcherOut[postMap[i]] = !(matcherIn[postMap[i]] = elem);
+              }
+            }
+          }
+
+          if (seed) {
+            if (postFinder || preFilter) {
+              if (postFinder) {
+                // Get the final matcherOut by condensing this intermediate into postFinder contexts
+                temp = [];
+                i = matcherOut.length;
+                while (i--) {
+                  if ((elem = matcherOut[i])) {
+                    // Restore matcherIn since elem is not yet a final match
+                    temp.push((matcherIn[i] = elem));
+                  }
+                }
+                postFinder(null, (matcherOut = []), temp, xml);
+              }
+
+              // Move matched elements from seed to results to keep them synchronized
+              i = matcherOut.length;
+              while (i--) {
+                if (
+                  (elem = matcherOut[i]) &&
+                  (temp = postFinder ? indexOf(seed, elem) : preMap[i]) > -1
+                ) {
+                  seed[temp] = !(results[temp] = elem);
+                }
+              }
+            }
+
+            // Add elements to results, through postFinder if defined
+          } else {
+            matcherOut = condense(
+              matcherOut === results
+                ? matcherOut.splice(preexisting, matcherOut.length)
+                : matcherOut
+            );
+            if (postFinder) {
+              postFinder(null, results, matcherOut, xml);
+            } else {
+              push.apply(results, matcherOut);
+            }
+          }
+        });
+      }
+
+      function matcherFromTokens(tokens) {
+        var checkContext,
+          matcher,
+          j,
+          len = tokens.length,
+          leadingRelative = Expr.relative[tokens[0].type],
+          implicitRelative = leadingRelative || Expr.relative[" "],
+          i = leadingRelative ? 1 : 0,
+          // The foundational matcher ensures that elements are reachable from top-level context(s)
+          matchContext = addCombinator(
+            function (elem) {
+              return elem === checkContext;
+            },
+            implicitRelative,
+            true
+          ),
+          matchAnyContext = addCombinator(
+            function (elem) {
+              return indexOf(checkContext, elem) > -1;
+            },
+            implicitRelative,
+            true
+          ),
+          matchers = [
+            function (elem, context, xml) {
+              var ret =
+                (!leadingRelative && (xml || context !== outermostContext)) ||
+                ((checkContext = context).nodeType
+                  ? matchContext(elem, context, xml)
+                  : matchAnyContext(elem, context, xml));
+
+              // Avoid hanging onto element (issue #299)
+              checkContext = null;
+              return ret;
+            },
+          ];
+
+        for (; i < len; i++) {
+          if ((matcher = Expr.relative[tokens[i].type])) {
+            matchers = [addCombinator(elementMatcher(matchers), matcher)];
+          } else {
+            matcher = Expr.filter[tokens[i].type].apply(
+              null,
+              tokens[i].matches
+            );
+
+            // Return special upon seeing a positional matcher
+            if (matcher[expando]) {
+              // Find the next relative operator (if any) for proper handling
+              j = ++i;
+              for (; j < len; j++) {
+                if (Expr.relative[tokens[j].type]) {
+                  break;
+                }
+              }
+              return setMatcher(
+                i > 1 && elementMatcher(matchers),
+                i > 1 &&
+                  toSelector(
+                    // If the preceding token was a descendant combinator, insert an implicit any-element `*`
+                    tokens
+                      .slice(0, i - 1)
+                      .concat({ value: tokens[i - 2].type === " " ? "*" : "" })
+                  ).replace(rtrim, "$1"),
+                matcher,
+                i < j && matcherFromTokens(tokens.slice(i, j)),
+                j < len && matcherFromTokens((tokens = tokens.slice(j))),
+                j < len && toSelector(tokens)
+              );
+            }
+            matchers.push(matcher);
+          }
+        }
+
+        return elementMatcher(matchers);
+      }
+
+      function matcherFromGroupMatchers(elementMatchers, setMatchers) {
+        var bySet = setMatchers.length > 0,
+          byElement = elementMatchers.length > 0,
+          superMatcher = function (seed, context, xml, results, outermost) {
+            var elem,
+              j,
+              matcher,
+              matchedCount = 0,
+              i = "0",
+              unmatched = seed && [],
+              setMatched = [],
+              contextBackup = outermostContext,
+              // We must always have either seed elements or outermost context
+              elems = seed || (byElement && Expr.find["TAG"]("*", outermost)),
+              // Use integer dirruns iff this is the outermost matcher
+              dirrunsUnique = (dirruns +=
+                contextBackup == null ? 1 : Math.random() || 0.1),
+              len = elems.length;
+
+            if (outermost) {
+              // Support: IE 11+, Edge 17 - 18+
+              // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+              // two documents; shallow comparisons work.
+              // eslint-disable-next-line eqeqeq
+              outermostContext = context == document || context || outermost;
+            }
+
+            // Add elements passing elementMatchers directly to results
+            // Support: IE<9, Safari
+            // Tolerate NodeList properties (IE: "length"; Safari: <number>) matching elements by id
+            for (; i !== len && (elem = elems[i]) != null; i++) {
+              if (byElement && elem) {
+                j = 0;
+
+                // Support: IE 11+, Edge 17 - 18+
+                // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+                // two documents; shallow comparisons work.
+                // eslint-disable-next-line eqeqeq
+                if (!context && elem.ownerDocument != document) {
+                  setDocument(elem);
+                  xml = !documentIsHTML;
+                }
+                while ((matcher = elementMatchers[j++])) {
+                  if (matcher(elem, context || document, xml)) {
+                    results.push(elem);
+                    break;
+                  }
+                }
+                if (outermost) {
+                  dirruns = dirrunsUnique;
+                }
+              }
+
+              // Track unmatched elements for set filters
+              if (bySet) {
+                // They will have gone through all possible matchers
+                if ((elem = !matcher && elem)) {
+                  matchedCount--;
+                }
+
+                // Lengthen the array for every element, matched or not
+                if (seed) {
+                  unmatched.push(elem);
+                }
+              }
+            }
+
+            // `i` is now the count of elements visited above, and adding it to `matchedCount`
+            // makes the latter nonnegative.
+            matchedCount += i;
+
+            // Apply set filters to unmatched elements
+            // NOTE: This can be skipped if there are no unmatched elements (i.e., `matchedCount`
+            // equals `i`), unless we didn't visit _any_ elements in the above loop because we have
+            // no element matchers and no seed.
+            // Incrementing an initially-string "0" `i` allows `i` to remain a string only in that
+            // case, which will result in a "00" `matchedCount` that differs from `i` but is also
+            // numerically zero.
+            if (bySet && i !== matchedCount) {
+              j = 0;
+              while ((matcher = setMatchers[j++])) {
+                matcher(unmatched, setMatched, context, xml);
+              }
+
+              if (seed) {
+                // Reintegrate element matches to eliminate the need for sorting
+                if (matchedCount > 0) {
+                  while (i--) {
+                    if (!(unmatched[i] || setMatched[i])) {
+                      setMatched[i] = pop.call(results);
+                    }
+                  }
+                }
+
+                // Discard index placeholder values to get only actual matches
+                setMatched = condense(setMatched);
+              }
+
+              // Add matches to results
+              push.apply(results, setMatched);
+
+              // Seedless set matches succeeding multiple successful matchers stipulate sorting
+              if (
+                outermost &&
+                !seed &&
+                setMatched.length > 0 &&
+                matchedCount + setMatchers.length > 1
+              ) {
+                Sizzle.uniqueSort(results);
+              }
+            }
+
+            // Override manipulation of globals by nested matchers
+            if (outermost) {
+              dirruns = dirrunsUnique;
+              outermostContext = contextBackup;
+            }
+
+            return unmatched;
+          };
+
+        return bySet ? markFunction(superMatcher) : superMatcher;
+      }
+
+      compile = Sizzle.compile = function (
+        selector,
+        match /* Internal Use Only */
+      ) {
+        var i,
+          setMatchers = [],
+          elementMatchers = [],
+          cached = compilerCache[selector + " "];
+
+        if (!cached) {
+          // Generate a function of recursive functions that can be used to check each element
+          if (!match) {
+            match = tokenize(selector);
+          }
+          i = match.length;
+          while (i--) {
+            cached = matcherFromTokens(match[i]);
+            if (cached[expando]) {
+              setMatchers.push(cached);
+            } else {
+              elementMatchers.push(cached);
+            }
+          }
+
+          // Cache the compiled function
+          cached = compilerCache(
+            selector,
+            matcherFromGroupMatchers(elementMatchers, setMatchers)
+          );
+
+          // Save selector and tokenization
+          cached.selector = selector;
+        }
+        return cached;
+      };
+
+      /**
+       * A low-level selection function that works with Sizzle's compiled
+       *  selector functions
+       * @param {String|Function} selector A selector or a pre-compiled
+       *  selector function built with Sizzle.compile
+       * @param {Element} context
+       * @param {Array} [results]
+       * @param {Array} [seed] A set of elements to match against
+       */
+      select = Sizzle.select = function (selector, context, results, seed) {
+        var i,
+          tokens,
+          token,
+          type,
+          find,
+          compiled = typeof selector === "function" && selector,
+          match = !seed && tokenize((selector = compiled.selector || selector));
+
+        results = results || [];
+
+        // Try to minimize operations if there is only one selector in the list and no seed
+        // (the latter of which guarantees us context)
+        if (match.length === 1) {
+          // Reduce context if the leading compound selector is an ID
+          tokens = match[0] = match[0].slice(0);
+          if (
+            tokens.length > 2 &&
+            (token = tokens[0]).type === "ID" &&
+            context.nodeType === 9 &&
+            documentIsHTML &&
+            Expr.relative[tokens[1].type]
+          ) {
+            context = (Expr.find["ID"](
+              token.matches[0].replace(runescape, funescape),
+              context
+            ) || [])[0];
+            if (!context) {
+              return results;
+
+              // Precompiled matchers will still verify ancestry, so step up a level
+            } else if (compiled) {
+              context = context.parentNode;
+            }
+
+            selector = selector.slice(tokens.shift().value.length);
+          }
+
+          // Fetch a seed set for right-to-left matching
+          i = matchExpr["needsContext"].test(selector) ? 0 : tokens.length;
+          while (i--) {
+            token = tokens[i];
+
+            // Abort if we hit a combinator
+            if (Expr.relative[(type = token.type)]) {
+              break;
+            }
+            if ((find = Expr.find[type])) {
+              // Search, expanding context for leading sibling combinators
+              if (
+                (seed = find(
+                  token.matches[0].replace(runescape, funescape),
+                  (rsibling.test(tokens[0].type) &&
+                    testContext(context.parentNode)) ||
+                    context
+                ))
+              ) {
+                // If seed is empty or no tokens remain, we can return early
+                tokens.splice(i, 1);
+                selector = seed.length && toSelector(tokens);
+                if (!selector) {
+                  push.apply(results, seed);
+                  return results;
+                }
+
+                break;
+              }
+            }
+          }
+        }
+
+        // Compile and execute a filtering function if one is not provided
+        // Provide `match` to avoid retokenization if we modified the selector above
+        (compiled || compile(selector, match))(
+          seed,
+          context,
+          !documentIsHTML,
+          results,
+          !context ||
+            (rsibling.test(selector) && testContext(context.parentNode)) ||
+            context
+        );
+        return results;
+      };
+
+      // One-time assignments
+
+      // Sort stability
+      support.sortStable =
+        expando.split("").sort(sortOrder).join("") === expando;
+
+      // Support: Chrome 14-35+
+      // Always assume duplicates if they aren't passed to the comparison function
+      support.detectDuplicates = !!hasDuplicate;
+
+      // Initialize against the default document
+      setDocument();
+
+      // Support: Webkit<537.32 - Safari 6.0.3/Chrome 25 (fixed in Chrome 27)
+      // Detached nodes confoundingly follow *each other*
+      support.sortDetached = assert(function (el) {
+        // Should return 1, but returns 4 (following)
+        return (
+          el.compareDocumentPosition(document.createElement("fieldset")) & 1
+        );
+      });
+
+      // Support: IE<8
+      // Prevent attribute/property "interpolation"
+      // https://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
+      if (
+        !assert(function (el) {
+          el.innerHTML = "<a href='#'></a>";
+          return el.firstChild.getAttribute("href") === "#";
+        })
+      ) {
+        addHandle("type|href|height|width", function (elem, name, isXML) {
+          if (!isXML) {
+            return elem.getAttribute(
+              name,
+              name.toLowerCase() === "type" ? 1 : 2
+            );
+          }
+        });
+      }
+
+      // Support: IE<9
+      // Use defaultValue in place of getAttribute("value")
+      if (
+        !support.attributes ||
+        !assert(function (el) {
+          el.innerHTML = "<input/>";
+          el.firstChild.setAttribute("value", "");
+          return el.firstChild.getAttribute("value") === "";
+        })
+      ) {
+        addHandle("value", function (elem, _name, isXML) {
+          if (!isXML && elem.nodeName.toLowerCase() === "input") {
+            return elem.defaultValue;
+          }
+        });
+      }
+
+      // Support: IE<9
+      // Use getAttributeNode to fetch booleans when getAttribute lies
+      if (
+        !assert(function (el) {
+          return el.getAttribute("disabled") == null;
+        })
+      ) {
+        addHandle(booleans, function (elem, name, isXML) {
+          var val;
+          if (!isXML) {
+            return elem[name] === true
+              ? name.toLowerCase()
+              : (val = elem.getAttributeNode(name)) && val.specified
+              ? val.value
+              : null;
+          }
+        });
+      }
+
+      return Sizzle;
+    })(window);
+
+  jQuery.find = Sizzle;
+  jQuery.expr = Sizzle.selectors;
+
+  // Deprecated
+  jQuery.expr[":"] = jQuery.expr.pseudos;
+  jQuery.uniqueSort = jQuery.unique = Sizzle.uniqueSort;
+  jQuery.text = Sizzle.getText;
+  jQuery.isXMLDoc = Sizzle.isXML;
+  jQuery.contains = Sizzle.contains;
+  jQuery.escapeSelector = Sizzle.escape;
+
+  var dir = function (elem, dir, until) {
+    var matched = [],
+      truncate = until !== undefined;
+
+    while ((elem = elem[dir]) && elem.nodeType !== 9) {
+      if (elem.nodeType === 1) {
+        if (truncate && jQuery(elem).is(until)) {
+          break;
+        }
+        matched.push(elem);
+      }
+    }
+    return matched;
+  };
+
+  var siblings = function (n, elem) {
+    var matched = [];
+
+    for (; n; n = n.nextSibling) {
+      if (n.nodeType === 1 && n !== elem) {
+        matched.push(n);
+      }
+    }
+
+    return matched;
+  };
+
+  var rneedsContext = jQuery.expr.match.needsContext;
+
+  function nodeName(elem, name) {
+    return elem.nodeName && elem.nodeName.toLowerCase() === name.toLowerCase();
+  }
+  var rsingleTag =
+    /^<([a-z][^\/\0>:\x20\t\r\n\f]*)[\x20\t\r\n\f]*\/?>(?:<\/\1>|)$/i;
+
+  // Implement the identical functionality for filter and not
+  function winnow(elements, qualifier, not) {
+    if (isFunction(qualifier)) {
+      return jQuery.grep(elements, function (elem, i) {
+        return !!qualifier.call(elem, i, elem) !== not;
+      });
+    }
+
+    // Single element
+    if (qualifier.nodeType) {
+      return jQuery.grep(elements, function (elem) {
+        return (elem === qualifier) !== not;
+      });
+    }
+
+    // Arraylike of elements (jQuery, arguments, Array)
+    if (typeof qualifier !== "string") {
+      return jQuery.grep(elements, function (elem) {
+        return indexOf.call(qualifier, elem) > -1 !== not;
+      });
+    }
+
+    // Filtered directly for both simple and complex selectors
+    return jQuery.filter(qualifier, elements, not);
+  }
+
+  jQuery.filter = function (expr, elems, not) {
+    var elem = elems[0];
+
+    if (not) {
+      expr = ":not(" + expr + ")";
+    }
+
+    if (elems.length === 1 && elem.nodeType === 1) {
+      return jQuery.find.matchesSelector(elem, expr) ? [elem] : [];
+    }
+
+    return jQuery.find.matches(
+      expr,
+      jQuery.grep(elems, function (elem) {
+        return elem.nodeType === 1;
+      })
+    );
+  };
+
+  jQuery.fn.extend({
+    find: function (selector) {
+      var i,
+        ret,
+        len = this.length,
+        self = this;
+
+      if (typeof selector !== "string") {
+        return this.pushStack(
+          jQuery(selector).filter(function () {
+            for (i = 0; i < len; i++) {
+              if (jQuery.contains(self[i], this)) {
+                return true;
+              }
+            }
+          })
+        );
+      }
+
+      ret = this.pushStack([]);
+
+      for (i = 0; i < len; i++) {
+        jQuery.find(selector, self[i], ret);
+      }
+
+      return len > 1 ? jQuery.uniqueSort(ret) : ret;
+    },
+    filter: function (selector) {
+      return this.pushStack(winnow(this, selector || [], false));
+    },
+    not: function (selector) {
+      return this.pushStack(winnow(this, selector || [], true));
+    },
+    is: function (selector) {
+      return !!winnow(
+        this,
+
+        // If this is a positional/relative selector, check membership in the returned set
+        // so $("p:first").is("p:last") won't return true for a doc with two "p".
+        typeof selector === "string" && rneedsContext.test(selector)
+          ? jQuery(selector)
+          : selector || [],
+        false
+      ).length;
+    },
+  });
+
+  // Initialize a jQuery object
+
+  // A central reference to the root jQuery(document)
+  var rootjQuery,
+    // A simple way to check for HTML strings
+    // Prioritize #id over <tag> to avoid XSS via location.hash (#9521)
+    // Strict HTML recognition (#11290: must start with <)
+    // Shortcut simple #id case for speed
+    rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]+))$/,
+    init = (jQuery.fn.init = function (selector, context, root) {
+      var match, elem;
+
+      // HANDLE: $(""), $(null), $(undefined), $(false)
+      if (!selector) {
+        return this;
+      }
+
+      // Method init() accepts an alternate rootjQuery
+      // so migrate can support jQuery.sub (gh-2101)
+      root = root || rootjQuery;
+
+      // Handle HTML strings
+      if (typeof selector === "string") {
+        if (
+          selector[0] === "<" &&
+          selector[selector.length - 1] === ">" &&
+          selector.length >= 3
+        ) {
+          // Assume that strings that start and end with <> are HTML and skip the regex check
+          match = [null, selector, null];
+        } else {
+          match = rquickExpr.exec(selector);
+        }
+
+        // Match html or make sure no context is specified for #id
+        if (match && (match[1] || !context)) {
+          // HANDLE: $(html) -> $(array)
+          if (match[1]) {
+            context = context instanceof jQuery ? context[0] : context;
+
+            // Option to run scripts is true for back-compat
+            // Intentionally let the error be thrown if parseHTML is not present
+            jQuery.merge(
+              this,
+              jQuery.parseHTML(
+                match[1],
+                context && context.nodeType
+                  ? context.ownerDocument || context
+                  : document,
+                true
+              )
+            );
+
+            // HANDLE: $(html, props)
+            if (rsingleTag.test(match[1]) && jQuery.isPlainObject(context)) {
+              for (match in context) {
+                // Properties of context are called as methods if possible
+                if (isFunction(this[match])) {
+                  this[match](context[match]);
+
+                  // ...and otherwise set as attributes
+                } else {
+                  this.attr(match, context[match]);
+                }
+              }
+            }
+
+            return this;
+
+            // HANDLE: $(#id)
+          } else {
+            elem = document.getElementById(match[2]);
+
+            if (elem) {
+              // Inject the element directly into the jQuery object
+              this[0] = elem;
+              this.length = 1;
+            }
+            return this;
+          }
+
+          // HANDLE: $(expr, $(...))
+        } else if (!context || context.jquery) {
+          return (context || root).find(selector);
+
+          // HANDLE: $(expr, context)
+          // (which is just equivalent to: $(context).find(expr)
+        } else {
+          return this.constructor(context).find(selector);
+        }
+
+        // HANDLE: $(DOMElement)
+      } else if (selector.nodeType) {
+        this[0] = selector;
+        this.length = 1;
+        return this;
+
+        // HANDLE: $(function)
+        // Shortcut for document ready
+      } else if (isFunction(selector)) {
+        return root.ready !== undefined
+          ? root.ready(selector)
+          : // Execute immediately if ready is not present
+            selector(jQuery);
+      }
+
+      return jQuery.makeArray(selector, this);
+    });
+
+  // Give the init function the jQuery prototype for later instantiation
+  init.prototype = jQuery.fn;
+
+  // Initialize central reference
+  rootjQuery = jQuery(document);
+
+  var rparentsprev = /^(?:parents|prev(?:Until|All))/,
+    // Methods guaranteed to produce a unique set when starting from a unique set
+    guaranteedUnique = {
+      children: true,
+      contents: true,
+      next: true,
+      prev: true,
+    };
+
+  jQuery.fn.extend({
+    has: function (target) {
+      var targets = jQuery(target, this),
+        l = targets.length;
+
+      return this.filter(function () {
+        var i = 0;
+        for (; i < l; i++) {
+          if (jQuery.contains(this, targets[i])) {
+            return true;
+          }
+        }
+      });
+    },
+
+    closest: function (selectors, context) {
+      var cur,
+        i = 0,
+        l = this.length,
+        matched = [],
+        targets = typeof selectors !== "string" && jQuery(selectors);
+
+      // Positional selectors never match, since there's no _selection_ context
+      if (!rneedsContext.test(selectors)) {
+        for (; i < l; i++) {
+          for (cur = this[i]; cur && cur !== context; cur = cur.parentNode) {
+            // Always skip document fragments
+            if (
+              cur.nodeType < 11 &&
+              (targets
+                ? targets.index(cur) > -1
+                : // Don't pass non-elements to Sizzle
+                  cur.nodeType === 1 &&
+                  jQuery.find.matchesSelector(cur, selectors))
+            ) {
+              matched.push(cur);
+              break;
+            }
+          }
+        }
+      }
+
+      return this.pushStack(
+        matched.length > 1 ? jQuery.uniqueSort(matched) : matched
+      );
+    },
+
+    // Determine the position of an element within the set
+    index: function (elem) {
+      // No argument, return index in parent
+      if (!elem) {
+        return this[0] && this[0].parentNode
+          ? this.first().prevAll().length
+          : -1;
+      }
+
+      // Index in selector
+      if (typeof elem === "string") {
+        return indexOf.call(jQuery(elem), this[0]);
+      }
+
+      // Locate the position of the desired element
+      return indexOf.call(
+        this,
+
+        // If it receives a jQuery object, the first element is used
+        elem.jquery ? elem[0] : elem
+      );
+    },
+
+    add: function (selector, context) {
+      return this.pushStack(
+        jQuery.uniqueSort(jQuery.merge(this.get(), jQuery(selector, context)))
+      );
+    },
+
+    addBack: function (selector) {
+      return this.add(
+        selector == null ? this.prevObject : this.prevObject.filter(selector)
+      );
+    },
+  });
+
+  function sibling(cur, dir) {
+    while ((cur = cur[dir]) && cur.nodeType !== 1) {}
+    return cur;
+  }
+
+  jQuery.each(
+    {
+      parent: function (elem) {
+        var parent = elem.parentNode;
+        return parent && parent.nodeType !== 11 ? parent : null;
+      },
+      parents: function (elem) {
+        return dir(elem, "parentNode");
+      },
+      parentsUntil: function (elem, _i, until) {
+        return dir(elem, "parentNode", until);
+      },
+      next: function (elem) {
+        return sibling(elem, "nextSibling");
+      },
+      prev: function (elem) {
+        return sibling(elem, "previousSibling");
+      },
+      nextAll: function (elem) {
+        return dir(elem, "nextSibling");
+      },
+      prevAll: function (elem) {
+        return dir(elem, "previousSibling");
+      },
+      nextUntil: function (elem, _i, until) {
+        return dir(elem, "nextSibling", until);
+      },
+      prevUntil: function (elem, _i, until) {
+        return dir(elem, "previousSibling", until);
+      },
+      siblings: function (elem) {
+        return siblings((elem.parentNode || {}).firstChild, elem);
+      },
+      children: function (elem) {
+        return siblings(elem.firstChild);
+      },
+      contents: function (elem) {
+        if (
+          elem.contentDocument != null &&
+          // Support: IE 11+
+          // <object> elements with no `data` attribute has an object
+          // `contentDocument` with a `null` prototype.
+          getProto(elem.contentDocument)
+        ) {
+          return elem.contentDocument;
+        }
+
+        // Support: IE 9 - 11 only, iOS 7 only, Android Browser <=4.3 only
+        // Treat the template element as a regular one in browsers that
+        // don't support it.
+        if (nodeName(elem, "template")) {
+          elem = elem.content || elem;
+        }
+
+        return jQuery.merge([], elem.childNodes);
+      },
+    },
+    function (name, fn) {
+      jQuery.fn[name] = function (until, selector) {
+        var matched = jQuery.map(this, fn, until);
+
+        if (name.slice(-5) !== "Until") {
+          selector = until;
+        }
+
+        if (selector && typeof selector === "string") {
+          matched = jQuery.filter(selector, matched);
+        }
+
+        if (this.length > 1) {
+          // Remove duplicates
+          if (!guaranteedUnique[name]) {
+            jQuery.uniqueSort(matched);
+          }
+
+          // Reverse order for parents* and prev-derivatives
+          if (rparentsprev.test(name)) {
+            matched.reverse();
+          }
+        }
+
+        return this.pushStack(matched);
+      };
+    }
+  );
+  var rnothtmlwhite = /[^\x20\t\r\n\f]+/g;
+
+  // Convert String-formatted options into Object-formatted ones
+  function createOptions(options) {
+    var object = {};
+    jQuery.each(options.match(rnothtmlwhite) || [], function (_, flag) {
+      object[flag] = true;
+    });
+    return object;
+  }
+
+  /*
+   * Create a callback list using the following parameters:
+   *
+   *	options: an optional list of space-separated options that will change how
+   *			the callback list behaves or a more traditional option object
+   *
+   * By default a callback list will act like an event callback list and can be
+   * "fired" multiple times.
+   *
+   * Possible options:
+   *
+   *	once:			will ensure the callback list can only be fired once (like a Deferred)
+   *
+   *	memory:			will keep track of previous values and will call any callback added
+   *					after the list has been fired right away with the latest "memorized"
+   *					values (like a Deferred)
+   *
+   *	unique:			will ensure a callback can only be added once (no duplicate in the list)
+   *
+   *	stopOnFalse:	interrupt callings when a callback returns false
+   *
+   */
+  jQuery.Callbacks = function (options) {
+    // Convert options from String-formatted to Object-formatted if needed
+    // (we check in cache first)
+    options =
+      typeof options === "string"
+        ? createOptions(options)
+        : jQuery.extend({}, options);
+
+    var // Flag to know if list is currently firing
+      firing,
+      // Last fire value for non-forgettable lists
+      memory,
+      // Flag to know if list was already fired
+      fired,
+      // Flag to prevent firing
+      locked,
+      // Actual callback list
+      list = [],
+      // Queue of execution data for repeatable lists
+      queue = [],
+      // Index of currently firing callback (modified by add/remove as needed)
+      firingIndex = -1,
+      // Fire callbacks
+      fire = function () {
+        // Enforce single-firing
+        locked = locked || options.once;
+
+        // Execute callbacks for all pending executions,
+        // respecting firingIndex overrides and runtime changes
+        fired = firing = true;
+        for (; queue.length; firingIndex = -1) {
+          memory = queue.shift();
+          while (++firingIndex < list.length) {
+            // Run callback and check for early termination
+            if (
+              list[firingIndex].apply(memory[0], memory[1]) === false &&
+              options.stopOnFalse
+            ) {
+              // Jump to end and forget the data so .add doesn't re-fire
+              firingIndex = list.length;
+              memory = false;
+            }
+          }
+        }
+
+        // Forget the data if we're done with it
+        if (!options.memory) {
+          memory = false;
+        }
+
+        firing = false;
+
+        // Clean up if we're done firing for good
+        if (locked) {
+          // Keep an empty list if we have data for future add calls
+          if (memory) {
+            list = [];
+
+            // Otherwise, this object is spent
+          } else {
+            list = "";
+          }
+        }
+      },
+      // Actual Callbacks object
+      self = {
+        // Add a callback or a collection of callbacks to the list
+        add: function () {
+          if (list) {
+            // If we have memory from a past run, we should fire after adding
+            if (memory && !firing) {
+              firingIndex = list.length - 1;
+              queue.push(memory);
+            }
+
+            (function add(args) {
+              jQuery.each(args, function (_, arg) {
+                if (isFunction(arg)) {
+                  if (!options.unique || !self.has(arg)) {
+                    list.push(arg);
+                  }
+                } else if (arg && arg.length && toType(arg) !== "string") {
+                  // Inspect recursively
+                  add(arg);
+                }
+              });
+            })(arguments);
+
+            if (memory && !firing) {
+              fire();
+            }
+          }
+          return this;
+        },
+
+        // Remove a callback from the list
+        remove: function () {
+          jQuery.each(arguments, function (_, arg) {
+            var index;
+            while ((index = jQuery.inArray(arg, list, index)) > -1) {
+              list.splice(index, 1);
+
+              // Handle firing indexes
+              if (index <= firingIndex) {
+                firingIndex--;
+              }
+            }
+          });
+          return this;
+        },
+
+        // Check if a given callback is in the list.
+        // If no argument is given, return whether or not list has callbacks attached.
+        has: function (fn) {
+          return fn ? jQuery.inArray(fn, list) > -1 : list.length > 0;
+        },
+
+        // Remove all callbacks from the list
+        empty: function () {
+          if (list) {
+            list = [];
+          }
+          return this;
+        },
+
+        // Disable .fire and .add
+        // Abort any current/pending executions
+        // Clear all callbacks and values
+        disable: function () {
+          locked = queue = [];
+          list = memory = "";
+          return this;
+        },
+        disabled: function () {
+          return !list;
+        },
+
+        // Disable .fire
+        // Also disable .add unless we have memory (since it would have no effect)
+        // Abort any pending executions
+        lock: function () {
+          locked = queue = [];
+          if (!memory && !firing) {
+            list = memory = "";
+          }
+          return this;
+        },
+        locked: function () {
+          return !!locked;
+        },
+
+        // Call all callbacks with the given context and arguments
+        fireWith: function (context, args) {
+          if (!locked) {
+            args = args || [];
+            args = [context, args.slice ? args.slice() : args];
+            queue.push(args);
+            if (!firing) {
+              fire();
+            }
+          }
+          return this;
+        },
+
+        // Call all the callbacks with the given arguments
+        fire: function () {
+          self.fireWith(this, arguments);
+          return this;
+        },
+
+        // To know if the callbacks have already been called at least once
+        fired: function () {
+          return !!fired;
+        },
+      };
+
+    return self;
+  };
+
+  function Identity(v) {
+    return v;
+  }
+  function Thrower(ex) {
+    throw ex;
+  }
+
+  function adoptValue(value, resolve, reject, noValue) {
+    var method;
+
+    try {
+      // Check for promise aspect first to privilege synchronous behavior
+      if (value && isFunction((method = value.promise))) {
+        method.call(value).done(resolve).fail(reject);
+
+        // Other thenables
+      } else if (value && isFunction((method = value.then))) {
+        method.call(value, resolve, reject);
+
+        // Other non-thenables
+      } else {
+        // Control `resolve` arguments by letting Array#slice cast boolean `noValue` to integer:
+        // * false: [ value ].slice( 0 ) => resolve( value )
+        // * true: [ value ].slice( 1 ) => resolve()
+        resolve.apply(undefined, [value].slice(noValue));
+      }
+
+      // For Promises/A+, convert exceptions into rejections
+      // Since jQuery.when doesn't unwrap thenables, we can skip the extra checks appearing in
+      // Deferred#then to conditionally suppress rejection.
+    } catch (value) {
+      // Support: Android 4.0 only
+      // Strict mode functions invoked without .call/.apply get global-object context
+      reject.apply(undefined, [value]);
+    }
+  }
+
+  jQuery.extend({
+    Deferred: function (func) {
+      var tuples = [
+          // action, add listener, callbacks,
+          // ... .then handlers, argument index, [final state]
+          [
+            "notify",
+            "progress",
+            jQuery.Callbacks("memory"),
+            jQuery.Callbacks("memory"),
+            2,
+          ],
+          [
+            "resolve",
+            "done",
+            jQuery.Callbacks("once memory"),
+            jQuery.Callbacks("once memory"),
+            0,
+            "resolved",
+          ],
+          [
+            "reject",
+            "fail",
+            jQuery.Callbacks("once memory"),
+            jQuery.Callbacks("once memory"),
+            1,
+            "rejected",
+          ],
+        ],
+        state = "pending",
+        promise = {
+          state: function () {
+            return state;
+          },
+          always: function () {
+            deferred.done(arguments).fail(arguments);
+            return this;
+          },
+          catch: function (fn) {
+            return promise.then(null, fn);
+          },
+
+          // Keep pipe for back-compat
+          pipe: function (/* fnDone, fnFail, fnProgress */) {
+            var fns = arguments;
+
+            return jQuery
+              .Deferred(function (newDefer) {
+                jQuery.each(tuples, function (_i, tuple) {
+                  // Map tuples (progress, done, fail) to arguments (done, fail, progress)
+                  var fn = isFunction(fns[tuple[4]]) && fns[tuple[4]];
+
+                  // deferred.progress(function() { bind to newDefer or newDefer.notify })
+                  // deferred.done(function() { bind to newDefer or newDefer.resolve })
+                  // deferred.fail(function() { bind to newDefer or newDefer.reject })
+                  deferred[tuple[1]](function () {
+                    var returned = fn && fn.apply(this, arguments);
+                    if (returned && isFunction(returned.promise)) {
+                      returned
+                        .promise()
+                        .progress(newDefer.notify)
+                        .done(newDefer.resolve)
+                        .fail(newDefer.reject);
+                    } else {
+                      newDefer[tuple[0] + "With"](
+                        this,
+                        fn ? [returned] : arguments
+                      );
+                    }
+                  });
+                });
+                fns = null;
+              })
+              .promise();
+          },
+          then: function (onFulfilled, onRejected, onProgress) {
+            var maxDepth = 0;
+            function resolve(depth, deferred, handler, special) {
+              return function () {
+                var that = this,
+                  args = arguments,
+                  mightThrow = function () {
+                    var returned, then;
+
+                    // Support: Promises/A+ section 2.3.3.3.3
+                    // https://promisesaplus.com/#point-59
+                    // Ignore double-resolution attempts
+                    if (depth < maxDepth) {
+                      return;
+                    }
+
+                    returned = handler.apply(that, args);
+
+                    // Support: Promises/A+ section 2.3.1
+                    // https://promisesaplus.com/#point-48
+                    if (returned === deferred.promise()) {
+                      throw new TypeError("Thenable self-resolution");
+                    }
+
+                    // Support: Promises/A+ sections 2.3.3.1, 3.5
+                    // https://promisesaplus.com/#point-54
+                    // https://promisesaplus.com/#point-75
+                    // Retrieve `then` only once
+                    then =
+                      returned &&
+                      // Support: Promises/A+ section 2.3.4
+                      // https://promisesaplus.com/#point-64
+                      // Only check objects and functions for thenability
+                      (typeof returned === "object" ||
+                        typeof returned === "function") &&
+                      returned.then;
+
+                    // Handle a returned thenable
+                    if (isFunction(then)) {
+                      // Special processors (notify) just wait for resolution
+                      if (special) {
+                        then.call(
+                          returned,
+                          resolve(maxDepth, deferred, Identity, special),
+                          resolve(maxDepth, deferred, Thrower, special)
+                        );
+
+                        // Normal processors (resolve) also hook into progress
+                      } else {
+                        // ...and disregard older resolution values
+                        maxDepth++;
+
+                        then.call(
+                          returned,
+                          resolve(maxDepth, deferred, Identity, special),
+                          resolve(maxDepth, deferred, Thrower, special),
+                          resolve(
+                            maxDepth,
+                            deferred,
+                            Identity,
+                            deferred.notifyWith
+                          )
+                        );
+                      }
+
+                      // Handle all other returned values
+                    } else {
+                      // Only substitute handlers pass on context
+                      // and multiple values (non-spec behavior)
+                      if (handler !== Identity) {
+                        that = undefined;
+                        args = [returned];
+                      }
+
+                      // Process the value(s)
+                      // Default process is resolve
+                      (special || deferred.resolveWith)(that, args);
+                    }
+                  },
+                  // Only normal processors (resolve) catch and reject exceptions
+                  process = special
+                    ? mightThrow
+                    : function () {
+                        try {
+                          mightThrow();
+                        } catch (e) {
+                          if (jQuery.Deferred.exceptionHook) {
+                            jQuery.Deferred.exceptionHook(
+                              e,
+                              process.stackTrace
+                            );
+                          }
+
+                          // Support: Promises/A+ section 2.3.3.3.4.1
+                          // https://promisesaplus.com/#point-61
+                          // Ignore post-resolution exceptions
+                          if (depth + 1 >= maxDepth) {
+                            // Only substitute handlers pass on context
+                            // and multiple values (non-spec behavior)
+                            if (handler !== Thrower) {
+                              that = undefined;
+                              args = [e];
+                            }
+
+                            deferred.rejectWith(that, args);
+                          }
+                        }
+                      };
+
+                // Support: Promises/A+ section 2.3.3.3.1
+                // https://promisesaplus.com/#point-57
+                // Re-resolve promises immediately to dodge false rejection from
+                // subsequent errors
+                if (depth) {
+                  process();
+                } else {
+                  // Call an optional hook to record the stack, in case of exception
+                  // since it's otherwise lost when execution goes async
+                  if (jQuery.Deferred.getStackHook) {
+                    process.stackTrace = jQuery.Deferred.getStackHook();
+                  }
+                  window.setTimeout(process);
+                }
+              };
+            }
+
+            return jQuery
+              .Deferred(function (newDefer) {
+                // progress_handlers.add( ... )
+                tuples[0][3].add(
+                  resolve(
+                    0,
+                    newDefer,
+                    isFunction(onProgress) ? onProgress : Identity,
+                    newDefer.notifyWith
+                  )
+                );
+
+                // fulfilled_handlers.add( ... )
+                tuples[1][3].add(
+                  resolve(
+                    0,
+                    newDefer,
+                    isFunction(onFulfilled) ? onFulfilled : Identity
+                  )
+                );
+
+                // rejected_handlers.add( ... )
+                tuples[2][3].add(
+                  resolve(
+                    0,
+                    newDefer,
+                    isFunction(onRejected) ? onRejected : Thrower
+                  )
+                );
+              })
+              .promise();
+          },
+
+          // Get a promise for this deferred
+          // If obj is provided, the promise aspect is added to the object
+          promise: function (obj) {
+            return obj != null ? jQuery.extend(obj, promise) : promise;
+          },
+        },
+        deferred = {};
+
+      // Add list-specific methods
+      jQuery.each(tuples, function (i, tuple) {
+        var list = tuple[2],
+          stateString = tuple[5];
+
+        // promise.progress = list.add
+        // promise.done = list.add
+        // promise.fail = list.add
+        promise[tuple[1]] = list.add;
+
+        // Handle state
+        if (stateString) {
+          list.add(
+            function () {
+              // state = "resolved" (i.e., fulfilled)
+              // state = "rejected"
+              state = stateString;
+            },
+
+            // rejected_callbacks.disable
+            // fulfilled_callbacks.disable
+            tuples[3 - i][2].disable,
+
+            // rejected_handlers.disable
+            // fulfilled_handlers.disable
+            tuples[3 - i][3].disable,
+
+            // progress_callbacks.lock
+            tuples[0][2].lock,
+
+            // progress_handlers.lock
+            tuples[0][3].lock
+          );
+        }
+
+        // progress_handlers.fire
+        // fulfilled_handlers.fire
+        // rejected_handlers.fire
+        list.add(tuple[3].fire);
+
+        // deferred.notify = function() { deferred.notifyWith(...) }
+        // deferred.resolve = function() { deferred.resolveWith(...) }
+        // deferred.reject = function() { deferred.rejectWith(...) }
+        deferred[tuple[0]] = function () {
+          deferred[tuple[0] + "With"](
+            this === deferred ? undefined : this,
+            arguments
+          );
+          return this;
+        };
+
+        // deferred.notifyWith = list.fireWith
+        // deferred.resolveWith = list.fireWith
+        // deferred.rejectWith = list.fireWith
+        deferred[tuple[0] + "With"] = list.fireWith;
+      });
+
+      // Make the deferred a promise
+      promise.promise(deferred);
+
+      // Call given func if any
+      if (func) {
+        func.call(deferred, deferred);
+      }
+
+      // All done!
+      return deferred;
+    },
+
+    // Deferred helper
+    when: function (singleValue) {
+      var // count of uncompleted subordinates
+        remaining = arguments.length,
+        // count of unprocessed arguments
+        i = remaining,
+        // subordinate fulfillment data
+        resolveContexts = Array(i),
+        resolveValues = slice.call(arguments),
+        // the primary Deferred
+        primary = jQuery.Deferred(),
+        // subordinate callback factory
+        updateFunc = function (i) {
+          return function (value) {
+            resolveContexts[i] = this;
+            resolveValues[i] =
+              arguments.length > 1 ? slice.call(arguments) : value;
+            if (!--remaining) {
+              primary.resolveWith(resolveContexts, resolveValues);
+            }
+          };
+        };
+
+      // Single- and empty arguments are adopted like Promise.resolve
+      if (remaining <= 1) {
+        adoptValue(
+          singleValue,
+          primary.done(updateFunc(i)).resolve,
+          primary.reject,
+          !remaining
+        );
+
+        // Use .then() to unwrap secondary thenables (cf. gh-3000)
+        if (
+          primary.state() === "pending" ||
+          isFunction(resolveValues[i] && resolveValues[i].then)
+        ) {
+          return primary.then();
+        }
+      }
+
+      // Multiple arguments are aggregated like Promise.all array elements
+      while (i--) {
+        adoptValue(resolveValues[i], updateFunc(i), primary.reject);
+      }
+
+      return primary.promise();
+    },
+  });
+
+  // These usually indicate a programmer mistake during development,
+  // warn about them ASAP rather than swallowing them by default.
+  var rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
+
+  jQuery.Deferred.exceptionHook = function (error, stack) {
+    // Support: IE 8 - 9 only
+    // Console exists when dev tools are open, which can happen at any time
+    if (
+      window.console &&
+      window.console.warn &&
+      error &&
+      rerrorNames.test(error.name)
+    ) {
+      window.console.warn(
+        "jQuery.Deferred exception: " + error.message,
+        error.stack,
+        stack
+      );
+    }
+  };
+
+  jQuery.readyException = function (error) {
+    window.setTimeout(function () {
+      throw error;
+    });
+  };
+
+  // The deferred used on DOM ready
+  var readyList = jQuery.Deferred();
+
+  jQuery.fn.ready = function (fn) {
+    readyList
+      .then(fn)
+
+      // Wrap jQuery.readyException in a function so that the lookup
+      // happens at the time of error handling instead of callback
+      // registration.
+      .catch(function (error) {
+        jQuery.readyException(error);
+      });
+
+    return this;
+  };
+
+  jQuery.extend({
+    // Is the DOM ready to be used? Set to true once it occurs.
+    isReady: false,
+
+    // A counter to track how many items to wait for before
+    // the ready event fires. See #6781
+    readyWait: 1,
+
+    // Handle when the DOM is ready
+    ready: function (wait) {
+      // Abort if there are pending holds or we're already ready
+      if (wait === true ? --jQuery.readyWait : jQuery.isReady) {
+        return;
+      }
+
+      // Remember that the DOM is ready
+      jQuery.isReady = true;
+
+      // If a normal DOM Ready event fired, decrement, and wait if need be
+      if (wait !== true && --jQuery.readyWait > 0) {
+        return;
+      }
+
+      // If there are functions bound, to execute
+      readyList.resolveWith(document, [jQuery]);
+    },
+  });
+
+  jQuery.ready.then = readyList.then;
+
+  // The ready event handler and self cleanup method
+  function completed() {
+    document.removeEventListener("DOMContentLoaded", completed);
+    window.removeEventListener("load", completed);
+    jQuery.ready();
+  }
+
+  // Catch cases where $(document).ready() is called
+  // after the browser event has already occurred.
+  // Support: IE <=9 - 10 only
+  // Older IE sometimes signals "interactive" too soon
+  if (
+    document.readyState === "complete" ||
+    (document.readyState !== "loading" && !document.documentElement.doScroll)
+  ) {
+    // Handle it asynchronously to allow scripts the opportunity to delay ready
+    window.setTimeout(jQuery.ready);
+  } else {
+    // Use the handy event callback
+    document.addEventListener("DOMContentLoaded", completed);
+
+    // A fallback to window.onload, that will always work
+    window.addEventListener("load", completed);
+  }
+
+  // Multifunctional method to get and set values of a collection
+  // The value/s can optionally be executed if it's a function
+  var access = function (elems, fn, key, value, chainable, emptyGet, raw) {
+    var i = 0,
+      len = elems.length,
+      bulk = key == null;
+
+    // Sets many values
+    if (toType(key) === "object") {
+      chainable = true;
+      for (i in key) {
+        access(elems, fn, i, key[i], true, emptyGet, raw);
+      }
+
+      // Sets one value
+    } else if (value !== undefined) {
+      chainable = true;
+
+      if (!isFunction(value)) {
+        raw = true;
+      }
+
+      if (bulk) {
+        // Bulk operations run against the entire set
+        if (raw) {
+          fn.call(elems, value);
+          fn = null;
+
+          // ...except when executing function values
+        } else {
+          bulk = fn;
+          fn = function (elem, _key, value) {
+            return bulk.call(jQuery(elem), value);
+          };
+        }
+      }
+
+      if (fn) {
+        for (; i < len; i++) {
+          fn(
+            elems[i],
+            key,
+            raw ? value : value.call(elems[i], i, fn(elems[i], key))
+          );
+        }
+      }
+    }
+
+    if (chainable) {
+      return elems;
+    }
+
+    // Gets
+    if (bulk) {
+      return fn.call(elems);
+    }
+
+    return len ? fn(elems[0], key) : emptyGet;
+  };
+
+  // Matches dashed string for camelizing
+  var rmsPrefix = /^-ms-/,
+    rdashAlpha = /-([a-z])/g;
+
+  // Used by camelCase as callback to replace()
+  function fcamelCase(_all, letter) {
+    return letter.toUpperCase();
+  }
+
+  // Convert dashed to camelCase; used by the css and data modules
+  // Support: IE <=9 - 11, Edge 12 - 15
+  // Microsoft forgot to hump their vendor prefix (#9572)
+  function camelCase(string) {
+    return string.replace(rmsPrefix, "ms-").replace(rdashAlpha, fcamelCase);
+  }
+  var acceptData = function (owner) {
+    // Accepts only:
+    //  - Node
+    //    - Node.ELEMENT_NODE
+    //    - Node.DOCUMENT_NODE
+    //  - Object
+    //    - Any
+    return owner.nodeType === 1 || owner.nodeType === 9 || !+owner.nodeType;
+  };
+
+  function Data() {
+    this.expando = jQuery.expando + Data.uid++;
+  }
+
+  Data.uid = 1;
+
+  Data.prototype = {
+    cache: function (owner) {
+      // Check if the owner object already has a cache
+      var value = owner[this.expando];
+
+      // If not, create one
+      if (!value) {
+        value = {};
+
+        // We can accept data for non-element nodes in modern browsers,
+        // but we should not, see #8335.
+        // Always return an empty object.
+        if (acceptData(owner)) {
+          // If it is a node unlikely to be stringify-ed or looped over
+          // use plain assignment
+          if (owner.nodeType) {
+            owner[this.expando] = value;
+
+            // Otherwise secure it in a non-enumerable property
+            // configurable must be true to allow the property to be
+            // deleted when data is removed
+          } else {
+            Object.defineProperty(owner, this.expando, {
+              value: value,
+              configurable: true,
+            });
+          }
+        }
+      }
+
+      return value;
+    },
+    set: function (owner, data, value) {
+      var prop,
+        cache = this.cache(owner);
+
+      // Handle: [ owner, key, value ] args
+      // Always use camelCase key (gh-2257)
+      if (typeof data === "string") {
+        cache[camelCase(data)] = value;
+
+        // Handle: [ owner, { properties } ] args
+      } else {
+        // Copy the properties one-by-one to the cache object
+        for (prop in data) {
+          cache[camelCase(prop)] = data[prop];
+        }
+      }
+      return cache;
+    },
+    get: function (owner, key) {
+      return key === undefined
+        ? this.cache(owner)
+        : // Always use camelCase key (gh-2257)
+          owner[this.expando] && owner[this.expando][camelCase(key)];
+    },
+    access: function (owner, key, value) {
+      // In cases where either:
+      //
+      //   1. No key was specified
+      //   2. A string key was specified, but no value provided
+      //
+      // Take the "read" path and allow the get method to determine
+      // which value to return, respectively either:
+      //
+      //   1. The entire cache object
+      //   2. The data stored at the key
+      //
+      if (
+        key === undefined ||
+        (key && typeof key === "string" && value === undefined)
+      ) {
+        return this.get(owner, key);
+      }
+
+      // When the key is not a string, or both a key and value
+      // are specified, set or extend (existing objects) with either:
+      //
+      //   1. An object of properties
+      //   2. A key and value
+      //
+      this.set(owner, key, value);
+
+      // Since the "set" path can have two possible entry points
+      // return the expected data based on which path was taken[*]
+      return value !== undefined ? value : key;
+    },
+    remove: function (owner, key) {
+      var i,
+        cache = owner[this.expando];
+
+      if (cache === undefined) {
+        return;
+      }
+
+      if (key !== undefined) {
+        // Support array or space separated string of keys
+        if (Array.isArray(key)) {
+          // If key is an array of keys...
+          // We always set camelCase keys, so remove that.
+          key = key.map(camelCase);
+        } else {
+          key = camelCase(key);
+
+          // If a key with the spaces exists, use it.
+          // Otherwise, create an array by matching non-whitespace
+          key = key in cache ? [key] : key.match(rnothtmlwhite) || [];
+        }
+
+        i = key.length;
+
+        while (i--) {
+          delete cache[key[i]];
+        }
+      }
+
+      // Remove the expando if there's no more data
+      if (key === undefined || jQuery.isEmptyObject(cache)) {
+        // Support: Chrome <=35 - 45
+        // Webkit & Blink performance suffers when deleting properties
+        // from DOM nodes, so set to undefined instead
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=378607 (bug restricted)
+        if (owner.nodeType) {
+          owner[this.expando] = undefined;
+        } else {
+          delete owner[this.expando];
+        }
+      }
+    },
+    hasData: function (owner) {
+      var cache = owner[this.expando];
+      return cache !== undefined && !jQuery.isEmptyObject(cache);
+    },
+  };
+  var dataPriv = new Data();
+
+  var dataUser = new Data();
+
+  //	Implementation Summary
+  //
+  //	1. Enforce API surface and semantic compatibility with 1.9.x branch
+  //	2. Improve the module's maintainability by reducing the storage
+  //		paths to a single mechanism.
+  //	3. Use the same single mechanism to support "private" and "user" data.
+  //	4. _Never_ expose "private" data to user code (TODO: Drop _data, _removeData)
+  //	5. Avoid exposing implementation details on user objects (eg. expando properties)
+  //	6. Provide a clear path for implementation upgrade to WeakMap in 2014
+
+  var rbrace = /^(?:\{[\w\W]*\}|\[[\w\W]*\])$/,
+    rmultiDash = /[A-Z]/g;
+
+  function getData(data) {
+    if (data === "true") {
+      return true;
+    }
+
+    if (data === "false") {
+      return false;
+    }
+
+    if (data === "null") {
+      return null;
+    }
+
+    // Only convert to a number if it doesn't change the string
+    if (data === +data + "") {
+      return +data;
+    }
+
+    if (rbrace.test(data)) {
+      return JSON.parse(data);
+    }
+
+    return data;
+  }
+
+  function dataAttr(elem, key, data) {
+    var name;
+
+    // If nothing was found internally, try to fetch any
+    // data from the HTML5 data-* attribute
+    if (data === undefined && elem.nodeType === 1) {
+      name = "data-" + key.replace(rmultiDash, "-$&").toLowerCase();
+      data = elem.getAttribute(name);
+
+      if (typeof data === "string") {
+        try {
+          data = getData(data);
+        } catch (e) {}
+
+        // Make sure we set the data so it isn't changed later
+        dataUser.set(elem, key, data);
+      } else {
+        data = undefined;
+      }
+    }
+    return data;
+  }
+
+  jQuery.extend({
+    hasData: function (elem) {
+      return dataUser.hasData(elem) || dataPriv.hasData(elem);
+    },
+
+    data: function (elem, name, data) {
+      return dataUser.access(elem, name, data);
+    },
+
+    removeData: function (elem, name) {
+      dataUser.remove(elem, name);
+    },
+
+    // TODO: Now that all calls to _data and _removeData have been replaced
+    // with direct calls to dataPriv methods, these can be deprecated.
+    _data: function (elem, name, data) {
+      return dataPriv.access(elem, name, data);
+    },
+
+    _removeData: function (elem, name) {
+      dataPriv.remove(elem, name);
+    },
+  });
+
+  jQuery.fn.extend({
+    data: function (key, value) {
+      var i,
+        name,
+        data,
+        elem = this[0],
+        attrs = elem && elem.attributes;
+
+      // Gets all values
+      if (key === undefined) {
+        if (this.length) {
+          data = dataUser.get(elem);
+
+          if (elem.nodeType === 1 && !dataPriv.get(elem, "hasDataAttrs")) {
+            i = attrs.length;
+            while (i--) {
+              // Support: IE 11 only
+              // The attrs elements can be null (#14894)
+              if (attrs[i]) {
+                name = attrs[i].name;
+                if (name.indexOf("data-") === 0) {
+                  name = camelCase(name.slice(5));
+                  dataAttr(elem, name, data[name]);
+                }
+              }
+            }
+            dataPriv.set(elem, "hasDataAttrs", true);
+          }
+        }
+
+        return data;
+      }
+
+      // Sets multiple values
+      if (typeof key === "object") {
+        return this.each(function () {
+          dataUser.set(this, key);
+        });
+      }
+
+      return access(
+        this,
+        function (value) {
+          var data;
+
+          // The calling jQuery object (element matches) is not empty
+          // (and therefore has an element appears at this[ 0 ]) and the
+          // `value` parameter was not undefined. An empty jQuery object
+          // will result in `undefined` for elem = this[ 0 ] which will
+          // throw an exception if an attempt to read a data cache is made.
+          if (elem && value === undefined) {
+            // Attempt to get data from the cache
+            // The key will always be camelCased in Data
+            data = dataUser.get(elem, key);
+            if (data !== undefined) {
+              return data;
+            }
+
+            // Attempt to "discover" the data in
+            // HTML5 custom data-* attrs
+            data = dataAttr(elem, key);
+            if (data !== undefined) {
+              return data;
+            }
+
+            // We tried really hard, but the data doesn't exist.
+            return;
+          }
+
+          // Set the data...
+          this.each(function () {
+            // We always store the camelCased key
+            dataUser.set(this, key, value);
+          });
+        },
+        null,
+        value,
+        arguments.length > 1,
+        null,
+        true
+      );
+    },
+
+    removeData: function (key) {
+      return this.each(function () {
+        dataUser.remove(this, key);
+      });
+    },
+  });
+
+  jQuery.extend({
+    queue: function (elem, type, data) {
+      var queue;
+
+      if (elem) {
+        type = (type || "fx") + "queue";
+        queue = dataPriv.get(elem, type);
+
+        // Speed up dequeue by getting out quickly if this is just a lookup
+        if (data) {
+          if (!queue || Array.isArray(data)) {
+            queue = dataPriv.access(elem, type, jQuery.makeArray(data));
+          } else {
+            queue.push(data);
+          }
+        }
+        return queue || [];
+      }
+    },
+
+    dequeue: function (elem, type) {
+      type = type || "fx";
+
+      var queue = jQuery.queue(elem, type),
+        startLength = queue.length,
+        fn = queue.shift(),
+        hooks = jQuery._queueHooks(elem, type),
+        next = function () {
+          jQuery.dequeue(elem, type);
+        };
+
+      // If the fx queue is dequeued, always remove the progress sentinel
+      if (fn === "inprogress") {
+        fn = queue.shift();
+        startLength--;
+      }
+
+      if (fn) {
+        // Add a progress sentinel to prevent the fx queue from being
+        // automatically dequeued
+        if (type === "fx") {
+          queue.unshift("inprogress");
+        }
+
+        // Clear up the last queue stop function
+        delete hooks.stop;
+        fn.call(elem, next, hooks);
+      }
+
+      if (!startLength && hooks) {
+        hooks.empty.fire();
+      }
+    },
+
+    // Not public - generate a queueHooks object, or return the current one
+    _queueHooks: function (elem, type) {
+      var key = type + "queueHooks";
+      return (
+        dataPriv.get(elem, key) ||
+        dataPriv.access(elem, key, {
+          empty: jQuery.Callbacks("once memory").add(function () {
+            dataPriv.remove(elem, [type + "queue", key]);
+          }),
+        })
+      );
+    },
+  });
+
+  jQuery.fn.extend({
+    queue: function (type, data) {
+      var setter = 2;
+
+      if (typeof type !== "string") {
+        data = type;
+        type = "fx";
+        setter--;
+      }
+
+      if (arguments.length < setter) {
+        return jQuery.queue(this[0], type);
+      }
+
+      return data === undefined
+        ? this
+        : this.each(function () {
+            var queue = jQuery.queue(this, type, data);
+
+            // Ensure a hooks for this queue
+            jQuery._queueHooks(this, type);
+
+            if (type === "fx" && queue[0] !== "inprogress") {
+              jQuery.dequeue(this, type);
+            }
+          });
+    },
+    dequeue: function (type) {
+      return this.each(function () {
+        jQuery.dequeue(this, type);
+      });
+    },
+    clearQueue: function (type) {
+      return this.queue(type || "fx", []);
+    },
+
+    // Get a promise resolved when queues of a certain type
+    // are emptied (fx is the type by default)
+    promise: function (type, obj) {
+      var tmp,
+        count = 1,
+        defer = jQuery.Deferred(),
+        elements = this,
+        i = this.length,
+        resolve = function () {
+          if (!--count) {
+            defer.resolveWith(elements, [elements]);
+          }
+        };
+
+      if (typeof type !== "string") {
+        obj = type;
+        type = undefined;
+      }
+      type = type || "fx";
+
+      while (i--) {
+        tmp = dataPriv.get(elements[i], type + "queueHooks");
+        if (tmp && tmp.empty) {
+          count++;
+          tmp.empty.add(resolve);
+        }
+      }
+      resolve();
+      return defer.promise(obj);
+    },
+  });
+  var pnum = /[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/.source;
+
+  var rcssNum = new RegExp("^(?:([+-])=|)(" + pnum + ")([a-z%]*)$", "i");
+
+  var cssExpand = ["Top", "Right", "Bottom", "Left"];
+
+  var documentElement = document.documentElement;
+
+  var isAttached = function (elem) {
+      return jQuery.contains(elem.ownerDocument, elem);
+    },
+    composed = { composed: true };
+
+  // Support: IE 9 - 11+, Edge 12 - 18+, iOS 10.0 - 10.2 only
+  // Check attachment across shadow DOM boundaries when possible (gh-3504)
+  // Support: iOS 10.0-10.2 only
+  // Early iOS 10 versions support `attachShadow` but not `getRootNode`,
+  // leading to errors. We need to check for `getRootNode`.
+  if (documentElement.getRootNode) {
+    isAttached = function (elem) {
+      return (
+        jQuery.contains(elem.ownerDocument, elem) ||
+        elem.getRootNode(composed) === elem.ownerDocument
+      );
+    };
+  }
+  var isHiddenWithinTree = function (elem, el) {
+    // isHiddenWithinTree might be called from jQuery#filter function;
+    // in that case, element will be second argument
+    elem = el || elem;
+
+    // Inline style trumps all
+    return (
+      elem.style.display === "none" ||
+      (elem.style.display === "" &&
+        // Otherwise, check computed style
+        // Support: Firefox <=43 - 45
+        // Disconnected elements can have computed display: none, so first confirm that elem is
+        // in the document.
+        isAttached(elem) &&
+        jQuery.css(elem, "display") === "none")
+    );
+  };
+
+  function adjustCSS(elem, prop, valueParts, tween) {
+    var adjusted,
+      scale,
+      maxIterations = 20,
+      currentValue = tween
+        ? function () {
+            return tween.cur();
+          }
+        : function () {
+            return jQuery.css(elem, prop, "");
+          },
+      initial = currentValue(),
+      unit =
+        (valueParts && valueParts[3]) || (jQuery.cssNumber[prop] ? "" : "px"),
+      // Starting value computation is required for potential unit mismatches
+      initialInUnit =
+        elem.nodeType &&
+        (jQuery.cssNumber[prop] || (unit !== "px" && +initial)) &&
+        rcssNum.exec(jQuery.css(elem, prop));
+
+    if (initialInUnit && initialInUnit[3] !== unit) {
+      // Support: Firefox <=54
+      // Halve the iteration target value to prevent interference from CSS upper bounds (gh-2144)
+      initial = initial / 2;
+
+      // Trust units reported by jQuery.css
+      unit = unit || initialInUnit[3];
+
+      // Iteratively approximate from a nonzero starting point
+      initialInUnit = +initial || 1;
+
+      while (maxIterations--) {
+        // Evaluate and update our best guess (doubling guesses that zero out).
+        // Finish if the scale equals or crosses 1 (making the old*new product non-positive).
+        jQuery.style(elem, prop, initialInUnit + unit);
+        if (
+          (1 - scale) * (1 - (scale = currentValue() / initial || 0.5)) <=
+          0
+        ) {
+          maxIterations = 0;
+        }
+        initialInUnit = initialInUnit / scale;
+      }
+
+      initialInUnit = initialInUnit * 2;
+      jQuery.style(elem, prop, initialInUnit + unit);
+
+      // Make sure we update the tween properties later on
+      valueParts = valueParts || [];
+    }
+
+    if (valueParts) {
+      initialInUnit = +initialInUnit || +initial || 0;
+
+      // Apply relative offset (+=/-=) if specified
+      adjusted = valueParts[1]
+        ? initialInUnit + (valueParts[1] + 1) * valueParts[2]
+        : +valueParts[2];
+      if (tween) {
+        tween.unit = unit;
+        tween.start = initialInUnit;
+        tween.end = adjusted;
+      }
+    }
+    return adjusted;
+  }
+
+  var defaultDisplayMap = {};
+
+  function getDefaultDisplay(elem) {
+    var temp,
+      doc = elem.ownerDocument,
+      nodeName = elem.nodeName,
+      display = defaultDisplayMap[nodeName];
+
+    if (display) {
+      return display;
+    }
+
+    temp = doc.body.appendChild(doc.createElement(nodeName));
+    display = jQuery.css(temp, "display");
+
+    temp.parentNode.removeChild(temp);
+
+    if (display === "none") {
+      display = "block";
+    }
+    defaultDisplayMap[nodeName] = display;
+
+    return display;
+  }
+
+  function showHide(elements, show) {
+    var display,
+      elem,
+      values = [],
+      index = 0,
+      length = elements.length;
+
+    // Determine new display value for elements that need to change
+    for (; index < length; index++) {
+      elem = elements[index];
+      if (!elem.style) {
+        continue;
+      }
+
+      display = elem.style.display;
+      if (show) {
+        // Since we force visibility upon cascade-hidden elements, an immediate (and slow)
+        // check is required in this first loop unless we have a nonempty display value (either
+        // inline or about-to-be-restored)
+        if (display === "none") {
+          values[index] = dataPriv.get(elem, "display") || null;
+          if (!values[index]) {
+            elem.style.display = "";
+          }
+        }
+        if (elem.style.display === "" && isHiddenWithinTree(elem)) {
+          values[index] = getDefaultDisplay(elem);
+        }
+      } else {
+        if (display !== "none") {
+          values[index] = "none";
+
+          // Remember what we're overwriting
+          dataPriv.set(elem, "display", display);
+        }
+      }
+    }
+
+    // Set the display of the elements in a second loop to avoid constant reflow
+    for (index = 0; index < length; index++) {
+      if (values[index] != null) {
+        elements[index].style.display = values[index];
+      }
+    }
+
+    return elements;
+  }
+
+  jQuery.fn.extend({
+    show: function () {
+      return showHide(this, true);
+    },
+    hide: function () {
+      return showHide(this);
+    },
+    toggle: function (state) {
+      if (typeof state === "boolean") {
+        return state ? this.show() : this.hide();
+      }
+
+      return this.each(function () {
+        if (isHiddenWithinTree(this)) {
+          jQuery(this).show();
+        } else {
+          jQuery(this).hide();
+        }
+      });
+    },
+  });
+  var rcheckableType = /^(?:checkbox|radio)$/i;
+
+  var rtagName = /<([a-z][^\/\0>\x20\t\r\n\f]*)/i;
+
+  var rscriptType = /^$|^module$|\/(?:java|ecma)script/i;
+
+  (function () {
+    var fragment = document.createDocumentFragment(),
+      div = fragment.appendChild(document.createElement("div")),
+      input = document.createElement("input");
+
+    // Support: Android 4.0 - 4.3 only
+    // Check state lost if the name is set (#11217)
+    // Support: Windows Web Apps (WWA)
+    // `name` and `type` must use .setAttribute for WWA (#14901)
+    input.setAttribute("type", "radio");
+    input.setAttribute("checked", "checked");
+    input.setAttribute("name", "t");
+
+    div.appendChild(input);
+
+    // Support: Android <=4.1 only
+    // Older WebKit doesn't clone checked state correctly in fragments
+    support.checkClone = div.cloneNode(true).cloneNode(true).lastChild.checked;
+
+    // Support: IE <=11 only
+    // Make sure textarea (and checkbox) defaultValue is properly cloned
+    div.innerHTML = "<textarea>x</textarea>";
+    support.noCloneChecked = !!div.cloneNode(true).lastChild.defaultValue;
+
+    // Support: IE <=9 only
+    // IE <=9 replaces <option> tags with their contents when inserted outside of
+    // the select element.
+    div.innerHTML = "<option></option>";
+    support.option = !!div.lastChild;
+  })();
+
+  // We have to close these tags to support XHTML (#13200)
+  var wrapMap = {
+    // XHTML parsers do not magically insert elements in the
+    // same way that tag soup parsers do. So we cannot shorten
+    // this by omitting <tbody> or other required elements.
+    thead: [1, "<table>", "</table>"],
+    col: [2, "<table><colgroup>", "</colgroup></table>"],
+    tr: [2, "<table><tbody>", "</tbody></table>"],
+    td: [3, "<table><tbody><tr>", "</tr></tbody></table>"],
+
+    _default: [0, "", ""],
+  };
+
+  wrapMap.tbody =
+    wrapMap.tfoot =
+    wrapMap.colgroup =
+    wrapMap.caption =
+      wrapMap.thead;
+  wrapMap.th = wrapMap.td;
+
+  // Support: IE <=9 only
+  if (!support.option) {
+    wrapMap.optgroup = wrapMap.option = [
+      1,
+      "<select multiple='multiple'>",
+      "</select>",
+    ];
+  }
+
+  function getAll(context, tag) {
+    // Support: IE <=9 - 11 only
+    // Use typeof to avoid zero-argument method invocation on host objects (#15151)
+    var ret;
+
+    if (typeof context.getElementsByTagName !== "undefined") {
+      ret = context.getElementsByTagName(tag || "*");
+    } else if (typeof context.querySelectorAll !== "undefined") {
+      ret = context.querySelectorAll(tag || "*");
+    } else {
+      ret = [];
+    }
+
+    if (tag === undefined || (tag && nodeName(context, tag))) {
+      return jQuery.merge([context], ret);
+    }
+
+    return ret;
+  }
+
+  // Mark scripts as having already been evaluated
+  function setGlobalEval(elems, refElements) {
+    var i = 0,
+      l = elems.length;
+
+    for (; i < l; i++) {
+      dataPriv.set(
+        elems[i],
+        "globalEval",
+        !refElements || dataPriv.get(refElements[i], "globalEval")
+      );
+    }
+  }
+
+  var rhtml = /<|&#?\w+;/;
+
+  function buildFragment(elems, context, scripts, selection, ignored) {
+    var elem,
+      tmp,
+      tag,
+      wrap,
+      attached,
+      j,
+      fragment = context.createDocumentFragment(),
+      nodes = [],
+      i = 0,
+      l = elems.length;
+
+    for (; i < l; i++) {
+      elem = elems[i];
+
+      if (elem || elem === 0) {
+        // Add nodes directly
+        if (toType(elem) === "object") {
+          // Support: Android <=4.0 only, PhantomJS 1 only
+          // push.apply(_, arraylike) throws on ancient WebKit
+          jQuery.merge(nodes, elem.nodeType ? [elem] : elem);
+
+          // Convert non-html into a text node
+        } else if (!rhtml.test(elem)) {
+          nodes.push(context.createTextNode(elem));
+
+          // Convert html into DOM nodes
+        } else {
+          tmp = tmp || fragment.appendChild(context.createElement("div"));
+
+          // Deserialize a standard representation
+          tag = (rtagName.exec(elem) || ["", ""])[1].toLowerCase();
+          wrap = wrapMap[tag] || wrapMap._default;
+          tmp.innerHTML = wrap[1] + jQuery.htmlPrefilter(elem) + wrap[2];
+
+          // Descend through wrappers to the right content
+          j = wrap[0];
+          while (j--) {
+            tmp = tmp.lastChild;
+          }
+
+          // Support: Android <=4.0 only, PhantomJS 1 only
+          // push.apply(_, arraylike) throws on ancient WebKit
+          jQuery.merge(nodes, tmp.childNodes);
+
+          // Remember the top-level container
+          tmp = fragment.firstChild;
+
+          // Ensure the created nodes are orphaned (#12392)
+          tmp.textContent = "";
+        }
+      }
+    }
+
+    // Remove wrapper from fragment
+    fragment.textContent = "";
+
+    i = 0;
+    while ((elem = nodes[i++])) {
+      // Skip elements already in the context collection (trac-4087)
+      if (selection && jQuery.inArray(elem, selection) > -1) {
+        if (ignored) {
+          ignored.push(elem);
+        }
+        continue;
+      }
+
+      attached = isAttached(elem);
+
+      // Append to fragment
+      tmp = getAll(fragment.appendChild(elem), "script");
+
+      // Preserve script evaluation history
+      if (attached) {
+        setGlobalEval(tmp);
+      }
+
+      // Capture executables
+      if (scripts) {
+        j = 0;
+        while ((elem = tmp[j++])) {
+          if (rscriptType.test(elem.type || "")) {
+            scripts.push(elem);
+          }
+        }
+      }
+    }
+
+    return fragment;
+  }
+
+  var rtypenamespace = /^([^.]*)(?:\.(.+)|)/;
+
+  function returnTrue() {
+    return true;
+  }
+
+  function returnFalse() {
+    return false;
+  }
+
+  // Support: IE <=9 - 11+
+  // focus() and blur() are asynchronous, except when they are no-op.
+  // So expect focus to be synchronous when the element is already active,
+  // and blur to be synchronous when the element is not already active.
+  // (focus and blur are always synchronous in other supported browsers,
+  // this just defines when we can count on it).
+  function expectSync(elem, type) {
+    return (elem === safeActiveElement()) === (type === "focus");
+  }
+
+  // Support: IE <=9 only
+  // Accessing document.activeElement can throw unexpectedly
+  // https://bugs.jquery.com/ticket/13393
+  function safeActiveElement() {
+    try {
+      return document.activeElement;
+    } catch (err) {}
+  }
+
+  function on(elem, types, selector, data, fn, one) {
+    var origFn, type;
+
+    // Types can be a map of types/handlers
+    if (typeof types === "object") {
+      // ( types-Object, selector, data )
+      if (typeof selector !== "string") {
+        // ( types-Object, data )
+        data = data || selector;
+        selector = undefined;
+      }
+      for (type in types) {
+        on(elem, type, selector, data, types[type], one);
+      }
+      return elem;
+    }
+
+    if (data == null && fn == null) {
+      // ( types, fn )
+      fn = selector;
+      data = selector = undefined;
+    } else if (fn == null) {
+      if (typeof selector === "string") {
+        // ( types, selector, fn )
+        fn = data;
+        data = undefined;
+      } else {
+        // ( types, data, fn )
+        fn = data;
+        data = selector;
+        selector = undefined;
+      }
+    }
+    if (fn === false) {
+      fn = returnFalse;
+    } else if (!fn) {
+      return elem;
+    }
+
+    if (one === 1) {
+      origFn = fn;
+      fn = function (event) {
+        // Can use an empty set, since event contains the info
+        jQuery().off(event);
+        return origFn.apply(this, arguments);
+      };
+
+      // Use same guid so caller can remove using origFn
+      fn.guid = origFn.guid || (origFn.guid = jQuery.guid++);
+    }
+    return elem.each(function () {
+      jQuery.event.add(this, types, fn, data, selector);
+    });
+  }
+
+  /*
+   * Helper functions for managing events -- not part of the public interface.
+   * Props to Dean Edwards' addEvent library for many of the ideas.
+   */
+  jQuery.event = {
+    global: {},
+
+    add: function (elem, types, handler, data, selector) {
+      var handleObjIn,
+        eventHandle,
+        tmp,
+        events,
+        t,
+        handleObj,
+        special,
+        handlers,
+        type,
+        namespaces,
+        origType,
+        elemData = dataPriv.get(elem);
+
+      // Only attach events to objects that accept data
+      if (!acceptData(elem)) {
+        return;
+      }
+
+      // Caller can pass in an object of custom data in lieu of the handler
+      if (handler.handler) {
+        handleObjIn = handler;
+        handler = handleObjIn.handler;
+        selector = handleObjIn.selector;
+      }
+
+      // Ensure that invalid selectors throw exceptions at attach time
+      // Evaluate against documentElement in case elem is a non-element node (e.g., document)
+      if (selector) {
+        jQuery.find.matchesSelector(documentElement, selector);
+      }
+
+      // Make sure that the handler has a unique ID, used to find/remove it later
+      if (!handler.guid) {
+        handler.guid = jQuery.guid++;
+      }
+
+      // Init the element's event structure and main handler, if this is the first
+      if (!(events = elemData.events)) {
+        events = elemData.events = Object.create(null);
+      }
+      if (!(eventHandle = elemData.handle)) {
+        eventHandle = elemData.handle = function (e) {
+          // Discard the second event of a jQuery.event.trigger() and
+          // when an event is called after a page has unloaded
+          return typeof jQuery !== "undefined" &&
+            jQuery.event.triggered !== e.type
+            ? jQuery.event.dispatch.apply(elem, arguments)
+            : undefined;
+        };
+      }
+
+      // Handle multiple events separated by a space
+      types = (types || "").match(rnothtmlwhite) || [""];
+      t = types.length;
+      while (t--) {
+        tmp = rtypenamespace.exec(types[t]) || [];
+        type = origType = tmp[1];
+        namespaces = (tmp[2] || "").split(".").sort();
+
+        // There *must* be a type, no attaching namespace-only handlers
+        if (!type) {
+          continue;
+        }
+
+        // If event changes its type, use the special event handlers for the changed type
+        special = jQuery.event.special[type] || {};
+
+        // If selector defined, determine special event api type, otherwise given type
+        type = (selector ? special.delegateType : special.bindType) || type;
+
+        // Update special based on newly reset type
+        special = jQuery.event.special[type] || {};
+
+        // handleObj is passed to all event handlers
+        handleObj = jQuery.extend(
+          {
+            type: type,
+            origType: origType,
+            data: data,
+            handler: handler,
+            guid: handler.guid,
+            selector: selector,
+            needsContext:
+              selector && jQuery.expr.match.needsContext.test(selector),
+            namespace: namespaces.join("."),
+          },
+          handleObjIn
+        );
+
+        // Init the event handler queue if we're the first
+        if (!(handlers = events[type])) {
+          handlers = events[type] = [];
+          handlers.delegateCount = 0;
+
+          // Only use addEventListener if the special events handler returns false
+          if (
+            !special.setup ||
+            special.setup.call(elem, data, namespaces, eventHandle) === false
+          ) {
+            if (elem.addEventListener) {
+              elem.addEventListener(type, eventHandle);
+            }
+          }
+        }
+
+        if (special.add) {
+          special.add.call(elem, handleObj);
+
+          if (!handleObj.handler.guid) {
+            handleObj.handler.guid = handler.guid;
+          }
+        }
+
+        // Add to the element's handler list, delegates in front
+        if (selector) {
+          handlers.splice(handlers.delegateCount++, 0, handleObj);
+        } else {
+          handlers.push(handleObj);
+        }
+
+        // Keep track of which events have ever been used, for event optimization
+        jQuery.event.global[type] = true;
+      }
+    },
+
+    // Detach an event or set of events from an element
+    remove: function (elem, types, handler, selector, mappedTypes) {
+      var j,
+        origCount,
+        tmp,
+        events,
+        t,
+        handleObj,
+        special,
+        handlers,
+        type,
+        namespaces,
+        origType,
+        elemData = dataPriv.hasData(elem) && dataPriv.get(elem);
+
+      if (!elemData || !(events = elemData.events)) {
+        return;
+      }
+
+      // Once for each type.namespace in types; type may be omitted
+      types = (types || "").match(rnothtmlwhite) || [""];
+      t = types.length;
+      while (t--) {
+        tmp = rtypenamespace.exec(types[t]) || [];
+        type = origType = tmp[1];
+        namespaces = (tmp[2] || "").split(".").sort();
+
+        // Unbind all events (on this namespace, if provided) for the element
+        if (!type) {
+          for (type in events) {
+            jQuery.event.remove(elem, type + types[t], handler, selector, true);
+          }
+          continue;
+        }
+
+        special = jQuery.event.special[type] || {};
+        type = (selector ? special.delegateType : special.bindType) || type;
+        handlers = events[type] || [];
+        tmp =
+          tmp[2] &&
+          new RegExp("(^|\\.)" + namespaces.join("\\.(?:.*\\.|)") + "(\\.|$)");
+
+        // Remove matching events
+        origCount = j = handlers.length;
+        while (j--) {
+          handleObj = handlers[j];
+
+          if (
+            (mappedTypes || origType === handleObj.origType) &&
+            (!handler || handler.guid === handleObj.guid) &&
+            (!tmp || tmp.test(handleObj.namespace)) &&
+            (!selector ||
+              selector === handleObj.selector ||
+              (selector === "**" && handleObj.selector))
+          ) {
+            handlers.splice(j, 1);
+
+            if (handleObj.selector) {
+              handlers.delegateCount--;
+            }
+            if (special.remove) {
+              special.remove.call(elem, handleObj);
+            }
+          }
+        }
+
+        // Remove generic event handler if we removed something and no more handlers exist
+        // (avoids potential for endless recursion during removal of special event handlers)
+        if (origCount && !handlers.length) {
+          if (
+            !special.teardown ||
+            special.teardown.call(elem, namespaces, elemData.handle) === false
+          ) {
+            jQuery.removeEvent(elem, type, elemData.handle);
+          }
+
+          delete events[type];
+        }
+      }
+
+      // Remove data and the expando if it's no longer used
+      if (jQuery.isEmptyObject(events)) {
+        dataPriv.remove(elem, "handle events");
+      }
+    },
+
+    dispatch: function (nativeEvent) {
+      var i,
+        j,
+        ret,
+        matched,
+        handleObj,
+        handlerQueue,
+        args = new Array(arguments.length),
+        // Make a writable jQuery.Event from the native event object
+        event = jQuery.event.fix(nativeEvent),
+        handlers =
+          (dataPriv.get(this, "events") || Object.create(null))[event.type] ||
+          [],
+        special = jQuery.event.special[event.type] || {};
+
+      // Use the fix-ed jQuery.Event rather than the (read-only) native event
+      args[0] = event;
+
+      for (i = 1; i < arguments.length; i++) {
+        args[i] = arguments[i];
+      }
+
+      event.delegateTarget = this;
+
+      // Call the preDispatch hook for the mapped type, and let it bail if desired
+      if (
+        special.preDispatch &&
+        special.preDispatch.call(this, event) === false
+      ) {
+        return;
+      }
+
+      // Determine handlers
+      handlerQueue = jQuery.event.handlers.call(this, event, handlers);
+
+      // Run delegates first; they may want to stop propagation beneath us
+      i = 0;
+      while ((matched = handlerQueue[i++]) && !event.isPropagationStopped()) {
+        event.currentTarget = matched.elem;
+
+        j = 0;
+        while (
+          (handleObj = matched.handlers[j++]) &&
+          !event.isImmediatePropagationStopped()
+        ) {
+          // If the event is namespaced, then each handler is only invoked if it is
+          // specially universal or its namespaces are a superset of the event's.
+          if (
+            !event.rnamespace ||
+            handleObj.namespace === false ||
+            event.rnamespace.test(handleObj.namespace)
+          ) {
+            event.handleObj = handleObj;
+            event.data = handleObj.data;
+
+            ret = (
+              (jQuery.event.special[handleObj.origType] || {}).handle ||
+              handleObj.handler
+            ).apply(matched.elem, args);
+
+            if (ret !== undefined) {
+              if ((event.result = ret) === false) {
+                event.preventDefault();
+                event.stopPropagation();
+              }
+            }
+          }
+        }
+      }
+
+      // Call the postDispatch hook for the mapped type
+      if (special.postDispatch) {
+        special.postDispatch.call(this, event);
+      }
+
+      return event.result;
+    },
+
+    handlers: function (event, handlers) {
+      var i,
+        handleObj,
+        sel,
+        matchedHandlers,
+        matchedSelectors,
+        handlerQueue = [],
+        delegateCount = handlers.delegateCount,
+        cur = event.target;
+
+      // Find delegate handlers
+      if (
+        delegateCount &&
+        // Support: IE <=9
+        // Black-hole SVG <use> instance trees (trac-13180)
+        cur.nodeType &&
+        // Support: Firefox <=42
+        // Suppress spec-violating clicks indicating a non-primary pointer button (trac-3861)
+        // https://www.w3.org/TR/DOM-Level-3-Events/#event-type-click
+        // Support: IE 11 only
+        // ...but not arrow key "clicks" of radio inputs, which can have `button` -1 (gh-2343)
+        !(event.type === "click" && event.button >= 1)
+      ) {
+        for (; cur !== this; cur = cur.parentNode || this) {
+          // Don't check non-elements (#13208)
+          // Don't process clicks on disabled elements (#6911, #8165, #11382, #11764)
+          if (
+            cur.nodeType === 1 &&
+            !(event.type === "click" && cur.disabled === true)
+          ) {
+            matchedHandlers = [];
+            matchedSelectors = {};
+            for (i = 0; i < delegateCount; i++) {
+              handleObj = handlers[i];
+
+              // Don't conflict with Object.prototype properties (#13203)
+              sel = handleObj.selector + " ";
+
+              if (matchedSelectors[sel] === undefined) {
+                matchedSelectors[sel] = handleObj.needsContext
+                  ? jQuery(sel, this).index(cur) > -1
+                  : jQuery.find(sel, this, null, [cur]).length;
+              }
+              if (matchedSelectors[sel]) {
+                matchedHandlers.push(handleObj);
+              }
+            }
+            if (matchedHandlers.length) {
+              handlerQueue.push({ elem: cur, handlers: matchedHandlers });
+            }
+          }
+        }
+      }
+
+      // Add the remaining (directly-bound) handlers
+      cur = this;
+      if (delegateCount < handlers.length) {
+        handlerQueue.push({
+          elem: cur,
+          handlers: handlers.slice(delegateCount),
+        });
+      }
+
+      return handlerQueue;
+    },
+
+    addProp: function (name, hook) {
+      Object.defineProperty(jQuery.Event.prototype, name, {
+        enumerable: true,
+        configurable: true,
+
+        get: isFunction(hook)
+          ? function () {
+              if (this.originalEvent) {
+                return hook(this.originalEvent);
+              }
+            }
+          : function () {
+              if (this.originalEvent) {
+                return this.originalEvent[name];
+              }
+            },
+
+        set: function (value) {
+          Object.defineProperty(this, name, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: value,
+          });
+        },
+      });
+    },
+
+    fix: function (originalEvent) {
+      return originalEvent[jQuery.expando]
+        ? originalEvent
+        : new jQuery.Event(originalEvent);
+    },
+
+    special: {
+      load: {
+        // Prevent triggered image.load events from bubbling to window.load
+        noBubble: true,
+      },
+      click: {
+        // Utilize native event to ensure correct state for checkable inputs
+        setup: function (data) {
+          // For mutual compressibility with _default, replace `this` access with a local var.
+          // `|| data` is dead code meant only to preserve the variable through minification.
+          var el = this || data;
+
+          // Claim the first handler
+          if (
+            rcheckableType.test(el.type) &&
+            el.click &&
+            nodeName(el, "input")
+          ) {
+            // dataPriv.set( el, "click", ... )
+            leverageNative(el, "click", returnTrue);
+          }
+
+          // Return false to allow normal processing in the caller
+          return false;
+        },
+        trigger: function (data) {
+          // For mutual compressibility with _default, replace `this` access with a local var.
+          // `|| data` is dead code meant only to preserve the variable through minification.
+          var el = this || data;
+
+          // Force setup before triggering a click
+          if (
+            rcheckableType.test(el.type) &&
+            el.click &&
+            nodeName(el, "input")
+          ) {
+            leverageNative(el, "click");
+          }
+
+          // Return non-false to allow normal event-path propagation
+          return true;
+        },
+
+        // For cross-browser consistency, suppress native .click() on links
+        // Also prevent it if we're currently inside a leveraged native-event stack
+        _default: function (event) {
+          var target = event.target;
+          return (
+            (rcheckableType.test(target.type) &&
+              target.click &&
+              nodeName(target, "input") &&
+              dataPriv.get(target, "click")) ||
+            nodeName(target, "a")
+          );
+        },
+      },
+
+      beforeunload: {
+        postDispatch: function (event) {
+          // Support: Firefox 20+
+          // Firefox doesn't alert if the returnValue field is not set.
+          if (event.result !== undefined && event.originalEvent) {
+            event.originalEvent.returnValue = event.result;
+          }
+        },
+      },
+    },
+  };
+
+  // Ensure the presence of an event listener that handles manually-triggered
+  // synthetic events by interrupting progress until reinvoked in response to
+  // *native* events that it fires directly, ensuring that state changes have
+  // already occurred before other listeners are invoked.
+  function leverageNative(el, type, expectSync) {
+    // Missing expectSync indicates a trigger call, which must force setup through jQuery.event.add
+    if (!expectSync) {
+      if (dataPriv.get(el, type) === undefined) {
+        jQuery.event.add(el, type, returnTrue);
+      }
+      return;
+    }
+
+    // Register the controller as a special universal handler for all event namespaces
+    dataPriv.set(el, type, false);
+    jQuery.event.add(el, type, {
+      namespace: false,
+      handler: function (event) {
+        var notAsync,
+          result,
+          saved = dataPriv.get(this, type);
+
+        if (event.isTrigger & 1 && this[type]) {
+          // Interrupt processing of the outer synthetic .trigger()ed event
+          // Saved data should be false in such cases, but might be a leftover capture object
+          // from an async native handler (gh-4350)
+          if (!saved.length) {
+            // Store arguments for use when handling the inner native event
+            // There will always be at least one argument (an event object), so this array
+            // will not be confused with a leftover capture object.
+            saved = slice.call(arguments);
+            dataPriv.set(this, type, saved);
+
+            // Trigger the native event and capture its result
+            // Support: IE <=9 - 11+
+            // focus() and blur() are asynchronous
+            notAsync = expectSync(this, type);
+            this[type]();
+            result = dataPriv.get(this, type);
+            if (saved !== result || notAsync) {
+              dataPriv.set(this, type, false);
+            } else {
+              result = {};
+            }
+            if (saved !== result) {
+              // Cancel the outer synthetic event
+              event.stopImmediatePropagation();
+              event.preventDefault();
+
+              // Support: Chrome 86+
+              // In Chrome, if an element having a focusout handler is blurred by
+              // clicking outside of it, it invokes the handler synchronously. If
+              // that handler calls `.remove()` on the element, the data is cleared,
+              // leaving `result` undefined. We need to guard against this.
+              return result && result.value;
+            }
+
+            // If this is an inner synthetic event for an event with a bubbling surrogate
+            // (focus or blur), assume that the surrogate already propagated from triggering the
+            // native event and prevent that from happening again here.
+            // This technically gets the ordering wrong w.r.t. to `.trigger()` (in which the
+            // bubbling surrogate propagates *after* the non-bubbling base), but that seems
+            // less bad than duplication.
+          } else if ((jQuery.event.special[type] || {}).delegateType) {
+            event.stopPropagation();
+          }
+
+          // If this is a native event triggered above, everything is now in order
+          // Fire an inner synthetic event with the original arguments
+        } else if (saved.length) {
+          // ...and capture the result
+          dataPriv.set(this, type, {
+            value: jQuery.event.trigger(
+              // Support: IE <=9 - 11+
+              // Extend with the prototype to reset the above stopImmediatePropagation()
+              jQuery.extend(saved[0], jQuery.Event.prototype),
+              saved.slice(1),
+              this
+            ),
+          });
+
+          // Abort handling of the native event
+          event.stopImmediatePropagation();
+        }
+      },
+    });
+  }
+
+  jQuery.removeEvent = function (elem, type, handle) {
+    // This "if" is needed for plain objects
+    if (elem.removeEventListener) {
+      elem.removeEventListener(type, handle);
+    }
+  };
+
+  jQuery.Event = function (src, props) {
+    // Allow instantiation without the 'new' keyword
+    if (!(this instanceof jQuery.Event)) {
+      return new jQuery.Event(src, props);
+    }
+
+    // Event object
+    if (src && src.type) {
+      this.originalEvent = src;
+      this.type = src.type;
+
+      // Events bubbling up the document may have been marked as prevented
+      // by a handler lower down the tree; reflect the correct value.
+      this.isDefaultPrevented =
+        src.defaultPrevented ||
+        (src.defaultPrevented === undefined &&
+          // Support: Android <=2.3 only
+          src.returnValue === false)
+          ? returnTrue
+          : returnFalse;
+
+      // Create target properties
+      // Support: Safari <=6 - 7 only
+      // Target should not be a text node (#504, #13143)
+      this.target =
+        src.target && src.target.nodeType === 3
+          ? src.target.parentNode
+          : src.target;
+
+      this.currentTarget = src.currentTarget;
+      this.relatedTarget = src.relatedTarget;
+
+      // Event type
+    } else {
+      this.type = src;
+    }
+
+    // Put explicitly provided properties onto the event object
+    if (props) {
+      jQuery.extend(this, props);
+    }
+
+    // Create a timestamp if incoming event doesn't have one
+    this.timeStamp = (src && src.timeStamp) || Date.now();
+
+    // Mark it as fixed
+    this[jQuery.expando] = true;
+  };
+
+  // jQuery.Event is based on DOM3 Events as specified by the ECMAScript Language Binding
+  // https://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
+  jQuery.Event.prototype = {
+    constructor: jQuery.Event,
+    isDefaultPrevented: returnFalse,
+    isPropagationStopped: returnFalse,
+    isImmediatePropagationStopped: returnFalse,
+    isSimulated: false,
+
+    preventDefault: function () {
+      var e = this.originalEvent;
+
+      this.isDefaultPrevented = returnTrue;
+
+      if (e && !this.isSimulated) {
+        e.preventDefault();
+      }
+    },
+    stopPropagation: function () {
+      var e = this.originalEvent;
+
+      this.isPropagationStopped = returnTrue;
+
+      if (e && !this.isSimulated) {
+        e.stopPropagation();
+      }
+    },
+    stopImmediatePropagation: function () {
+      var e = this.originalEvent;
+
+      this.isImmediatePropagationStopped = returnTrue;
+
+      if (e && !this.isSimulated) {
+        e.stopImmediatePropagation();
+      }
+
+      this.stopPropagation();
+    },
+  };
+
+  // Includes all common event props including KeyEvent and MouseEvent specific props
+  jQuery.each(
+    {
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+      changedTouches: true,
+      ctrlKey: true,
+      detail: true,
+      eventPhase: true,
+      metaKey: true,
+      pageX: true,
+      pageY: true,
+      shiftKey: true,
+      view: true,
+      char: true,
+      code: true,
+      charCode: true,
+      key: true,
+      keyCode: true,
+      button: true,
+      buttons: true,
+      clientX: true,
+      clientY: true,
+      offsetX: true,
+      offsetY: true,
+      pointerId: true,
+      pointerType: true,
+      screenX: true,
+      screenY: true,
+      targetTouches: true,
+      toElement: true,
+      touches: true,
+      which: true,
+    },
+    jQuery.event.addProp
+  );
+
+  jQuery.each(
+    { focus: "focusin", blur: "focusout" },
+    function (type, delegateType) {
+      jQuery.event.special[type] = {
+        // Utilize native event if possible so blur/focus sequence is correct
+        setup: function () {
+          // Claim the first handler
+          // dataPriv.set( this, "focus", ... )
+          // dataPriv.set( this, "blur", ... )
+          leverageNative(this, type, expectSync);
+
+          // Return false to allow normal processing in the caller
+          return false;
+        },
+        trigger: function () {
+          // Force setup before trigger
+          leverageNative(this, type);
+
+          // Return non-false to allow normal event-path propagation
+          return true;
+        },
+
+        // Suppress native focus or blur as it's already being fired
+        // in leverageNative.
+        _default: function () {
+          return true;
+        },
+
+        delegateType: delegateType,
+      };
+    }
+  );
+
+  // Create mouseenter/leave events using mouseover/out and event-time checks
+  // so that event delegation works in jQuery.
+  // Do the same for pointerenter/pointerleave and pointerover/pointerout
+  //
+  // Support: Safari 7 only
+  // Safari sends mouseenter too often; see:
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=470258
+  // for the description of the bug (it existed in older Chrome versions as well).
+  jQuery.each(
+    {
+      mouseenter: "mouseover",
+      mouseleave: "mouseout",
+      pointerenter: "pointerover",
+      pointerleave: "pointerout",
+    },
+    function (orig, fix) {
+      jQuery.event.special[orig] = {
+        delegateType: fix,
+        bindType: fix,
+
+        handle: function (event) {
+          var ret,
+            target = this,
+            related = event.relatedTarget,
+            handleObj = event.handleObj;
+
+          // For mouseenter/leave call the handler if related is outside the target.
+          // NB: No relatedTarget if the mouse left/entered the browser window
+          if (
+            !related ||
+            (related !== target && !jQuery.contains(target, related))
+          ) {
+            event.type = handleObj.origType;
+            ret = handleObj.handler.apply(this, arguments);
+            event.type = fix;
+          }
+          return ret;
+        },
+      };
+    }
+  );
+
+  jQuery.fn.extend({
+    on: function (types, selector, data, fn) {
+      return on(this, types, selector, data, fn);
+    },
+    one: function (types, selector, data, fn) {
+      return on(this, types, selector, data, fn, 1);
+    },
+    off: function (types, selector, fn) {
+      var handleObj, type;
+      if (types && types.preventDefault && types.handleObj) {
+        // ( event )  dispatched jQuery.Event
+        handleObj = types.handleObj;
+        jQuery(types.delegateTarget).off(
+          handleObj.namespace
+            ? handleObj.origType + "." + handleObj.namespace
+            : handleObj.origType,
+          handleObj.selector,
+          handleObj.handler
+        );
+        return this;
+      }
+      if (typeof types === "object") {
+        // ( types-object [, selector] )
+        for (type in types) {
+          this.off(type, selector, types[type]);
+        }
+        return this;
+      }
+      if (selector === false || typeof selector === "function") {
+        // ( types [, fn] )
+        fn = selector;
+        selector = undefined;
+      }
+      if (fn === false) {
+        fn = returnFalse;
+      }
+      return this.each(function () {
+        jQuery.event.remove(this, types, fn, selector);
+      });
+    },
+  });
+
+  var // Support: IE <=10 - 11, Edge 12 - 13 only
+    // In IE/Edge using regex groups here causes severe slowdowns.
+    // See https://connect.microsoft.com/IE/feedback/details/1736512/
+    rnoInnerhtml = /<script|<style|<link/i,
+    // checked="checked" or checked
+    rchecked = /checked\s*(?:[^=]|=\s*.checked.)/i,
+    rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g;
+
+  // Prefer a tbody over its parent table for containing new rows
+  function manipulationTarget(elem, content) {
+    if (
+      nodeName(elem, "table") &&
+      nodeName(content.nodeType !== 11 ? content : content.firstChild, "tr")
+    ) {
+      return jQuery(elem).children("tbody")[0] || elem;
+    }
+
+    return elem;
+  }
+
+  // Replace/restore the type attribute of script elements for safe DOM manipulation
+  function disableScript(elem) {
+    elem.type = (elem.getAttribute("type") !== null) + "/" + elem.type;
+    return elem;
+  }
+  function restoreScript(elem) {
+    if ((elem.type || "").slice(0, 5) === "true/") {
+      elem.type = elem.type.slice(5);
+    } else {
+      elem.removeAttribute("type");
+    }
+
+    return elem;
+  }
+
+  function cloneCopyEvent(src, dest) {
+    var i, l, type, pdataOld, udataOld, udataCur, events;
+
+    if (dest.nodeType !== 1) {
+      return;
+    }
+
+    // 1. Copy private data: events, handlers, etc.
+    if (dataPriv.hasData(src)) {
+      pdataOld = dataPriv.get(src);
+      events = pdataOld.events;
+
+      if (events) {
+        dataPriv.remove(dest, "handle events");
+
+        for (type in events) {
+          for (i = 0, l = events[type].length; i < l; i++) {
+            jQuery.event.add(dest, type, events[type][i]);
+          }
+        }
+      }
+    }
+
+    // 2. Copy user data
+    if (dataUser.hasData(src)) {
+      udataOld = dataUser.access(src);
+      udataCur = jQuery.extend({}, udataOld);
+
+      dataUser.set(dest, udataCur);
+    }
+  }
+
+  // Fix IE bugs, see support tests
+  function fixInput(src, dest) {
+    var nodeName = dest.nodeName.toLowerCase();
+
+    // Fails to persist the checked state of a cloned checkbox or radio button.
+    if (nodeName === "input" && rcheckableType.test(src.type)) {
+      dest.checked = src.checked;
+
+      // Fails to return the selected option to the default selected state when cloning options
+    } else if (nodeName === "input" || nodeName === "textarea") {
+      dest.defaultValue = src.defaultValue;
+    }
+  }
+
+  function domManip(collection, args, callback, ignored) {
+    // Flatten any nested arrays
+    args = flat(args);
+
+    var fragment,
+      first,
+      scripts,
+      hasScripts,
+      node,
+      doc,
+      i = 0,
+      l = collection.length,
+      iNoClone = l - 1,
+      value = args[0],
+      valueIsFunction = isFunction(value);
+
+    // We can't cloneNode fragments that contain checked, in WebKit
+    if (
+      valueIsFunction ||
+      (l > 1 &&
+        typeof value === "string" &&
+        !support.checkClone &&
+        rchecked.test(value))
+    ) {
+      return collection.each(function (index) {
+        var self = collection.eq(index);
+        if (valueIsFunction) {
+          args[0] = value.call(this, index, self.html());
+        }
+        domManip(self, args, callback, ignored);
+      });
+    }
+
+    if (l) {
+      fragment = buildFragment(
+        args,
+        collection[0].ownerDocument,
+        false,
+        collection,
+        ignored
+      );
+      first = fragment.firstChild;
+
+      if (fragment.childNodes.length === 1) {
+        fragment = first;
+      }
+
+      // Require either new content or an interest in ignored elements to invoke the callback
+      if (first || ignored) {
+        scripts = jQuery.map(getAll(fragment, "script"), disableScript);
+        hasScripts = scripts.length;
+
+        // Use the original fragment for the last item
+        // instead of the first because it can end up
+        // being emptied incorrectly in certain situations (#8070).
+        for (; i < l; i++) {
+          node = fragment;
+
+          if (i !== iNoClone) {
+            node = jQuery.clone(node, true, true);
+
+            // Keep references to cloned scripts for later restoration
+            if (hasScripts) {
+              // Support: Android <=4.0 only, PhantomJS 1 only
+              // push.apply(_, arraylike) throws on ancient WebKit
+              jQuery.merge(scripts, getAll(node, "script"));
+            }
+          }
+
+          callback.call(collection[i], node, i);
+        }
+
+        if (hasScripts) {
+          doc = scripts[scripts.length - 1].ownerDocument;
+
+          // Reenable scripts
+          jQuery.map(scripts, restoreScript);
+
+          // Evaluate executable scripts on first document insertion
+          for (i = 0; i < hasScripts; i++) {
+            node = scripts[i];
+            if (
+              rscriptType.test(node.type || "") &&
+              !dataPriv.access(node, "globalEval") &&
+              jQuery.contains(doc, node)
+            ) {
+              if (node.src && (node.type || "").toLowerCase() !== "module") {
+                // Optional AJAX dependency, but won't run scripts if not present
+                if (jQuery._evalUrl && !node.noModule) {
+                  jQuery._evalUrl(
+                    node.src,
+                    {
+                      nonce: node.nonce || node.getAttribute("nonce"),
+                    },
+                    doc
+                  );
+                }
+              } else {
+                DOMEval(node.textContent.replace(rcleanScript, ""), node, doc);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return collection;
+  }
+
+  function remove(elem, selector, keepData) {
+    var node,
+      nodes = selector ? jQuery.filter(selector, elem) : elem,
+      i = 0;
+
+    for (; (node = nodes[i]) != null; i++) {
+      if (!keepData && node.nodeType === 1) {
+        jQuery.cleanData(getAll(node));
+      }
+
+      if (node.parentNode) {
+        if (keepData && isAttached(node)) {
+          setGlobalEval(getAll(node, "script"));
+        }
+        node.parentNode.removeChild(node);
+      }
+    }
+
+    return elem;
+  }
+
+  jQuery.extend({
+    htmlPrefilter: function (html) {
+      return html;
+    },
+
+    clone: function (elem, dataAndEvents, deepDataAndEvents) {
+      var i,
+        l,
+        srcElements,
+        destElements,
+        clone = elem.cloneNode(true),
+        inPage = isAttached(elem);
+
+      // Fix IE cloning issues
+      if (
+        !support.noCloneChecked &&
+        (elem.nodeType === 1 || elem.nodeType === 11) &&
+        !jQuery.isXMLDoc(elem)
+      ) {
+        // We eschew Sizzle here for performance reasons: https://jsperf.com/getall-vs-sizzle/2
+        destElements = getAll(clone);
+        srcElements = getAll(elem);
+
+        for (i = 0, l = srcElements.length; i < l; i++) {
+          fixInput(srcElements[i], destElements[i]);
+        }
+      }
+
+      // Copy the events from the original to the clone
+      if (dataAndEvents) {
+        if (deepDataAndEvents) {
+          srcElements = srcElements || getAll(elem);
+          destElements = destElements || getAll(clone);
+
+          for (i = 0, l = srcElements.length; i < l; i++) {
+            cloneCopyEvent(srcElements[i], destElements[i]);
+          }
+        } else {
+          cloneCopyEvent(elem, clone);
+        }
+      }
+
+      // Preserve script evaluation history
+      destElements = getAll(clone, "script");
+      if (destElements.length > 0) {
+        setGlobalEval(destElements, !inPage && getAll(elem, "script"));
+      }
+
+      // Return the cloned set
+      return clone;
+    },
+
+    cleanData: function (elems) {
+      var data,
+        elem,
+        type,
+        special = jQuery.event.special,
+        i = 0;
+
+      for (; (elem = elems[i]) !== undefined; i++) {
+        if (acceptData(elem)) {
+          if ((data = elem[dataPriv.expando])) {
+            if (data.events) {
+              for (type in data.events) {
+                if (special[type]) {
+                  jQuery.event.remove(elem, type);
+
+                  // This is a shortcut to avoid jQuery.event.remove's overhead
+                } else {
+                  jQuery.removeEvent(elem, type, data.handle);
+                }
+              }
+            }
+
+            // Support: Chrome <=35 - 45+
+            // Assign undefined instead of using delete, see Data#remove
+            elem[dataPriv.expando] = undefined;
+          }
+          if (elem[dataUser.expando]) {
+            // Support: Chrome <=35 - 45+
+            // Assign undefined instead of using delete, see Data#remove
+            elem[dataUser.expando] = undefined;
+          }
+        }
+      }
+    },
+  });
+
+  jQuery.fn.extend({
+    detach: function (selector) {
+      return remove(this, selector, true);
+    },
+
+    remove: function (selector) {
+      return remove(this, selector);
+    },
+
+    text: function (value) {
+      return access(
+        this,
+        function (value) {
+          return value === undefined
+            ? jQuery.text(this)
+            : this.empty().each(function () {
+                if (
+                  this.nodeType === 1 ||
+                  this.nodeType === 11 ||
+                  this.nodeType === 9
+                ) {
+                  this.textContent = value;
+                }
+              });
+        },
+        null,
+        value,
+        arguments.length
+      );
+    },
+
+    append: function () {
+      return domManip(this, arguments, function (elem) {
+        if (
+          this.nodeType === 1 ||
+          this.nodeType === 11 ||
+          this.nodeType === 9
+        ) {
+          var target = manipulationTarget(this, elem);
+          target.appendChild(elem);
+        }
+      });
+    },
+
+    prepend: function () {
+      return domManip(this, arguments, function (elem) {
+        if (
+          this.nodeType === 1 ||
+          this.nodeType === 11 ||
+          this.nodeType === 9
+        ) {
+          var target = manipulationTarget(this, elem);
+          target.insertBefore(elem, target.firstChild);
+        }
+      });
+    },
+
+    before: function () {
+      return domManip(this, arguments, function (elem) {
+        if (this.parentNode) {
+          this.parentNode.insertBefore(elem, this);
+        }
+      });
+    },
+
+    after: function () {
+      return domManip(this, arguments, function (elem) {
+        if (this.parentNode) {
+          this.parentNode.insertBefore(elem, this.nextSibling);
+        }
+      });
+    },
+
+    empty: function () {
+      var elem,
+        i = 0;
+
+      for (; (elem = this[i]) != null; i++) {
+        if (elem.nodeType === 1) {
+          // Prevent memory leaks
+          jQuery.cleanData(getAll(elem, false));
+
+          // Remove any remaining nodes
+          elem.textContent = "";
+        }
+      }
+
+      return this;
+    },
+
+    clone: function (dataAndEvents, deepDataAndEvents) {
+      dataAndEvents = dataAndEvents == null ? false : dataAndEvents;
+      deepDataAndEvents =
+        deepDataAndEvents == null ? dataAndEvents : deepDataAndEvents;
+
+      return this.map(function () {
+        return jQuery.clone(this, dataAndEvents, deepDataAndEvents);
+      });
+    },
+
+    html: function (value) {
+      return access(
+        this,
+        function (value) {
+          var elem = this[0] || {},
+            i = 0,
+            l = this.length;
+
+          if (value === undefined && elem.nodeType === 1) {
+            return elem.innerHTML;
+          }
+
+          // See if we can take a shortcut and just use innerHTML
+          if (
+            typeof value === "string" &&
+            !rnoInnerhtml.test(value) &&
+            !wrapMap[(rtagName.exec(value) || ["", ""])[1].toLowerCase()]
+          ) {
+            value = jQuery.htmlPrefilter(value);
+
+            try {
+              for (; i < l; i++) {
+                elem = this[i] || {};
+
+                // Remove element nodes and prevent memory leaks
+                if (elem.nodeType === 1) {
+                  jQuery.cleanData(getAll(elem, false));
+                  elem.innerHTML = value;
+                }
+              }
+
+              elem = 0;
+
+              // If using innerHTML throws an exception, use the fallback method
+            } catch (e) {}
+          }
+
+          if (elem) {
+            this.empty().append(value);
+          }
+        },
+        null,
+        value,
+        arguments.length
+      );
+    },
+
+    replaceWith: function () {
+      var ignored = [];
+
+      // Make the changes, replacing each non-ignored context element with the new content
+      return domManip(
+        this,
+        arguments,
+        function (elem) {
+          var parent = this.parentNode;
+
+          if (jQuery.inArray(this, ignored) < 0) {
+            jQuery.cleanData(getAll(this));
+            if (parent) {
+              parent.replaceChild(elem, this);
+            }
+          }
+
+          // Force callback invocation
+        },
+        ignored
+      );
+    },
+  });
+
+  jQuery.each(
+    {
+      appendTo: "append",
+      prependTo: "prepend",
+      insertBefore: "before",
+      insertAfter: "after",
+      replaceAll: "replaceWith",
+    },
+    function (name, original) {
+      jQuery.fn[name] = function (selector) {
+        var elems,
+          ret = [],
+          insert = jQuery(selector),
+          last = insert.length - 1,
+          i = 0;
+
+        for (; i <= last; i++) {
+          elems = i === last ? this : this.clone(true);
+          jQuery(insert[i])[original](elems);
+
+          // Support: Android <=4.0 only, PhantomJS 1 only
+          // .get() because push.apply(_, arraylike) throws on ancient WebKit
+          push.apply(ret, elems.get());
+        }
+
+        return this.pushStack(ret);
+      };
+    }
+  );
+  var rnumnonpx = new RegExp("^(" + pnum + ")(?!px)[a-z%]+$", "i");
+
+  var getStyles = function (elem) {
+    // Support: IE <=11 only, Firefox <=30 (#15098, #14150)
+    // IE throws on elements created in popups
+    // FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
+    var view = elem.ownerDocument.defaultView;
+
+    if (!view || !view.opener) {
+      view = window;
+    }
+
+    return view.getComputedStyle(elem);
+  };
+
+  var swap = function (elem, options, callback) {
+    var ret,
+      name,
+      old = {};
+
+    // Remember the old values, and insert the new ones
+    for (name in options) {
+      old[name] = elem.style[name];
+      elem.style[name] = options[name];
+    }
+
+    ret = callback.call(elem);
+
+    // Revert the old values
+    for (name in options) {
+      elem.style[name] = old[name];
+    }
+
+    return ret;
+  };
+
+  var rboxStyle = new RegExp(cssExpand.join("|"), "i");
+
+  (function () {
+    // Executing both pixelPosition & boxSizingReliable tests require only one layout
+    // so they're executed at the same time to save the second computation.
+    function computeStyleTests() {
+      // This is a singleton, we need to execute it only once
+      if (!div) {
+        return;
+      }
+
+      container.style.cssText =
+        "position:absolute;left:-11111px;width:60px;" +
+        "margin-top:1px;padding:0;border:0";
+      div.style.cssText =
+        "position:relative;display:block;box-sizing:border-box;overflow:scroll;" +
+        "margin:auto;border:1px;padding:1px;" +
+        "width:60%;top:1%";
+      documentElement.appendChild(container).appendChild(div);
+
+      var divStyle = window.getComputedStyle(div);
+      pixelPositionVal = divStyle.top !== "1%";
+
+      // Support: Android 4.0 - 4.3 only, Firefox <=3 - 44
+      reliableMarginLeftVal = roundPixelMeasures(divStyle.marginLeft) === 12;
+
+      // Support: Android 4.0 - 4.3 only, Safari <=9.1 - 10.1, iOS <=7.0 - 9.3
+      // Some styles come back with percentage values, even though they shouldn't
+      div.style.right = "60%";
+      pixelBoxStylesVal = roundPixelMeasures(divStyle.right) === 36;
+
+      // Support: IE 9 - 11 only
+      // Detect misreporting of content dimensions for box-sizing:border-box elements
+      boxSizingReliableVal = roundPixelMeasures(divStyle.width) === 36;
+
+      // Support: IE 9 only
+      // Detect overflow:scroll screwiness (gh-3699)
+      // Support: Chrome <=64
+      // Don't get tricked when zoom affects offsetWidth (gh-4029)
+      div.style.position = "absolute";
+      scrollboxSizeVal = roundPixelMeasures(div.offsetWidth / 3) === 12;
+
+      documentElement.removeChild(container);
+
+      // Nullify the div so it wouldn't be stored in the memory and
+      // it will also be a sign that checks already performed
+      div = null;
+    }
+
+    function roundPixelMeasures(measure) {
+      return Math.round(parseFloat(measure));
+    }
+
+    var pixelPositionVal,
+      boxSizingReliableVal,
+      scrollboxSizeVal,
+      pixelBoxStylesVal,
+      reliableTrDimensionsVal,
+      reliableMarginLeftVal,
+      container = document.createElement("div"),
+      div = document.createElement("div");
+
+    // Finish early in limited (non-browser) environments
+    if (!div.style) {
+      return;
+    }
+
+    // Support: IE <=9 - 11 only
+    // Style of cloned element affects source element cloned (#8908)
+    div.style.backgroundClip = "content-box";
+    div.cloneNode(true).style.backgroundClip = "";
+    support.clearCloneStyle = div.style.backgroundClip === "content-box";
+
+    jQuery.extend(support, {
+      boxSizingReliable: function () {
+        computeStyleTests();
+        return boxSizingReliableVal;
+      },
+      pixelBoxStyles: function () {
+        computeStyleTests();
+        return pixelBoxStylesVal;
+      },
+      pixelPosition: function () {
+        computeStyleTests();
+        return pixelPositionVal;
+      },
+      reliableMarginLeft: function () {
+        computeStyleTests();
+        return reliableMarginLeftVal;
+      },
+      scrollboxSize: function () {
+        computeStyleTests();
+        return scrollboxSizeVal;
+      },
+
+      // Support: IE 9 - 11+, Edge 15 - 18+
+      // IE/Edge misreport `getComputedStyle` of table rows with width/height
+      // set in CSS while `offset*` properties report correct values.
+      // Behavior in IE 9 is more subtle than in newer versions & it passes
+      // some versions of this test; make sure not to make it pass there!
+      //
+      // Support: Firefox 70+
+      // Only Firefox includes border widths
+      // in computed dimensions. (gh-4529)
+      reliableTrDimensions: function () {
+        var table, tr, trChild, trStyle;
+        if (reliableTrDimensionsVal == null) {
+          table = document.createElement("table");
+          tr = document.createElement("tr");
+          trChild = document.createElement("div");
+
+          table.style.cssText =
+            "position:absolute;left:-11111px;border-collapse:separate";
+          tr.style.cssText = "border:1px solid";
+
+          // Support: Chrome 86+
+          // Height set through cssText does not get applied.
+          // Computed height then comes back as 0.
+          tr.style.height = "1px";
+          trChild.style.height = "9px";
+
+          // Support: Android 8 Chrome 86+
+          // In our bodyBackground.html iframe,
+          // display for all div elements is set to "inline",
+          // which causes a problem only in Android 8 Chrome 86.
+          // Ensuring the div is display: block
+          // gets around this issue.
+          trChild.style.display = "block";
+
+          documentElement
+            .appendChild(table)
+            .appendChild(tr)
+            .appendChild(trChild);
+
+          trStyle = window.getComputedStyle(tr);
+          reliableTrDimensionsVal =
+            parseInt(trStyle.height, 10) +
+              parseInt(trStyle.borderTopWidth, 10) +
+              parseInt(trStyle.borderBottomWidth, 10) ===
+            tr.offsetHeight;
+
+          documentElement.removeChild(table);
+        }
+        return reliableTrDimensionsVal;
+      },
+    });
+  })();
+
+  function curCSS(elem, name, computed) {
+    var width,
+      minWidth,
+      maxWidth,
+      ret,
+      // Support: Firefox 51+
+      // Retrieving style before computed somehow
+      // fixes an issue with getting wrong values
+      // on detached elements
+      style = elem.style;
+
+    computed = computed || getStyles(elem);
+
+    // getPropertyValue is needed for:
+    //   .css('filter') (IE 9 only, #12537)
+    //   .css('--customProperty) (#3144)
+    if (computed) {
+      ret = computed.getPropertyValue(name) || computed[name];
+
+      if (ret === "" && !isAttached(elem)) {
+        ret = jQuery.style(elem, name);
+      }
+
+      // A tribute to the "awesome hack by Dean Edwards"
+      // Android Browser returns percentage for some values,
+      // but width seems to be reliably pixels.
+      // This is against the CSSOM draft spec:
+      // https://drafts.csswg.org/cssom/#resolved-values
+      if (
+        !support.pixelBoxStyles() &&
+        rnumnonpx.test(ret) &&
+        rboxStyle.test(name)
+      ) {
+        // Remember the original values
+        width = style.width;
+        minWidth = style.minWidth;
+        maxWidth = style.maxWidth;
+
+        // Put in the new values to get a computed value out
+        style.minWidth = style.maxWidth = style.width = ret;
+        ret = computed.width;
+
+        // Revert the changed values
+        style.width = width;
+        style.minWidth = minWidth;
+        style.maxWidth = maxWidth;
+      }
+    }
+
+    return ret !== undefined
+      ? // Support: IE <=9 - 11 only
+        // IE returns zIndex value as an integer.
+        ret + ""
+      : ret;
+  }
+
+  function addGetHookIf(conditionFn, hookFn) {
+    // Define the hook, we'll check on the first run if it's really needed.
+    return {
+      get: function () {
+        if (conditionFn()) {
+          // Hook not needed (or it's not possible to use it due
+          // to missing dependency), remove it.
+          delete this.get;
+          return;
+        }
+
+        // Hook needed; redefine it so that the support test is not executed again.
+        return (this.get = hookFn).apply(this, arguments);
+      },
+    };
+  }
+
+  var cssPrefixes = ["Webkit", "Moz", "ms"],
+    emptyStyle = document.createElement("div").style,
+    vendorProps = {};
+
+  // Return a vendor-prefixed property or undefined
+  function vendorPropName(name) {
+    // Check for vendor prefixed names
+    var capName = name[0].toUpperCase() + name.slice(1),
+      i = cssPrefixes.length;
+
+    while (i--) {
+      name = cssPrefixes[i] + capName;
+      if (name in emptyStyle) {
+        return name;
+      }
+    }
+  }
+
+  // Return a potentially-mapped jQuery.cssProps or vendor prefixed property
+  function finalPropName(name) {
+    var final = jQuery.cssProps[name] || vendorProps[name];
+
+    if (final) {
+      return final;
+    }
+    if (name in emptyStyle) {
+      return name;
+    }
+    return (vendorProps[name] = vendorPropName(name) || name);
+  }
+
+  var // Swappable if display is none or starts with table
+    // except "table", "table-cell", or "table-caption"
+    // See here for display values: https://developer.mozilla.org/en-US/docs/CSS/display
+    rdisplayswap = /^(none|table(?!-c[ea]).+)/,
+    rcustomProp = /^--/,
+    cssShow = { position: "absolute", visibility: "hidden", display: "block" },
+    cssNormalTransform = {
+      letterSpacing: "0",
+      fontWeight: "400",
+    };
+
+  function setPositiveNumber(_elem, value, subtract) {
+    // Any relative (+/-) values have already been
+    // normalized at this point
+    var matches = rcssNum.exec(value);
+    return matches
+      ? // Guard against undefined "subtract", e.g., when used as in cssHooks
+        Math.max(0, matches[2] - (subtract || 0)) + (matches[3] || "px")
+      : value;
+  }
+
+  function boxModelAdjustment(
+    elem,
+    dimension,
+    box,
+    isBorderBox,
+    styles,
+    computedVal
+  ) {
+    var i = dimension === "width" ? 1 : 0,
+      extra = 0,
+      delta = 0;
+
+    // Adjustment may not be necessary
+    if (box === (isBorderBox ? "border" : "content")) {
+      return 0;
+    }
+
+    for (; i < 4; i += 2) {
+      // Both box models exclude margin
+      if (box === "margin") {
+        delta += jQuery.css(elem, box + cssExpand[i], true, styles);
+      }
+
+      // If we get here with a content-box, we're seeking "padding" or "border" or "margin"
+      if (!isBorderBox) {
+        // Add padding
+        delta += jQuery.css(elem, "padding" + cssExpand[i], true, styles);
+
+        // For "border" or "margin", add border
+        if (box !== "padding") {
+          delta += jQuery.css(
+            elem,
+            "border" + cssExpand[i] + "Width",
+            true,
+            styles
+          );
+
+          // But still keep track of it otherwise
+        } else {
+          extra += jQuery.css(
+            elem,
+            "border" + cssExpand[i] + "Width",
+            true,
+            styles
+          );
+        }
+
+        // If we get here with a border-box (content + padding + border), we're seeking "content" or
+        // "padding" or "margin"
+      } else {
+        // For "content", subtract padding
+        if (box === "content") {
+          delta -= jQuery.css(elem, "padding" + cssExpand[i], true, styles);
+        }
+
+        // For "content" or "padding", subtract border
+        if (box !== "margin") {
+          delta -= jQuery.css(
+            elem,
+            "border" + cssExpand[i] + "Width",
+            true,
+            styles
+          );
+        }
+      }
+    }
+
+    // Account for positive content-box scroll gutter when requested by providing computedVal
+    if (!isBorderBox && computedVal >= 0) {
+      // offsetWidth/offsetHeight is a rounded sum of content, padding, scroll gutter, and border
+      // Assuming integer scroll gutter, subtract the rest and round down
+      delta +=
+        Math.max(
+          0,
+          Math.ceil(
+            elem["offset" + dimension[0].toUpperCase() + dimension.slice(1)] -
+              computedVal -
+              delta -
+              extra -
+              0.5
+
+            // If offsetWidth/offsetHeight is unknown, then we can't determine content-box scroll gutter
+            // Use an explicit zero to avoid NaN (gh-3964)
+          )
+        ) || 0;
+    }
+
+    return delta;
+  }
+
+  function getWidthOrHeight(elem, dimension, extra) {
+    // Start with computed style
+    var styles = getStyles(elem),
+      // To avoid forcing a reflow, only fetch boxSizing if we need it (gh-4322).
+      // Fake content-box until we know it's needed to know the true value.
+      boxSizingNeeded = !support.boxSizingReliable() || extra,
+      isBorderBox =
+        boxSizingNeeded &&
+        jQuery.css(elem, "boxSizing", false, styles) === "border-box",
+      valueIsBorderBox = isBorderBox,
+      val = curCSS(elem, dimension, styles),
+      offsetProp = "offset" + dimension[0].toUpperCase() + dimension.slice(1);
+
+    // Support: Firefox <=54
+    // Return a confounding non-pixel value or feign ignorance, as appropriate.
+    if (rnumnonpx.test(val)) {
+      if (!extra) {
+        return val;
+      }
+      val = "auto";
+    }
+
+    // Support: IE 9 - 11 only
+    // Use offsetWidth/offsetHeight for when box sizing is unreliable.
+    // In those cases, the computed value can be trusted to be border-box.
+    if (
+      ((!support.boxSizingReliable() && isBorderBox) ||
+        // Support: IE 10 - 11+, Edge 15 - 18+
+        // IE/Edge misreport `getComputedStyle` of table rows with width/height
+        // set in CSS while `offset*` properties report correct values.
+        // Interestingly, in some cases IE 9 doesn't suffer from this issue.
+        (!support.reliableTrDimensions() && nodeName(elem, "tr")) ||
+        // Fall back to offsetWidth/offsetHeight when value is "auto"
+        // This happens for inline elements with no explicit setting (gh-3571)
+        val === "auto" ||
+        // Support: Android <=4.1 - 4.3 only
+        // Also use offsetWidth/offsetHeight for misreported inline dimensions (gh-3602)
+        (!parseFloat(val) &&
+          jQuery.css(elem, "display", false, styles) === "inline")) &&
+      // Make sure the element is visible & connected
+      elem.getClientRects().length
+    ) {
+      isBorderBox =
+        jQuery.css(elem, "boxSizing", false, styles) === "border-box";
+
+      // Where available, offsetWidth/offsetHeight approximate border box dimensions.
+      // Where not available (e.g., SVG), assume unreliable box-sizing and interpret the
+      // retrieved value as a content box dimension.
+      valueIsBorderBox = offsetProp in elem;
+      if (valueIsBorderBox) {
+        val = elem[offsetProp];
+      }
+    }
+
+    // Normalize "" and auto
+    val = parseFloat(val) || 0;
+
+    // Adjust for the element's box model
+    return (
+      val +
+      boxModelAdjustment(
+        elem,
+        dimension,
+        extra || (isBorderBox ? "border" : "content"),
+        valueIsBorderBox,
+        styles,
+
+        // Provide the current computed size to request scroll gutter calculation (gh-3589)
+        val
+      ) +
+      "px"
+    );
+  }
+
+  jQuery.extend({
+    // Add in style property hooks for overriding the default
+    // behavior of getting and setting a style property
+    cssHooks: {
+      opacity: {
+        get: function (elem, computed) {
+          if (computed) {
+            // We should always get a number back from opacity
+            var ret = curCSS(elem, "opacity");
+            return ret === "" ? "1" : ret;
+          }
+        },
+      },
+    },
+
+    // Don't automatically add "px" to these possibly-unitless properties
+    cssNumber: {
+      animationIterationCount: true,
+      columnCount: true,
+      fillOpacity: true,
+      flexGrow: true,
+      flexShrink: true,
+      fontWeight: true,
+      gridArea: true,
+      gridColumn: true,
+      gridColumnEnd: true,
+      gridColumnStart: true,
+      gridRow: true,
+      gridRowEnd: true,
+      gridRowStart: true,
+      lineHeight: true,
+      opacity: true,
+      order: true,
+      orphans: true,
+      widows: true,
+      zIndex: true,
+      zoom: true,
+    },
+
+    // Add in properties whose names you wish to fix before
+    // setting or getting the value
+    cssProps: {},
+
+    // Get and set the style property on a DOM Node
+    style: function (elem, name, value, extra) {
+      // Don't set styles on text and comment nodes
+      if (!elem || elem.nodeType === 3 || elem.nodeType === 8 || !elem.style) {
+        return;
+      }
+
+      // Make sure that we're working with the right name
+      var ret,
+        type,
+        hooks,
+        origName = camelCase(name),
+        isCustomProp = rcustomProp.test(name),
+        style = elem.style;
+
+      // Make sure that we're working with the right name. We don't
+      // want to query the value if it is a CSS custom property
+      // since they are user-defined.
+      if (!isCustomProp) {
+        name = finalPropName(origName);
+      }
+
+      // Gets hook for the prefixed version, then unprefixed version
+      hooks = jQuery.cssHooks[name] || jQuery.cssHooks[origName];
+
+      // Check if we're setting a value
+      if (value !== undefined) {
+        type = typeof value;
+
+        // Convert "+=" or "-=" to relative numbers (#7345)
+        if (type === "string" && (ret = rcssNum.exec(value)) && ret[1]) {
+          value = adjustCSS(elem, name, ret);
+
+          // Fixes bug #9237
+          type = "number";
+        }
+
+        // Make sure that null and NaN values aren't set (#7116)
+        if (value == null || value !== value) {
+          return;
+        }
+
+        // If a number was passed in, add the unit (except for certain CSS properties)
+        // The isCustomProp check can be removed in jQuery 4.0 when we only auto-append
+        // "px" to a few hardcoded values.
+        if (type === "number" && !isCustomProp) {
+          value += (ret && ret[3]) || (jQuery.cssNumber[origName] ? "" : "px");
+        }
+
+        // background-* props affect original clone's values
+        if (
+          !support.clearCloneStyle &&
+          value === "" &&
+          name.indexOf("background") === 0
+        ) {
+          style[name] = "inherit";
+        }
+
+        // If a hook was provided, use that value, otherwise just set the specified value
+        if (
+          !hooks ||
+          !("set" in hooks) ||
+          (value = hooks.set(elem, value, extra)) !== undefined
+        ) {
+          if (isCustomProp) {
+            style.setProperty(name, value);
+          } else {
+            style[name] = value;
+          }
+        }
+      } else {
+        // If a hook was provided get the non-computed value from there
+        if (
+          hooks &&
+          "get" in hooks &&
+          (ret = hooks.get(elem, false, extra)) !== undefined
+        ) {
+          return ret;
+        }
+
+        // Otherwise just get the value from the style object
+        return style[name];
+      }
+    },
+
+    css: function (elem, name, extra, styles) {
+      var val,
+        num,
+        hooks,
+        origName = camelCase(name),
+        isCustomProp = rcustomProp.test(name);
+
+      // Make sure that we're working with the right name. We don't
+      // want to modify the value if it is a CSS custom property
+      // since they are user-defined.
+      if (!isCustomProp) {
+        name = finalPropName(origName);
+      }
+
+      // Try prefixed name followed by the unprefixed name
+      hooks = jQuery.cssHooks[name] || jQuery.cssHooks[origName];
+
+      // If a hook was provided get the computed value from there
+      if (hooks && "get" in hooks) {
+        val = hooks.get(elem, true, extra);
+      }
+
+      // Otherwise, if a way to get the computed value exists, use that
+      if (val === undefined) {
+        val = curCSS(elem, name, styles);
+      }
+
+      // Convert "normal" to computed value
+      if (val === "normal" && name in cssNormalTransform) {
+        val = cssNormalTransform[name];
+      }
+
+      // Make numeric if forced or a qualifier was provided and val looks numeric
+      if (extra === "" || extra) {
+        num = parseFloat(val);
+        return extra === true || isFinite(num) ? num || 0 : val;
+      }
+
+      return val;
+    },
+  });
+
+  jQuery.each(["height", "width"], function (_i, dimension) {
+    jQuery.cssHooks[dimension] = {
+      get: function (elem, computed, extra) {
+        if (computed) {
+          // Certain elements can have dimension info if we invisibly show them
+          // but it must have a current display style that would benefit
+          return rdisplayswap.test(jQuery.css(elem, "display")) &&
+            // Support: Safari 8+
+            // Table columns in Safari have non-zero offsetWidth & zero
+            // getBoundingClientRect().width unless display is changed.
+            // Support: IE <=11 only
+            // Running getBoundingClientRect on a disconnected node
+            // in IE throws an error.
+            (!elem.getClientRects().length ||
+              !elem.getBoundingClientRect().width)
+            ? swap(elem, cssShow, function () {
+                return getWidthOrHeight(elem, dimension, extra);
+              })
+            : getWidthOrHeight(elem, dimension, extra);
+        }
+      },
+
+      set: function (elem, value, extra) {
+        var matches,
+          styles = getStyles(elem),
+          // Only read styles.position if the test has a chance to fail
+          // to avoid forcing a reflow.
+          scrollboxSizeBuggy =
+            !support.scrollboxSize() && styles.position === "absolute",
+          // To avoid forcing a reflow, only fetch boxSizing if we need it (gh-3991)
+          boxSizingNeeded = scrollboxSizeBuggy || extra,
+          isBorderBox =
+            boxSizingNeeded &&
+            jQuery.css(elem, "boxSizing", false, styles) === "border-box",
+          subtract = extra
+            ? boxModelAdjustment(elem, dimension, extra, isBorderBox, styles)
+            : 0;
+
+        // Account for unreliable border-box dimensions by comparing offset* to computed and
+        // faking a content-box to get border and padding (gh-3699)
+        if (isBorderBox && scrollboxSizeBuggy) {
+          subtract -= Math.ceil(
+            elem["offset" + dimension[0].toUpperCase() + dimension.slice(1)] -
+              parseFloat(styles[dimension]) -
+              boxModelAdjustment(elem, dimension, "border", false, styles) -
+              0.5
+          );
+        }
+
+        // Convert to pixels if value adjustment is needed
+        if (
+          subtract &&
+          (matches = rcssNum.exec(value)) &&
+          (matches[3] || "px") !== "px"
+        ) {
+          elem.style[dimension] = value;
+          value = jQuery.css(elem, dimension);
+        }
+
+        return setPositiveNumber(elem, value, subtract);
+      },
+    };
+  });
+
+  jQuery.cssHooks.marginLeft = addGetHookIf(
+    support.reliableMarginLeft,
+    function (elem, computed) {
+      if (computed) {
+        return (
+          (parseFloat(curCSS(elem, "marginLeft")) ||
+            elem.getBoundingClientRect().left -
+              swap(elem, { marginLeft: 0 }, function () {
+                return elem.getBoundingClientRect().left;
+              })) + "px"
+        );
+      }
+    }
+  );
+
+  // These hooks are used by animate to expand properties
+  jQuery.each(
+    {
+      margin: "",
+      padding: "",
+      border: "Width",
+    },
+    function (prefix, suffix) {
+      jQuery.cssHooks[prefix + suffix] = {
+        expand: function (value) {
+          var i = 0,
+            expanded = {},
+            // Assumes a single number if not a string
+            parts = typeof value === "string" ? value.split(" ") : [value];
+
+          for (; i < 4; i++) {
+            expanded[prefix + cssExpand[i] + suffix] =
+              parts[i] || parts[i - 2] || parts[0];
+          }
+
+          return expanded;
+        },
+      };
+
+      if (prefix !== "margin") {
+        jQuery.cssHooks[prefix + suffix].set = setPositiveNumber;
+      }
+    }
+  );
+
+  jQuery.fn.extend({
+    css: function (name, value) {
+      return access(
+        this,
+        function (elem, name, value) {
+          var styles,
+            len,
+            map = {},
+            i = 0;
+
+          if (Array.isArray(name)) {
+            styles = getStyles(elem);
+            len = name.length;
+
+            for (; i < len; i++) {
+              map[name[i]] = jQuery.css(elem, name[i], false, styles);
+            }
+
+            return map;
+          }
+
+          return value !== undefined
+            ? jQuery.style(elem, name, value)
+            : jQuery.css(elem, name);
+        },
+        name,
+        value,
+        arguments.length > 1
+      );
+    },
+  });
+
+  function Tween(elem, options, prop, end, easing) {
+    return new Tween.prototype.init(elem, options, prop, end, easing);
+  }
+  jQuery.Tween = Tween;
+
+  Tween.prototype = {
+    constructor: Tween,
+    init: function (elem, options, prop, end, easing, unit) {
+      this.elem = elem;
+      this.prop = prop;
+      this.easing = easing || jQuery.easing._default;
+      this.options = options;
+      this.start = this.now = this.cur();
+      this.end = end;
+      this.unit = unit || (jQuery.cssNumber[prop] ? "" : "px");
+    },
+    cur: function () {
+      var hooks = Tween.propHooks[this.prop];
+
+      return hooks && hooks.get
+        ? hooks.get(this)
+        : Tween.propHooks._default.get(this);
+    },
+    run: function (percent) {
+      var eased,
+        hooks = Tween.propHooks[this.prop];
+
+      if (this.options.duration) {
+        this.pos = eased = jQuery.easing[this.easing](
+          percent,
+          this.options.duration * percent,
+          0,
+          1,
+          this.options.duration
+        );
+      } else {
+        this.pos = eased = percent;
+      }
+      this.now = (this.end - this.start) * eased + this.start;
+
+      if (this.options.step) {
+        this.options.step.call(this.elem, this.now, this);
+      }
+
+      if (hooks && hooks.set) {
+        hooks.set(this);
+      } else {
+        Tween.propHooks._default.set(this);
+      }
+      return this;
+    },
+  };
+
+  Tween.prototype.init.prototype = Tween.prototype;
+
+  Tween.propHooks = {
+    _default: {
+      get: function (tween) {
+        var result;
+
+        // Use a property on the element directly when it is not a DOM element,
+        // or when there is no matching style property that exists.
+        if (
+          tween.elem.nodeType !== 1 ||
+          (tween.elem[tween.prop] != null &&
+            tween.elem.style[tween.prop] == null)
+        ) {
+          return tween.elem[tween.prop];
+        }
+
+        // Passing an empty string as a 3rd parameter to .css will automatically
+        // attempt a parseFloat and fallback to a string if the parse fails.
+        // Simple values such as "10px" are parsed to Float;
+        // complex values such as "rotate(1rad)" are returned as-is.
+        result = jQuery.css(tween.elem, tween.prop, "");
+
+        // Empty strings, null, undefined and "auto" are converted to 0.
+        return !result || result === "auto" ? 0 : result;
+      },
+      set: function (tween) {
+        // Use step hook for back compat.
+        // Use cssHook if its there.
+        // Use .style if available and use plain properties where available.
+        if (jQuery.fx.step[tween.prop]) {
+          jQuery.fx.step[tween.prop](tween);
+        } else if (
+          tween.elem.nodeType === 1 &&
+          (jQuery.cssHooks[tween.prop] ||
+            tween.elem.style[finalPropName(tween.prop)] != null)
+        ) {
+          jQuery.style(tween.elem, tween.prop, tween.now + tween.unit);
+        } else {
+          tween.elem[tween.prop] = tween.now;
+        }
+      },
+    },
+  };
+
+  // Support: IE <=9 only
+  // Panic based approach to setting things on disconnected nodes
+  Tween.propHooks.scrollTop = Tween.propHooks.scrollLeft = {
+    set: function (tween) {
+      if (tween.elem.nodeType && tween.elem.parentNode) {
+        tween.elem[tween.prop] = tween.now;
+      }
+    },
+  };
+
+  jQuery.easing = {
+    linear: function (p) {
+      return p;
+    },
+    swing: function (p) {
+      return 0.5 - Math.cos(p * Math.PI) / 2;
+    },
+    _default: "swing",
+  };
+
+  jQuery.fx = Tween.prototype.init;
+
+  // Back compat <1.8 extension point
+  jQuery.fx.step = {};
+
+  var fxNow,
+    inProgress,
+    rfxtypes = /^(?:toggle|show|hide)$/,
+    rrun = /queueHooks$/;
+
+  function schedule() {
+    if (inProgress) {
+      if (document.hidden === false && window.requestAnimationFrame) {
+        window.requestAnimationFrame(schedule);
+      } else {
+        window.setTimeout(schedule, jQuery.fx.interval);
+      }
+
+      jQuery.fx.tick();
+    }
+  }
+
+  // Animations created synchronously will run synchronously
+  function createFxNow() {
+    window.setTimeout(function () {
+      fxNow = undefined;
+    });
+    return (fxNow = Date.now());
+  }
+
+  // Generate parameters to create a standard animation
+  function genFx(type, includeWidth) {
+    var which,
+      i = 0,
+      attrs = { height: type };
+
+    // If we include width, step value is 1 to do all cssExpand values,
+    // otherwise step value is 2 to skip over Left and Right
+    includeWidth = includeWidth ? 1 : 0;
+    for (; i < 4; i += 2 - includeWidth) {
+      which = cssExpand[i];
+      attrs["margin" + which] = attrs["padding" + which] = type;
+    }
+
+    if (includeWidth) {
+      attrs.opacity = attrs.width = type;
+    }
+
+    return attrs;
+  }
+
+  function createTween(value, prop, animation) {
+    var tween,
+      collection = (Animation.tweeners[prop] || []).concat(
+        Animation.tweeners["*"]
+      ),
+      index = 0,
+      length = collection.length;
+    for (; index < length; index++) {
+      if ((tween = collection[index].call(animation, prop, value))) {
+        // We're done with this property
+        return tween;
+      }
+    }
+  }
+
+  function defaultPrefilter(elem, props, opts) {
+    var prop,
+      value,
+      toggle,
+      hooks,
+      oldfire,
+      propTween,
+      restoreDisplay,
+      display,
+      isBox = "width" in props || "height" in props,
+      anim = this,
+      orig = {},
+      style = elem.style,
+      hidden = elem.nodeType && isHiddenWithinTree(elem),
+      dataShow = dataPriv.get(elem, "fxshow");
+
+    // Queue-skipping animations hijack the fx hooks
+    if (!opts.queue) {
+      hooks = jQuery._queueHooks(elem, "fx");
+      if (hooks.unqueued == null) {
+        hooks.unqueued = 0;
+        oldfire = hooks.empty.fire;
+        hooks.empty.fire = function () {
+          if (!hooks.unqueued) {
+            oldfire();
+          }
+        };
+      }
+      hooks.unqueued++;
+
+      anim.always(function () {
+        // Ensure the complete handler is called before this completes
+        anim.always(function () {
+          hooks.unqueued--;
+          if (!jQuery.queue(elem, "fx").length) {
+            hooks.empty.fire();
+          }
+        });
+      });
+    }
+
+    // Detect show/hide animations
+    for (prop in props) {
+      value = props[prop];
+      if (rfxtypes.test(value)) {
+        delete props[prop];
+        toggle = toggle || value === "toggle";
+        if (value === (hidden ? "hide" : "show")) {
+          // Pretend to be hidden if this is a "show" and
+          // there is still data from a stopped show/hide
+          if (value === "show" && dataShow && dataShow[prop] !== undefined) {
+            hidden = true;
+
+            // Ignore all other no-op show/hide data
+          } else {
+            continue;
+          }
+        }
+        orig[prop] = (dataShow && dataShow[prop]) || jQuery.style(elem, prop);
+      }
+    }
+
+    // Bail out if this is a no-op like .hide().hide()
+    propTween = !jQuery.isEmptyObject(props);
+    if (!propTween && jQuery.isEmptyObject(orig)) {
+      return;
+    }
+
+    // Restrict "overflow" and "display" styles during box animations
+    if (isBox && elem.nodeType === 1) {
+      // Support: IE <=9 - 11, Edge 12 - 15
+      // Record all 3 overflow attributes because IE does not infer the shorthand
+      // from identically-valued overflowX and overflowY and Edge just mirrors
+      // the overflowX value there.
+      opts.overflow = [style.overflow, style.overflowX, style.overflowY];
+
+      // Identify a display type, preferring old show/hide data over the CSS cascade
+      restoreDisplay = dataShow && dataShow.display;
+      if (restoreDisplay == null) {
+        restoreDisplay = dataPriv.get(elem, "display");
+      }
+      display = jQuery.css(elem, "display");
+      if (display === "none") {
+        if (restoreDisplay) {
+          display = restoreDisplay;
+        } else {
+          // Get nonempty value(s) by temporarily forcing visibility
+          showHide([elem], true);
+          restoreDisplay = elem.style.display || restoreDisplay;
+          display = jQuery.css(elem, "display");
+          showHide([elem]);
+        }
+      }
+
+      // Animate inline elements as inline-block
+      if (
+        display === "inline" ||
+        (display === "inline-block" && restoreDisplay != null)
+      ) {
+        if (jQuery.css(elem, "float") === "none") {
+          // Restore the original display value at the end of pure show/hide animations
+          if (!propTween) {
+            anim.done(function () {
+              style.display = restoreDisplay;
+            });
+            if (restoreDisplay == null) {
+              display = style.display;
+              restoreDisplay = display === "none" ? "" : display;
+            }
+          }
+          style.display = "inline-block";
+        }
+      }
+    }
+
+    if (opts.overflow) {
+      style.overflow = "hidden";
+      anim.always(function () {
+        style.overflow = opts.overflow[0];
+        style.overflowX = opts.overflow[1];
+        style.overflowY = opts.overflow[2];
+      });
+    }
+
+    // Implement show/hide animations
+    propTween = false;
+    for (prop in orig) {
+      // General show/hide setup for this element animation
+      if (!propTween) {
+        if (dataShow) {
+          if ("hidden" in dataShow) {
+            hidden = dataShow.hidden;
+          }
+        } else {
+          dataShow = dataPriv.access(elem, "fxshow", {
+            display: restoreDisplay,
+          });
+        }
+
+        // Store hidden/visible for toggle so `.stop().toggle()` "reverses"
+        if (toggle) {
+          dataShow.hidden = !hidden;
+        }
+
+        // Show elements before animating them
+        if (hidden) {
+          showHide([elem], true);
+        }
+
+        /* eslint-disable no-loop-func */
+
+        anim.done(function () {
+          /* eslint-enable no-loop-func */
+
+          // The final step of a "hide" animation is actually hiding the element
+          if (!hidden) {
+            showHide([elem]);
+          }
+          dataPriv.remove(elem, "fxshow");
+          for (prop in orig) {
+            jQuery.style(elem, prop, orig[prop]);
+          }
+        });
+      }
+
+      // Per-property setup
+      propTween = createTween(hidden ? dataShow[prop] : 0, prop, anim);
+      if (!(prop in dataShow)) {
+        dataShow[prop] = propTween.start;
+        if (hidden) {
+          propTween.end = propTween.start;
+          propTween.start = 0;
+        }
+      }
+    }
+  }
+
+  function propFilter(props, specialEasing) {
+    var index, name, easing, value, hooks;
+
+    // camelCase, specialEasing and expand cssHook pass
+    for (index in props) {
+      name = camelCase(index);
+      easing = specialEasing[name];
+      value = props[index];
+      if (Array.isArray(value)) {
+        easing = value[1];
+        value = props[index] = value[0];
+      }
+
+      if (index !== name) {
+        props[name] = value;
+        delete props[index];
+      }
+
+      hooks = jQuery.cssHooks[name];
+      if (hooks && "expand" in hooks) {
+        value = hooks.expand(value);
+        delete props[name];
+
+        // Not quite $.extend, this won't overwrite existing keys.
+        // Reusing 'index' because we have the correct "name"
+        for (index in value) {
+          if (!(index in props)) {
+            props[index] = value[index];
+            specialEasing[index] = easing;
+          }
+        }
+      } else {
+        specialEasing[name] = easing;
+      }
+    }
+  }
+
+  function Animation(elem, properties, options) {
+    var result,
+      stopped,
+      index = 0,
+      length = Animation.prefilters.length,
+      deferred = jQuery.Deferred().always(function () {
+        // Don't match elem in the :animated selector
+        delete tick.elem;
+      }),
+      tick = function () {
+        if (stopped) {
+          return false;
+        }
+        var currentTime = fxNow || createFxNow(),
+          remaining = Math.max(
+            0,
+            animation.startTime + animation.duration - currentTime
+          ),
+          // Support: Android 2.3 only
+          // Archaic crash bug won't allow us to use `1 - ( 0.5 || 0 )` (#12497)
+          temp = remaining / animation.duration || 0,
+          percent = 1 - temp,
+          index = 0,
+          length = animation.tweens.length;
+
+        for (; index < length; index++) {
+          animation.tweens[index].run(percent);
+        }
+
+        deferred.notifyWith(elem, [animation, percent, remaining]);
+
+        // If there's more to do, yield
+        if (percent < 1 && length) {
+          return remaining;
+        }
+
+        // If this was an empty animation, synthesize a final progress notification
+        if (!length) {
+          deferred.notifyWith(elem, [animation, 1, 0]);
+        }
+
+        // Resolve the animation and report its conclusion
+        deferred.resolveWith(elem, [animation]);
+        return false;
+      },
+      animation = deferred.promise({
+        elem: elem,
+        props: jQuery.extend({}, properties),
+        opts: jQuery.extend(
+          true,
+          {
+            specialEasing: {},
+            easing: jQuery.easing._default,
+          },
+          options
+        ),
+        originalProperties: properties,
+        originalOptions: options,
+        startTime: fxNow || createFxNow(),
+        duration: options.duration,
+        tweens: [],
+        createTween: function (prop, end) {
+          var tween = jQuery.Tween(
+            elem,
+            animation.opts,
+            prop,
+            end,
+            animation.opts.specialEasing[prop] || animation.opts.easing
+          );
+          animation.tweens.push(tween);
+          return tween;
+        },
+        stop: function (gotoEnd) {
+          var index = 0,
+            // If we are going to the end, we want to run all the tweens
+            // otherwise we skip this part
+            length = gotoEnd ? animation.tweens.length : 0;
+          if (stopped) {
+            return this;
+          }
+          stopped = true;
+          for (; index < length; index++) {
+            animation.tweens[index].run(1);
+          }
+
+          // Resolve when we played the last frame; otherwise, reject
+          if (gotoEnd) {
+            deferred.notifyWith(elem, [animation, 1, 0]);
+            deferred.resolveWith(elem, [animation, gotoEnd]);
+          } else {
+            deferred.rejectWith(elem, [animation, gotoEnd]);
+          }
+          return this;
+        },
+      }),
+      props = animation.props;
+
+    propFilter(props, animation.opts.specialEasing);
+
+    for (; index < length; index++) {
+      result = Animation.prefilters[index].call(
+        animation,
+        elem,
+        props,
+        animation.opts
+      );
+      if (result) {
+        if (isFunction(result.stop)) {
+          jQuery._queueHooks(animation.elem, animation.opts.queue).stop =
+            result.stop.bind(result);
+        }
+        return result;
+      }
+    }
+
+    jQuery.map(props, createTween, animation);
+
+    if (isFunction(animation.opts.start)) {
+      animation.opts.start.call(elem, animation);
+    }
+
+    // Attach callbacks from options
+    animation
+      .progress(animation.opts.progress)
+      .done(animation.opts.done, animation.opts.complete)
+      .fail(animation.opts.fail)
+      .always(animation.opts.always);
+
+    jQuery.fx.timer(
+      jQuery.extend(tick, {
+        elem: elem,
+        anim: animation,
+        queue: animation.opts.queue,
+      })
+    );
+
+    return animation;
+  }
+
+  jQuery.Animation = jQuery.extend(Animation, {
+    tweeners: {
+      "*": [
+        function (prop, value) {
+          var tween = this.createTween(prop, value);
+          adjustCSS(tween.elem, prop, rcssNum.exec(value), tween);
+          return tween;
+        },
+      ],
+    },
+
+    tweener: function (props, callback) {
+      if (isFunction(props)) {
+        callback = props;
+        props = ["*"];
+      } else {
+        props = props.match(rnothtmlwhite);
+      }
+
+      var prop,
+        index = 0,
+        length = props.length;
+
+      for (; index < length; index++) {
+        prop = props[index];
+        Animation.tweeners[prop] = Animation.tweeners[prop] || [];
+        Animation.tweeners[prop].unshift(callback);
+      }
+    },
+
+    prefilters: [defaultPrefilter],
+
+    prefilter: function (callback, prepend) {
+      if (prepend) {
+        Animation.prefilters.unshift(callback);
+      } else {
+        Animation.prefilters.push(callback);
+      }
+    },
+  });
+
+  jQuery.speed = function (speed, easing, fn) {
+    var opt =
+      speed && typeof speed === "object"
+        ? jQuery.extend({}, speed)
+        : {
+            complete: fn || (!fn && easing) || (isFunction(speed) && speed),
+            duration: speed,
+            easing: (fn && easing) || (easing && !isFunction(easing) && easing),
+          };
+
+    // Go to the end state if fx are off
+    if (jQuery.fx.off) {
+      opt.duration = 0;
+    } else {
+      if (typeof opt.duration !== "number") {
+        if (opt.duration in jQuery.fx.speeds) {
+          opt.duration = jQuery.fx.speeds[opt.duration];
+        } else {
+          opt.duration = jQuery.fx.speeds._default;
+        }
+      }
+    }
+
+    // Normalize opt.queue - true/undefined/null -> "fx"
+    if (opt.queue == null || opt.queue === true) {
+      opt.queue = "fx";
+    }
+
+    // Queueing
+    opt.old = opt.complete;
+
+    opt.complete = function () {
+      if (isFunction(opt.old)) {
+        opt.old.call(this);
+      }
+
+      if (opt.queue) {
+        jQuery.dequeue(this, opt.queue);
+      }
+    };
+
+    return opt;
+  };
+
+  jQuery.fn.extend({
+    fadeTo: function (speed, to, easing, callback) {
+      // Show any hidden elements after setting opacity to 0
+      return (
+        this.filter(isHiddenWithinTree)
+          .css("opacity", 0)
+          .show()
+
+          // Animate to the value specified
+          .end()
+          .animate({ opacity: to }, speed, easing, callback)
+      );
+    },
+    animate: function (prop, speed, easing, callback) {
+      var empty = jQuery.isEmptyObject(prop),
+        optall = jQuery.speed(speed, easing, callback),
+        doAnimation = function () {
+          // Operate on a copy of prop so per-property easing won't be lost
+          var anim = Animation(this, jQuery.extend({}, prop), optall);
+
+          // Empty animations, or finishing resolves immediately
+          if (empty || dataPriv.get(this, "finish")) {
+            anim.stop(true);
+          }
+        };
+
+      doAnimation.finish = doAnimation;
+
+      return empty || optall.queue === false
+        ? this.each(doAnimation)
+        : this.queue(optall.queue, doAnimation);
+    },
+    stop: function (type, clearQueue, gotoEnd) {
+      var stopQueue = function (hooks) {
+        var stop = hooks.stop;
+        delete hooks.stop;
+        stop(gotoEnd);
+      };
+
+      if (typeof type !== "string") {
+        gotoEnd = clearQueue;
+        clearQueue = type;
+        type = undefined;
+      }
+      if (clearQueue) {
+        this.queue(type || "fx", []);
+      }
+
+      return this.each(function () {
+        var dequeue = true,
+          index = type != null && type + "queueHooks",
+          timers = jQuery.timers,
+          data = dataPriv.get(this);
+
+        if (index) {
+          if (data[index] && data[index].stop) {
+            stopQueue(data[index]);
+          }
+        } else {
+          for (index in data) {
+            if (data[index] && data[index].stop && rrun.test(index)) {
+              stopQueue(data[index]);
+            }
+          }
+        }
+
+        for (index = timers.length; index--; ) {
+          if (
+            timers[index].elem === this &&
+            (type == null || timers[index].queue === type)
+          ) {
+            timers[index].anim.stop(gotoEnd);
+            dequeue = false;
+            timers.splice(index, 1);
+          }
+        }
+
+        // Start the next in the queue if the last step wasn't forced.
+        // Timers currently will call their complete callbacks, which
+        // will dequeue but only if they were gotoEnd.
+        if (dequeue || !gotoEnd) {
+          jQuery.dequeue(this, type);
+        }
+      });
+    },
+    finish: function (type) {
+      if (type !== false) {
+        type = type || "fx";
+      }
+      return this.each(function () {
+        var index,
+          data = dataPriv.get(this),
+          queue = data[type + "queue"],
+          hooks = data[type + "queueHooks"],
+          timers = jQuery.timers,
+          length = queue ? queue.length : 0;
+
+        // Enable finishing flag on private data
+        data.finish = true;
+
+        // Empty the queue first
+        jQuery.queue(this, type, []);
+
+        if (hooks && hooks.stop) {
+          hooks.stop.call(this, true);
+        }
+
+        // Look for any active animations, and finish them
+        for (index = timers.length; index--; ) {
+          if (timers[index].elem === this && timers[index].queue === type) {
+            timers[index].anim.stop(true);
+            timers.splice(index, 1);
+          }
+        }
+
+        // Look for any animations in the old queue and finish them
+        for (index = 0; index < length; index++) {
+          if (queue[index] && queue[index].finish) {
+            queue[index].finish.call(this);
+          }
+        }
+
+        // Turn off finishing flag
+        delete data.finish;
+      });
+    },
+  });
+
+  jQuery.each(["toggle", "show", "hide"], function (_i, name) {
+    var cssFn = jQuery.fn[name];
+    jQuery.fn[name] = function (speed, easing, callback) {
+      return speed == null || typeof speed === "boolean"
+        ? cssFn.apply(this, arguments)
+        : this.animate(genFx(name, true), speed, easing, callback);
+    };
+  });
+
+  // Generate shortcuts for custom animations
+  jQuery.each(
+    {
+      slideDown: genFx("show"),
+      slideUp: genFx("hide"),
+      slideToggle: genFx("toggle"),
+      fadeIn: { opacity: "show" },
+      fadeOut: { opacity: "hide" },
+      fadeToggle: { opacity: "toggle" },
+    },
+    function (name, props) {
+      jQuery.fn[name] = function (speed, easing, callback) {
+        return this.animate(props, speed, easing, callback);
+      };
+    }
+  );
+
+  jQuery.timers = [];
+  jQuery.fx.tick = function () {
+    var timer,
+      i = 0,
+      timers = jQuery.timers;
+
+    fxNow = Date.now();
+
+    for (; i < timers.length; i++) {
+      timer = timers[i];
+
+      // Run the timer and safely remove it when done (allowing for external removal)
+      if (!timer() && timers[i] === timer) {
+        timers.splice(i--, 1);
+      }
+    }
+
+    if (!timers.length) {
+      jQuery.fx.stop();
+    }
+    fxNow = undefined;
+  };
+
+  jQuery.fx.timer = function (timer) {
+    jQuery.timers.push(timer);
+    jQuery.fx.start();
+  };
+
+  jQuery.fx.interval = 13;
+  jQuery.fx.start = function () {
+    if (inProgress) {
+      return;
+    }
+
+    inProgress = true;
+    schedule();
+  };
+
+  jQuery.fx.stop = function () {
+    inProgress = null;
+  };
+
+  jQuery.fx.speeds = {
+    slow: 600,
+    fast: 200,
+
+    // Default speed
+    _default: 400,
+  };
+
+  // Based off of the plugin by Clint Helfers, with permission.
+  // https://web.archive.org/web/20100324014747/http://blindsignals.com/index.php/2009/07/jquery-delay/
+  jQuery.fn.delay = function (time, type) {
+    time = jQuery.fx ? jQuery.fx.speeds[time] || time : time;
+    type = type || "fx";
+
+    return this.queue(type, function (next, hooks) {
+      var timeout = window.setTimeout(next, time);
+      hooks.stop = function () {
+        window.clearTimeout(timeout);
+      };
+    });
+  };
+
+  (function () {
+    var input = document.createElement("input"),
+      select = document.createElement("select"),
+      opt = select.appendChild(document.createElement("option"));
+
+    input.type = "checkbox";
+
+    // Support: Android <=4.3 only
+    // Default value for a checkbox should be "on"
+    support.checkOn = input.value !== "";
+
+    // Support: IE <=11 only
+    // Must access selectedIndex to make default options select
+    support.optSelected = opt.selected;
+
+    // Support: IE <=11 only
+    // An input loses its value after becoming a radio
+    input = document.createElement("input");
+    input.value = "t";
+    input.type = "radio";
+    support.radioValue = input.value === "t";
+  })();
+
+  var boolHook,
+    attrHandle = jQuery.expr.attrHandle;
+
+  jQuery.fn.extend({
+    attr: function (name, value) {
+      return access(this, jQuery.attr, name, value, arguments.length > 1);
+    },
+
+    removeAttr: function (name) {
+      return this.each(function () {
+        jQuery.removeAttr(this, name);
+      });
+    },
+  });
+
+  jQuery.extend({
+    attr: function (elem, name, value) {
+      var ret,
+        hooks,
+        nType = elem.nodeType;
+
+      // Don't get/set attributes on text, comment and attribute nodes
+      if (nType === 3 || nType === 8 || nType === 2) {
+        return;
+      }
+
+      // Fallback to prop when attributes are not supported
+      if (typeof elem.getAttribute === "undefined") {
+        return jQuery.prop(elem, name, value);
+      }
+
+      // Attribute hooks are determined by the lowercase version
+      // Grab necessary hook if one is defined
+      if (nType !== 1 || !jQuery.isXMLDoc(elem)) {
+        hooks =
+          jQuery.attrHooks[name.toLowerCase()] ||
+          (jQuery.expr.match.bool.test(name) ? boolHook : undefined);
+      }
+
+      if (value !== undefined) {
+        if (value === null) {
+          jQuery.removeAttr(elem, name);
+          return;
+        }
+
+        if (
+          hooks &&
+          "set" in hooks &&
+          (ret = hooks.set(elem, value, name)) !== undefined
+        ) {
+          return ret;
+        }
+
+        elem.setAttribute(name, value + "");
+        return value;
+      }
+
+      if (hooks && "get" in hooks && (ret = hooks.get(elem, name)) !== null) {
+        return ret;
+      }
+
+      ret = jQuery.find.attr(elem, name);
+
+      // Non-existent attributes return null, we normalize to undefined
+      return ret == null ? undefined : ret;
+    },
+
+    attrHooks: {
+      type: {
+        set: function (elem, value) {
+          if (
+            !support.radioValue &&
+            value === "radio" &&
+            nodeName(elem, "input")
+          ) {
+            var val = elem.value;
+            elem.setAttribute("type", value);
+            if (val) {
+              elem.value = val;
+            }
+            return value;
+          }
+        },
+      },
+    },
+
+    removeAttr: function (elem, value) {
+      var name,
+        i = 0,
+        // Attribute names can contain non-HTML whitespace characters
+        // https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+        attrNames = value && value.match(rnothtmlwhite);
+
+      if (attrNames && elem.nodeType === 1) {
+        while ((name = attrNames[i++])) {
+          elem.removeAttribute(name);
+        }
+      }
+    },
+  });
+
+  // Hooks for boolean attributes
+  boolHook = {
+    set: function (elem, value, name) {
+      if (value === false) {
+        // Remove boolean attributes when set to false
+        jQuery.removeAttr(elem, name);
+      } else {
+        elem.setAttribute(name, name);
+      }
+      return name;
+    },
+  };
+
+  jQuery.each(jQuery.expr.match.bool.source.match(/\w+/g), function (_i, name) {
+    var getter = attrHandle[name] || jQuery.find.attr;
+
+    attrHandle[name] = function (elem, name, isXML) {
+      var ret,
+        handle,
+        lowercaseName = name.toLowerCase();
+
+      if (!isXML) {
+        // Avoid an infinite loop by temporarily removing this function from the getter
+        handle = attrHandle[lowercaseName];
+        attrHandle[lowercaseName] = ret;
+        ret = getter(elem, name, isXML) != null ? lowercaseName : null;
+        attrHandle[lowercaseName] = handle;
+      }
+      return ret;
+    };
+  });
+
+  var rfocusable = /^(?:input|select|textarea|button)$/i,
+    rclickable = /^(?:a|area)$/i;
+
+  jQuery.fn.extend({
+    prop: function (name, value) {
+      return access(this, jQuery.prop, name, value, arguments.length > 1);
+    },
+
+    removeProp: function (name) {
+      return this.each(function () {
+        delete this[jQuery.propFix[name] || name];
+      });
+    },
+  });
+
+  jQuery.extend({
+    prop: function (elem, name, value) {
+      var ret,
+        hooks,
+        nType = elem.nodeType;
+
+      // Don't get/set properties on text, comment and attribute nodes
+      if (nType === 3 || nType === 8 || nType === 2) {
+        return;
+      }
+
+      if (nType !== 1 || !jQuery.isXMLDoc(elem)) {
+        // Fix name and attach hooks
+        name = jQuery.propFix[name] || name;
+        hooks = jQuery.propHooks[name];
+      }
+
+      if (value !== undefined) {
+        if (
+          hooks &&
+          "set" in hooks &&
+          (ret = hooks.set(elem, value, name)) !== undefined
+        ) {
+          return ret;
+        }
+
+        return (elem[name] = value);
+      }
+
+      if (hooks && "get" in hooks && (ret = hooks.get(elem, name)) !== null) {
+        return ret;
+      }
+
+      return elem[name];
+    },
+
+    propHooks: {
+      tabIndex: {
+        get: function (elem) {
+          // Support: IE <=9 - 11 only
+          // elem.tabIndex doesn't always return the
+          // correct value when it hasn't been explicitly set
+          // https://web.archive.org/web/20141116233347/http://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/
+          // Use proper attribute retrieval(#12072)
+          var tabindex = jQuery.find.attr(elem, "tabindex");
+
+          if (tabindex) {
+            return parseInt(tabindex, 10);
+          }
+
+          if (
+            rfocusable.test(elem.nodeName) ||
+            (rclickable.test(elem.nodeName) && elem.href)
+          ) {
+            return 0;
+          }
+
+          return -1;
+        },
+      },
+    },
+
+    propFix: {
+      for: "htmlFor",
+      class: "className",
+    },
+  });
+
+  // Support: IE <=11 only
+  // Accessing the selectedIndex property
+  // forces the browser to respect setting selected
+  // on the option
+  // The getter ensures a default option is selected
+  // when in an optgroup
+  // eslint rule "no-unused-expressions" is disabled for this code
+  // since it considers such accessions noop
+  if (!support.optSelected) {
+    jQuery.propHooks.selected = {
+      get: function (elem) {
+        /* eslint no-unused-expressions: "off" */
+
+        var parent = elem.parentNode;
+        if (parent && parent.parentNode) {
+          parent.parentNode.selectedIndex;
+        }
+        return null;
+      },
+      set: function (elem) {
+        /* eslint no-unused-expressions: "off" */
+
+        var parent = elem.parentNode;
+        if (parent) {
+          parent.selectedIndex;
+
+          if (parent.parentNode) {
+            parent.parentNode.selectedIndex;
+          }
+        }
+      },
+    };
+  }
+
+  jQuery.each(
+    [
+      "tabIndex",
+      "readOnly",
+      "maxLength",
+      "cellSpacing",
+      "cellPadding",
+      "rowSpan",
+      "colSpan",
+      "useMap",
+      "frameBorder",
+      "contentEditable",
+    ],
+    function () {
+      jQuery.propFix[this.toLowerCase()] = this;
+    }
+  );
+
+  // Strip and collapse whitespace according to HTML spec
+  // https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace
+  function stripAndCollapse(value) {
+    var tokens = value.match(rnothtmlwhite) || [];
+    return tokens.join(" ");
+  }
+
+  function getClass(elem) {
+    return (elem.getAttribute && elem.getAttribute("class")) || "";
+  }
+
+  function classesToArray(value) {
+    if (Array.isArray(value)) {
+      return value;
+    }
+    if (typeof value === "string") {
+      return value.match(rnothtmlwhite) || [];
+    }
+    return [];
+  }
+
+  jQuery.fn.extend({
+    addClass: function (value) {
+      var classes,
+        elem,
+        cur,
+        curValue,
+        clazz,
+        j,
+        finalValue,
+        i = 0;
+
+      if (isFunction(value)) {
+        return this.each(function (j) {
+          jQuery(this).addClass(value.call(this, j, getClass(this)));
+        });
+      }
+
+      classes = classesToArray(value);
+
+      if (classes.length) {
+        while ((elem = this[i++])) {
+          curValue = getClass(elem);
+          cur = elem.nodeType === 1 && " " + stripAndCollapse(curValue) + " ";
+
+          if (cur) {
+            j = 0;
+            while ((clazz = classes[j++])) {
+              if (cur.indexOf(" " + clazz + " ") < 0) {
+                cur += clazz + " ";
+              }
+            }
+
+            // Only assign if different to avoid unneeded rendering.
+            finalValue = stripAndCollapse(cur);
+            if (curValue !== finalValue) {
+              elem.setAttribute("class", finalValue);
+            }
+          }
+        }
+      }
+
+      return this;
+    },
+
+    removeClass: function (value) {
+      var classes,
+        elem,
+        cur,
+        curValue,
+        clazz,
+        j,
+        finalValue,
+        i = 0;
+
+      if (isFunction(value)) {
+        return this.each(function (j) {
+          jQuery(this).removeClass(value.call(this, j, getClass(this)));
+        });
+      }
+
+      if (!arguments.length) {
+        return this.attr("class", "");
+      }
+
+      classes = classesToArray(value);
+
+      if (classes.length) {
+        while ((elem = this[i++])) {
+          curValue = getClass(elem);
+
+          // This expression is here for better compressibility (see addClass)
+          cur = elem.nodeType === 1 && " " + stripAndCollapse(curValue) + " ";
+
+          if (cur) {
+            j = 0;
+            while ((clazz = classes[j++])) {
+              // Remove *all* instances
+              while (cur.indexOf(" " + clazz + " ") > -1) {
+                cur = cur.replace(" " + clazz + " ", " ");
+              }
+            }
+
+            // Only assign if different to avoid unneeded rendering.
+            finalValue = stripAndCollapse(cur);
+            if (curValue !== finalValue) {
+              elem.setAttribute("class", finalValue);
+            }
+          }
+        }
+      }
+
+      return this;
+    },
+
+    toggleClass: function (value, stateVal) {
+      var type = typeof value,
+        isValidValue = type === "string" || Array.isArray(value);
+
+      if (typeof stateVal === "boolean" && isValidValue) {
+        return stateVal ? this.addClass(value) : this.removeClass(value);
+      }
+
+      if (isFunction(value)) {
+        return this.each(function (i) {
+          jQuery(this).toggleClass(
+            value.call(this, i, getClass(this), stateVal),
+            stateVal
+          );
+        });
+      }
+
+      return this.each(function () {
+        var className, i, self, classNames;
+
+        if (isValidValue) {
+          // Toggle individual class names
+          i = 0;
+          self = jQuery(this);
+          classNames = classesToArray(value);
+
+          while ((className = classNames[i++])) {
+            // Check each className given, space separated list
+            if (self.hasClass(className)) {
+              self.removeClass(className);
+            } else {
+              self.addClass(className);
+            }
+          }
+
+          // Toggle whole class name
+        } else if (value === undefined || type === "boolean") {
+          className = getClass(this);
+          if (className) {
+            // Store className if set
+            dataPriv.set(this, "__className__", className);
+          }
+
+          // If the element has a class name or if we're passed `false`,
+          // then remove the whole classname (if there was one, the above saved it).
+          // Otherwise bring back whatever was previously saved (if anything),
+          // falling back to the empty string if nothing was stored.
+          if (this.setAttribute) {
+            this.setAttribute(
+              "class",
+              className || value === false
+                ? ""
+                : dataPriv.get(this, "__className__") || ""
+            );
+          }
+        }
+      });
+    },
+
+    hasClass: function (selector) {
+      var className,
+        elem,
+        i = 0;
+
+      className = " " + selector + " ";
+      while ((elem = this[i++])) {
+        if (
+          elem.nodeType === 1 &&
+          (" " + stripAndCollapse(getClass(elem)) + " ").indexOf(className) > -1
+        ) {
+          return true;
+        }
+      }
+
+      return false;
+    },
+  });
+
+  var rreturn = /\r/g;
+
+  jQuery.fn.extend({
+    val: function (value) {
+      var hooks,
+        ret,
+        valueIsFunction,
+        elem = this[0];
+
+      if (!arguments.length) {
+        if (elem) {
+          hooks =
+            jQuery.valHooks[elem.type] ||
+            jQuery.valHooks[elem.nodeName.toLowerCase()];
+
+          if (
+            hooks &&
+            "get" in hooks &&
+            (ret = hooks.get(elem, "value")) !== undefined
+          ) {
+            return ret;
+          }
+
+          ret = elem.value;
+
+          // Handle most common string cases
+          if (typeof ret === "string") {
+            return ret.replace(rreturn, "");
+          }
+
+          // Handle cases where value is null/undef or number
+          return ret == null ? "" : ret;
+        }
+
+        return;
+      }
+
+      valueIsFunction = isFunction(value);
+
+      return this.each(function (i) {
+        var val;
+
+        if (this.nodeType !== 1) {
+          return;
+        }
+
+        if (valueIsFunction) {
+          val = value.call(this, i, jQuery(this).val());
+        } else {
+          val = value;
+        }
+
+        // Treat null/undefined as ""; convert numbers to string
+        if (val == null) {
+          val = "";
+        } else if (typeof val === "number") {
+          val += "";
+        } else if (Array.isArray(val)) {
+          val = jQuery.map(val, function (value) {
+            return value == null ? "" : value + "";
+          });
+        }
+
+        hooks =
+          jQuery.valHooks[this.type] ||
+          jQuery.valHooks[this.nodeName.toLowerCase()];
+
+        // If set returns undefined, fall back to normal setting
+        if (
+          !hooks ||
+          !("set" in hooks) ||
+          hooks.set(this, val, "value") === undefined
+        ) {
+          this.value = val;
+        }
+      });
+    },
+  });
+
+  jQuery.extend({
+    valHooks: {
+      option: {
+        get: function (elem) {
+          var val = jQuery.find.attr(elem, "value");
+          return val != null
+            ? val
+            : // Support: IE <=10 - 11 only
+              // option.text throws exceptions (#14686, #14858)
+              // Strip and collapse whitespace
+              // https://html.spec.whatwg.org/#strip-and-collapse-whitespace
+              stripAndCollapse(jQuery.text(elem));
+        },
+      },
+      select: {
+        get: function (elem) {
+          var value,
+            option,
+            i,
+            options = elem.options,
+            index = elem.selectedIndex,
+            one = elem.type === "select-one",
+            values = one ? null : [],
+            max = one ? index + 1 : options.length;
+
+          if (index < 0) {
+            i = max;
+          } else {
+            i = one ? index : 0;
+          }
+
+          // Loop through all the selected options
+          for (; i < max; i++) {
+            option = options[i];
+
+            // Support: IE <=9 only
+            // IE8-9 doesn't update selected after form reset (#2551)
+            if (
+              (option.selected || i === index) &&
+              // Don't return options that are disabled or in a disabled optgroup
+              !option.disabled &&
+              (!option.parentNode.disabled ||
+                !nodeName(option.parentNode, "optgroup"))
+            ) {
+              // Get the specific value for the option
+              value = jQuery(option).val();
+
+              // We don't need an array for one selects
+              if (one) {
+                return value;
+              }
+
+              // Multi-Selects return an array
+              values.push(value);
+            }
+          }
+
+          return values;
+        },
+
+        set: function (elem, value) {
+          var optionSet,
+            option,
+            options = elem.options,
+            values = jQuery.makeArray(value),
+            i = options.length;
+
+          while (i--) {
+            option = options[i];
+
+            /* eslint-disable no-cond-assign */
+
+            if (
+              (option.selected =
+                jQuery.inArray(jQuery.valHooks.option.get(option), values) > -1)
+            ) {
+              optionSet = true;
+            }
+
+            /* eslint-enable no-cond-assign */
+          }
+
+          // Force browsers to behave consistently when non-matching value is set
+          if (!optionSet) {
+            elem.selectedIndex = -1;
+          }
+          return values;
+        },
+      },
+    },
+  });
+
+  // Radios and checkboxes getter/setter
+  jQuery.each(["radio", "checkbox"], function () {
+    jQuery.valHooks[this] = {
+      set: function (elem, value) {
+        if (Array.isArray(value)) {
+          return (elem.checked =
+            jQuery.inArray(jQuery(elem).val(), value) > -1);
+        }
+      },
+    };
+    if (!support.checkOn) {
+      jQuery.valHooks[this].get = function (elem) {
+        return elem.getAttribute("value") === null ? "on" : elem.value;
+      };
+    }
+  });
+
+  // Return jQuery for attributes-only inclusion
+
+  support.focusin = "onfocusin" in window;
+
+  var rfocusMorph = /^(?:focusinfocus|focusoutblur)$/,
+    stopPropagationCallback = function (e) {
+      e.stopPropagation();
+    };
+
+  jQuery.extend(jQuery.event, {
+    trigger: function (event, data, elem, onlyHandlers) {
+      var i,
+        cur,
+        tmp,
+        bubbleType,
+        ontype,
+        handle,
+        special,
+        lastElement,
+        eventPath = [elem || document],
+        type = hasOwn.call(event, "type") ? event.type : event,
+        namespaces = hasOwn.call(event, "namespace")
+          ? event.namespace.split(".")
+          : [];
+
+      cur = lastElement = tmp = elem = elem || document;
+
+      // Don't do events on text and comment nodes
+      if (elem.nodeType === 3 || elem.nodeType === 8) {
+        return;
+      }
+
+      // focus/blur morphs to focusin/out; ensure we're not firing them right now
+      if (rfocusMorph.test(type + jQuery.event.triggered)) {
+        return;
+      }
+
+      if (type.indexOf(".") > -1) {
+        // Namespaced trigger; create a regexp to match event type in handle()
+        namespaces = type.split(".");
+        type = namespaces.shift();
+        namespaces.sort();
+      }
+      ontype = type.indexOf(":") < 0 && "on" + type;
+
+      // Caller can pass in a jQuery.Event object, Object, or just an event type string
+      event = event[jQuery.expando]
+        ? event
+        : new jQuery.Event(type, typeof event === "object" && event);
+
+      // Trigger bitmask: & 1 for native handlers; & 2 for jQuery (always true)
+      event.isTrigger = onlyHandlers ? 2 : 3;
+      event.namespace = namespaces.join(".");
+      event.rnamespace = event.namespace
+        ? new RegExp("(^|\\.)" + namespaces.join("\\.(?:.*\\.|)") + "(\\.|$)")
+        : null;
+
+      // Clean up the event in case it is being reused
+      event.result = undefined;
+      if (!event.target) {
+        event.target = elem;
+      }
+
+      // Clone any incoming data and prepend the event, creating the handler arg list
+      data = data == null ? [event] : jQuery.makeArray(data, [event]);
+
+      // Allow special events to draw outside the lines
+      special = jQuery.event.special[type] || {};
+      if (
+        !onlyHandlers &&
+        special.trigger &&
+        special.trigger.apply(elem, data) === false
+      ) {
+        return;
+      }
+
+      // Determine event propagation path in advance, per W3C events spec (#9951)
+      // Bubble up to document, then to window; watch for a global ownerDocument var (#9724)
+      if (!onlyHandlers && !special.noBubble && !isWindow(elem)) {
+        bubbleType = special.delegateType || type;
+        if (!rfocusMorph.test(bubbleType + type)) {
+          cur = cur.parentNode;
+        }
+        for (; cur; cur = cur.parentNode) {
+          eventPath.push(cur);
+          tmp = cur;
+        }
+
+        // Only add window if we got to document (e.g., not plain obj or detached DOM)
+        if (tmp === (elem.ownerDocument || document)) {
+          eventPath.push(tmp.defaultView || tmp.parentWindow || window);
+        }
+      }
+
+      // Fire handlers on the event path
+      i = 0;
+      while ((cur = eventPath[i++]) && !event.isPropagationStopped()) {
+        lastElement = cur;
+        event.type = i > 1 ? bubbleType : special.bindType || type;
+
+        // jQuery handler
+        handle =
+          (dataPriv.get(cur, "events") || Object.create(null))[event.type] &&
+          dataPriv.get(cur, "handle");
+        if (handle) {
+          handle.apply(cur, data);
+        }
+
+        // Native handler
+        handle = ontype && cur[ontype];
+        if (handle && handle.apply && acceptData(cur)) {
+          event.result = handle.apply(cur, data);
+          if (event.result === false) {
+            event.preventDefault();
+          }
+        }
+      }
+      event.type = type;
+
+      // If nobody prevented the default action, do it now
+      if (!onlyHandlers && !event.isDefaultPrevented()) {
+        if (
+          (!special._default ||
+            special._default.apply(eventPath.pop(), data) === false) &&
+          acceptData(elem)
+        ) {
+          // Call a native DOM method on the target with the same name as the event.
+          // Don't do default actions on window, that's where global variables be (#6170)
+          if (ontype && isFunction(elem[type]) && !isWindow(elem)) {
+            // Don't re-trigger an onFOO event when we call its FOO() method
+            tmp = elem[ontype];
+
+            if (tmp) {
+              elem[ontype] = null;
+            }
+
+            // Prevent re-triggering of the same event, since we already bubbled it above
+            jQuery.event.triggered = type;
+
+            if (event.isPropagationStopped()) {
+              lastElement.addEventListener(type, stopPropagationCallback);
+            }
+
+            elem[type]();
+
+            if (event.isPropagationStopped()) {
+              lastElement.removeEventListener(type, stopPropagationCallback);
+            }
+
+            jQuery.event.triggered = undefined;
+
+            if (tmp) {
+              elem[ontype] = tmp;
+            }
+          }
+        }
+      }
+
+      return event.result;
+    },
+
+    // Piggyback on a donor event to simulate a different one
+    // Used only for `focus(in | out)` events
+    simulate: function (type, elem, event) {
+      var e = jQuery.extend(new jQuery.Event(), event, {
+        type: type,
+        isSimulated: true,
+      });
+
+      jQuery.event.trigger(e, null, elem);
+    },
+  });
+
+  jQuery.fn.extend({
+    trigger: function (type, data) {
+      return this.each(function () {
+        jQuery.event.trigger(type, data, this);
+      });
+    },
+    triggerHandler: function (type, data) {
+      var elem = this[0];
+      if (elem) {
+        return jQuery.event.trigger(type, data, elem, true);
+      }
+    },
+  });
+
+  // Support: Firefox <=44
+  // Firefox doesn't have focus(in | out) events
+  // Related ticket - https://bugzilla.mozilla.org/show_bug.cgi?id=687787
+  //
+  // Support: Chrome <=48 - 49, Safari <=9.0 - 9.1
+  // focus(in | out) events fire after focus & blur events,
+  // which is spec violation - http://www.w3.org/TR/DOM-Level-3-Events/#events-focusevent-event-order
+  // Related ticket - https://bugs.chromium.org/p/chromium/issues/detail?id=449857
+  if (!support.focusin) {
+    jQuery.each({ focus: "focusin", blur: "focusout" }, function (orig, fix) {
+      // Attach a single capturing handler on the document while someone wants focusin/focusout
+      var handler = function (event) {
+        jQuery.event.simulate(fix, event.target, jQuery.event.fix(event));
+      };
+
+      jQuery.event.special[fix] = {
+        setup: function () {
+          // Handle: regular nodes (via `this.ownerDocument`), window
+          // (via `this.document`) & document (via `this`).
+          var doc = this.ownerDocument || this.document || this,
+            attaches = dataPriv.access(doc, fix);
+
+          if (!attaches) {
+            doc.addEventListener(orig, handler, true);
+          }
+          dataPriv.access(doc, fix, (attaches || 0) + 1);
+        },
+        teardown: function () {
+          var doc = this.ownerDocument || this.document || this,
+            attaches = dataPriv.access(doc, fix) - 1;
+
+          if (!attaches) {
+            doc.removeEventListener(orig, handler, true);
+            dataPriv.remove(doc, fix);
+          } else {
+            dataPriv.access(doc, fix, attaches);
+          }
+        },
+      };
+    });
+  }
+  var location = window.location;
+
+  var nonce = { guid: Date.now() };
+
+  var rquery = /\?/;
+
+  // Cross-browser xml parsing
+  jQuery.parseXML = function (data) {
+    var xml, parserErrorElem;
+    if (!data || typeof data !== "string") {
+      return null;
+    }
+
+    // Support: IE 9 - 11 only
+    // IE throws on parseFromString with invalid input.
+    try {
+      xml = new window.DOMParser().parseFromString(data, "text/xml");
+    } catch (e) {}
+
+    parserErrorElem = xml && xml.getElementsByTagName("parsererror")[0];
+    if (!xml || parserErrorElem) {
+      jQuery.error(
+        "Invalid XML: " +
+          (parserErrorElem
+            ? jQuery
+                .map(parserErrorElem.childNodes, function (el) {
+                  return el.textContent;
+                })
+                .join("\n")
+            : data)
+      );
+    }
+    return xml;
+  };
+
+  var rbracket = /\[\]$/,
+    rCRLF = /\r?\n/g,
+    rsubmitterTypes = /^(?:submit|button|image|reset|file)$/i,
+    rsubmittable = /^(?:input|select|textarea|keygen)/i;
+
+  function buildParams(prefix, obj, traditional, add) {
+    var name;
+
+    if (Array.isArray(obj)) {
+      // Serialize array item.
+      jQuery.each(obj, function (i, v) {
+        if (traditional || rbracket.test(prefix)) {
+          // Treat each array item as a scalar.
+          add(prefix, v);
+        } else {
+          // Item is non-scalar (array or object), encode its numeric index.
+          buildParams(
+            prefix + "[" + (typeof v === "object" && v != null ? i : "") + "]",
+            v,
+            traditional,
+            add
+          );
+        }
+      });
+    } else if (!traditional && toType(obj) === "object") {
+      // Serialize object item.
+      for (name in obj) {
+        buildParams(prefix + "[" + name + "]", obj[name], traditional, add);
+      }
+    } else {
+      // Serialize scalar item.
+      add(prefix, obj);
+    }
+  }
+
+  // Serialize an array of form elements or a set of
+  // key/values into a query string
+  jQuery.param = function (a, traditional) {
+    var prefix,
+      s = [],
+      add = function (key, valueOrFunction) {
+        // If value is a function, invoke it and use its return value
+        var value = isFunction(valueOrFunction)
+          ? valueOrFunction()
+          : valueOrFunction;
+
+        s[s.length] =
+          encodeURIComponent(key) +
+          "=" +
+          encodeURIComponent(value == null ? "" : value);
+      };
+
+    if (a == null) {
+      return "";
+    }
+
+    // If an array was passed in, assume that it is an array of form elements.
+    if (Array.isArray(a) || (a.jquery && !jQuery.isPlainObject(a))) {
+      // Serialize the form elements
+      jQuery.each(a, function () {
+        add(this.name, this.value);
+      });
+    } else {
+      // If traditional, encode the "old" way (the way 1.3.2 or older
+      // did it), otherwise encode params recursively.
+      for (prefix in a) {
+        buildParams(prefix, a[prefix], traditional, add);
+      }
+    }
+
+    // Return the resulting serialization
+    return s.join("&");
+  };
+
+  jQuery.fn.extend({
+    serialize: function () {
+      return jQuery.param(this.serializeArray());
+    },
+    serializeArray: function () {
+      return this.map(function () {
+        // Can add propHook for "elements" to filter or add form elements
+        var elements = jQuery.prop(this, "elements");
+        return elements ? jQuery.makeArray(elements) : this;
+      })
+        .filter(function () {
+          var type = this.type;
+
+          // Use .is( ":disabled" ) so that fieldset[disabled] works
+          return (
+            this.name &&
+            !jQuery(this).is(":disabled") &&
+            rsubmittable.test(this.nodeName) &&
+            !rsubmitterTypes.test(type) &&
+            (this.checked || !rcheckableType.test(type))
+          );
+        })
+        .map(function (_i, elem) {
+          var val = jQuery(this).val();
+
+          if (val == null) {
+            return null;
+          }
+
+          if (Array.isArray(val)) {
+            return jQuery.map(val, function (val) {
+              return { name: elem.name, value: val.replace(rCRLF, "\r\n") };
+            });
+          }
+
+          return { name: elem.name, value: val.replace(rCRLF, "\r\n") };
+        })
+        .get();
+    },
+  });
+
+  var r20 = /%20/g,
+    rhash = /#.*$/,
+    rantiCache = /([?&])_=[^&]*/,
+    rheaders = /^(.*?):[ \t]*([^\r\n]*)$/gm,
+    // #7653, #8125, #8152: local protocol detection
+    rlocalProtocol =
+      /^(?:about|app|app-storage|.+-extension|file|res|widget):$/,
+    rnoContent = /^(?:GET|HEAD)$/,
+    rprotocol = /^\/\//,
+    /* Prefilters
+     * 1) They are useful to introduce custom dataTypes (see ajax/jsonp.js for an example)
+     * 2) These are called:
+     *    - BEFORE asking for a transport
+     *    - AFTER param serialization (s.data is a string if s.processData is true)
+     * 3) key is the dataType
+     * 4) the catchall symbol "*" can be used
+     * 5) execution will start with transport dataType and THEN continue down to "*" if needed
+     */
+    prefilters = {},
+    /* Transports bindings
+     * 1) key is the dataType
+     * 2) the catchall symbol "*" can be used
+     * 3) selection will start with transport dataType and THEN go to "*" if needed
+     */
+    transports = {},
+    // Avoid comment-prolog char sequence (#10098); must appease lint and evade compression
+    allTypes = "*/".concat("*"),
+    // Anchor tag for parsing the document origin
+    originAnchor = document.createElement("a");
+
+  originAnchor.href = location.href;
+
+  // Base "constructor" for jQuery.ajaxPrefilter and jQuery.ajaxTransport
+  function addToPrefiltersOrTransports(structure) {
+    // dataTypeExpression is optional and defaults to "*"
+    return function (dataTypeExpression, func) {
+      if (typeof dataTypeExpression !== "string") {
+        func = dataTypeExpression;
+        dataTypeExpression = "*";
+      }
+
+      var dataType,
+        i = 0,
+        dataTypes = dataTypeExpression.toLowerCase().match(rnothtmlwhite) || [];
+
+      if (isFunction(func)) {
+        // For each dataType in the dataTypeExpression
+        while ((dataType = dataTypes[i++])) {
+          // Prepend if requested
+          if (dataType[0] === "+") {
+            dataType = dataType.slice(1) || "*";
+            (structure[dataType] = structure[dataType] || []).unshift(func);
+
+            // Otherwise append
+          } else {
+            (structure[dataType] = structure[dataType] || []).push(func);
+          }
+        }
+      }
+    };
+  }
+
+  // Base inspection function for prefilters and transports
+  function inspectPrefiltersOrTransports(
+    structure,
+    options,
+    originalOptions,
+    jqXHR
+  ) {
+    var inspected = {},
+      seekingTransport = structure === transports;
+
+    function inspect(dataType) {
+      var selected;
+      inspected[dataType] = true;
+      jQuery.each(structure[dataType] || [], function (_, prefilterOrFactory) {
+        var dataTypeOrTransport = prefilterOrFactory(
+          options,
+          originalOptions,
+          jqXHR
+        );
+        if (
+          typeof dataTypeOrTransport === "string" &&
+          !seekingTransport &&
+          !inspected[dataTypeOrTransport]
+        ) {
+          options.dataTypes.unshift(dataTypeOrTransport);
+          inspect(dataTypeOrTransport);
+          return false;
+        } else if (seekingTransport) {
+          return !(selected = dataTypeOrTransport);
+        }
+      });
+      return selected;
+    }
+
+    return inspect(options.dataTypes[0]) || (!inspected["*"] && inspect("*"));
+  }
+
+  // A special extend for ajax options
+  // that takes "flat" options (not to be deep extended)
+  // Fixes #9887
+  function ajaxExtend(target, src) {
+    var key,
+      deep,
+      flatOptions = jQuery.ajaxSettings.flatOptions || {};
+
+    for (key in src) {
+      if (src[key] !== undefined) {
+        (flatOptions[key] ? target : deep || (deep = {}))[key] = src[key];
+      }
+    }
+    if (deep) {
+      jQuery.extend(true, target, deep);
+    }
+
+    return target;
+  }
+
+  /* Handles responses to an ajax request:
+   * - finds the right dataType (mediates between content-type and expected dataType)
+   * - returns the corresponding response
+   */
+  function ajaxHandleResponses(s, jqXHR, responses) {
+    var ct,
+      type,
+      finalDataType,
+      firstDataType,
+      contents = s.contents,
+      dataTypes = s.dataTypes;
+
+    // Remove auto dataType and get content-type in the process
+    while (dataTypes[0] === "*") {
+      dataTypes.shift();
+      if (ct === undefined) {
+        ct = s.mimeType || jqXHR.getResponseHeader("Content-Type");
+      }
+    }
+
+    // Check if we're dealing with a known content-type
+    if (ct) {
+      for (type in contents) {
+        if (contents[type] && contents[type].test(ct)) {
+          dataTypes.unshift(type);
+          break;
+        }
+      }
+    }
+
+    // Check to see if we have a response for the expected dataType
+    if (dataTypes[0] in responses) {
+      finalDataType = dataTypes[0];
+    } else {
+      // Try convertible dataTypes
+      for (type in responses) {
+        if (!dataTypes[0] || s.converters[type + " " + dataTypes[0]]) {
+          finalDataType = type;
+          break;
+        }
+        if (!firstDataType) {
+          firstDataType = type;
+        }
+      }
+
+      // Or just use first one
+      finalDataType = finalDataType || firstDataType;
+    }
+
+    // If we found a dataType
+    // We add the dataType to the list if needed
+    // and return the corresponding response
+    if (finalDataType) {
+      if (finalDataType !== dataTypes[0]) {
+        dataTypes.unshift(finalDataType);
+      }
+      return responses[finalDataType];
+    }
+  }
+
+  /* Chain conversions given the request and the original response
+   * Also sets the responseXXX fields on the jqXHR instance
+   */
+  function ajaxConvert(s, response, jqXHR, isSuccess) {
+    var conv2,
+      current,
+      conv,
+      tmp,
+      prev,
+      converters = {},
+      // Work with a copy of dataTypes in case we need to modify it for conversion
+      dataTypes = s.dataTypes.slice();
+
+    // Create converters map with lowercased keys
+    if (dataTypes[1]) {
+      for (conv in s.converters) {
+        converters[conv.toLowerCase()] = s.converters[conv];
+      }
+    }
+
+    current = dataTypes.shift();
+
+    // Convert to each sequential dataType
+    while (current) {
+      if (s.responseFields[current]) {
+        jqXHR[s.responseFields[current]] = response;
+      }
+
+      // Apply the dataFilter if provided
+      if (!prev && isSuccess && s.dataFilter) {
+        response = s.dataFilter(response, s.dataType);
+      }
+
+      prev = current;
+      current = dataTypes.shift();
+
+      if (current) {
+        // There's only work to do if current dataType is non-auto
+        if (current === "*") {
+          current = prev;
+
+          // Convert response if prev dataType is non-auto and differs from current
+        } else if (prev !== "*" && prev !== current) {
+          // Seek a direct converter
+          conv = converters[prev + " " + current] || converters["* " + current];
+
+          // If none found, seek a pair
+          if (!conv) {
+            for (conv2 in converters) {
+              // If conv2 outputs current
+              tmp = conv2.split(" ");
+              if (tmp[1] === current) {
+                // If prev can be converted to accepted input
+                conv =
+                  converters[prev + " " + tmp[0]] || converters["* " + tmp[0]];
+                if (conv) {
+                  // Condense equivalence converters
+                  if (conv === true) {
+                    conv = converters[conv2];
+
+                    // Otherwise, insert the intermediate dataType
+                  } else if (converters[conv2] !== true) {
+                    current = tmp[0];
+                    dataTypes.unshift(tmp[1]);
+                  }
+                  break;
+                }
+              }
+            }
+          }
+
+          // Apply converter (if not an equivalence)
+          if (conv !== true) {
+            // Unless errors are allowed to bubble, catch and return them
+            if (conv && s.throws) {
+              response = conv(response);
+            } else {
+              try {
+                response = conv(response);
+              } catch (e) {
+                return {
+                  state: "parsererror",
+                  error: conv
+                    ? e
+                    : "No conversion from " + prev + " to " + current,
+                };
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return { state: "success", data: response };
+  }
+
+  jQuery.extend({
+    // Counter for holding the number of active queries
+    active: 0,
+
+    // Last-Modified header cache for next request
+    lastModified: {},
+    etag: {},
+
+    ajaxSettings: {
+      url: location.href,
+      type: "GET",
+      isLocal: rlocalProtocol.test(location.protocol),
+      global: true,
+      processData: true,
+      async: true,
+      contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+
+      /*
+		timeout: 0,
+		data: null,
+		dataType: null,
+		username: null,
+		password: null,
+		cache: null,
+		throws: false,
+		traditional: false,
+		headers: {},
+		*/
+
+      accepts: {
+        "*": allTypes,
+        text: "text/plain",
+        html: "text/html",
+        xml: "application/xml, text/xml",
+        json: "application/json, text/javascript",
+      },
+
+      contents: {
+        xml: /\bxml\b/,
+        html: /\bhtml/,
+        json: /\bjson\b/,
+      },
+
+      responseFields: {
+        xml: "responseXML",
+        text: "responseText",
+        json: "responseJSON",
+      },
+
+      // Data converters
+      // Keys separate source (or catchall "*") and destination types with a single space
+      converters: {
+        // Convert anything to text
+        "* text": String,
+
+        // Text to html (true = no transformation)
+        "text html": true,
+
+        // Evaluate text as a json expression
+        "text json": JSON.parse,
+
+        // Parse text as xml
+        "text xml": jQuery.parseXML,
+      },
+
+      // For options that shouldn't be deep extended:
+      // you can add your own custom options here if
+      // and when you create one that shouldn't be
+      // deep extended (see ajaxExtend)
+      flatOptions: {
+        url: true,
+        context: true,
+      },
+    },
+
+    // Creates a full fledged settings object into target
+    // with both ajaxSettings and settings fields.
+    // If target is omitted, writes into ajaxSettings.
+    ajaxSetup: function (target, settings) {
+      return settings
+        ? // Building a settings object
+          ajaxExtend(ajaxExtend(target, jQuery.ajaxSettings), settings)
+        : // Extending ajaxSettings
+          ajaxExtend(jQuery.ajaxSettings, target);
+    },
+
+    ajaxPrefilter: addToPrefiltersOrTransports(prefilters),
+    ajaxTransport: addToPrefiltersOrTransports(transports),
+
+    // Main method
+    ajax: function (url, options) {
+      // If url is an object, simulate pre-1.5 signature
+      if (typeof url === "object") {
+        options = url;
+        url = undefined;
+      }
+
+      // Force options to be an object
+      options = options || {};
+
+      var transport,
+        // URL without anti-cache param
+        cacheURL,
+        // Response headers
+        responseHeadersString,
+        responseHeaders,
+        // timeout handle
+        timeoutTimer,
+        // Url cleanup var
+        urlAnchor,
+        // Request state (becomes false upon send and true upon completion)
+        completed,
+        // To know if global events are to be dispatched
+        fireGlobals,
+        // Loop variable
+        i,
+        // uncached part of the url
+        uncached,
+        // Create the final options object
+        s = jQuery.ajaxSetup({}, options),
+        // Callbacks context
+        callbackContext = s.context || s,
+        // Context for global events is callbackContext if it is a DOM node or jQuery collection
+        globalEventContext =
+          s.context && (callbackContext.nodeType || callbackContext.jquery)
+            ? jQuery(callbackContext)
+            : jQuery.event,
+        // Deferreds
+        deferred = jQuery.Deferred(),
+        completeDeferred = jQuery.Callbacks("once memory"),
+        // Status-dependent callbacks
+        statusCode = s.statusCode || {},
+        // Headers (they are sent all at once)
+        requestHeaders = {},
+        requestHeadersNames = {},
+        // Default abort message
+        strAbort = "canceled",
+        // Fake xhr
+        jqXHR = {
+          readyState: 0,
+
+          // Builds headers hashtable if needed
+          getResponseHeader: function (key) {
+            var match;
+            if (completed) {
+              if (!responseHeaders) {
+                responseHeaders = {};
+                while ((match = rheaders.exec(responseHeadersString))) {
+                  responseHeaders[match[1].toLowerCase() + " "] = (
+                    responseHeaders[match[1].toLowerCase() + " "] || []
+                  ).concat(match[2]);
+                }
+              }
+              match = responseHeaders[key.toLowerCase() + " "];
+            }
+            return match == null ? null : match.join(", ");
+          },
+
+          // Raw string
+          getAllResponseHeaders: function () {
+            return completed ? responseHeadersString : null;
+          },
+
+          // Caches the header
+          setRequestHeader: function (name, value) {
+            if (completed == null) {
+              name = requestHeadersNames[name.toLowerCase()] =
+                requestHeadersNames[name.toLowerCase()] || name;
+              requestHeaders[name] = value;
+            }
+            return this;
+          },
+
+          // Overrides response content-type header
+          overrideMimeType: function (type) {
+            if (completed == null) {
+              s.mimeType = type;
+            }
+            return this;
+          },
+
+          // Status-dependent callbacks
+          statusCode: function (map) {
+            var code;
+            if (map) {
+              if (completed) {
+                // Execute the appropriate callbacks
+                jqXHR.always(map[jqXHR.status]);
+              } else {
+                // Lazy-add the new callbacks in a way that preserves old ones
+                for (code in map) {
+                  statusCode[code] = [statusCode[code], map[code]];
+                }
+              }
+            }
+            return this;
+          },
+
+          // Cancel the request
+          abort: function (statusText) {
+            var finalText = statusText || strAbort;
+            if (transport) {
+              transport.abort(finalText);
+            }
+            done(0, finalText);
+            return this;
+          },
+        };
+
+      // Attach deferreds
+      deferred.promise(jqXHR);
+
+      // Add protocol if not provided (prefilters might expect it)
+      // Handle falsy url in the settings object (#10093: consistency with old signature)
+      // We also use the url parameter if available
+      s.url = ((url || s.url || location.href) + "").replace(
+        rprotocol,
+        location.protocol + "//"
+      );
+
+      // Alias method option to type as per ticket #12004
+      s.type = options.method || options.type || s.method || s.type;
+
+      // Extract dataTypes list
+      s.dataTypes = (s.dataType || "*").toLowerCase().match(rnothtmlwhite) || [
+        "",
+      ];
+
+      // A cross-domain request is in order when the origin doesn't match the current origin.
+      if (s.crossDomain == null) {
+        urlAnchor = document.createElement("a");
+
+        // Support: IE <=8 - 11, Edge 12 - 15
+        // IE throws exception on accessing the href property if url is malformed,
+        // e.g. http://example.com:80x/
+        try {
+          urlAnchor.href = s.url;
+
+          // Support: IE <=8 - 11 only
+          // Anchor's host property isn't correctly set when s.url is relative
+          urlAnchor.href = urlAnchor.href;
+          s.crossDomain =
+            originAnchor.protocol + "//" + originAnchor.host !==
+            urlAnchor.protocol + "//" + urlAnchor.host;
+        } catch (e) {
+          // If there is an error parsing the URL, assume it is crossDomain,
+          // it can be rejected by the transport if it is invalid
+          s.crossDomain = true;
+        }
+      }
+
+      // Convert data if not already a string
+      if (s.data && s.processData && typeof s.data !== "string") {
+        s.data = jQuery.param(s.data, s.traditional);
+      }
+
+      // Apply prefilters
+      inspectPrefiltersOrTransports(prefilters, s, options, jqXHR);
+
+      // If request was aborted inside a prefilter, stop there
+      if (completed) {
+        return jqXHR;
+      }
+
+      // We can fire global events as of now if asked to
+      // Don't fire events if jQuery.event is undefined in an AMD-usage scenario (#15118)
+      fireGlobals = jQuery.event && s.global;
+
+      // Watch for a new set of requests
+      if (fireGlobals && jQuery.active++ === 0) {
+        jQuery.event.trigger("ajaxStart");
+      }
+
+      // Uppercase the type
+      s.type = s.type.toUpperCase();
+
+      // Determine if request has content
+      s.hasContent = !rnoContent.test(s.type);
+
+      // Save the URL in case we're toying with the If-Modified-Since
+      // and/or If-None-Match header later on
+      // Remove hash to simplify url manipulation
+      cacheURL = s.url.replace(rhash, "");
+
+      // More options handling for requests with no content
+      if (!s.hasContent) {
+        // Remember the hash so we can put it back
+        uncached = s.url.slice(cacheURL.length);
+
+        // If data is available and should be processed, append data to url
+        if (s.data && (s.processData || typeof s.data === "string")) {
+          cacheURL += (rquery.test(cacheURL) ? "&" : "?") + s.data;
+
+          // #9682: remove data so that it's not used in an eventual retry
+          delete s.data;
+        }
+
+        // Add or update anti-cache param if needed
+        if (s.cache === false) {
+          cacheURL = cacheURL.replace(rantiCache, "$1");
+          uncached =
+            (rquery.test(cacheURL) ? "&" : "?") +
+            "_=" +
+            nonce.guid++ +
+            uncached;
+        }
+
+        // Put hash and anti-cache on the URL that will be requested (gh-1732)
+        s.url = cacheURL + uncached;
+
+        // Change '%20' to '+' if this is encoded form body content (gh-2658)
+      } else if (
+        s.data &&
+        s.processData &&
+        (s.contentType || "").indexOf("application/x-www-form-urlencoded") === 0
+      ) {
+        s.data = s.data.replace(r20, "+");
+      }
+
+      // Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.
+      if (s.ifModified) {
+        if (jQuery.lastModified[cacheURL]) {
+          jqXHR.setRequestHeader(
+            "If-Modified-Since",
+            jQuery.lastModified[cacheURL]
+          );
+        }
+        if (jQuery.etag[cacheURL]) {
+          jqXHR.setRequestHeader("If-None-Match", jQuery.etag[cacheURL]);
+        }
+      }
+
+      // Set the correct header, if data is being sent
+      if (
+        (s.data && s.hasContent && s.contentType !== false) ||
+        options.contentType
+      ) {
+        jqXHR.setRequestHeader("Content-Type", s.contentType);
+      }
+
+      // Set the Accepts header for the server, depending on the dataType
+      jqXHR.setRequestHeader(
+        "Accept",
+        s.dataTypes[0] && s.accepts[s.dataTypes[0]]
+          ? s.accepts[s.dataTypes[0]] +
+              (s.dataTypes[0] !== "*" ? ", " + allTypes + "; q=0.01" : "")
+          : s.accepts["*"]
+      );
+
+      // Check for headers option
+      for (i in s.headers) {
+        jqXHR.setRequestHeader(i, s.headers[i]);
+      }
+
+      // Allow custom headers/mimetypes and early abort
+      if (
+        s.beforeSend &&
+        (s.beforeSend.call(callbackContext, jqXHR, s) === false || completed)
+      ) {
+        // Abort if not done already and return
+        return jqXHR.abort();
+      }
+
+      // Aborting is no longer a cancellation
+      strAbort = "abort";
+
+      // Install callbacks on deferreds
+      completeDeferred.add(s.complete);
+      jqXHR.done(s.success);
+      jqXHR.fail(s.error);
+
+      // Get transport
+      transport = inspectPrefiltersOrTransports(transports, s, options, jqXHR);
+
+      // If no transport, we auto-abort
+      if (!transport) {
+        done(-1, "No Transport");
+      } else {
+        jqXHR.readyState = 1;
+
+        // Send global event
+        if (fireGlobals) {
+          globalEventContext.trigger("ajaxSend", [jqXHR, s]);
+        }
+
+        // If request was aborted inside ajaxSend, stop there
+        if (completed) {
+          return jqXHR;
+        }
+
+        // Timeout
+        if (s.async && s.timeout > 0) {
+          timeoutTimer = window.setTimeout(function () {
+            jqXHR.abort("timeout");
+          }, s.timeout);
+        }
+
+        try {
+          completed = false;
+          transport.send(requestHeaders, done);
+        } catch (e) {
+          // Rethrow post-completion exceptions
+          if (completed) {
+            throw e;
+          }
+
+          // Propagate others as results
+          done(-1, e);
+        }
+      }
+
+      // Callback for when everything is done
+      function done(status, nativeStatusText, responses, headers) {
+        var isSuccess,
+          success,
+          error,
+          response,
+          modified,
+          statusText = nativeStatusText;
+
+        // Ignore repeat invocations
+        if (completed) {
+          return;
+        }
+
+        completed = true;
+
+        // Clear timeout if it exists
+        if (timeoutTimer) {
+          window.clearTimeout(timeoutTimer);
+        }
+
+        // Dereference transport for early garbage collection
+        // (no matter how long the jqXHR object will be used)
+        transport = undefined;
+
+        // Cache response headers
+        responseHeadersString = headers || "";
+
+        // Set readyState
+        jqXHR.readyState = status > 0 ? 4 : 0;
+
+        // Determine if successful
+        isSuccess = (status >= 200 && status < 300) || status === 304;
+
+        // Get response data
+        if (responses) {
+          response = ajaxHandleResponses(s, jqXHR, responses);
+        }
+
+        // Use a noop converter for missing script but not if jsonp
+        if (
+          !isSuccess &&
+          jQuery.inArray("script", s.dataTypes) > -1 &&
+          jQuery.inArray("json", s.dataTypes) < 0
+        ) {
+          s.converters["text script"] = function () {};
+        }
+
+        // Convert no matter what (that way responseXXX fields are always set)
+        response = ajaxConvert(s, response, jqXHR, isSuccess);
+
+        // If successful, handle type chaining
+        if (isSuccess) {
+          // Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.
+          if (s.ifModified) {
+            modified = jqXHR.getResponseHeader("Last-Modified");
+            if (modified) {
+              jQuery.lastModified[cacheURL] = modified;
+            }
+            modified = jqXHR.getResponseHeader("etag");
+            if (modified) {
+              jQuery.etag[cacheURL] = modified;
+            }
+          }
+
+          // if no content
+          if (status === 204 || s.type === "HEAD") {
+            statusText = "nocontent";
+
+            // if not modified
+          } else if (status === 304) {
+            statusText = "notmodified";
+
+            // If we have data, let's convert it
+          } else {
+            statusText = response.state;
+            success = response.data;
+            error = response.error;
+            isSuccess = !error;
+          }
+        } else {
+          // Extract error from statusText and normalize for non-aborts
+          error = statusText;
+          if (status || !statusText) {
+            statusText = "error";
+            if (status < 0) {
+              status = 0;
+            }
+          }
+        }
+
+        // Set data for the fake xhr object
+        jqXHR.status = status;
+        jqXHR.statusText = (nativeStatusText || statusText) + "";
+
+        // Success/Error
+        if (isSuccess) {
+          deferred.resolveWith(callbackContext, [success, statusText, jqXHR]);
+        } else {
+          deferred.rejectWith(callbackContext, [jqXHR, statusText, error]);
+        }
+
+        // Status-dependent callbacks
+        jqXHR.statusCode(statusCode);
+        statusCode = undefined;
+
+        if (fireGlobals) {
+          globalEventContext.trigger(isSuccess ? "ajaxSuccess" : "ajaxError", [
+            jqXHR,
+            s,
+            isSuccess ? success : error,
+          ]);
+        }
+
+        // Complete
+        completeDeferred.fireWith(callbackContext, [jqXHR, statusText]);
+
+        if (fireGlobals) {
+          globalEventContext.trigger("ajaxComplete", [jqXHR, s]);
+
+          // Handle the global AJAX counter
+          if (!--jQuery.active) {
+            jQuery.event.trigger("ajaxStop");
+          }
+        }
+      }
+
+      return jqXHR;
+    },
+
+    getJSON: function (url, data, callback) {
+      return jQuery.get(url, data, callback, "json");
+    },
+
+    getScript: function (url, callback) {
+      return jQuery.get(url, undefined, callback, "script");
+    },
+  });
+
+  jQuery.each(["get", "post"], function (_i, method) {
+    jQuery[method] = function (url, data, callback, type) {
+      // Shift arguments if data argument was omitted
+      if (isFunction(data)) {
+        type = type || callback;
+        callback = data;
+        data = undefined;
+      }
+
+      // The url can be an options object (which then must have .url)
+      return jQuery.ajax(
+        jQuery.extend(
+          {
+            url: url,
+            type: method,
+            dataType: type,
+            data: data,
+            success: callback,
+          },
+          jQuery.isPlainObject(url) && url
+        )
+      );
+    };
+  });
+
+  jQuery.ajaxPrefilter(function (s) {
+    var i;
+    for (i in s.headers) {
+      if (i.toLowerCase() === "content-type") {
+        s.contentType = s.headers[i] || "";
+      }
+    }
+  });
+
+  jQuery._evalUrl = function (url, options, doc) {
+    return jQuery.ajax({
+      url: url,
+
+      // Make this explicit, since user can override this through ajaxSetup (#11264)
+      type: "GET",
+      dataType: "script",
+      cache: true,
+      async: false,
+      global: false,
+
+      // Only evaluate the response if it is successful (gh-4126)
+      // dataFilter is not invoked for failure responses, so using it instead
+      // of the default converter is kludgy but it works.
+      converters: {
+        "text script": function () {},
+      },
+      dataFilter: function (response) {
+        jQuery.globalEval(response, options, doc);
+      },
+    });
+  };
+
+  jQuery.fn.extend({
+    wrapAll: function (html) {
+      var wrap;
+
+      if (this[0]) {
+        if (isFunction(html)) {
+          html = html.call(this[0]);
+        }
+
+        // The elements to wrap the target around
+        wrap = jQuery(html, this[0].ownerDocument).eq(0).clone(true);
+
+        if (this[0].parentNode) {
+          wrap.insertBefore(this[0]);
+        }
+
+        wrap
+          .map(function () {
+            var elem = this;
+
+            while (elem.firstElementChild) {
+              elem = elem.firstElementChild;
+            }
+
+            return elem;
+          })
+          .append(this);
+      }
+
+      return this;
+    },
+
+    wrapInner: function (html) {
+      if (isFunction(html)) {
+        return this.each(function (i) {
+          jQuery(this).wrapInner(html.call(this, i));
+        });
+      }
+
+      return this.each(function () {
+        var self = jQuery(this),
+          contents = self.contents();
+
+        if (contents.length) {
+          contents.wrapAll(html);
+        } else {
+          self.append(html);
+        }
+      });
+    },
+
+    wrap: function (html) {
+      var htmlIsFunction = isFunction(html);
+
+      return this.each(function (i) {
+        jQuery(this).wrapAll(htmlIsFunction ? html.call(this, i) : html);
+      });
+    },
+
+    unwrap: function (selector) {
+      this.parent(selector)
+        .not("body")
+        .each(function () {
+          jQuery(this).replaceWith(this.childNodes);
+        });
+      return this;
+    },
+  });
+
+  jQuery.expr.pseudos.hidden = function (elem) {
+    return !jQuery.expr.pseudos.visible(elem);
+  };
+  jQuery.expr.pseudos.visible = function (elem) {
+    return !!(
+      elem.offsetWidth ||
+      elem.offsetHeight ||
+      elem.getClientRects().length
+    );
+  };
+
+  jQuery.ajaxSettings.xhr = function () {
+    try {
+      return new window.XMLHttpRequest();
+    } catch (e) {}
+  };
+
+  var xhrSuccessStatus = {
+      // File protocol always yields status code 0, assume 200
+      0: 200,
+
+      // Support: IE <=9 only
+      // #1450: sometimes IE returns 1223 when it should be 204
+      1223: 204,
+    },
+    xhrSupported = jQuery.ajaxSettings.xhr();
+
+  support.cors = !!xhrSupported && "withCredentials" in xhrSupported;
+  support.ajax = xhrSupported = !!xhrSupported;
+
+  jQuery.ajaxTransport(function (options) {
+    var callback, errorCallback;
+
+    // Cross domain only allowed if supported through XMLHttpRequest
+    if (support.cors || (xhrSupported && !options.crossDomain)) {
+      return {
+        send: function (headers, complete) {
+          var i,
+            xhr = options.xhr();
+
+          xhr.open(
+            options.type,
+            options.url,
+            options.async,
+            options.username,
+            options.password
+          );
+
+          // Apply custom fields if provided
+          if (options.xhrFields) {
+            for (i in options.xhrFields) {
+              xhr[i] = options.xhrFields[i];
+            }
+          }
+
+          // Override mime type if needed
+          if (options.mimeType && xhr.overrideMimeType) {
+            xhr.overrideMimeType(options.mimeType);
+          }
+
+          // X-Requested-With header
+          // For cross-domain requests, seeing as conditions for a preflight are
+          // akin to a jigsaw puzzle, we simply never set it to be sure.
+          // (it can always be set on a per-request basis or even using ajaxSetup)
+          // For same-domain requests, won't change header if already provided.
+          if (!options.crossDomain && !headers["X-Requested-With"]) {
+            headers["X-Requested-With"] = "XMLHttpRequest";
+          }
+
+          // Set headers
+          for (i in headers) {
+            xhr.setRequestHeader(i, headers[i]);
+          }
+
+          // Callback
+          callback = function (type) {
+            return function () {
+              if (callback) {
+                callback =
+                  errorCallback =
+                  xhr.onload =
+                  xhr.onerror =
+                  xhr.onabort =
+                  xhr.ontimeout =
+                  xhr.onreadystatechange =
+                    null;
+
+                if (type === "abort") {
+                  xhr.abort();
+                } else if (type === "error") {
+                  // Support: IE <=9 only
+                  // On a manual native abort, IE9 throws
+                  // errors on any property access that is not readyState
+                  if (typeof xhr.status !== "number") {
+                    complete(0, "error");
+                  } else {
+                    complete(
+                      // File: protocol always yields status 0; see #8605, #14207
+                      xhr.status,
+                      xhr.statusText
+                    );
+                  }
+                } else {
+                  complete(
+                    xhrSuccessStatus[xhr.status] || xhr.status,
+                    xhr.statusText,
+
+                    // Support: IE <=9 only
+                    // IE9 has no XHR2 but throws on binary (trac-11426)
+                    // For XHR2 non-text, let the caller handle it (gh-2498)
+                    (xhr.responseType || "text") !== "text" ||
+                      typeof xhr.responseText !== "string"
+                      ? { binary: xhr.response }
+                      : { text: xhr.responseText },
+                    xhr.getAllResponseHeaders()
+                  );
+                }
+              }
+            };
+          };
+
+          // Listen to events
+          xhr.onload = callback();
+          errorCallback = xhr.onerror = xhr.ontimeout = callback("error");
+
+          // Support: IE 9 only
+          // Use onreadystatechange to replace onabort
+          // to handle uncaught aborts
+          if (xhr.onabort !== undefined) {
+            xhr.onabort = errorCallback;
+          } else {
+            xhr.onreadystatechange = function () {
+              // Check readyState before timeout as it changes
+              if (xhr.readyState === 4) {
+                // Allow onerror to be called first,
+                // but that will not handle a native abort
+                // Also, save errorCallback to a variable
+                // as xhr.onerror cannot be accessed
+                window.setTimeout(function () {
+                  if (callback) {
+                    errorCallback();
+                  }
+                });
+              }
+            };
+          }
+
+          // Create the abort callback
+          callback = callback("abort");
+
+          try {
+            // Do send the request (this may raise an exception)
+            xhr.send((options.hasContent && options.data) || null);
+          } catch (e) {
+            // #14683: Only rethrow if this hasn't been notified as an error yet
+            if (callback) {
+              throw e;
+            }
+          }
+        },
+
+        abort: function () {
+          if (callback) {
+            callback();
+          }
+        },
+      };
+    }
+  });
+
+  // Prevent auto-execution of scripts when no explicit dataType was provided (See gh-2432)
+  jQuery.ajaxPrefilter(function (s) {
+    if (s.crossDomain) {
+      s.contents.script = false;
+    }
+  });
+
+  // Install script dataType
+  jQuery.ajaxSetup({
+    accepts: {
+      script:
+        "text/javascript, application/javascript, " +
+        "application/ecmascript, application/x-ecmascript",
+    },
+    contents: {
+      script: /\b(?:java|ecma)script\b/,
+    },
+    converters: {
+      "text script": function (text) {
+        jQuery.globalEval(text);
+        return text;
+      },
+    },
+  });
+
+  // Handle cache's special case and crossDomain
+  jQuery.ajaxPrefilter("script", function (s) {
+    if (s.cache === undefined) {
+      s.cache = false;
+    }
+    if (s.crossDomain) {
+      s.type = "GET";
+    }
+  });
+
+  // Bind script tag hack transport
+  jQuery.ajaxTransport("script", function (s) {
+    // This transport only deals with cross domain or forced-by-attrs requests
+    if (s.crossDomain || s.scriptAttrs) {
+      var script, callback;
+      return {
+        send: function (_, complete) {
+          script = jQuery("<script>")
+            .attr(s.scriptAttrs || {})
+            .prop({ charset: s.scriptCharset, src: s.url })
+            .on(
+              "load error",
+              (callback = function (evt) {
+                script.remove();
+                callback = null;
+                if (evt) {
+                  complete(evt.type === "error" ? 404 : 200, evt.type);
+                }
+              })
+            );
+
+          // Use native DOM manipulation to avoid our domManip AJAX trickery
+          document.head.appendChild(script[0]);
+        },
+        abort: function () {
+          if (callback) {
+            callback();
+          }
+        },
+      };
+    }
+  });
+
+  var oldCallbacks = [],
+    rjsonp = /(=)\?(?=&|$)|\?\?/;
+
+  // Default jsonp settings
+  jQuery.ajaxSetup({
+    jsonp: "callback",
+    jsonpCallback: function () {
+      var callback = oldCallbacks.pop() || jQuery.expando + "_" + nonce.guid++;
+      this[callback] = true;
+      return callback;
+    },
+  });
+
+  // Detect, normalize options and install callbacks for jsonp requests
+  jQuery.ajaxPrefilter("json jsonp", function (s, originalSettings, jqXHR) {
+    var callbackName,
+      overwritten,
+      responseContainer,
+      jsonProp =
+        s.jsonp !== false &&
+        (rjsonp.test(s.url)
+          ? "url"
+          : typeof s.data === "string" &&
+            (s.contentType || "").indexOf(
+              "application/x-www-form-urlencoded"
+            ) === 0 &&
+            rjsonp.test(s.data) &&
+            "data");
+
+    // Handle iff the expected data type is "jsonp" or we have a parameter to set
+    if (jsonProp || s.dataTypes[0] === "jsonp") {
+      // Get callback name, remembering preexisting value associated with it
+      callbackName = s.jsonpCallback = isFunction(s.jsonpCallback)
+        ? s.jsonpCallback()
+        : s.jsonpCallback;
+
+      // Insert callback into url or form data
+      if (jsonProp) {
+        s[jsonProp] = s[jsonProp].replace(rjsonp, "$1" + callbackName);
+      } else if (s.jsonp !== false) {
+        s.url +=
+          (rquery.test(s.url) ? "&" : "?") + s.jsonp + "=" + callbackName;
+      }
+
+      // Use data converter to retrieve json after script execution
+      s.converters["script json"] = function () {
+        if (!responseContainer) {
+          jQuery.error(callbackName + " was not called");
+        }
+        return responseContainer[0];
+      };
+
+      // Force json dataType
+      s.dataTypes[0] = "json";
+
+      // Install callback
+      overwritten = window[callbackName];
+      window[callbackName] = function () {
+        responseContainer = arguments;
+      };
+
+      // Clean-up function (fires after converters)
+      jqXHR.always(function () {
+        // If previous value didn't exist - remove it
+        if (overwritten === undefined) {
+          jQuery(window).removeProp(callbackName);
+
+          // Otherwise restore preexisting value
+        } else {
+          window[callbackName] = overwritten;
+        }
+
+        // Save back as free
+        if (s[callbackName]) {
+          // Make sure that re-using the options doesn't screw things around
+          s.jsonpCallback = originalSettings.jsonpCallback;
+
+          // Save the callback name for future use
+          oldCallbacks.push(callbackName);
+        }
+
+        // Call if it was a function and we have a response
+        if (responseContainer && isFunction(overwritten)) {
+          overwritten(responseContainer[0]);
+        }
+
+        responseContainer = overwritten = undefined;
+      });
+
+      // Delegate to script
+      return "script";
+    }
+  });
+
+  // Support: Safari 8 only
+  // In Safari 8 documents created via document.implementation.createHTMLDocument
+  // collapse sibling forms: the second one becomes a child of the first one.
+  // Because of that, this security measure has to be disabled in Safari 8.
+  // https://bugs.webkit.org/show_bug.cgi?id=137337
+  support.createHTMLDocument = (function () {
+    var body = document.implementation.createHTMLDocument("").body;
+    body.innerHTML = "<form></form><form></form>";
+    return body.childNodes.length === 2;
+  })();
+
+  // Argument "data" should be string of html
+  // context (optional): If specified, the fragment will be created in this context,
+  // defaults to document
+  // keepScripts (optional): If true, will include scripts passed in the html string
+  jQuery.parseHTML = function (data, context, keepScripts) {
+    if (typeof data !== "string") {
+      return [];
+    }
+    if (typeof context === "boolean") {
+      keepScripts = context;
+      context = false;
+    }
+
+    var base, parsed, scripts;
+
+    if (!context) {
+      // Stop scripts or inline event handlers from being executed immediately
+      // by using document.implementation
+      if (support.createHTMLDocument) {
+        context = document.implementation.createHTMLDocument("");
+
+        // Set the base href for the created document
+        // so any parsed elements with URLs
+        // are based on the document's URL (gh-2965)
+        base = context.createElement("base");
+        base.href = document.location.href;
+        context.head.appendChild(base);
+      } else {
+        context = document;
+      }
+    }
+
+    parsed = rsingleTag.exec(data);
+    scripts = !keepScripts && [];
+
+    // Single tag
+    if (parsed) {
+      return [context.createElement(parsed[1])];
+    }
+
+    parsed = buildFragment([data], context, scripts);
+
+    if (scripts && scripts.length) {
+      jQuery(scripts).remove();
+    }
+
+    return jQuery.merge([], parsed.childNodes);
+  };
+
+  /**
+   * Load a url into a page
+   */
+  jQuery.fn.load = function (url, params, callback) {
+    var selector,
+      type,
+      response,
+      self = this,
+      off = url.indexOf(" ");
+
+    if (off > -1) {
+      selector = stripAndCollapse(url.slice(off));
+      url = url.slice(0, off);
+    }
+
+    // If it's a function
+    if (isFunction(params)) {
+      // We assume that it's the callback
+      callback = params;
+      params = undefined;
+
+      // Otherwise, build a param string
+    } else if (params && typeof params === "object") {
+      type = "POST";
+    }
+
+    // If we have elements to modify, make the request
+    if (self.length > 0) {
+      jQuery
+        .ajax({
+          url: url,
+
+          // If "type" variable is undefined, then "GET" method will be used.
+          // Make value of this field explicit since
+          // user can override it through ajaxSetup method
+          type: type || "GET",
+          dataType: "html",
+          data: params,
+        })
+        .done(function (responseText) {
+          // Save response for use in complete callback
+          response = arguments;
+
+          self.html(
+            selector
+              ? // If a selector was specified, locate the right elements in a dummy div
+                // Exclude scripts to avoid IE 'Permission Denied' errors
+                jQuery("<div>")
+                  .append(jQuery.parseHTML(responseText))
+                  .find(selector)
+              : // Otherwise use the full result
+                responseText
+          );
+
+          // If the request succeeds, this function gets "data", "status", "jqXHR"
+          // but they are ignored because response was set above.
+          // If it fails, this function gets "jqXHR", "status", "error"
+        })
+        .always(
+          callback &&
+            function (jqXHR, status) {
+              self.each(function () {
+                callback.apply(
+                  this,
+                  response || [jqXHR.responseText, status, jqXHR]
+                );
+              });
+            }
+        );
+    }
+
+    return this;
+  };
+
+  jQuery.expr.pseudos.animated = function (elem) {
+    return jQuery.grep(jQuery.timers, function (fn) {
+      return elem === fn.elem;
+    }).length;
+  };
+
+  jQuery.offset = {
+    setOffset: function (elem, options, i) {
+      var curPosition,
+        curLeft,
+        curCSSTop,
+        curTop,
+        curOffset,
+        curCSSLeft,
+        calculatePosition,
+        position = jQuery.css(elem, "position"),
+        curElem = jQuery(elem),
+        props = {};
+
+      // Set position first, in-case top/left are set even on static elem
+      if (position === "static") {
+        elem.style.position = "relative";
+      }
+
+      curOffset = curElem.offset();
+      curCSSTop = jQuery.css(elem, "top");
+      curCSSLeft = jQuery.css(elem, "left");
+      calculatePosition =
+        (position === "absolute" || position === "fixed") &&
+        (curCSSTop + curCSSLeft).indexOf("auto") > -1;
+
+      // Need to be able to calculate position if either
+      // top or left is auto and position is either absolute or fixed
+      if (calculatePosition) {
+        curPosition = curElem.position();
+        curTop = curPosition.top;
+        curLeft = curPosition.left;
+      } else {
+        curTop = parseFloat(curCSSTop) || 0;
+        curLeft = parseFloat(curCSSLeft) || 0;
+      }
+
+      if (isFunction(options)) {
+        // Use jQuery.extend here to allow modification of coordinates argument (gh-1848)
+        options = options.call(elem, i, jQuery.extend({}, curOffset));
+      }
+
+      if (options.top != null) {
+        props.top = options.top - curOffset.top + curTop;
+      }
+      if (options.left != null) {
+        props.left = options.left - curOffset.left + curLeft;
+      }
+
+      if ("using" in options) {
+        options.using.call(elem, props);
+      } else {
+        curElem.css(props);
+      }
+    },
+  };
+
+  jQuery.fn.extend({
+    // offset() relates an element's border box to the document origin
+    offset: function (options) {
+      // Preserve chaining for setter
+      if (arguments.length) {
+        return options === undefined
+          ? this
+          : this.each(function (i) {
+              jQuery.offset.setOffset(this, options, i);
+            });
+      }
+
+      var rect,
+        win,
+        elem = this[0];
+
+      if (!elem) {
+        return;
+      }
+
+      // Return zeros for disconnected and hidden (display: none) elements (gh-2310)
+      // Support: IE <=11 only
+      // Running getBoundingClientRect on a
+      // disconnected node in IE throws an error
+      if (!elem.getClientRects().length) {
+        return { top: 0, left: 0 };
+      }
+
+      // Get document-relative position by adding viewport scroll to viewport-relative gBCR
+      rect = elem.getBoundingClientRect();
+      win = elem.ownerDocument.defaultView;
+      return {
+        top: rect.top + win.pageYOffset,
+        left: rect.left + win.pageXOffset,
+      };
+    },
+
+    // position() relates an element's margin box to its offset parent's padding box
+    // This corresponds to the behavior of CSS absolute positioning
+    position: function () {
+      if (!this[0]) {
+        return;
+      }
+
+      var offsetParent,
+        offset,
+        doc,
+        elem = this[0],
+        parentOffset = { top: 0, left: 0 };
+
+      // position:fixed elements are offset from the viewport, which itself always has zero offset
+      if (jQuery.css(elem, "position") === "fixed") {
+        // Assume position:fixed implies availability of getBoundingClientRect
+        offset = elem.getBoundingClientRect();
+      } else {
+        offset = this.offset();
+
+        // Account for the *real* offset parent, which can be the document or its root element
+        // when a statically positioned element is identified
+        doc = elem.ownerDocument;
+        offsetParent = elem.offsetParent || doc.documentElement;
+        while (
+          offsetParent &&
+          (offsetParent === doc.body || offsetParent === doc.documentElement) &&
+          jQuery.css(offsetParent, "position") === "static"
+        ) {
+          offsetParent = offsetParent.parentNode;
+        }
+        if (
+          offsetParent &&
+          offsetParent !== elem &&
+          offsetParent.nodeType === 1
+        ) {
+          // Incorporate borders into its offset, since they are outside its content origin
+          parentOffset = jQuery(offsetParent).offset();
+          parentOffset.top += jQuery.css(offsetParent, "borderTopWidth", true);
+          parentOffset.left += jQuery.css(
+            offsetParent,
+            "borderLeftWidth",
+            true
+          );
+        }
+      }
+
+      // Subtract parent offsets and element margins
+      return {
+        top:
+          offset.top - parentOffset.top - jQuery.css(elem, "marginTop", true),
+        left:
+          offset.left -
+          parentOffset.left -
+          jQuery.css(elem, "marginLeft", true),
+      };
+    },
+
+    // This method will return documentElement in the following cases:
+    // 1) For the element inside the iframe without offsetParent, this method will return
+    //    documentElement of the parent window
+    // 2) For the hidden or detached element
+    // 3) For body or html element, i.e. in case of the html node - it will return itself
+    //
+    // but those exceptions were never presented as a real life use-cases
+    // and might be considered as more preferable results.
+    //
+    // This logic, however, is not guaranteed and can change at any point in the future
+    offsetParent: function () {
+      return this.map(function () {
+        var offsetParent = this.offsetParent;
+
+        while (
+          offsetParent &&
+          jQuery.css(offsetParent, "position") === "static"
+        ) {
+          offsetParent = offsetParent.offsetParent;
+        }
+
+        return offsetParent || documentElement;
+      });
+    },
+  });
+
+  // Create scrollLeft and scrollTop methods
+  jQuery.each(
+    { scrollLeft: "pageXOffset", scrollTop: "pageYOffset" },
+    function (method, prop) {
+      var top = "pageYOffset" === prop;
+
+      jQuery.fn[method] = function (val) {
+        return access(
+          this,
+          function (elem, method, val) {
+            // Coalesce documents and windows
+            var win;
+            if (isWindow(elem)) {
+              win = elem;
+            } else if (elem.nodeType === 9) {
+              win = elem.defaultView;
+            }
+
+            if (val === undefined) {
+              return win ? win[prop] : elem[method];
+            }
+
+            if (win) {
+              win.scrollTo(
+                !top ? val : win.pageXOffset,
+                top ? val : win.pageYOffset
+              );
+            } else {
+              elem[method] = val;
+            }
+          },
+          method,
+          val,
+          arguments.length
+        );
+      };
+    }
+  );
+
+  // Support: Safari <=7 - 9.1, Chrome <=37 - 49
+  // Add the top/left cssHooks using jQuery.fn.position
+  // Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=29084
+  // Blink bug: https://bugs.chromium.org/p/chromium/issues/detail?id=589347
+  // getComputedStyle returns percent when specified for top/left/bottom/right;
+  // rather than make the css module depend on the offset module, just check for it here
+  jQuery.each(["top", "left"], function (_i, prop) {
+    jQuery.cssHooks[prop] = addGetHookIf(
+      support.pixelPosition,
+      function (elem, computed) {
+        if (computed) {
+          computed = curCSS(elem, prop);
+
+          // If curCSS returns percentage, fallback to offset
+          return rnumnonpx.test(computed)
+            ? jQuery(elem).position()[prop] + "px"
+            : computed;
+        }
+      }
+    );
+  });
+
+  // Create innerHeight, innerWidth, height, width, outerHeight and outerWidth methods
+  jQuery.each({ Height: "height", Width: "width" }, function (name, type) {
+    jQuery.each(
+      {
+        padding: "inner" + name,
+        content: type,
+        "": "outer" + name,
+      },
+      function (defaultExtra, funcName) {
+        // Margin is only for outerHeight, outerWidth
+        jQuery.fn[funcName] = function (margin, value) {
+          var chainable =
+              arguments.length && (defaultExtra || typeof margin !== "boolean"),
+            extra =
+              defaultExtra ||
+              (margin === true || value === true ? "margin" : "border");
+
+          return access(
+            this,
+            function (elem, type, value) {
+              var doc;
+
+              if (isWindow(elem)) {
+                // $( window ).outerWidth/Height return w/h including scrollbars (gh-1729)
+                return funcName.indexOf("outer") === 0
+                  ? elem["inner" + name]
+                  : elem.document.documentElement["client" + name];
+              }
+
+              // Get document width or height
+              if (elem.nodeType === 9) {
+                doc = elem.documentElement;
+
+                // Either scroll[Width/Height] or offset[Width/Height] or client[Width/Height],
+                // whichever is greatest
+                return Math.max(
+                  elem.body["scroll" + name],
+                  doc["scroll" + name],
+                  elem.body["offset" + name],
+                  doc["offset" + name],
+                  doc["client" + name]
+                );
+              }
+
+              return value === undefined
+                ? // Get width or height on the element, requesting but not forcing parseFloat
+                  jQuery.css(elem, type, extra)
+                : // Set width or height on the element
+                  jQuery.style(elem, type, value, extra);
+            },
+            type,
+            chainable ? margin : undefined,
+            chainable
+          );
+        };
+      }
+    );
+  });
+
+  jQuery.each(
+    [
+      "ajaxStart",
+      "ajaxStop",
+      "ajaxComplete",
+      "ajaxError",
+      "ajaxSuccess",
+      "ajaxSend",
+    ],
+    function (_i, type) {
+      jQuery.fn[type] = function (fn) {
+        return this.on(type, fn);
+      };
+    }
+  );
+
+  jQuery.fn.extend({
+    bind: function (types, data, fn) {
+      return this.on(types, null, data, fn);
+    },
+    unbind: function (types, fn) {
+      return this.off(types, null, fn);
+    },
+
+    delegate: function (selector, types, data, fn) {
+      return this.on(types, selector, data, fn);
+    },
+    undelegate: function (selector, types, fn) {
+      // ( namespace ) or ( selector, types [, fn] )
+      return arguments.length === 1
+        ? this.off(selector, "**")
+        : this.off(types, selector || "**", fn);
+    },
+
+    hover: function (fnOver, fnOut) {
+      return this.mouseenter(fnOver).mouseleave(fnOut || fnOver);
+    },
+  });
+
+  jQuery.each(
+    (
+      "blur focus focusin focusout resize scroll click dblclick " +
+      "mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave " +
+      "change select submit keydown keypress keyup contextmenu"
+    ).split(" "),
+    function (_i, name) {
+      // Handle event binding
+      jQuery.fn[name] = function (data, fn) {
+        return arguments.length > 0
+          ? this.on(name, null, data, fn)
+          : this.trigger(name);
+      };
+    }
+  );
+
+  // Support: Android <=4.0 only
+  // Make sure we trim BOM and NBSP
+  var rtrim = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
+
+  // Bind a function to a context, optionally partially applying any
+  // arguments.
+  // jQuery.proxy is deprecated to promote standards (specifically Function#bind)
+  // However, it is not slated for removal any time soon
+  jQuery.proxy = function (fn, context) {
+    var tmp, args, proxy;
+
+    if (typeof context === "string") {
+      tmp = fn[context];
+      context = fn;
+      fn = tmp;
+    }
+
+    // Quick check to determine if target is callable, in the spec
+    // this throws a TypeError, but we will just return undefined.
+    if (!isFunction(fn)) {
+      return undefined;
+    }
+
+    // Simulated bind
+    args = slice.call(arguments, 2);
+    proxy = function () {
+      return fn.apply(context || this, args.concat(slice.call(arguments)));
+    };
+
+    // Set the guid of unique handler to the same of original handler, so it can be removed
+    proxy.guid = fn.guid = fn.guid || jQuery.guid++;
+
+    return proxy;
+  };
+
+  jQuery.holdReady = function (hold) {
+    if (hold) {
+      jQuery.readyWait++;
+    } else {
+      jQuery.ready(true);
+    }
+  };
+  jQuery.isArray = Array.isArray;
+  jQuery.parseJSON = JSON.parse;
+  jQuery.nodeName = nodeName;
+  jQuery.isFunction = isFunction;
+  jQuery.isWindow = isWindow;
+  jQuery.camelCase = camelCase;
+  jQuery.type = toType;
+
+  jQuery.now = Date.now;
+
+  jQuery.isNumeric = function (obj) {
+    // As of jQuery 3.0, isNumeric is limited to
+    // strings and numbers (primitives or objects)
+    // that can be coerced to finite numbers (gh-2662)
+    var type = jQuery.type(obj);
+    return (
+      (type === "number" || type === "string") &&
+      // parseFloat NaNs numeric-cast false positives ("")
+      // ...but misinterprets leading-number strings, particularly hex literals ("0x...")
+      // subtraction forces infinities to NaN
+      !isNaN(obj - parseFloat(obj))
+    );
+  };
+
+  jQuery.trim = function (text) {
+    return text == null ? "" : (text + "").replace(rtrim, "");
+  };
+
+  // Register as a named AMD module, since jQuery can be concatenated with other
+  // files that may use define, but not via a proper concatenation script that
+  // understands anonymous AMD modules. A named AMD is safest and most robust
+  // way to register. Lowercase jquery is used because AMD module names are
+  // derived from file names, and jQuery is normally delivered in a lowercase
+  // file name. Do this after creating the global so that if an AMD module wants
+  // to call noConflict to hide this version of jQuery, it will work.
+
+  // Note that for maximum portability, libraries that are not jQuery should
+  // declare themselves as anonymous modules, and avoid setting a global if an
+  // AMD loader is present. jQuery is a special case. For more information, see
+  // https://github.com/jrburke/requirejs/wiki/Updating-existing-libraries#wiki-anon
+
+  if (typeof define === "function" && define.amd) {
+    define("jquery", [], function () {
+      return jQuery;
+    });
+  }
+
+  var // Map over jQuery in case of overwrite
+    _jQuery = window.jQuery,
+    // Map over the $ in case of overwrite
+    _$ = window.$;
+
+  jQuery.noConflict = function (deep) {
+    if (window.$ === jQuery) {
+      window.$ = _$;
+    }
+
+    if (deep && window.jQuery === jQuery) {
+      window.jQuery = _jQuery;
+    }
+
+    return jQuery;
+  };
+
+  // Expose jQuery and $ identifiers, even in AMD
+  // (#7102#comment:10, https://github.com/jquery/jquery/pull/557)
+  // and CommonJS for browser emulators (#13566)
+  if (typeof noGlobal === "undefined") {
+    window.jQuery = window.$ = jQuery;
+  }
+
+  return jQuery;
+});

--- a/packages/babel-parser/src/parse-error/pipeline-operator-errors.ts
+++ b/packages/babel-parser/src/parse-error/pipeline-operator-errors.ts
@@ -12,7 +12,7 @@ type GetSetMemberType<T extends Set<any>> = T extends Set<infer M>
   ? M
   : unknown;
 
-type UnparenthesizedPipeBodyTypes = GetSetMemberType<
+export type UnparenthesizedPipeBodyTypes = GetSetMemberType<
   typeof UnparenthesizedPipeBodyDescriptions
 >;
 

--- a/packages/babel-parser/src/parser/base.ts
+++ b/packages/babel-parser/src/parser/base.ts
@@ -10,6 +10,7 @@ import type {
   PluginConfig,
   PluginOptions,
 } from "../typings.ts";
+import type * as N from "../types.ts";
 
 export default class BaseParser {
   // Properties set by constructor in index.js
@@ -33,6 +34,8 @@ export default class BaseParser {
   // not want to ever copy them, which happens if state gets cloned
   declare input: string;
   declare length: number;
+  // Comment store for Program.comments
+  declare comments: Array<N.Comment>;
 
   // This method accepts either a string (plugin name) or an array pair
   // (plugin name and options object). If an options object is given,

--- a/packages/babel-parser/src/parser/comments.ts
+++ b/packages/babel-parser/src/parser/comments.ts
@@ -102,7 +102,10 @@ function adjustInnerComments(
 export default class CommentsParser extends BaseParser {
   addComment(comment: Comment): void {
     if (this.filename) comment.loc.filename = this.filename;
-    this.state.comments.push(comment);
+    const { commentsLen } = this.state;
+    if (this.comments.length != commentsLen) this.comments.length = commentsLen;
+    this.comments.push(comment);
+    this.state.commentsLen++;
   }
 
   /**

--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -56,7 +56,10 @@ import {
   newExpressionScope,
 } from "../util/expression-scope.ts";
 import { Errors, type ParseError } from "../parse-error.ts";
-import { UnparenthesizedPipeBodyDescriptions } from "../parse-error/pipeline-operator-errors.ts";
+import {
+  UnparenthesizedPipeBodyDescriptions,
+  type UnparenthesizedPipeBodyTypes,
+} from "../parse-error/pipeline-operator-errors.ts";
 import { setInnerComments } from "./comments.ts";
 import { cloneIdentifier, type Undone } from "./node.ts";
 import type Parser from "./index.ts";
@@ -126,7 +129,7 @@ export default abstract class ExpressionParser extends LValParser {
 
     if (name === "__proto__") {
       if (isRecord) {
-        this.raise(Errors.RecordNoProto, { at: key });
+        this.raise(Errors.RecordNoProto, key);
         return;
       }
       if (protoRef.used) {
@@ -137,7 +140,7 @@ export default abstract class ExpressionParser extends LValParser {
             refExpressionErrors.doubleProtoLoc = key.loc.start;
           }
         } else {
-          this.raise(Errors.DuplicateProto, { at: key });
+          this.raise(Errors.DuplicateProto, key);
         }
       }
 
@@ -424,8 +427,7 @@ export default abstract class ExpressionParser extends LValParser {
         !this.prodParam.hasIn ||
         !this.match(tt._in)
       ) {
-        this.raise(Errors.PrivateInExpectedIn, {
-          at: left,
+        this.raise(Errors.PrivateInExpectedIn, left, {
           identifierName: value,
         });
       }
@@ -466,9 +468,10 @@ export default abstract class ExpressionParser extends LValParser {
           this.hasPlugin(["pipelineOperator", { proposal: "minimal" }])
         ) {
           if (this.state.type === tt._await && this.prodParam.hasAwait) {
-            throw this.raise(Errors.UnexpectedAwaitAfterPipelineBody, {
-              at: this.state.startLoc,
-            });
+            throw this.raise(
+              Errors.UnexpectedAwaitAfterPipelineBody,
+              this.state.startLoc,
+            );
           }
         }
 
@@ -487,9 +490,10 @@ export default abstract class ExpressionParser extends LValParser {
           (coalesce && (nextOp === tt.logicalOR || nextOp === tt.logicalAND)) ||
           (logical && nextOp === tt.nullishCoalescing)
         ) {
-          throw this.raise(Errors.MixingCoalesceWithLogical, {
-            at: this.state.startLoc,
-          });
+          throw this.raise(
+            Errors.MixingCoalesceWithLogical,
+            this.state.startLoc,
+          );
         }
 
         return this.parseExprOp(finishedNode, leftStartLoc, minPrec);
@@ -518,9 +522,7 @@ export default abstract class ExpressionParser extends LValParser {
           case "smart":
             return this.withTopicBindingContext(() => {
               if (this.prodParam.hasYield && this.isContextual(tt._yield)) {
-                throw this.raise(Errors.PipeBodyIsTighter, {
-                  at: this.state.startLoc,
-                });
+                throw this.raise(Errors.PipeBodyIsTighter, this.state.startLoc);
               }
               return this.parseSmartPipelineBodyInStyle(
                 this.parseExprOpBaseRightExpr(op, prec),
@@ -567,15 +569,13 @@ export default abstract class ExpressionParser extends LValParser {
 
     // TODO: Check how to handle type casts in Flow and TS once they are supported
     if (requiredParentheses && !body.extra?.parenthesized) {
-      this.raise(Errors.PipeUnparenthesizedBody, {
-        at: startLoc,
-        // @ts-expect-error TS2322: Type 'string' is not assignable to type '"AssignmentExpression" | "ArrowFunctionExpression" | "ConditionalExpression" | "YieldExpression"'.
-        type: body.type,
+      this.raise(Errors.PipeUnparenthesizedBody, startLoc, {
+        type: body.type as UnparenthesizedPipeBodyTypes,
       });
     }
     if (!this.topicReferenceWasUsedInCurrentContext()) {
       // A Hack pipe body must use the topic reference at least once.
-      this.raise(Errors.PipeTopicUnused, { at: startLoc });
+      this.raise(Errors.PipeTopicUnused, startLoc);
     }
 
     return body;
@@ -585,9 +585,7 @@ export default abstract class ExpressionParser extends LValParser {
     node: N.AwaitExpression | Undone<N.UnaryExpression>,
   ) {
     if (this.match(tt.exponent)) {
-      this.raise(Errors.UnexpectedTokenUnaryExponentiation, {
-        at: node.argument,
-      });
+      this.raise(Errors.UnexpectedTokenUnaryExponentiation, node.argument);
     }
   }
 
@@ -627,9 +625,9 @@ export default abstract class ExpressionParser extends LValParser {
         const arg = node.argument;
 
         if (arg.type === "Identifier") {
-          this.raise(Errors.StrictDelete, { at: node });
+          this.raise(Errors.StrictDelete, node);
         } else if (this.hasPropertyAsPrivateName(arg)) {
-          this.raise(Errors.DeletePrivateField, { at: node });
+          this.raise(Errors.DeletePrivateField, node);
         }
       }
 
@@ -654,7 +652,7 @@ export default abstract class ExpressionParser extends LValParser {
         ? tokenCanStartExpression(type)
         : tokenCanStartExpression(type) && !this.match(tt.modulo);
       if (startsExpr && !this.isAmbiguousAwait()) {
-        this.raiseOverwrite(Errors.AwaitNotInAsyncContext, { at: startLoc });
+        this.raiseOverwrite(Errors.AwaitNotInAsyncContext, startLoc);
         return this.parseAwait(startLoc);
       }
     }
@@ -753,9 +751,7 @@ export default abstract class ExpressionParser extends LValParser {
 
     if (type === tt.questionDot) {
       if (noCalls) {
-        this.raise(Errors.OptionalChainingNoNew, {
-          at: this.state.startLoc,
-        });
+        this.raise(Errors.OptionalChainingNoNew, this.state.startLoc);
         if (this.lookaheadCharCode() === charCodes.leftParenthesis) {
           // stop at `?.` when parsing `new a?.()`
           state.stop = true;
@@ -806,7 +802,7 @@ export default abstract class ExpressionParser extends LValParser {
       this.expect(tt.bracketR);
     } else if (this.match(tt.privateName)) {
       if (base.type === "Super") {
-        this.raise(Errors.SuperPrivateField, { at: startLoc });
+        this.raise(Errors.SuperPrivateField, startLoc);
       }
       this.classScope.usePrivateName(this.state.value, this.state.startLoc);
       node.property = this.parsePrivateName();
@@ -937,7 +933,7 @@ export default abstract class ExpressionParser extends LValParser {
     node.tag = base;
     node.quasi = this.parseTemplate(true);
     if (state.optionalChainMember) {
-      this.raise(Errors.OptionalChainingNoTemplate, { at: startLoc });
+      this.raise(Errors.OptionalChainingNoTemplate, startLoc);
     }
     return this.finishNode(node, "TaggedTemplateExpression");
   }
@@ -975,8 +971,7 @@ export default abstract class ExpressionParser extends LValParser {
         }
       }
       if (node.arguments.length === 0 || node.arguments.length > 2) {
-        this.raise(Errors.ImportCallArity, {
-          at: node,
+        this.raise(Errors.ImportCallArity, node, {
           maxArgumentCount:
             this.hasPlugin("importAttributes") ||
             this.hasPlugin("importAssertions") ||
@@ -987,7 +982,7 @@ export default abstract class ExpressionParser extends LValParser {
       } else {
         for (const arg of node.arguments) {
           if (arg.type === "SpreadElement") {
-            this.raise(Errors.ImportCallSpreadArgument, { at: arg });
+            this.raise(Errors.ImportCallSpreadArgument, arg);
           }
         }
       }
@@ -1023,9 +1018,10 @@ export default abstract class ExpressionParser extends LValParser {
             !this.hasPlugin("importAssertions") &&
             !this.hasPlugin("moduleAttributes")
           ) {
-            this.raise(Errors.ImportCallArgumentTrailingComma, {
-              at: this.state.lastTokStartLoc,
-            });
+            this.raise(
+              Errors.ImportCallArgumentTrailingComma,
+              this.state.lastTokStartLoc,
+            );
           }
           if (nodeForExtra) {
             this.addTrailingCommaExtraToNode(nodeForExtra);
@@ -1119,9 +1115,7 @@ export default abstract class ExpressionParser extends LValParser {
             return this.finishNode(node, "Import");
           }
         } else {
-          this.raise(Errors.UnsupportedImport, {
-            at: this.state.lastTokStartLoc,
-          });
+          this.raise(Errors.UnsupportedImport, this.state.lastTokStartLoc);
           return this.finishNode(node, "Import");
         }
 
@@ -1226,7 +1220,7 @@ export default abstract class ExpressionParser extends LValParser {
         if (callee.type === "MemberExpression") {
           return this.finishNode(node, "BindExpression");
         } else {
-          throw this.raise(Errors.UnsupportedBind, { at: callee });
+          throw this.raise(Errors.UnsupportedBind, callee);
         }
       }
 
@@ -1237,8 +1231,7 @@ export default abstract class ExpressionParser extends LValParser {
         // We can throw a better error message and recover, rather than
         // just throwing "Unexpected token" (which is the default
         // behavior of this big switch statement).
-        this.raise(Errors.PrivateInExpectedIn, {
-          at: this.state.startLoc,
+        this.raise(Errors.PrivateInExpectedIn, this.state.startLoc, {
           identifierName: this.state.value,
         });
         return this.parsePrivateName();
@@ -1451,7 +1444,7 @@ export default abstract class ExpressionParser extends LValParser {
             ? Errors.PrimaryTopicNotAllowed
             : // In this case, `pipeProposal === "hack"` is true.
               Errors.PipeTopicUnbound,
-          { at: startLoc },
+          startLoc,
         );
       }
 
@@ -1462,8 +1455,7 @@ export default abstract class ExpressionParser extends LValParser {
       return this.finishNode(node, nodeType);
     } else {
       // The token does not match the plugin’s configuration.
-      throw this.raise(Errors.PipeTopicUnconfiguredToken, {
-        at: startLoc,
+      throw this.raise(Errors.PipeTopicUnconfiguredToken, startLoc, {
         token: tokenLabelName(tokenType),
       });
     }
@@ -1496,7 +1488,7 @@ export default abstract class ExpressionParser extends LValParser {
       case "smart":
         return tokenType === tt.hash;
       default:
-        throw this.raise(Errors.PipeTopicRequiresHackPipes, { at: startLoc });
+        throw this.raise(Errors.PipeTopicRequiresHackPipes, startLoc);
     }
   }
 
@@ -1511,9 +1503,7 @@ export default abstract class ExpressionParser extends LValParser {
     const params = [this.parseIdentifier()];
     this.prodParam.exit();
     if (this.hasPrecedingLineBreak()) {
-      this.raise(Errors.LineTerminatorBeforeArrow, {
-        at: this.state.curPosition(),
-      });
+      this.raise(Errors.LineTerminatorBeforeArrow, this.state.curPosition());
     }
     this.expect(tt.arrow);
     // let foo = async bar => {};
@@ -1558,12 +1548,12 @@ export default abstract class ExpressionParser extends LValParser {
       !this.scope.allowDirectSuper &&
       !this.options.allowSuperOutsideMethod
     ) {
-      this.raise(Errors.SuperNotAllowed, { at: node });
+      this.raise(Errors.SuperNotAllowed, node);
     } else if (
       !this.scope.allowSuper &&
       !this.options.allowSuperOutsideMethod
     ) {
-      this.raise(Errors.UnexpectedSuper, { at: node });
+      this.raise(Errors.UnexpectedSuper, node);
     }
 
     if (
@@ -1571,7 +1561,7 @@ export default abstract class ExpressionParser extends LValParser {
       !this.match(tt.bracketL) &&
       !this.match(tt.dot)
     ) {
-      this.raise(Errors.UnsupportedSuper, { at: node });
+      this.raise(Errors.UnsupportedSuper, node);
     }
 
     return this.finishNode(node, "Super");
@@ -1636,8 +1626,7 @@ export default abstract class ExpressionParser extends LValParser {
     node.property = this.parseIdentifier(true);
 
     if (node.property.name !== propertyName || containsEsc) {
-      this.raise(Errors.UnsupportedMetaProperty, {
-        at: node.property,
+      this.raise(Errors.UnsupportedMetaProperty, node.property, {
         target: meta.name,
         onlyValidPropertyName: propertyName,
       });
@@ -1659,7 +1648,7 @@ export default abstract class ExpressionParser extends LValParser {
 
     if (this.isContextual(tt._meta)) {
       if (!this.inModule) {
-        this.raise(Errors.ImportMetaOutsideModule, { at: id });
+        this.raise(Errors.ImportMetaOutsideModule, id);
       }
       this.sawUnambiguousESM = true;
     } else if (this.isContextual(tt._source) || this.isContextual(tt._defer)) {
@@ -1674,10 +1663,13 @@ export default abstract class ExpressionParser extends LValParser {
         isSource ? "sourcePhaseImports" : "deferredImportEvaluation",
       );
       if (!this.options.createImportExpressions) {
-        throw this.raise(Errors.DynamicImportPhaseRequiresImportExpressions, {
-          at: this.state.startLoc,
-          phase: this.state.value,
-        });
+        throw this.raise(
+          Errors.DynamicImportPhaseRequiresImportExpressions,
+          this.state.startLoc,
+          {
+            phase: this.state.value,
+          },
+        );
       }
       this.next();
       (node as Undone<N.ImportExpression>).phase = isSource
@@ -1916,7 +1908,7 @@ export default abstract class ExpressionParser extends LValParser {
         !this.scope.inClass &&
         !this.options.allowNewTargetOutsideFunction
       ) {
-        this.raise(Errors.UnexpectedNewTarget, { at: metaProp });
+        this.raise(Errors.UnexpectedNewTarget, metaProp);
       }
 
       return metaProp;
@@ -1954,7 +1946,7 @@ export default abstract class ExpressionParser extends LValParser {
       isImport &&
       (callee.type === "Import" || callee.type === "ImportExpression")
     ) {
-      this.raise(Errors.ImportCallNotNewExpression, { at: callee });
+      this.raise(Errors.ImportCallNotNewExpression, callee);
     }
   }
 
@@ -1968,13 +1960,14 @@ export default abstract class ExpressionParser extends LValParser {
     );
     if (value === null) {
       if (!isTagged) {
-        this.raise(Errors.InvalidEscapeSequenceTemplate, {
+        this.raise(
+          Errors.InvalidEscapeSequenceTemplate,
           // FIXME: Adding 1 is probably wrong.
-          at: createPositionWithColumnOffset(
+          createPositionWithColumnOffset(
             this.state.firstInvalidTemplateEscapePos,
             1,
           ),
-        });
+        );
       }
     }
 
@@ -2082,7 +2075,7 @@ export default abstract class ExpressionParser extends LValParser {
         !this.isObjectProperty(prop) &&
         prop.type !== "SpreadElement"
       ) {
-        this.raise(Errors.InvalidRecordProperty, { at: prop });
+        this.raise(Errors.InvalidRecordProperty, prop);
       }
 
       // @ts-expect-error shorthand may not index prop
@@ -2133,9 +2126,7 @@ export default abstract class ExpressionParser extends LValParser {
     let decorators = [];
     if (this.match(tt.at)) {
       if (this.hasPlugin("decorators")) {
-        this.raise(Errors.UnsupportedPropertyDecorator, {
-          at: this.state.startLoc,
-        });
+        this.raise(Errors.UnsupportedPropertyDecorator, this.state.startLoc);
       }
 
       // we needn't check if decorators (stage 0) plugin is enabled since it's checked by
@@ -2189,8 +2180,7 @@ export default abstract class ExpressionParser extends LValParser {
         prop.kind = keyName;
         if (this.match(tt.star)) {
           isGenerator = true;
-          this.raise(Errors.AccessorIsGenerator, {
-            at: this.state.curPosition(),
+          this.raise(Errors.AccessorIsGenerator, this.state.curPosition(), {
             kind: keyName,
           });
           this.next();
@@ -2230,7 +2220,7 @@ export default abstract class ExpressionParser extends LValParser {
     if (params.length !== paramCount) {
       this.raise(
         method.kind === "get" ? Errors.BadGetterArity : Errors.BadSetterArity,
-        { at: method },
+        method,
       );
     }
 
@@ -2238,7 +2228,7 @@ export default abstract class ExpressionParser extends LValParser {
       method.kind === "set" &&
       params[params.length - 1]?.type === "RestElement"
     ) {
-      this.raise(Errors.BadSetterRestParameter, { at: method });
+      this.raise(Errors.BadSetterRestParameter, method);
     }
   }
 
@@ -2320,9 +2310,7 @@ export default abstract class ExpressionParser extends LValParser {
             refExpressionErrors.shorthandAssignLoc = shorthandAssignLoc;
           }
         } else {
-          this.raise(Errors.InvalidCoverInitializedName, {
-            at: shorthandAssignLoc,
-          });
+          this.raise(Errors.InvalidCoverInitializedName, shorthandAssignLoc);
         }
         prop.value = this.parseMaybeDefault(
           startLoc,
@@ -2410,9 +2398,7 @@ export default abstract class ExpressionParser extends LValParser {
                 refExpressionErrors.privateKeyLoc = privateKeyLoc;
               }
             } else {
-              this.raise(Errors.UnexpectedPrivateField, {
-                at: privateKeyLoc,
-              });
+              this.raise(Errors.UnexpectedPrivateField, privateKeyLoc);
             }
             key = this.parsePrivateName();
             break;
@@ -2592,16 +2578,16 @@ export default abstract class ExpressionParser extends LValParser {
 
           if (hasStrictModeDirective && nonSimple) {
             // This logic is here to align the error location with the ESTree plugin.
-            this.raise(Errors.IllegalLanguageModeDirective, {
-              at:
-                // @ts-expect-error kind may not index node
-                (node.kind === "method" || node.kind === "constructor") &&
+            this.raise(
+              Errors.IllegalLanguageModeDirective,
+              // @ts-expect-error kind may not index node
+              (node.kind === "method" || node.kind === "constructor") &&
                 // @ts-expect-error key may not index node
                 !!node.key
-                  ? // @ts-expect-error node.key has been guarded
-                    node.key.loc.end
-                  : node,
-            });
+                ? // @ts-expect-error node.key has been guarded
+                  node.key.loc.end
+                : node,
+            );
           }
 
           const strictModeChanged = !oldStrict && this.state.strict;
@@ -2725,8 +2711,7 @@ export default abstract class ExpressionParser extends LValParser {
     let elt;
     if (this.match(tt.comma)) {
       if (!allowEmpty) {
-        this.raise(Errors.UnexpectedToken, {
-          at: this.state.curPosition(),
+        this.raise(Errors.UnexpectedToken, this.state.curPosition(), {
           unexpected: ",",
         });
       }
@@ -2741,9 +2726,7 @@ export default abstract class ExpressionParser extends LValParser {
     } else if (this.match(tt.question)) {
       this.expectPlugin("partialApplication");
       if (!allowPlaceholder) {
-        this.raise(Errors.UnexpectedArgumentPlaceholder, {
-          at: this.state.startLoc,
-        });
+        this.raise(Errors.UnexpectedArgumentPlaceholder, this.state.startLoc);
       }
       const node = this.startNode();
       this.next();
@@ -2825,8 +2808,7 @@ export default abstract class ExpressionParser extends LValParser {
     }
 
     if (checkKeywords && isKeyword(word)) {
-      this.raise(Errors.UnexpectedKeyword, {
-        at: startLoc,
+      this.raise(Errors.UnexpectedKeyword, startLoc, {
         keyword: word,
       });
       return;
@@ -2839,33 +2821,30 @@ export default abstract class ExpressionParser extends LValParser {
         : isStrictReservedWord;
 
     if (reservedTest(word, this.inModule)) {
-      this.raise(Errors.UnexpectedReservedWord, {
-        at: startLoc,
+      this.raise(Errors.UnexpectedReservedWord, startLoc, {
         reservedWord: word,
       });
       return;
     } else if (word === "yield") {
       if (this.prodParam.hasYield) {
-        this.raise(Errors.YieldBindingIdentifier, { at: startLoc });
+        this.raise(Errors.YieldBindingIdentifier, startLoc);
         return;
       }
     } else if (word === "await") {
       if (this.prodParam.hasAwait) {
-        this.raise(Errors.AwaitBindingIdentifier, { at: startLoc });
+        this.raise(Errors.AwaitBindingIdentifier, startLoc);
         return;
       }
 
       if (this.scope.inStaticBlock) {
-        this.raise(Errors.AwaitBindingIdentifierInStaticBlock, {
-          at: startLoc,
-        });
+        this.raise(Errors.AwaitBindingIdentifierInStaticBlock, startLoc);
         return;
       }
 
-      this.expressionScope.recordAsyncArrowParametersError({ at: startLoc });
+      this.expressionScope.recordAsyncArrowParametersError(startLoc);
     } else if (word === "arguments") {
       if (this.scope.inClassAndNotInNonArrowFunction) {
-        this.raise(Errors.ArgumentsInClass, { at: startLoc });
+        this.raise(Errors.ArgumentsInClass, startLoc);
         return;
       }
     }
@@ -2886,14 +2865,12 @@ export default abstract class ExpressionParser extends LValParser {
 
     this.expressionScope.recordParameterInitializerError(
       Errors.AwaitExpressionFormalParameter,
-      {
-        // @ts-expect-error todo(flow->ts)
-        at: node,
-      },
+      // @ts-expect-error todo(flow->ts)
+      node,
     );
 
     if (this.eat(tt.star)) {
-      this.raise(Errors.ObsoleteAwaitStar, { at: node });
+      this.raise(Errors.ObsoleteAwaitStar, node);
     }
 
     if (!this.scope.inFunction && !this.options.allowAwaitOutsideFunction) {
@@ -2939,10 +2916,8 @@ export default abstract class ExpressionParser extends LValParser {
 
     this.expressionScope.recordParameterInitializerError(
       Errors.YieldInParameter,
-      {
-        // @ts-expect-error todo(flow->ts)
-        at: node,
-      },
+      // @ts-expect-error todo(flow->ts)
+      node,
     );
 
     this.next();
@@ -3005,9 +2980,7 @@ export default abstract class ExpressionParser extends LValParser {
       if (left.type === "SequenceExpression") {
         // Ensure that the pipeline head is not a comma-delimited
         // sequence expression.
-        this.raise(Errors.PipelineHeadSequenceExpression, {
-          at: leftStartLoc,
-        });
+        this.raise(Errors.PipelineHeadSequenceExpression, leftStartLoc);
       }
     }
   }
@@ -3050,12 +3023,12 @@ export default abstract class ExpressionParser extends LValParser {
     // and `(x |> y) => #` is an invalid arrow function.
     // This is because smart-mix `|>` has tighter precedence than `=>`.
     if (this.match(tt.arrow)) {
-      throw this.raise(Errors.PipelineBodyNoArrow, { at: this.state.startLoc });
+      throw this.raise(Errors.PipelineBodyNoArrow, this.state.startLoc);
     }
 
     // A topic-style smart-mix pipe body must use the topic reference at least once.
     if (!this.topicReferenceWasUsedInCurrentContext()) {
-      this.raise(Errors.PipelineTopicUnused, { at: startLoc });
+      this.raise(Errors.PipelineTopicUnused, startLoc);
     }
   }
 

--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -162,7 +162,7 @@ export default abstract class ExpressionParser extends LValParser {
     // Unlike parseTopLevel, we need to drain remaining commentStacks
     // because the top level node is _not_ Program.
     this.finalizeRemainingComments();
-    expr.comments = this.state.comments;
+    expr.comments = this.comments;
     expr.errors = this.state.errors;
     if (this.options.tokens) {
       expr.tokens = this.tokens;
@@ -2108,7 +2108,7 @@ export default abstract class ExpressionParser extends LValParser {
   }
 
   addTrailingCommaExtraToNode(node: N.Node): void {
-    this.addExtra(node, "trailingComma", this.state.lastTokStart);
+    this.addExtra(node, "trailingComma", this.state.lastTokStartLoc.index);
     this.addExtra(node, "trailingCommaLoc", this.state.lastTokStartLoc, false);
   }
 

--- a/packages/babel-parser/src/parser/index.ts
+++ b/packages/babel-parser/src/parser/index.ts
@@ -44,6 +44,7 @@ export default class Parser extends StatementParser {
     file.errors = null;
     this.parseTopLevel(file, program);
     file.errors = this.state.errors;
+    file.comments.length = this.state.commentsLen;
     return file;
   }
 }

--- a/packages/babel-parser/src/parser/lval.ts
+++ b/packages/babel-parser/src/parser/lval.ts
@@ -111,7 +111,7 @@ export default abstract class LValParser extends NodeUtils {
         if (parenthesized.type === "Identifier") {
           this.expressionScope.recordArrowParameterBindingError(
             Errors.InvalidParenthesizedAssignment,
-            { at: node },
+            node,
           );
         } else if (
           parenthesized.type !== "MemberExpression" &&
@@ -120,10 +120,10 @@ export default abstract class LValParser extends NodeUtils {
           // A parenthesized member expression can be in LHS but not in pattern.
           // If the LHS is later interpreted as a pattern, `checkLVal` will throw for member expression binding
           // i.e. `([(a.b) = []] = []) => {}`
-          this.raise(Errors.InvalidParenthesizedAssignment, { at: node });
+          this.raise(Errors.InvalidParenthesizedAssignment, node);
         }
       } else {
-        this.raise(Errors.InvalidParenthesizedAssignment, { at: node });
+        this.raise(Errors.InvalidParenthesizedAssignment, node);
       }
     }
 
@@ -151,9 +151,7 @@ export default abstract class LValParser extends NodeUtils {
             prop.type === "RestElement" &&
             node.extra?.trailingCommaLoc
           ) {
-            this.raise(Errors.RestTrailingComma, {
-              at: node.extra.trailingCommaLoc,
-            });
+            this.raise(Errors.RestTrailingComma, node.extra.trailingCommaLoc);
           }
         }
         break;
@@ -188,7 +186,7 @@ export default abstract class LValParser extends NodeUtils {
 
       case "AssignmentExpression":
         if (node.operator !== "=") {
-          this.raise(Errors.MissingEqInAssignment, { at: node.left.loc.end });
+          this.raise(Errors.MissingEqInAssignment, node.left.loc.end);
         }
 
         node.type = "AssignmentPattern";
@@ -217,7 +215,7 @@ export default abstract class LValParser extends NodeUtils {
         prop.kind === "get" || prop.kind === "set"
           ? Errors.PatternHasAccessor
           : Errors.PatternHasMethod,
-        { at: prop.key },
+        prop.key,
       );
     } else if (prop.type === "SpreadElement") {
       prop.type = "RestElement";
@@ -226,7 +224,7 @@ export default abstract class LValParser extends NodeUtils {
       this.toAssignable(arg, isLHS);
 
       if (!isLast) {
-        this.raise(Errors.RestTrailingComma, { at: prop });
+        this.raise(Errors.RestTrailingComma, prop);
       }
     } else {
       this.toAssignable(prop, isLHS);
@@ -257,9 +255,9 @@ export default abstract class LValParser extends NodeUtils {
 
       if (elt.type === "RestElement") {
         if (i < end) {
-          this.raise(Errors.RestTrailingComma, { at: elt });
+          this.raise(Errors.RestTrailingComma, elt);
         } else if (trailingCommaLoc) {
-          this.raise(Errors.RestTrailingComma, { at: trailingCommaLoc });
+          this.raise(Errors.RestTrailingComma, trailingCommaLoc);
         }
       }
     }
@@ -416,9 +414,7 @@ export default abstract class LValParser extends NodeUtils {
       } else {
         const decorators = [];
         if (this.match(tt.at) && this.hasPlugin("decorators")) {
-          this.raise(Errors.UnsupportedParameterDecorator, {
-            at: this.state.startLoc,
-          });
+          this.raise(Errors.UnsupportedParameterDecorator, this.state.startLoc);
         }
         // invariant: hasPlugin("decorators-legacy")
         while (this.match(tt.at)) {
@@ -615,15 +611,14 @@ export default abstract class LValParser extends NodeUtils {
       if (isOptionalMemberExpression) {
         this.expectPlugin("optionalChainingAssign", expression.loc.start);
         if (ancestor.type !== "AssignmentExpression") {
-          this.raise(Errors.InvalidLhsOptionalChaining, {
-            at: expression,
+          this.raise(Errors.InvalidLhsOptionalChaining, expression, {
             ancestor,
           });
         }
       }
 
       if (binding !== BindingFlag.TYPE_NONE) {
-        this.raise(Errors.InvalidPropertyBindingPattern, { at: expression });
+        this.raise(Errors.InvalidPropertyBindingPattern, expression);
       }
       return;
     }
@@ -639,7 +634,7 @@ export default abstract class LValParser extends NodeUtils {
 
       if (checkClashes) {
         if (checkClashes.has(name)) {
-          this.raise(Errors.ParamDupe, { at: expression });
+          this.raise(Errors.ParamDupe, expression);
         } else {
           checkClashes.add(name);
         }
@@ -662,7 +657,7 @@ export default abstract class LValParser extends NodeUtils {
           ? Errors.InvalidLhs
           : Errors.InvalidLhsBinding;
 
-      this.raise(ParseErrorClass, { at: expression, ancestor });
+      this.raise(ParseErrorClass, expression, { ancestor });
       return;
     }
 
@@ -700,17 +695,16 @@ export default abstract class LValParser extends NodeUtils {
         : isStrictBindOnlyReservedWord(at.name))
     ) {
       if (bindingType === BindingFlag.TYPE_NONE) {
-        this.raise(Errors.StrictEvalArguments, { at, referenceName: at.name });
+        this.raise(Errors.StrictEvalArguments, at, { referenceName: at.name });
       } else {
-        this.raise(Errors.StrictEvalArgumentsBinding, {
-          at,
+        this.raise(Errors.StrictEvalArgumentsBinding, at, {
           bindingName: at.name,
         });
       }
     }
 
     if (bindingType & BindingFlag.FLAG_NO_LET_IN_LEXICAL && at.name === "let") {
-      this.raise(Errors.LetInLexicalBinding, { at });
+      this.raise(Errors.LetInLexicalBinding, at);
     }
 
     if (!(bindingType & BindingFlag.TYPE_NONE)) {
@@ -735,7 +729,7 @@ export default abstract class LValParser extends NodeUtils {
         if (allowPattern) break;
       /* falls through */
       default:
-        this.raise(Errors.InvalidRestAssignmentPattern, { at: node });
+        this.raise(Errors.InvalidRestAssignmentPattern, node);
     }
   }
 
@@ -750,7 +744,7 @@ export default abstract class LValParser extends NodeUtils {
       this.lookaheadCharCode() === close
         ? Errors.RestTrailingComma
         : Errors.ElementAfterRest,
-      { at: this.state.startLoc },
+      this.state.startLoc,
     );
 
     return true;

--- a/packages/babel-parser/src/parser/node.ts
+++ b/packages/babel-parser/src/parser/node.ts
@@ -98,8 +98,9 @@ export type Undone<T extends NodeType> = Omit<T, "type">;
 
 export abstract class NodeUtils extends UtilParser {
   startNode<T extends NodeType>(): Undone<T> {
+    const loc = this.state.startLoc;
     // @ts-expect-error cast Node as Undone<T>
-    return new Node(this, this.state.start, this.state.startLoc);
+    return new Node(this, loc.index, loc);
   }
 
   startNodeAt<T extends NodeType>(loc: Position): Undone<T> {

--- a/packages/babel-parser/src/parser/node.ts
+++ b/packages/babel-parser/src/parser/node.ts
@@ -1,4 +1,3 @@
-import type Parser from "./index.ts";
 import UtilParser from "./util.ts";
 import { SourceLocation, type Position } from "../util/location.ts";
 import type { Comment, Node as NodeType, NodeBase } from "../types.ts";
@@ -6,7 +5,7 @@ import type { Comment, Node as NodeType, NodeBase } from "../types.ts";
 // Start an AST node, attaching a start offset.
 
 class Node implements NodeBase {
-  constructor(parser: Parser, pos: number, loc: Position) {
+  constructor(parser: UtilParser, pos: number, loc: Position) {
     this.start = pos;
     this.end = 0;
     this.loc = new SourceLocation(loc);
@@ -99,13 +98,11 @@ export type Undone<T extends NodeType> = Omit<T, "type">;
 export abstract class NodeUtils extends UtilParser {
   startNode<T extends NodeType>(): Undone<T> {
     const loc = this.state.startLoc;
-    // @ts-expect-error cast Node as Undone<T>
-    return new Node(this, loc.index, loc);
+    return new Node(this, loc.index, loc) as unknown as Undone<T>;
   }
 
   startNodeAt<T extends NodeType>(loc: Position): Undone<T> {
-    // @ts-expect-error cast Node as Undone<T>
-    return new Node(this, loc.index, loc);
+    return new Node(this, loc.index, loc) as unknown as Undone<T>;
   }
 
   /** Start a new node with a previous node's location. */

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -217,7 +217,7 @@ export default abstract class StatementParser extends ExpressionParser {
       this.scope.undefinedExports.size > 0
     ) {
       for (const [localName, at] of Array.from(this.scope.undefinedExports)) {
-        this.raise(Errors.ModuleExportUndefined, { at, localName });
+        this.raise(Errors.ModuleExportUndefined, at, { localName });
       }
     }
     let finishedProgram: N.Program;
@@ -454,7 +454,7 @@ export default abstract class StatementParser extends ExpressionParser {
               : this.options.annexB
                 ? Errors.SloppyFunctionAnnexB
                 : Errors.SloppyFunction,
-            { at: this.state.startLoc },
+            this.state.startLoc,
           );
         }
         return this.parseFunctionStatement(
@@ -487,11 +487,9 @@ export default abstract class StatementParser extends ExpressionParser {
         // [+Await] await [no LineTerminator here] using [no LineTerminator here] BindingList[+Using]
         if (!this.state.containsEsc && this.startsAwaitUsing()) {
           if (!this.isAwaitAllowed()) {
-            this.raise(Errors.AwaitUsingNotInAsyncContext, { at: node });
+            this.raise(Errors.AwaitUsingNotInAsyncContext, node);
           } else if (!allowDeclaration) {
-            this.raise(Errors.UnexpectedLexicalDeclaration, {
-              at: node,
-            });
+            this.raise(Errors.UnexpectedLexicalDeclaration, node);
           }
           this.next(); // eat 'await'
           return this.parseVarStatement(
@@ -510,13 +508,9 @@ export default abstract class StatementParser extends ExpressionParser {
         }
         this.expectPlugin("explicitResourceManagement");
         if (!this.scope.inModule && this.scope.inTopLevel) {
-          this.raise(Errors.UnexpectedUsingDeclaration, {
-            at: this.state.startLoc,
-          });
+          this.raise(Errors.UnexpectedUsingDeclaration, this.state.startLoc);
         } else if (!allowDeclaration) {
-          this.raise(Errors.UnexpectedLexicalDeclaration, {
-            at: this.state.startLoc,
-          });
+          this.raise(Errors.UnexpectedLexicalDeclaration, this.state.startLoc);
         }
         return this.parseVarStatement(
           node as Undone<N.VariableDeclaration>,
@@ -543,9 +537,7 @@ export default abstract class StatementParser extends ExpressionParser {
       // fall through
       case tt._const: {
         if (!allowDeclaration) {
-          this.raise(Errors.UnexpectedLexicalDeclaration, {
-            at: this.state.startLoc,
-          });
+          this.raise(Errors.UnexpectedLexicalDeclaration, this.state.startLoc);
         }
       }
       // fall through
@@ -576,9 +568,7 @@ export default abstract class StatementParser extends ExpressionParser {
       // fall through
       case tt._export: {
         if (!this.options.allowImportExportEverywhere && !topLevel) {
-          this.raise(Errors.UnexpectedImportExport, {
-            at: this.state.startLoc,
-          });
+          this.raise(Errors.UnexpectedImportExport, this.state.startLoc);
         }
 
         this.next(); // eat `import`/`export`
@@ -622,9 +612,10 @@ export default abstract class StatementParser extends ExpressionParser {
       default: {
         if (this.isAsyncFunction()) {
           if (!allowDeclaration) {
-            this.raise(Errors.AsyncFunctionInSingleStatementContext, {
-              at: this.state.startLoc,
-            });
+            this.raise(
+              Errors.AsyncFunctionInSingleStatementContext,
+              this.state.startLoc,
+            );
           }
           this.next(); // eat 'async'
           return this.parseFunctionStatement(
@@ -667,7 +658,7 @@ export default abstract class StatementParser extends ExpressionParser {
 
   assertModuleNodeAllowed(node: N.Node): void {
     if (!this.options.allowImportExportEverywhere && !this.inModule) {
-      this.raise(Errors.ImportOutsideModule, { at: node });
+      this.raise(Errors.ImportOutsideModule, node);
     }
   }
 
@@ -703,9 +694,10 @@ export default abstract class StatementParser extends ExpressionParser {
           // If `decoratorsBeforeExport` was set to `true` or `false`, we
           // already threw an error about decorators not being in a valid
           // position.
-          this.raise(Errors.DecoratorsBeforeAfterExport, {
-            at: classNode.decorators[0],
-          });
+          this.raise(
+            Errors.DecoratorsBeforeAfterExport,
+            classNode.decorators[0],
+          );
         }
         classNode.decorators.unshift(...maybeDecorators);
       } else {
@@ -733,12 +725,10 @@ export default abstract class StatementParser extends ExpressionParser {
       }
 
       if (!this.decoratorsEnabledBeforeExport()) {
-        this.raise(Errors.DecoratorExportClass, { at: this.state.startLoc });
+        this.raise(Errors.DecoratorExportClass, this.state.startLoc);
       }
     } else if (!this.canHaveLeadingDecorator()) {
-      throw this.raise(Errors.UnexpectedLeadingDecorator, {
-        at: this.state.startLoc,
-      });
+      throw this.raise(Errors.UnexpectedLeadingDecorator, this.state.startLoc);
     }
 
     return decorators;
@@ -768,9 +758,10 @@ export default abstract class StatementParser extends ExpressionParser {
             false &&
           node.expression !== expr
         ) {
-          this.raise(Errors.DecoratorArgumentsOutsideParentheses, {
-            at: paramsStartLoc,
-          });
+          this.raise(
+            Errors.DecoratorArgumentsOutsideParentheses,
+            paramsStartLoc,
+          );
         }
       } else {
         expr = this.parseIdentifier(false);
@@ -856,7 +847,7 @@ export default abstract class StatementParser extends ExpressionParser {
     }
     if (i === this.state.labels.length) {
       const type = isBreak ? "BreakStatement" : "ContinueStatement";
-      this.raise(Errors.IllegalBreakContinue, { at: node, type });
+      this.raise(Errors.IllegalBreakContinue, node, { type });
     }
   }
 
@@ -948,9 +939,7 @@ export default abstract class StatementParser extends ExpressionParser {
         if (startsWithAwaitUsing) {
           kind = "await using";
           if (!this.isAwaitAllowed()) {
-            this.raise(Errors.AwaitUsingNotInAsyncContext, {
-              at: this.state.startLoc,
-            });
+            this.raise(Errors.AwaitUsingNotInAsyncContext, this.state.startLoc);
           }
           this.next(); // eat 'await'
         } else {
@@ -962,7 +951,7 @@ export default abstract class StatementParser extends ExpressionParser {
 
         const isForIn = this.match(tt._in);
         if (isForIn && starsWithUsingDeclaration) {
-          this.raise(Errors.ForInUsing, { at: init });
+          this.raise(Errors.ForInUsing, init);
         }
         if (
           (isForIn || this.isContextual(tt._of)) &&
@@ -987,7 +976,7 @@ export default abstract class StatementParser extends ExpressionParser {
     if (isForOf) {
       // Check for leading tokens that are forbidden in for-of loops:
       if (startsWithLet) {
-        this.raise(Errors.ForOfLet, { at: init });
+        this.raise(Errors.ForOfLet, init);
       }
 
       if (
@@ -1000,7 +989,7 @@ export default abstract class StatementParser extends ExpressionParser {
         // parsed as an identifier. If it was parsed as the start of an async
         // arrow function (e.g. `for (async of => {} of []);`), the LVal check
         // further down will raise a more appropriate error.
-        this.raise(Errors.ForOfAsync, { at: init });
+        this.raise(Errors.ForOfAsync, init);
       }
     }
     if (isForOf || this.match(tt._in)) {
@@ -1054,7 +1043,7 @@ export default abstract class StatementParser extends ExpressionParser {
 
   parseReturnStatement(this: Parser, node: Undone<N.ReturnStatement>) {
     if (!this.prodParam.hasReturn && !this.options.allowReturnOutsideFunction) {
-      this.raise(Errors.IllegalReturn, { at: this.state.startLoc });
+      this.raise(Errors.IllegalReturn, this.state.startLoc);
     }
 
     this.next();
@@ -1099,9 +1088,10 @@ export default abstract class StatementParser extends ExpressionParser {
           cur.test = this.parseExpression();
         } else {
           if (sawDefault) {
-            this.raise(Errors.MultipleDefaultsInSwitch, {
-              at: this.state.lastTokStartLoc,
-            });
+            this.raise(
+              Errors.MultipleDefaultsInSwitch,
+              this.state.lastTokStartLoc,
+            );
           }
           sawDefault = true;
           cur.test = null;
@@ -1125,7 +1115,7 @@ export default abstract class StatementParser extends ExpressionParser {
   parseThrowStatement(this: Parser, node: Undone<N.ThrowStatement>) {
     this.next();
     if (this.hasPrecedingLineBreak()) {
-      this.raise(Errors.NewlineAfterThrow, { at: this.state.lastTokEndLoc });
+      this.raise(Errors.NewlineAfterThrow, this.state.lastTokEndLoc);
     }
     node.argument = this.parseExpression();
     this.semicolon();
@@ -1185,7 +1175,7 @@ export default abstract class StatementParser extends ExpressionParser {
     node.finalizer = this.eat(tt._finally) ? this.parseBlock() : null;
 
     if (!node.handler && !node.finalizer) {
-      this.raise(Errors.NoCatchOrFinally, { at: node });
+      this.raise(Errors.NoCatchOrFinally, node);
     }
 
     return this.finishNode(node, "TryStatement");
@@ -1234,7 +1224,7 @@ export default abstract class StatementParser extends ExpressionParser {
     node: Undone<N.WithStatement>,
   ): N.WithStatement {
     if (this.state.strict) {
-      this.raise(Errors.StrictWith, { at: this.state.startLoc });
+      this.raise(Errors.StrictWith, this.state.startLoc);
     }
     this.next();
     node.object = this.parseHeaderExpression();
@@ -1268,8 +1258,7 @@ export default abstract class StatementParser extends ExpressionParser {
   ): N.LabeledStatement {
     for (const label of this.state.labels) {
       if (label.name === maybeName) {
-        this.raise(Errors.LabelRedeclaration, {
-          at: expr,
+        this.raise(Errors.LabelRedeclaration, expr, {
           labelName: maybeName,
         });
       }
@@ -1486,15 +1475,13 @@ export default abstract class StatementParser extends ExpressionParser {
         init.kind !== "var" ||
         init.declarations[0].id.type !== "Identifier")
     ) {
-      this.raise(Errors.ForInOfLoopInitializer, {
-        at: init,
+      this.raise(Errors.ForInOfLoopInitializer, init, {
         type: isForIn ? "ForInStatement" : "ForOfStatement",
       });
     }
 
     if (init.type === "AssignmentPattern") {
-      this.raise(Errors.InvalidLhs, {
-        at: init,
+      this.raise(Errors.InvalidLhs, init, {
         ancestor: { type: "ForStatement" },
       });
     }
@@ -1546,18 +1533,24 @@ export default abstract class StatementParser extends ExpressionParser {
           decl.id.type !== "Identifier" &&
           !(isFor && (this.match(tt._in) || this.isContextual(tt._of)))
         ) {
-          this.raise(Errors.DeclarationMissingInitializer, {
-            at: this.state.lastTokEndLoc,
-            kind: "destructuring",
-          });
+          this.raise(
+            Errors.DeclarationMissingInitializer,
+            this.state.lastTokEndLoc,
+            {
+              kind: "destructuring",
+            },
+          );
         } else if (
           kind === "const" &&
           !(this.match(tt._in) || this.isContextual(tt._of))
         ) {
-          this.raise(Errors.DeclarationMissingInitializer, {
-            at: this.state.lastTokEndLoc,
-            kind: "const",
-          });
+          this.raise(
+            Errors.DeclarationMissingInitializer,
+            this.state.lastTokEndLoc,
+            {
+              kind: "const",
+            },
+          );
         }
       }
       declarations.push(this.finishNode(decl, "VariableDeclarator"));
@@ -1604,9 +1597,10 @@ export default abstract class StatementParser extends ExpressionParser {
 
     if (this.match(tt.star)) {
       if (hangingDeclaration) {
-        this.raise(Errors.GeneratorInSingleStatementContext, {
-          at: this.state.startLoc,
-        });
+        this.raise(
+          Errors.GeneratorInSingleStatementContext,
+          this.state.startLoc,
+        );
       }
       this.next(); // eat *
       node.generator = true;
@@ -1761,9 +1755,10 @@ export default abstract class StatementParser extends ExpressionParser {
       while (!this.match(tt.braceR)) {
         if (this.eat(tt.semi)) {
           if (decorators.length > 0) {
-            throw this.raise(Errors.DecoratorSemicolon, {
-              at: this.state.lastTokEndLoc,
-            });
+            throw this.raise(
+              Errors.DecoratorSemicolon,
+              this.state.lastTokEndLoc,
+            );
           }
           continue;
         }
@@ -1793,7 +1788,7 @@ export default abstract class StatementParser extends ExpressionParser {
           // @ts-expect-error Fixme
           member.decorators.length > 0
         ) {
-          this.raise(Errors.DecoratorConstructor, { at: member });
+          this.raise(Errors.DecoratorConstructor, member);
         }
       }
     });
@@ -1803,7 +1798,7 @@ export default abstract class StatementParser extends ExpressionParser {
     this.next(); // eat `}`
 
     if (decorators.length) {
-      throw this.raise(Errors.TrailingDecorator, { at: this.state.startLoc });
+      throw this.raise(Errors.TrailingDecorator, this.state.startLoc);
     }
 
     this.classScope.exit();
@@ -1905,9 +1900,7 @@ export default abstract class StatementParser extends ExpressionParser {
       }
 
       if (this.isNonstaticConstructor(publicMethod)) {
-        this.raise(Errors.ConstructorIsGenerator, {
-          at: publicMethod.key,
-        });
+        this.raise(Errors.ConstructorIsGenerator, publicMethod.key);
       }
 
       this.pushClassMethod(
@@ -1946,10 +1939,10 @@ export default abstract class StatementParser extends ExpressionParser {
 
         // TypeScript allows multiple overloaded constructor declarations.
         if (state.hadConstructor && !this.hasPlugin("typescript")) {
-          this.raise(Errors.DuplicateConstructor, { at: key });
+          this.raise(Errors.DuplicateConstructor, key);
         }
         if (isConstructor && this.hasPlugin("typescript") && member.override) {
-          this.raise(Errors.OverrideOnConstructor, { at: key });
+          this.raise(Errors.OverrideOnConstructor, key);
         }
         state.hadConstructor = true;
         allowsDirectSuper = state.hadSuperClass;
@@ -1998,7 +1991,7 @@ export default abstract class StatementParser extends ExpressionParser {
         );
       } else {
         if (this.isNonstaticConstructor(publicMethod)) {
-          this.raise(Errors.ConstructorIsAsync, { at: publicMethod.key });
+          this.raise(Errors.ConstructorIsAsync, publicMethod.key);
         }
 
         this.pushClassMethod(
@@ -2028,7 +2021,7 @@ export default abstract class StatementParser extends ExpressionParser {
         this.pushClassPrivateMethod(classBody, privateMethod, false, false);
       } else {
         if (this.isNonstaticConstructor(publicMethod)) {
-          this.raise(Errors.ConstructorIsAccessor, { at: publicMethod.key });
+          this.raise(Errors.ConstructorIsAccessor, publicMethod.key);
         }
         this.pushClassMethod(
           classBody,
@@ -2076,14 +2069,12 @@ export default abstract class StatementParser extends ExpressionParser {
       member.static &&
       value === "prototype"
     ) {
-      this.raise(Errors.StaticPrototype, { at: this.state.startLoc });
+      this.raise(Errors.StaticPrototype, this.state.startLoc);
     }
 
     if (type === tt.privateName) {
       if (value === "constructor") {
-        this.raise(Errors.ConstructorClassPrivateField, {
-          at: this.state.startLoc,
-        });
+        this.raise(Errors.ConstructorClassPrivateField, this.state.startLoc);
       }
       const key = this.parsePrivateName();
       member.key = key;
@@ -2119,7 +2110,7 @@ export default abstract class StatementParser extends ExpressionParser {
     this.state.labels = oldLabels;
     classBody.body.push(this.finishNode<N.StaticBlock>(member, "StaticBlock"));
     if (member.decorators?.length) {
-      this.raise(Errors.DecoratorStaticBlock, { at: member });
+      this.raise(Errors.DecoratorStaticBlock, member);
     }
   }
 
@@ -2134,7 +2125,7 @@ export default abstract class StatementParser extends ExpressionParser {
     ) {
       // Non-computed field, which is either an identifier named "constructor"
       // or a string literal named "constructor"
-      this.raise(Errors.ConstructorClassField, { at: prop.key });
+      this.raise(Errors.ConstructorClassField, prop.key);
     }
 
     classBody.body.push(this.parseClassProperty(prop));
@@ -2168,7 +2159,7 @@ export default abstract class StatementParser extends ExpressionParser {
       if (key.name === "constructor" || key.value === "constructor") {
         // Non-computed field, which is either an identifier named "constructor"
         // or a string literal named "constructor"
-        this.raise(Errors.ConstructorClassField, { at: key });
+        this.raise(Errors.ConstructorClassField, key);
       }
     }
 
@@ -2313,7 +2304,7 @@ export default abstract class StatementParser extends ExpressionParser {
       if (optionalId || !isStatement) {
         node.id = null;
       } else {
-        throw this.raise(Errors.MissingClassName, { at: this.state.startLoc });
+        throw this.raise(Errors.MissingClassName, this.state.startLoc);
       }
     }
   }
@@ -2363,7 +2354,7 @@ export default abstract class StatementParser extends ExpressionParser {
     if (hasStar && !hasNamespace) {
       if (hasDefault) this.unexpected();
       if (decorators) {
-        throw this.raise(Errors.UnsupportedDecoratorExport, { at: node });
+        throw this.raise(Errors.UnsupportedDecoratorExport, node);
       }
       this.parseExportFrom(node as Undone<N.ExportNamedDeclaration>, true);
 
@@ -2387,7 +2378,7 @@ export default abstract class StatementParser extends ExpressionParser {
     if (isFromRequired || hasSpecifiers) {
       hasDeclaration = false;
       if (decorators) {
-        throw this.raise(Errors.UnsupportedDecoratorExport, { at: node });
+        throw this.raise(Errors.UnsupportedDecoratorExport, node);
       }
       this.parseExportFrom(
         node as Undone<N.ExportNamedDeclaration>,
@@ -2405,7 +2396,7 @@ export default abstract class StatementParser extends ExpressionParser {
       if (node2.declaration?.type === "ClassDeclaration") {
         this.maybeTakeDecorators(decorators, node2.declaration, node2);
       } else if (decorators) {
-        throw this.raise(Errors.UnsupportedDecoratorExport, { at: node });
+        throw this.raise(Errors.UnsupportedDecoratorExport, node);
       }
       return this.finishNode(node2, "ExportNamedDeclaration");
     }
@@ -2419,7 +2410,7 @@ export default abstract class StatementParser extends ExpressionParser {
       if (decl.type === "ClassDeclaration") {
         this.maybeTakeDecorators(decorators, decl as N.ClassDeclaration, node2);
       } else if (decorators) {
-        throw this.raise(Errors.UnsupportedDecoratorExport, { at: node });
+        throw this.raise(Errors.UnsupportedDecoratorExport, node);
       }
 
       this.checkExport(node2, true, true);
@@ -2542,7 +2533,7 @@ export default abstract class StatementParser extends ExpressionParser {
         this.hasPlugin("decorators") &&
         this.getPluginOption("decorators", "decoratorsBeforeExport") === true
       ) {
-        this.raise(Errors.DecoratorBeforeExport, { at: this.state.startLoc });
+        this.raise(Errors.DecoratorBeforeExport, this.state.startLoc);
       }
       return this.parseClass(
         this.maybeTakeDecorators(
@@ -2555,9 +2546,7 @@ export default abstract class StatementParser extends ExpressionParser {
     }
 
     if (this.match(tt._const) || this.match(tt._var) || this.isLet()) {
-      throw this.raise(Errors.UnsupportedDefaultExport, {
-        at: this.state.startLoc,
-      });
+      throw this.raise(Errors.UnsupportedDefaultExport, this.state.startLoc);
     }
 
     const res = this.parseMaybeAssignAllowIn();
@@ -2655,9 +2644,7 @@ export default abstract class StatementParser extends ExpressionParser {
         if (
           this.getPluginOption("decorators", "decoratorsBeforeExport") === true
         ) {
-          this.raise(Errors.DecoratorBeforeExport, {
-            at: this.state.startLoc,
-          });
+          this.raise(Errors.DecoratorBeforeExport, this.state.startLoc);
         }
 
         return true;
@@ -2694,9 +2681,7 @@ export default abstract class StatementParser extends ExpressionParser {
             declaration.end - declaration.start === 4 && // does not contain escape
             !declaration.extra?.parenthesized
           ) {
-            this.raise(Errors.ExportDefaultFromAsIdentifier, {
-              at: declaration,
-            });
+            this.raise(Errors.ExportDefaultFromAsIdentifier, declaration);
           }
         }
         // @ts-expect-error node.specifiers may not exist
@@ -2711,8 +2696,7 @@ export default abstract class StatementParser extends ExpressionParser {
           if (!isFrom && specifier.local) {
             const { local } = specifier;
             if (local.type !== "Identifier") {
-              this.raise(Errors.ExportBindingIsString, {
-                at: specifier,
+              this.raise(Errors.ExportBindingIsString, specifier, {
                 localName: local.value,
                 exportName,
               });
@@ -2778,9 +2762,9 @@ export default abstract class StatementParser extends ExpressionParser {
   ): void {
     if (this.exportedIdentifiers.has(exportName)) {
       if (exportName === "default") {
-        this.raise(Errors.DuplicateDefaultExport, { at: node });
+        this.raise(Errors.DuplicateDefaultExport, node);
       } else {
-        this.raise(Errors.DuplicateExport, { at: node, exportName });
+        this.raise(Errors.DuplicateExport, node, { exportName });
       }
     }
     this.exportedIdentifiers.add(exportName);
@@ -2843,8 +2827,7 @@ export default abstract class StatementParser extends ExpressionParser {
       const result = this.parseStringLiteral(this.state.value);
       const surrogate = result.value.match(loneSurrogate);
       if (surrogate) {
-        this.raise(Errors.ModuleExportNameHasLoneSurrogate, {
-          at: result,
+        this.raise(Errors.ModuleExportNameHasLoneSurrogate, result, {
           surrogateCharCode: surrogate[0].charCodeAt(0),
         });
       }
@@ -2878,26 +2861,27 @@ export default abstract class StatementParser extends ExpressionParser {
 
     if (node.phase === "source") {
       if (singleBindingType !== "ImportDefaultSpecifier") {
-        this.raise(Errors.SourcePhaseImportRequiresDefault, {
-          at: specifiers[0].loc.start,
-        });
+        this.raise(
+          Errors.SourcePhaseImportRequiresDefault,
+          specifiers[0].loc.start,
+        );
       }
     } else if (node.phase === "defer") {
       if (singleBindingType !== "ImportNamespaceSpecifier") {
-        this.raise(Errors.DeferImportRequiresNamespace, {
-          at: specifiers[0].loc.start,
-        });
+        this.raise(
+          Errors.DeferImportRequiresNamespace,
+          specifiers[0].loc.start,
+        );
       }
     } else if (node.module) {
       if (singleBindingType !== "ImportDefaultSpecifier") {
-        this.raise(Errors.ImportReflectionNotBinding, {
-          at: specifiers[0].loc.start,
-        });
+        this.raise(Errors.ImportReflectionNotBinding, specifiers[0].loc.start);
       }
       if (node.assertions?.length > 0) {
-        this.raise(Errors.ImportReflectionHasAssertion, {
-          at: node.specifiers[0].loc.start,
-        });
+        this.raise(
+          Errors.ImportReflectionHasAssertion,
+          specifiers[0].loc.start,
+        );
       }
     }
   }
@@ -2927,9 +2911,10 @@ export default abstract class StatementParser extends ExpressionParser {
           }
         });
         if (nonDefaultNamedSpecifier !== undefined) {
-          this.raise(Errors.ImportJSONBindingNotDefault, {
-            at: nonDefaultNamedSpecifier.loc.start,
-          });
+          this.raise(
+            Errors.ImportJSONBindingNotDefault,
+            nonDefaultNamedSpecifier.loc.start,
+          );
         }
       }
     }
@@ -3189,10 +3174,13 @@ export default abstract class StatementParser extends ExpressionParser {
       // if a duplicate entry is found, throw an error
       // for now this logic will come into play only when someone declares `type` twice
       if (attrNames.has(keyName)) {
-        this.raise(Errors.ModuleAttributesWithDuplicateKeys, {
-          at: this.state.startLoc,
-          key: keyName,
-        });
+        this.raise(
+          Errors.ModuleAttributesWithDuplicateKeys,
+          this.state.startLoc,
+          {
+            key: keyName,
+          },
+        );
       }
       attrNames.add(keyName);
       if (this.match(tt.string)) {
@@ -3203,9 +3191,10 @@ export default abstract class StatementParser extends ExpressionParser {
       this.expect(tt.colon);
 
       if (!this.match(tt.string)) {
-        throw this.raise(Errors.ModuleAttributeInvalidValue, {
-          at: this.state.startLoc,
-        });
+        throw this.raise(
+          Errors.ModuleAttributeInvalidValue,
+          this.state.startLoc,
+        );
       }
       node.value = this.parseStringLiteral(this.state.value);
       attrs.push(this.finishNode(node, "ImportAttribute"));
@@ -3228,23 +3217,21 @@ export default abstract class StatementParser extends ExpressionParser {
       node.key = this.parseIdentifier(true);
 
       if (node.key.name !== "type") {
-        this.raise(Errors.ModuleAttributeDifferentFromType, {
-          at: node.key,
-        });
+        this.raise(Errors.ModuleAttributeDifferentFromType, node.key);
       }
 
       if (attributes.has(node.key.name)) {
-        this.raise(Errors.ModuleAttributesWithDuplicateKeys, {
-          at: node.key,
+        this.raise(Errors.ModuleAttributesWithDuplicateKeys, node.key, {
           key: node.key.name,
         });
       }
       attributes.add(node.key.name);
       this.expect(tt.colon);
       if (!this.match(tt.string)) {
-        throw this.raise(Errors.ModuleAttributeInvalidValue, {
-          at: this.state.startLoc,
-        });
+        throw this.raise(
+          Errors.ModuleAttributeInvalidValue,
+          this.state.startLoc,
+        );
       }
       node.value = this.parseStringLiteral(this.state.value);
       attrs.push(this.finishNode(node, "ImportAttribute"));
@@ -3290,9 +3277,7 @@ export default abstract class StatementParser extends ExpressionParser {
           this.getPluginOption("importAttributes", "deprecatedAssertSyntax") !==
           true
         ) {
-          this.raise(Errors.ImportAttributesUseAssert, {
-            at: this.state.startLoc,
-          });
+          this.raise(Errors.ImportAttributesUseAssert, this.state.startLoc);
         }
         this.addExtra(node, "deprecatedAssertSyntax", true);
       } else {
@@ -3371,9 +3356,7 @@ export default abstract class StatementParser extends ExpressionParser {
       } else {
         // Detect an attempt to deep destructure
         if (this.eat(tt.colon)) {
-          throw this.raise(Errors.DestructureNamedImport, {
-            at: this.state.startLoc,
-          });
+          throw this.raise(Errors.DestructureNamedImport, this.state.startLoc);
         }
 
         this.expect(tt.comma);
@@ -3410,8 +3393,7 @@ export default abstract class StatementParser extends ExpressionParser {
     } else {
       const { imported } = specifier;
       if (importedIsString) {
-        throw this.raise(Errors.ImportBindingIsString, {
-          at: specifier,
+        throw this.raise(Errors.ImportBindingIsString, specifier, {
           importName: (imported as N.StringLiteral).value,
         });
       }

--- a/packages/babel-parser/src/parser/util.ts
+++ b/packages/babel-parser/src/parser/util.ts
@@ -102,7 +102,7 @@ export default abstract class UtilParser extends Tokenizer {
   ): void {
     if (!this.eatContextual(token)) {
       if (toParseError != null) {
-        throw this.raise(toParseError, { at: this.state.startLoc });
+        throw this.raise(toParseError, this.state.startLoc);
       }
       this.unexpected(null, token);
     }
@@ -138,7 +138,7 @@ export default abstract class UtilParser extends Tokenizer {
 
   semicolon(allowAsi: boolean = true): void {
     if (allowAsi ? this.isLineTerminator() : this.eat(tt.semi)) return;
-    this.raise(Errors.MissingSemicolon, { at: this.state.lastTokEndLoc });
+    this.raise(Errors.MissingSemicolon, this.state.lastTokEndLoc);
   }
 
   // Expect a token of a given type. If found, consume it, otherwise,
@@ -232,17 +232,15 @@ export default abstract class UtilParser extends Tokenizer {
     }
 
     if (shorthandAssignLoc != null) {
-      this.raise(Errors.InvalidCoverInitializedName, {
-        at: shorthandAssignLoc,
-      });
+      this.raise(Errors.InvalidCoverInitializedName, shorthandAssignLoc);
     }
 
     if (doubleProtoLoc != null) {
-      this.raise(Errors.DuplicateProto, { at: doubleProtoLoc });
+      this.raise(Errors.DuplicateProto, doubleProtoLoc);
     }
 
     if (privateKeyLoc != null) {
-      this.raise(Errors.UnexpectedPrivateField, { at: privateKeyLoc });
+      this.raise(Errors.UnexpectedPrivateField, privateKeyLoc);
     }
 
     if (optionalParametersLoc != null) {

--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -403,9 +403,9 @@ export default (superClass: typeof Parser) =>
       isLHS: boolean,
     ) {
       if (prop.kind === "get" || prop.kind === "set") {
-        this.raise(Errors.PatternHasAccessor, { at: prop.key });
+        this.raise(Errors.PatternHasAccessor, prop.key);
       } else if (prop.method) {
-        this.raise(Errors.PatternHasMethod, { at: prop.key });
+        this.raise(Errors.PatternHasMethod, prop.key);
       } else {
         super.toAssignableObjectExpressionProp(prop, isLast, isLHS);
       }

--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -362,9 +362,7 @@ export default (superClass: typeof Parser) =>
       this.expectContextual(tt._checks);
       // Force '%' and 'checks' to be adjacent
       if (this.state.lastTokStartLoc.index > moduloLoc.index + 1) {
-        this.raise(FlowErrors.UnexpectedSpaceBetweenModuloChecks, {
-          at: moduloLoc,
-        });
+        this.raise(FlowErrors.UnexpectedSpaceBetweenModuloChecks, moduloLoc);
       }
       if (this.eat(tt.parenL)) {
         node.value = super.parseExpression();
@@ -465,9 +463,10 @@ export default (superClass: typeof Parser) =>
           return this.flowParseDeclareModuleExports(node);
         } else {
           if (insideModule) {
-            this.raise(FlowErrors.NestedDeclareModule, {
-              at: this.state.lastTokStartLoc,
-            });
+            this.raise(
+              FlowErrors.NestedDeclareModule,
+              this.state.lastTokStartLoc,
+            );
           }
           return this.flowParseDeclareModule(node);
         }
@@ -521,9 +520,10 @@ export default (superClass: typeof Parser) =>
         if (this.match(tt._import)) {
           this.next();
           if (!this.isContextual(tt._type) && !this.match(tt._typeof)) {
-            this.raise(FlowErrors.InvalidNonTypeImportInDeclareModule, {
-              at: this.state.lastTokStartLoc,
-            });
+            this.raise(
+              FlowErrors.InvalidNonTypeImportInDeclareModule,
+              this.state.lastTokStartLoc,
+            );
           }
           super.parseImport(bodyNode);
         } else {
@@ -549,21 +549,15 @@ export default (superClass: typeof Parser) =>
       body.forEach(bodyElement => {
         if (isEsModuleType(bodyElement)) {
           if (kind === "CommonJS") {
-            this.raise(FlowErrors.AmbiguousDeclareModuleKind, {
-              at: bodyElement,
-            });
+            this.raise(FlowErrors.AmbiguousDeclareModuleKind, bodyElement);
           }
           kind = "ES";
         } else if (bodyElement.type === "DeclareModuleExports") {
           if (hasModuleExport) {
-            this.raise(FlowErrors.DuplicateDeclareModuleExports, {
-              at: bodyElement,
-            });
+            this.raise(FlowErrors.DuplicateDeclareModuleExports, bodyElement);
           }
           if (kind === "ES") {
-            this.raise(FlowErrors.AmbiguousDeclareModuleKind, {
-              at: bodyElement,
-            });
+            this.raise(FlowErrors.AmbiguousDeclareModuleKind, bodyElement);
           }
           kind = "CommonJS";
           hasModuleExport = true;
@@ -605,11 +599,14 @@ export default (superClass: typeof Parser) =>
             | "let"
             | "type"
             | "interface";
-          throw this.raise(FlowErrors.UnsupportedDeclareExportKind, {
-            at: this.state.startLoc,
-            unsupportedExportKind: label,
-            suggestion: exportSuggestions[label],
-          });
+          throw this.raise(
+            FlowErrors.UnsupportedDeclareExportKind,
+            this.state.startLoc,
+            {
+              unsupportedExportKind: label,
+              suggestion: exportSuggestions[label],
+            },
+          );
         }
 
         if (
@@ -761,9 +758,10 @@ export default (superClass: typeof Parser) =>
 
     checkNotUnderscore(word: string) {
       if (word === "_") {
-        this.raise(FlowErrors.UnexpectedReservedUnderscore, {
-          at: this.state.startLoc,
-        });
+        this.raise(
+          FlowErrors.UnexpectedReservedUnderscore,
+          this.state.startLoc,
+        );
       }
     }
 
@@ -774,8 +772,8 @@ export default (superClass: typeof Parser) =>
         declaration
           ? FlowErrors.AssignReservedType
           : FlowErrors.UnexpectedReservedType,
+        startLoc,
         {
-          at: startLoc,
           reservedType: word,
         },
       );
@@ -876,7 +874,7 @@ export default (superClass: typeof Parser) =>
         node.default = this.flowParseType();
       } else {
         if (requireDefault) {
-          this.raise(FlowErrors.MissingTypeParamDefault, { at: nodeStartLoc });
+          this.raise(FlowErrors.MissingTypeParamDefault, nodeStartLoc);
         }
       }
 
@@ -1214,9 +1212,10 @@ export default (superClass: typeof Parser) =>
           !this.match(tt.braceR) &&
           !this.match(tt.braceBarR)
         ) {
-          this.raise(FlowErrors.UnexpectedExplicitInexactInObject, {
-            at: inexactStartLoc,
-          });
+          this.raise(
+            FlowErrors.UnexpectedExplicitInexactInObject,
+            inexactStartLoc,
+          );
         }
       }
 
@@ -1256,31 +1255,34 @@ export default (superClass: typeof Parser) =>
 
         if (isInexactToken) {
           if (!allowSpread) {
-            this.raise(FlowErrors.InexactInsideNonObject, {
-              at: this.state.lastTokStartLoc,
-            });
+            this.raise(
+              FlowErrors.InexactInsideNonObject,
+              this.state.lastTokStartLoc,
+            );
           } else if (!allowInexact) {
-            this.raise(FlowErrors.InexactInsideExact, {
-              at: this.state.lastTokStartLoc,
-            });
+            this.raise(
+              FlowErrors.InexactInsideExact,
+              this.state.lastTokStartLoc,
+            );
           }
           if (variance) {
-            this.raise(FlowErrors.InexactVariance, { at: variance });
+            this.raise(FlowErrors.InexactVariance, variance);
           }
 
           return null;
         }
 
         if (!allowSpread) {
-          this.raise(FlowErrors.UnexpectedSpreadType, {
-            at: this.state.lastTokStartLoc,
-          });
+          this.raise(
+            FlowErrors.UnexpectedSpreadType,
+            this.state.lastTokStartLoc,
+          );
         }
         if (protoStartLoc != null) {
           this.unexpected(protoStartLoc);
         }
         if (variance) {
-          this.raise(FlowErrors.SpreadVariance, { at: variance });
+          this.raise(FlowErrors.SpreadVariance, variance);
         }
 
         node.argument = this.flowParseType();
@@ -1315,9 +1317,10 @@ export default (superClass: typeof Parser) =>
             node.key.name === "constructor" &&
             node.value.this
           ) {
-            this.raise(FlowErrors.ThisParamBannedInConstructor, {
-              at: node.value.this,
-            });
+            this.raise(
+              FlowErrors.ThisParamBannedInConstructor,
+              node.value.this,
+            );
           }
         } else {
           if (kind !== "init") this.unexpected();
@@ -1353,7 +1356,7 @@ export default (superClass: typeof Parser) =>
           property.kind === "get"
             ? FlowErrors.GetterMayNotHaveThisParam
             : FlowErrors.SetterMayNotHaveThisParam,
-          { at: property.value.this },
+          property.value.this,
         );
       }
 
@@ -1362,12 +1365,12 @@ export default (superClass: typeof Parser) =>
           property.kind === "get"
             ? Errors.BadGetterArity
             : Errors.BadSetterArity,
-          { at: property },
+          property,
         );
       }
 
       if (property.kind === "set" && property.value.rest) {
-        this.raise(Errors.BadSetterRestParameter, { at: property });
+        this.raise(Errors.BadSetterRestParameter, property);
       }
     }
 
@@ -1447,13 +1450,13 @@ export default (superClass: typeof Parser) =>
 
       if (lh.type === tt.colon || lh.type === tt.question) {
         if (isThis && !first) {
-          this.raise(FlowErrors.ThisParamMustBeFirst, { at: node });
+          this.raise(FlowErrors.ThisParamMustBeFirst, node);
         }
         name = this.parseIdentifier(isThis);
         if (this.eat(tt.question)) {
           optional = true;
           if (isThis) {
-            this.raise(FlowErrors.ThisParamMayNotBeOptional, { at: node });
+            this.raise(FlowErrors.ThisParamMayNotBeOptional, node);
           }
         }
         typeAnnotation = this.flowParseTypeInitialiser();
@@ -1678,9 +1681,10 @@ export default (superClass: typeof Parser) =>
               );
             }
 
-            throw this.raise(FlowErrors.UnexpectedSubtractionOperand, {
-              at: this.state.startLoc,
-            });
+            throw this.raise(
+              FlowErrors.UnexpectedSubtractionOperand,
+              this.state.startLoc,
+            );
           }
           this.unexpected();
           return;
@@ -2074,9 +2078,7 @@ export default (superClass: typeof Parser) =>
           // e.g.   Source: a ? (b): c => (d): e => f
           //      Result 1: a ? b : (c => ((d): e => f))
           //      Result 2: a ? ((b): c => d) : (e => f)
-          this.raise(FlowErrors.AmbiguousConditionalArrow, {
-            at: state.startLoc,
-          });
+          this.raise(FlowErrors.AmbiguousConditionalArrow, state.startLoc);
         }
 
         if (failed && valid.length === 1) {
@@ -2331,11 +2333,9 @@ export default (superClass: typeof Parser) =>
           member.type !== "ClassPrivateProperty" &&
           member.type !== "PropertyDefinition" // Used by estree plugin
         ) {
-          this.raise(FlowErrors.DeclareClassElement, { at: startLoc });
+          this.raise(FlowErrors.DeclareClassElement, startLoc);
         } else if (member.value) {
-          this.raise(FlowErrors.DeclareClassFieldInitializer, {
-            at: member.value,
-          });
+          this.raise(FlowErrors.DeclareClassFieldInitializer, member.value);
         }
       }
     }
@@ -2350,8 +2350,7 @@ export default (superClass: typeof Parser) =>
 
       // Allow @@iterator and @@asyncIterator as a identifier only inside type
       if (!this.isIterator(word) || !this.state.inType) {
-        this.raise(Errors.InvalidIdentifier, {
-          at: this.state.curPosition(),
+        this.raise(Errors.InvalidIdentifier, this.state.curPosition(), {
           identifierName: fullWord,
         });
       }
@@ -2434,9 +2433,7 @@ export default (superClass: typeof Parser) =>
           !expr.extra?.parenthesized &&
           (exprList.length > 1 || !isParenthesizedExpr)
         ) {
-          this.raise(FlowErrors.TypeCastInPattern, {
-            at: expr.typeAnnotation,
-          });
+          this.raise(FlowErrors.TypeCastInPattern, expr.typeAnnotation);
         }
       }
 
@@ -2537,7 +2534,7 @@ export default (superClass: typeof Parser) =>
       if (method.params && isConstructor) {
         const params = method.params;
         if (params.length > 0 && this.isThisParam(params[0])) {
-          this.raise(FlowErrors.ThisParamBannedInConstructor, { at: method });
+          this.raise(FlowErrors.ThisParamBannedInConstructor, method);
         }
         // estree support
       } else if (
@@ -2550,7 +2547,7 @@ export default (superClass: typeof Parser) =>
         // @ts-expect-error estree
         const params = method.value.params;
         if (params.length > 0 && this.isThisParam(params[0])) {
-          this.raise(FlowErrors.ThisParamBannedInConstructor, { at: method });
+          this.raise(FlowErrors.ThisParamBannedInConstructor, method);
         }
       }
     }
@@ -2600,9 +2597,9 @@ export default (superClass: typeof Parser) =>
       if (params.length > 0) {
         const param = params[0];
         if (this.isThisParam(param) && method.kind === "get") {
-          this.raise(FlowErrors.GetterMayNotHaveThisParam, { at: param });
+          this.raise(FlowErrors.GetterMayNotHaveThisParam, param);
         } else if (this.isThisParam(param)) {
-          this.raise(FlowErrors.SetterMayNotHaveThisParam, { at: param });
+          this.raise(FlowErrors.SetterMayNotHaveThisParam, param);
         }
       }
     }
@@ -2657,10 +2654,10 @@ export default (superClass: typeof Parser) =>
     parseAssignableListItemTypes(param: N.Pattern): N.Pattern {
       if (this.eat(tt.question)) {
         if (param.type !== "Identifier") {
-          this.raise(FlowErrors.PatternIsOptional, { at: param });
+          this.raise(FlowErrors.PatternIsOptional, param);
         }
         if (this.isThisParam(param)) {
-          this.raise(FlowErrors.ThisParamMayNotBeOptional, { at: param });
+          this.raise(FlowErrors.ThisParamMayNotBeOptional, param);
         }
 
         (param as any as N.Identifier).optional = true;
@@ -2669,11 +2666,11 @@ export default (superClass: typeof Parser) =>
         // @ts-expect-error: refine typings
         param.typeAnnotation = this.flowParseTypeAnnotation();
       } else if (this.isThisParam(param)) {
-        this.raise(FlowErrors.ThisParamAnnotationRequired, { at: param });
+        this.raise(FlowErrors.ThisParamAnnotationRequired, param);
       }
 
       if (this.match(tt.eq) && this.isThisParam(param)) {
-        this.raise(FlowErrors.ThisParamNoDefault, { at: param });
+        this.raise(FlowErrors.ThisParamNoDefault, param);
       }
 
       this.resetEndLocation(param);
@@ -2691,9 +2688,7 @@ export default (superClass: typeof Parser) =>
         node.typeAnnotation &&
         node.right.start < node.typeAnnotation.start
       ) {
-        this.raise(FlowErrors.TypeBeforeInitializer, {
-          at: node.typeAnnotation,
-        });
+        this.raise(FlowErrors.TypeBeforeInitializer, node.typeAnnotation);
       }
 
       return node;
@@ -2702,9 +2697,10 @@ export default (superClass: typeof Parser) =>
     checkImportReflection(node: Undone<N.ImportDeclaration>) {
       super.checkImportReflection(node);
       if (node.module && node.importKind !== "value") {
-        this.raise(FlowErrors.ImportReflectionHasImportType, {
-          at: node.specifiers[0].loc.start,
-        });
+        this.raise(
+          FlowErrors.ImportReflectionHasImportType,
+          node.specifiers[0].loc.start,
+        );
       }
     }
 
@@ -2804,8 +2800,7 @@ export default (superClass: typeof Parser) =>
         } else {
           if (importedIsString) {
             /*:: invariant(firstIdent instanceof N.StringLiteral) */
-            throw this.raise(Errors.ImportBindingIsString, {
-              at: specifier,
+            throw this.raise(Errors.ImportBindingIsString, specifier, {
               importName: firstIdent.value,
             });
           }
@@ -2825,9 +2820,7 @@ export default (superClass: typeof Parser) =>
       const specifierIsTypeImport = hasTypeImportKind(specifier);
 
       if (isInTypeOnlyImport && specifierIsTypeImport) {
-        this.raise(FlowErrors.ImportTypeShorthandOnlyInPureImport, {
-          at: specifier,
-        });
+        this.raise(FlowErrors.ImportTypeShorthandOnlyInPureImport, specifier);
       }
 
       if (isInTypeOnlyImport || specifierIsTypeImport) {
@@ -3008,7 +3001,7 @@ export default (superClass: typeof Parser) =>
               /*:: invariant(typeParameters) */
               this.raise(
                 FlowErrors.UnexpectedTypeParameterBeforeAsyncArrowFunction,
-                { at: typeParameters },
+                typeParameters,
               );
             }
             // @ts-expect-error: refine tryParse typings
@@ -3041,9 +3034,10 @@ export default (superClass: typeof Parser) =>
         if (arrow.thrown) throw arrow.error;
 
         /*:: invariant(typeParameters) */
-        throw this.raise(FlowErrors.UnexpectedTokenAfterTypeParameter, {
-          at: typeParameters,
-        });
+        throw this.raise(
+          FlowErrors.UnexpectedTokenAfterTypeParameter,
+          typeParameters,
+        );
       }
 
       return super.parseMaybeAssign(refExpressionErrors, afterLeftParse);
@@ -3121,7 +3115,7 @@ export default (superClass: typeof Parser) =>
       // ensure the `this` param is first, if it exists
       for (let i = 0; i < node.params.length; i++) {
         if (this.isThisParam(node.params[i]) && i > 0) {
-          this.raise(FlowErrors.ThisParamMustBeFirst, { at: node.params[i] });
+          this.raise(FlowErrors.ThisParamMustBeFirst, node.params[i]);
         }
       }
 
@@ -3309,9 +3303,10 @@ export default (superClass: typeof Parser) =>
     parseTopLevel(file: N.File, program: N.Program): N.File {
       const fileNode = super.parseTopLevel(file, program);
       if (this.state.hasFlowComment) {
-        this.raise(FlowErrors.UnterminatedFlowComment, {
-          at: this.state.curPosition(),
-        });
+        this.raise(
+          FlowErrors.UnterminatedFlowComment,
+          this.state.curPosition(),
+        );
       }
       return fileNode;
     }
@@ -3319,9 +3314,7 @@ export default (superClass: typeof Parser) =>
     skipBlockComment(): N.CommentBlock | undefined {
       if (this.hasPlugin("flowComments") && this.skipFlowComment()) {
         if (this.state.hasFlowComment) {
-          throw this.raise(FlowErrors.NestedFlowComment, {
-            at: this.state.startLoc,
-          });
+          throw this.raise(FlowErrors.NestedFlowComment, this.state.startLoc);
         }
         this.hasFlowCommentCompletion();
         const commentSkip = this.skipFlowComment();
@@ -3370,9 +3363,7 @@ export default (superClass: typeof Parser) =>
     hasFlowCommentCompletion(): void {
       const end = this.input.indexOf("*/", this.state.pos);
       if (end === -1) {
-        throw this.raise(Errors.UnterminatedComment, {
-          at: this.state.curPosition(),
-        });
+        throw this.raise(Errors.UnterminatedComment, this.state.curPosition());
       }
     }
 
@@ -3388,8 +3379,7 @@ export default (superClass: typeof Parser) =>
         memberName: string;
       },
     ): void {
-      this.raise(FlowErrors.EnumBooleanMemberNotInitialized, {
-        at: loc,
+      this.raise(FlowErrors.EnumBooleanMemberNotInitialized, loc, {
         memberName,
         enumName,
       });
@@ -3405,42 +3395,32 @@ export default (superClass: typeof Parser) =>
           : enumContext.explicitType === "symbol"
             ? FlowErrors.EnumInvalidMemberInitializerSymbolType
             : FlowErrors.EnumInvalidMemberInitializerPrimaryType,
-        {
-          at: loc,
-          ...enumContext,
-        },
+        loc,
+        enumContext,
       );
     }
 
     flowEnumErrorNumberMemberNotInitialized(
       loc: Position,
-      {
-        enumName,
-        memberName,
-      }: {
+      details: {
         enumName: string;
         memberName: string;
       },
     ): void {
-      this.raise(FlowErrors.EnumNumberMemberNotInitialized, {
-        at: loc,
-        enumName,
-        memberName,
-      });
+      this.raise(FlowErrors.EnumNumberMemberNotInitialized, loc, details);
     }
 
     flowEnumErrorStringMemberInconsistentlyInitialized(
       node: N.Node,
-      {
-        enumName,
-      }: {
+      details: {
         enumName: string;
       },
     ): void {
-      this.raise(FlowErrors.EnumStringMemberInconsistentlyInitialized, {
-        at: node,
-        enumName,
-      });
+      this.raise(
+        FlowErrors.EnumStringMemberInconsistentlyInitialized,
+        node,
+        details,
+      );
     }
 
     flowEnumMemberInit(): EnumMemberInit {
@@ -3543,16 +3523,14 @@ export default (superClass: typeof Parser) =>
           continue;
         }
         if (/^[a-z]/.test(memberName)) {
-          this.raise(FlowErrors.EnumInvalidMemberName, {
-            at: id,
+          this.raise(FlowErrors.EnumInvalidMemberName, id, {
             memberName,
             suggestion: memberName[0].toUpperCase() + memberName.slice(1),
             enumName,
           });
         }
         if (seenNames.has(memberName)) {
-          this.raise(FlowErrors.EnumDuplicateMemberName, {
-            at: id,
+          this.raise(FlowErrors.EnumDuplicateMemberName, id, {
             memberName,
             enumName,
           });
@@ -3656,10 +3634,13 @@ export default (superClass: typeof Parser) =>
       if (!this.eatContextual(tt._of)) return null;
 
       if (!tokenIsIdentifier(this.state.type)) {
-        throw this.raise(FlowErrors.EnumInvalidExplicitTypeUnknownSupplied, {
-          at: this.state.startLoc,
-          enumName,
-        });
+        throw this.raise(
+          FlowErrors.EnumInvalidExplicitTypeUnknownSupplied,
+          this.state.startLoc,
+          {
+            enumName,
+          },
+        );
       }
 
       const { value } = this.state;
@@ -3671,8 +3652,7 @@ export default (superClass: typeof Parser) =>
         value !== "string" &&
         value !== "symbol"
       ) {
-        this.raise(FlowErrors.EnumInvalidExplicitType, {
-          at: this.state.startLoc,
+        this.raise(FlowErrors.EnumInvalidExplicitType, this.state.startLoc, {
           enumName,
           invalidEnumType: value,
         });
@@ -3761,8 +3741,7 @@ export default (superClass: typeof Parser) =>
             this.expect(tt.braceR);
             return this.finishNode(node, "EnumNumberBody");
           } else {
-            this.raise(FlowErrors.EnumInconsistentMemberValues, {
-              at: nameLoc,
+            this.raise(FlowErrors.EnumInconsistentMemberValues, nameLoc, {
               enumName,
             });
             return empty();

--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -361,7 +361,7 @@ export default (superClass: typeof Parser) =>
       this.next(); // eat `%`
       this.expectContextual(tt._checks);
       // Force '%' and 'checks' to be adjacent
-      if (this.state.lastTokStart > moduloLoc.index + 1) {
+      if (this.state.lastTokStartLoc.index > moduloLoc.index + 1) {
         this.raise(FlowErrors.UnexpectedSpaceBetweenModuloChecks, {
           at: moduloLoc,
         });

--- a/packages/babel-parser/src/plugins/flow/scope.ts
+++ b/packages/babel-parser/src/plugins/flow/scope.ts
@@ -1,5 +1,5 @@
 import type { Position } from "../../util/location.ts";
-import ScopeHandler, { Scope } from "../../util/scope.ts";
+import ScopeHandler, { NameType, Scope } from "../../util/scope.ts";
 import { BindingFlag, type ScopeFlag } from "../../util/scopeflags.ts";
 import type * as N from "../../types.ts";
 
@@ -33,11 +33,12 @@ export default class FlowScopeHandler extends ScopeHandler<FlowScope> {
   ): boolean {
     if (super.isRedeclaredInScope(scope, name, bindingType)) return true;
 
-    if (bindingType & BindingFlag.FLAG_FLOW_DECLARE_FN) {
-      return (
-        !scope.declareFunctions.has(name) &&
-        (scope.lexical.has(name) || scope.functions.has(name))
-      );
+    if (
+      bindingType & BindingFlag.FLAG_FLOW_DECLARE_FN &&
+      !scope.declareFunctions.has(name)
+    ) {
+      const type = scope.names.get(name);
+      return (type & NameType.Function) > 0 || (type & NameType.Lexical) > 0;
     }
 
     return false;

--- a/packages/babel-parser/src/plugins/jsx/index.ts
+++ b/packages/babel-parser/src/plugins/jsx/index.ts
@@ -93,9 +93,10 @@ export default (superClass: typeof Parser) =>
       let chunkStart = this.state.pos;
       for (;;) {
         if (this.state.pos >= this.length) {
-          throw this.raise(JsxErrors.UnterminatedJsxContent, {
-            at: this.state.startLoc,
-          });
+          throw this.raise(
+            JsxErrors.UnterminatedJsxContent,
+            this.state.startLoc,
+          );
         }
 
         const ch = this.input.charCodeAt(this.state.pos);
@@ -125,8 +126,7 @@ export default (superClass: typeof Parser) =>
           case charCodes.greaterThan:
           case charCodes.rightCurlyBrace:
             if (process.env.BABEL_8_BREAKING) {
-              this.raise(JsxErrors.UnexpectedToken, {
-                at: this.state.curPosition(),
+              this.raise(JsxErrors.UnexpectedToken, this.state.curPosition(), {
                 unexpected: this.input[this.state.pos],
                 HTMLEntity:
                   ch === charCodes.rightCurlyBrace ? "&rbrace;" : "&gt;",
@@ -170,9 +170,7 @@ export default (superClass: typeof Parser) =>
       let chunkStart = ++this.state.pos;
       for (;;) {
         if (this.state.pos >= this.length) {
-          throw this.raise(Errors.UnterminatedString, {
-            at: this.state.startLoc,
-          });
+          throw this.raise(Errors.UnterminatedString, this.state.startLoc);
         }
 
         const ch = this.input.charCodeAt(this.state.pos);
@@ -320,7 +318,7 @@ export default (superClass: typeof Parser) =>
           this.next();
           node = this.jsxParseExpressionContainer(node, tc.j_oTag);
           if (node.expression.type === "JSXEmptyExpression") {
-            this.raise(JsxErrors.AttributeIsEmpty, { at: node });
+            this.raise(JsxErrors.AttributeIsEmpty, node);
           }
           return node;
 
@@ -329,9 +327,7 @@ export default (superClass: typeof Parser) =>
           return this.parseExprAtom();
 
         default:
-          throw this.raise(JsxErrors.UnsupportedJsxValue, {
-            at: this.state.startLoc,
-          });
+          throw this.raise(JsxErrors.UnsupportedJsxValue, this.state.startLoc);
       }
     }
 
@@ -372,9 +368,10 @@ export default (superClass: typeof Parser) =>
             expression.type === "SequenceExpression" &&
             !expression.extra?.parenthesized
           ) {
-            this.raise(JsxErrors.UnexpectedSequenceExpression, {
-              at: expression.expressions[1],
-            });
+            this.raise(
+              JsxErrors.UnexpectedSequenceExpression,
+              expression.expressions[1],
+            );
           }
         }
 
@@ -500,12 +497,9 @@ export default (superClass: typeof Parser) =>
           !isFragment(closingElement) &&
           closingElement !== null
         ) {
-          this.raise(JsxErrors.MissingClosingTagFragment, {
-            at: closingElement,
-          });
+          this.raise(JsxErrors.MissingClosingTagFragment, closingElement);
         } else if (!isFragment(openingElement) && isFragment(closingElement)) {
-          this.raise(JsxErrors.MissingClosingTagElement, {
-            at: closingElement,
+          this.raise(JsxErrors.MissingClosingTagElement, closingElement, {
             openingTagName: getQualifiedJSXName(openingElement.name),
           });
         } else if (!isFragment(openingElement) && !isFragment(closingElement)) {
@@ -513,8 +507,7 @@ export default (superClass: typeof Parser) =>
             getQualifiedJSXName(closingElement.name) !==
             getQualifiedJSXName(openingElement.name)
           ) {
-            this.raise(JsxErrors.MissingClosingTagElement, {
-              at: closingElement,
+            this.raise(JsxErrors.MissingClosingTagElement, closingElement, {
               openingTagName: getQualifiedJSXName(openingElement.name),
             });
           }
@@ -530,9 +523,10 @@ export default (superClass: typeof Parser) =>
       }
       node.children = children;
       if (this.match(tt.lt)) {
-        throw this.raise(JsxErrors.UnwrappedAdjacentJSXElements, {
-          at: this.state.startLoc,
-        });
+        throw this.raise(
+          JsxErrors.UnwrappedAdjacentJSXElements,
+          this.state.startLoc,
+        );
       }
 
       return isFragment(openingElement)

--- a/packages/babel-parser/src/plugins/placeholders.ts
+++ b/packages/babel-parser/src/plugins/placeholders.ts
@@ -246,9 +246,10 @@ export default (superClass: typeof Parser) =>
           node.body = this.finishPlaceholder(placeholder, "ClassBody");
           return this.finishNode(node, type);
         } else {
-          throw this.raise(PlaceholderErrors.ClassNameIsRequired, {
-            at: this.state.startLoc,
-          });
+          throw this.raise(
+            PlaceholderErrors.ClassNameIsRequired,
+            this.state.startLoc,
+          );
         }
       } else {
         this.parseClassId(node, isStatement, optionalId);
@@ -377,9 +378,7 @@ export default (superClass: typeof Parser) =>
     // Throws if the current token and the prev one are separated by a space.
     assertNoSpace(): void {
       if (this.state.start > this.state.lastTokEndLoc.index) {
-        this.raise(PlaceholderErrors.UnexpectedSpace, {
-          at: this.state.lastTokEndLoc,
-        });
+        this.raise(PlaceholderErrors.UnexpectedSpace, this.state.lastTokEndLoc);
       }
     }
   };

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -359,8 +359,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         after: TsModifier,
       ) => {
         if (modifier === before && modified[after]) {
-          this.raise(TSErrors.InvalidModifiersOrder, {
-            at: loc,
+          this.raise(TSErrors.InvalidModifiersOrder, loc, {
             orderedModifiers: [before, after],
           });
         }
@@ -375,8 +374,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           (modified[mod1] && modifier === mod2) ||
           (modified[mod2] && modifier === mod1)
         ) {
-          this.raise(TSErrors.IncompatibleModifiers, {
-            at: loc,
+          this.raise(TSErrors.IncompatibleModifiers, loc, {
             modifiers: [mod1, mod2],
           });
         }
@@ -393,8 +391,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
         if (tsIsAccessModifier(modifier)) {
           if (modified.accessibility) {
-            this.raise(TSErrors.DuplicateAccessibilityModifier, {
-              at: startLoc,
+            this.raise(TSErrors.DuplicateAccessibilityModifier, startLoc, {
               modifier,
             });
           } else {
@@ -406,14 +403,14 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           }
         } else if (tsIsVarianceAnnotations(modifier)) {
           if (modified[modifier]) {
-            this.raise(TSErrors.DuplicateModifier, { at: startLoc, modifier });
+            this.raise(TSErrors.DuplicateModifier, startLoc, { modifier });
           }
           modified[modifier] = true;
 
           enforceOrder(startLoc, modifier, "in", "out");
         } else {
           if (Object.hasOwnProperty.call(modified, modifier)) {
-            this.raise(TSErrors.DuplicateModifier, { at: startLoc, modifier });
+            this.raise(TSErrors.DuplicateModifier, startLoc, { modifier });
           } else {
             enforceOrder(startLoc, modifier, "static", "readonly");
             enforceOrder(startLoc, modifier, "static", "override");
@@ -427,8 +424,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         }
 
         if (disallowedModifiers?.includes(modifier)) {
-          this.raise(errorTemplate, {
-            at: startLoc,
+          this.raise(errorTemplate, startLoc, {
             modifier,
           });
         }
@@ -565,9 +561,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       this.expect(tt._import);
       this.expect(tt.parenL);
       if (!this.match(tt.string)) {
-        this.raise(TSErrors.UnsupportedImportTypeArgument, {
-          at: this.state.startLoc,
-        });
+        this.raise(TSErrors.UnsupportedImportTypeArgument, this.state.startLoc);
       }
 
       // For compatibility to estree we cannot call parseLiteral directly here
@@ -712,7 +706,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         refTrailingCommaPos,
       );
       if (node.params.length === 0) {
-        this.raise(TSErrors.EmptyTypeParameters, { at: node });
+        this.raise(TSErrors.EmptyTypeParameters, node);
       }
       if (refTrailingCommaPos.value !== -1) {
         this.addExtra(node, "trailingComma", refTrailingCommaPos.value);
@@ -760,8 +754,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       for (const pattern of list) {
         const { type } = pattern;
         if (type === "AssignmentPattern" || type === "TSParameterProperty") {
-          this.raise(TSErrors.UnsupportedSignatureParameterKind, {
-            at: pattern,
+          this.raise(TSErrors.UnsupportedSignatureParameterKind, pattern, {
             type,
           });
         }
@@ -833,13 +826,14 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
       if (this.match(tt.parenL) || this.match(tt.lt)) {
         if (readonly) {
-          this.raise(TSErrors.ReadonlyForMethodSignature, { at: node });
+          this.raise(TSErrors.ReadonlyForMethodSignature, node);
         }
         const method: N.TsMethodSignature = nodeAny;
         if (method.kind && this.match(tt.lt)) {
-          this.raise(TSErrors.AccesorCannotHaveTypeParameters, {
-            at: this.state.curPosition(),
-          });
+          this.raise(
+            TSErrors.AccesorCannotHaveTypeParameters,
+            this.state.curPosition(),
+          );
         }
         this.tsFillSignature(tt.colon, method);
         this.tsParseTypeMemberSemicolon();
@@ -851,41 +845,46 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           : "typeAnnotation";
         if (method.kind === "get") {
           if (method[paramsKey].length > 0) {
-            this.raise(Errors.BadGetterArity, { at: this.state.curPosition() });
+            this.raise(Errors.BadGetterArity, this.state.curPosition());
             if (this.isThisParam(method[paramsKey][0])) {
-              this.raise(TSErrors.AccesorCannotDeclareThisParameter, {
-                at: this.state.curPosition(),
-              });
+              this.raise(
+                TSErrors.AccesorCannotDeclareThisParameter,
+                this.state.curPosition(),
+              );
             }
           }
         } else if (method.kind === "set") {
           if (method[paramsKey].length !== 1) {
-            this.raise(Errors.BadSetterArity, { at: this.state.curPosition() });
+            this.raise(Errors.BadSetterArity, this.state.curPosition());
           } else {
             const firstParameter = method[paramsKey][0];
             if (this.isThisParam(firstParameter)) {
-              this.raise(TSErrors.AccesorCannotDeclareThisParameter, {
-                at: this.state.curPosition(),
-              });
+              this.raise(
+                TSErrors.AccesorCannotDeclareThisParameter,
+                this.state.curPosition(),
+              );
             }
             if (
               firstParameter.type === "Identifier" &&
               firstParameter.optional
             ) {
-              this.raise(TSErrors.SetAccesorCannotHaveOptionalParameter, {
-                at: this.state.curPosition(),
-              });
+              this.raise(
+                TSErrors.SetAccesorCannotHaveOptionalParameter,
+                this.state.curPosition(),
+              );
             }
             if (firstParameter.type === "RestElement") {
-              this.raise(TSErrors.SetAccesorCannotHaveRestParameter, {
-                at: this.state.curPosition(),
-              });
+              this.raise(
+                TSErrors.SetAccesorCannotHaveRestParameter,
+                this.state.curPosition(),
+              );
             }
           }
           if (method[returnTypeKey]) {
-            this.raise(TSErrors.SetAccesorCannotHaveReturnType, {
-              at: method[returnTypeKey],
-            });
+            this.raise(
+              TSErrors.SetAccesorCannotHaveReturnType,
+              method[returnTypeKey],
+            );
           }
         } else {
           method.kind = "method";
@@ -1053,9 +1052,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           type !== "TSOptionalType" &&
           !(type === "TSNamedTupleMember" && elementNode.optional)
         ) {
-          this.raise(TSErrors.OptionalTypeBeforeRequired, {
-            at: elementNode,
-          });
+          this.raise(TSErrors.OptionalTypeBeforeRequired, elementNode);
         }
 
         seenOptionalElement ||=
@@ -1125,14 +1122,15 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
           if (this.eat(tt.question)) {
             labeledNode.optional = true;
-            this.raise(TSErrors.TupleOptionalAfterType, {
-              at: this.state.lastTokStartLoc,
-            });
+            this.raise(
+              TSErrors.TupleOptionalAfterType,
+              this.state.lastTokStartLoc,
+            );
           }
         } else {
           labeledNode = this.startNodeAtNode<N.TsNamedTupleMember>(type);
           labeledNode.optional = optional;
-          this.raise(TSErrors.InvalidTupleMemberLabel, { at: type });
+          this.raise(TSErrors.InvalidTupleMemberLabel, type);
           // @ts-expect-error This produces an invalid AST, but at least we don't drop
           // nodes representing the invalid source.
           labeledNode.label = type;
@@ -1338,7 +1336,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         case "TSArrayType":
           return;
         default:
-          this.raise(TSErrors.UnexpectedReadonly, { at: node });
+          this.raise(TSErrors.UnexpectedReadonly, node);
       }
     }
 
@@ -1588,10 +1586,13 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       }
 
       if (containsEsc) {
-        this.raise(Errors.InvalidEscapedReservedWord, {
-          at: this.state.lastTokStartLoc,
-          reservedWord: "asserts",
-        });
+        this.raise(
+          Errors.InvalidEscapedReservedWord,
+          this.state.lastTokStartLoc,
+          {
+            reservedWord: "asserts",
+          },
+        );
       }
 
       return true;
@@ -1666,7 +1667,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
     tsParseTypeAssertion(): N.TsTypeAssertion {
       if (this.getPluginOption("typescript", "disallowAmbiguousJSXLike")) {
-        this.raise(TSErrors.ReservedTypeAssertion, { at: this.state.startLoc });
+        this.raise(TSErrors.ReservedTypeAssertion, this.state.startLoc);
       }
 
       const node = this.startNode<N.TsTypeAssertion>();
@@ -1700,8 +1701,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       );
 
       if (!delimitedList.length) {
-        this.raise(TSErrors.EmptyHeritageClauseType, {
-          at: originalStartLoc,
+        this.raise(TSErrors.EmptyHeritageClauseType, originalStartLoc, {
           token,
         });
       }
@@ -1723,7 +1723,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         this.checkIdentifier(node.id, BindingFlag.TYPE_TS_INTERFACE);
       } else {
         node.id = null;
-        this.raise(TSErrors.MissingInterfaceName, { at: this.state.startLoc });
+        this.raise(TSErrors.MissingInterfaceName, this.state.startLoc);
       }
 
       node.typeParameters = this.tsTryParseTypeParameters(
@@ -1952,9 +1952,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         node.importKind === "type" &&
         moduleReference.type !== "TSExternalModuleReference"
       ) {
-        this.raise(TSErrors.ImportAliasHasImportType, {
-          at: moduleReference,
-        });
+        this.raise(TSErrors.ImportAliasHasImportType, moduleReference);
       }
       node.moduleReference = moduleReference;
       this.semicolon();
@@ -2251,7 +2249,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         }),
       );
       if (node.params.length === 0) {
-        this.raise(TSErrors.EmptyTypeArguments, { at: node });
+        this.raise(TSErrors.EmptyTypeArguments, node);
       } else if (!this.state.inType && this.curContext() === tc.brace) {
         // rescan `>` when we are no longer in type context and JSX parsing context
         // since it was tokenized when `inType` is `true`.
@@ -2301,7 +2299,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         !(flags & ParseBindingListFlags.IS_CONSTRUCTOR_PARAMS) &&
         (accessibility || readonly || override)
       ) {
-        this.raise(TSErrors.UnexpectedParameterModifier, { at: startLoc });
+        this.raise(TSErrors.UnexpectedParameterModifier, startLoc);
       }
 
       const left = this.parseMaybeDefault();
@@ -2316,7 +2314,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         if (readonly) pp.readonly = readonly;
         if (override) pp.override = override;
         if (elt.type !== "Identifier" && elt.type !== "AssignmentPattern") {
-          this.raise(TSErrors.UnsupportedParameterPropertyKind, { at: pp });
+          this.raise(TSErrors.UnsupportedParameterPropertyKind, pp);
         }
         pp.parameter = elt as any as N.Identifier | N.AssignmentPattern;
         return this.finishNode(pp, "TSParameterProperty");
@@ -2344,7 +2342,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           (param as any).optional &&
           !this.state.isAmbientContext
         ) {
-          this.raise(TSErrors.PatternIsOptional, { at: param });
+          this.raise(TSErrors.PatternIsOptional, param);
         }
       }
     }
@@ -2379,7 +2377,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         return this.finishNode(node, bodilessType);
       }
       if (bodilessType === "TSDeclareFunction" && this.state.isAmbientContext) {
-        this.raise(TSErrors.DeclareFunctionHasImplementation, { at: node });
+        this.raise(TSErrors.DeclareFunctionHasImplementation, node);
         if ((node as Undone<N.FunctionDeclaration>).declare) {
           return super.parseFunctionBodyAndFinish(node, bodilessType, isMethod);
         }
@@ -2402,9 +2400,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     tsCheckForInvalidTypeCasts(items: Array<N.Expression | undefined | null>) {
       items.forEach(node => {
         if (node?.type === "TSTypeCastExpression") {
-          this.raise(TSErrors.UnexpectedTypeAnnotation, {
-            at: node.typeAnnotation,
-          });
+          this.raise(TSErrors.UnexpectedTypeAnnotation, node.typeAnnotation);
         }
       });
     }
@@ -2569,7 +2565,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           ) {
             this.raise(
               TSErrors.InvalidPropertyAccessAfterInstantiationExpression,
-              { at: this.state.startLoc },
+              this.state.startLoc,
             );
           }
           return result;
@@ -2612,8 +2608,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           this.next(); // "as" or "satisfies"
           if (this.match(tt._const)) {
             if (isSatisfies) {
-              this.raise(Errors.UnexpectedKeyword, {
-                at: this.state.startLoc,
+              this.raise(Errors.UnexpectedKeyword, this.state.startLoc, {
                 keyword: "const",
               });
             }
@@ -2655,9 +2650,10 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     checkImportReflection(node: Undone<N.ImportDeclaration>) {
       super.checkImportReflection(node);
       if (node.module && node.importKind !== "value") {
-        this.raise(TSErrors.ImportReflectionHasImportType, {
-          at: node.specifiers[0].loc.start,
-        });
+        this.raise(
+          TSErrors.ImportReflectionHasImportType,
+          node.specifiers[0].loc.start,
+        );
       }
     }
 
@@ -2745,9 +2741,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         // @ts-expect-error refine typings
         importNode.specifiers[0].type === "ImportDefaultSpecifier"
       ) {
-        this.raise(TSErrors.TypeImportCannotSpecifyDefaultAndNamed, {
-          at: importNode,
-        });
+        this.raise(TSErrors.TypeImportCannotSpecifyDefaultAndNamed, importNode);
       }
 
       return importNode;
@@ -2847,15 +2841,13 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
         // var and let aren't ever allowed initializers.
         if (kind !== "const" || !!id.typeAnnotation) {
-          this.raise(TSErrors.InitializerNotAllowedInAmbientContext, {
-            at: init,
-          });
+          this.raise(TSErrors.InitializerNotAllowedInAmbientContext, init);
         } else if (
           !isValidAmbientConstInitializer(init, this.hasPlugin("estree"))
         ) {
           this.raise(
             TSErrors.ConstInitiailizerMustBeStringOrNumericLiteralOrLiteralEnumReference,
-            { at: init },
+            init,
           );
         }
       }
@@ -2937,9 +2929,10 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           this.next(); // eat "static"
           this.next(); // eat "{"
           if (this.tsHasSomeModifiers(member, modifiers)) {
-            this.raise(TSErrors.StaticBlockCannotHaveModifier, {
-              at: this.state.curPosition(),
-            });
+            this.raise(
+              TSErrors.StaticBlockCannotHaveModifier,
+              this.state.curPosition(),
+            );
           }
           super.parseClassStaticBlock(classBody, member as N.StaticBlock);
         } else {
@@ -2971,33 +2964,30 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         classBody.body.push(idx);
 
         if ((member as any).abstract) {
-          this.raise(TSErrors.IndexSignatureHasAbstract, { at: member });
+          this.raise(TSErrors.IndexSignatureHasAbstract, member);
         }
         if ((member as any).accessibility) {
-          this.raise(TSErrors.IndexSignatureHasAccessibility, {
-            at: member,
+          this.raise(TSErrors.IndexSignatureHasAccessibility, member, {
             modifier: (member as any).accessibility,
           });
         }
         if ((member as any).declare) {
-          this.raise(TSErrors.IndexSignatureHasDeclare, { at: member });
+          this.raise(TSErrors.IndexSignatureHasDeclare, member);
         }
         if ((member as any).override) {
-          this.raise(TSErrors.IndexSignatureHasOverride, { at: member });
+          this.raise(TSErrors.IndexSignatureHasOverride, member);
         }
 
         return;
       }
 
       if (!this.state.inAbstractClass && (member as any).abstract) {
-        this.raise(TSErrors.NonAbstractClassHasAbstractMethod, {
-          at: member,
-        });
+        this.raise(TSErrors.NonAbstractClassHasAbstractMethod, member);
       }
 
       if ((member as any).override) {
         if (!state.hadSuperClass) {
-          this.raise(TSErrors.OverrideNotInSubClass, { at: member });
+          this.raise(TSErrors.OverrideNotInSubClass, member);
         }
       }
 
@@ -3018,11 +3008,11 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       if (optional) methodOrProp.optional = true;
 
       if ((methodOrProp as any).readonly && this.match(tt.parenL)) {
-        this.raise(TSErrors.ClassMethodHasReadonly, { at: methodOrProp });
+        this.raise(TSErrors.ClassMethodHasReadonly, methodOrProp);
       }
 
       if ((methodOrProp as any).declare && this.match(tt.parenL)) {
-        this.raise(TSErrors.ClassMethodHasDeclare, { at: methodOrProp });
+        this.raise(TSErrors.ClassMethodHasDeclare, methodOrProp);
       }
     }
 
@@ -3128,9 +3118,10 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         isDeclare &&
         (this.isContextual(tt._declare) || !this.shouldParseExportDeclaration())
       ) {
-        throw this.raise(TSErrors.ExpectedAmbientAfterExportDeclare, {
-          at: this.state.startLoc,
-        });
+        throw this.raise(
+          TSErrors.ExpectedAmbientAfterExportDeclare,
+          this.state.startLoc,
+        );
       }
 
       const isIdentifier = tokenIsIdentifier(this.state.type);
@@ -3206,19 +3197,23 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         !(node.readonly && !node.typeAnnotation) &&
         this.match(tt.eq)
       ) {
-        this.raise(TSErrors.DeclareClassFieldHasInitializer, {
-          at: this.state.startLoc,
-        });
+        this.raise(
+          TSErrors.DeclareClassFieldHasInitializer,
+          this.state.startLoc,
+        );
       }
       if (node.abstract && this.match(tt.eq)) {
         const { key } = node;
-        this.raise(TSErrors.AbstractPropertyHasInitializer, {
-          at: this.state.startLoc,
-          propertyName:
-            key.type === "Identifier" && !node.computed
-              ? key.name
-              : `[${this.input.slice(key.start, key.end)}]`,
-        });
+        this.raise(
+          TSErrors.AbstractPropertyHasInitializer,
+          this.state.startLoc,
+          {
+            propertyName:
+              key.type === "Identifier" && !node.computed
+                ? key.name
+                : `[${this.input.slice(key.start, key.end)}]`,
+          },
+        );
       }
 
       return super.parseClassProperty(node);
@@ -3229,13 +3224,12 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     ): N.ClassPrivateProperty {
       // @ts-expect-error abstract may not index node
       if (node.abstract) {
-        this.raise(TSErrors.PrivateElementHasAbstract, { at: node });
+        this.raise(TSErrors.PrivateElementHasAbstract, node);
       }
 
       // @ts-expect-error accessibility may not index node
       if (node.accessibility) {
-        this.raise(TSErrors.PrivateElementHasAccessibility, {
-          at: node,
+        this.raise(TSErrors.PrivateElementHasAccessibility, node, {
           // @ts-expect-error refine typings
           modifier: node.accessibility,
         });
@@ -3250,7 +3244,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     ): N.ClassAccessorProperty {
       this.parseClassPropertyAnnotation(node);
       if (node.optional) {
-        this.raise(TSErrors.AccessorCannotBeOptional, { at: node });
+        this.raise(TSErrors.AccessorCannotBeOptional, node);
       }
       return super.parseClassAccessorProperty(node);
     }
@@ -3267,16 +3261,14 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         this.tsParseConstModifier,
       );
       if (typeParameters && isConstructor) {
-        this.raise(TSErrors.ConstructorHasTypeParameters, {
-          at: typeParameters,
-        });
+        this.raise(TSErrors.ConstructorHasTypeParameters, typeParameters);
       }
 
       // @ts-expect-error declare does not exist in ClassMethod
       const { declare = false, kind } = method;
 
       if (declare && (kind === "get" || kind === "set")) {
-        this.raise(TSErrors.DeclareAccessor, { at: method, kind });
+        this.raise(TSErrors.DeclareAccessor, method, { kind });
       }
       if (typeParameters) method.typeParameters = typeParameters;
       super.pushClassMethod(
@@ -3471,10 +3463,13 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
             if (!parameter.constraint) {
               // A single type parameter must either have constraints
               // or a trailing comma, otherwise it's ambiguous with JSX.
-              this.raise(TSErrors.SingleTypeParameterWithoutTrailingComma, {
-                at: createPositionWithColumnOffset(parameter.loc.end, 1),
-                typeParameterName: parameter.name.name,
-              });
+              this.raise(
+                TSErrors.SingleTypeParameterWithoutTrailingComma,
+                createPositionWithColumnOffset(parameter.loc.end, 1),
+                {
+                  typeParameterName: parameter.name.name,
+                },
+              );
             }
           }
         }
@@ -3539,7 +3534,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         !node.extra?.trailingComma &&
         this.getPluginOption("typescript", "disallowAmbiguousJSXLike")
       ) {
-        this.raise(TSErrors.ReservedArrowTypeParam, { at: node });
+        this.raise(TSErrors.ReservedArrowTypeParam, node);
       }
     }
 
@@ -3621,10 +3616,10 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           if (isLHS) {
             this.expressionScope.recordArrowParameterBindingError(
               TSErrors.UnexpectedTypeCastInParameter,
-              { at: node },
+              node,
             );
           } else {
-            this.raise(TSErrors.UnexpectedTypeCastInParameter, { at: node });
+            this.raise(TSErrors.UnexpectedTypeCastInParameter, node);
           }
           this.toAssignable(node.expression, isLHS);
           break;
@@ -3762,9 +3757,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         node.typeAnnotation &&
         node.right.start < node.typeAnnotation.start
       ) {
-        this.raise(TSErrors.TypeAnnotationAfterAssign, {
-          at: node.typeAnnotation,
-        });
+        this.raise(TSErrors.TypeAnnotationAfterAssign, node.typeAnnotation);
       }
 
       return node;
@@ -3931,9 +3924,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         //   Foo {}
         if (!this.hasFollowingLineBreak()) {
           node.abstract = true;
-          this.raise(TSErrors.NonClassMethodPropertyHasAbstractModifer, {
-            at: node,
-          });
+          this.raise(TSErrors.NonClassMethodPropertyHasAbstractModifer, node);
           return this.tsParseInterfaceDeclaration(
             node as N.TsInterfaceDeclaration,
           );
@@ -3971,8 +3962,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           : !!method.body;
         if (hasBody) {
           const { key } = method;
-          this.raise(TSErrors.AbstractMethodHasImplementation, {
-            at: method,
+          this.raise(TSErrors.AbstractMethodHasImplementation, method, {
             methodName:
               key.type === "Identifier" && !method.computed
                 ? key.name
@@ -4130,7 +4120,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           isImport
             ? TSErrors.TypeModifierIsUsedInTypeImports
             : TSErrors.TypeModifierIsUsedInTypeExports,
-          { at: loc },
+          loc,
         );
       }
 

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -506,7 +506,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         result.push(element);
 
         if (this.eat(tt.comma)) {
-          trailingCommaPos = this.state.lastTokStart;
+          trailingCommaPos = this.state.lastTokStartLoc.index;
           continue;
         }
 

--- a/packages/babel-parser/src/plugins/typescript/scope.ts
+++ b/packages/babel-parser/src/plugins/typescript/scope.ts
@@ -1,26 +1,26 @@
 import type { Position } from "../../util/location.ts";
-import ScopeHandler, { Scope } from "../../util/scope.ts";
+import ScopeHandler, { NameType, Scope } from "../../util/scope.ts";
 import { BindingFlag, ScopeFlag } from "../../util/scopeflags.ts";
 import type * as N from "../../types.ts";
 import { Errors } from "../../parse-error.ts";
 
-class TypeScriptScope extends Scope {
-  types: Set<string> = new Set();
-
+const enum TsNameType {
+  Types = 1 << 0,
   // enums (which are also in .types)
-  enums: Set<string> = new Set();
-
+  Enums = 1 << 1,
   // const enums (which are also in .enums and .types)
-  constEnums: Set<string> = new Set();
-
+  ConstEnums = 1 << 2,
   // classes (which are also in .lexical) and interface (which are also in .types)
-  classes: Set<string> = new Set();
-
+  Classes = 1 << 3,
   // namespaces and ambient functions (or classes) are too difficult to track,
   // especially without type analysis.
   // We need to track them anyway, to avoid "X is not defined" errors
   // when exporting them.
-  exportOnlyBindings: Set<string> = new Set();
+  ExportOnlyBindings = 1 << 4,
+}
+
+class TypeScriptScope extends Scope {
+  tsNames: Map<string, TsNameType> = new Map();
 }
 
 // See https://github.com/babel/babel/pull/9766#discussion_r268920730 for an
@@ -79,9 +79,11 @@ export default class TypeScriptScopeHandler extends ScopeHandler<TypeScriptScope
     }
 
     const scope = this.currentScope();
+    let type = scope.tsNames.get(name) || 0;
+
     if (bindingType & BindingFlag.FLAG_TS_EXPORT_ONLY) {
       this.maybeExportDefined(scope, name);
-      scope.exportOnlyBindings.add(name);
+      scope.tsNames.set(name, type | TsNameType.ExportOnlyBindings);
       return;
     }
 
@@ -93,13 +95,18 @@ export default class TypeScriptScopeHandler extends ScopeHandler<TypeScriptScope
         this.checkRedeclarationInScope(scope, name, bindingType, loc);
         this.maybeExportDefined(scope, name);
       }
-      scope.types.add(name);
+      type = type | TsNameType.Types;
     }
-    if (bindingType & BindingFlag.FLAG_TS_ENUM) scope.enums.add(name);
+    if (bindingType & BindingFlag.FLAG_TS_ENUM) {
+      type = type | TsNameType.Enums;
+    }
     if (bindingType & BindingFlag.FLAG_TS_CONST_ENUM) {
-      scope.constEnums.add(name);
+      type = type | TsNameType.ConstEnums;
     }
-    if (bindingType & BindingFlag.FLAG_CLASS) scope.classes.add(name);
+    if (bindingType & BindingFlag.FLAG_CLASS) {
+      type = type | TsNameType.Classes;
+    }
+    if (type) scope.tsNames.set(name, type);
   }
 
   isRedeclaredInScope(
@@ -107,18 +114,22 @@ export default class TypeScriptScopeHandler extends ScopeHandler<TypeScriptScope
     name: string,
     bindingType: BindingFlag,
   ): boolean {
-    if (scope.enums.has(name)) {
+    const type = scope.tsNames.get(name);
+    if ((type & TsNameType.Enums) > 0) {
       if (bindingType & BindingFlag.FLAG_TS_ENUM) {
         // Enums can be merged with other enums if they are both
         //  const or both non-const.
         const isConst = !!(bindingType & BindingFlag.FLAG_TS_CONST_ENUM);
-        const wasConst = scope.constEnums.has(name);
+        const wasConst = (type & TsNameType.ConstEnums) > 0;
         return isConst !== wasConst;
       }
       return true;
     }
-    if (bindingType & BindingFlag.FLAG_CLASS && scope.classes.has(name)) {
-      if (scope.lexical.has(name)) {
+    if (
+      bindingType & BindingFlag.FLAG_CLASS &&
+      (type & TsNameType.Classes) > 0
+    ) {
+      if (scope.names.get(name) & NameType.Lexical) {
         // Classes can be merged with interfaces
         return !!(bindingType & BindingFlag.KIND_VALUE);
       } else {
@@ -126,7 +137,7 @@ export default class TypeScriptScopeHandler extends ScopeHandler<TypeScriptScope
         return false;
       }
     }
-    if (bindingType & BindingFlag.KIND_TYPE && scope.types.has(name)) {
+    if (bindingType & BindingFlag.KIND_TYPE && (type & TsNameType.Types) > 0) {
       return true;
     }
 
@@ -141,7 +152,13 @@ export default class TypeScriptScopeHandler extends ScopeHandler<TypeScriptScope
     const len = this.scopeStack.length;
     for (let i = len - 1; i >= 0; i--) {
       const scope = this.scopeStack[i];
-      if (scope.types.has(name) || scope.exportOnlyBindings.has(name)) return;
+      const type = scope.tsNames.get(name);
+      if (
+        (type & TsNameType.Types) > 0 ||
+        (type & TsNameType.ExportOnlyBindings) > 0
+      ) {
+        return;
+      }
     }
 
     super.checkLocalExport(id);

--- a/packages/babel-parser/src/plugins/typescript/scope.ts
+++ b/packages/babel-parser/src/plugins/typescript/scope.ts
@@ -69,8 +69,7 @@ export default class TypeScriptScopeHandler extends ScopeHandler<TypeScriptScope
   declareName(name: string, bindingType: BindingFlag, loc: Position) {
     if (bindingType & BindingFlag.FLAG_TS_IMPORT) {
       if (this.hasImport(name, true)) {
-        this.parser.raise(Errors.VarRedeclaration, {
-          at: loc,
+        this.parser.raise(Errors.VarRedeclaration, loc, {
           identifierName: name,
         });
       }

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -22,7 +22,6 @@ import {
   Errors,
   type ParseError,
   type ParseErrorConstructor,
-  type RaiseProperties,
 } from "../parse-error.ts";
 import {
   lineBreakG,
@@ -33,6 +32,8 @@ import {
 } from "../util/whitespace.ts";
 import State from "./state.ts";
 import type { LookaheadState, DeferredStrictError } from "./state.ts";
+import type { Undone } from "../parser/node.ts";
+import type { Node } from "../types.ts";
 
 import {
   readInt,
@@ -249,7 +250,7 @@ export default abstract class Tokenizer extends CommentsParser {
       // time for any literals that occur after the next node of the strict
       // directive.
       this.state.strictErrors.forEach(([toParseError, at]) =>
-        this.raise(toParseError, { at }),
+        this.raise(toParseError, at),
       );
       this.state.strictErrors.clear();
     }
@@ -284,9 +285,7 @@ export default abstract class Tokenizer extends CommentsParser {
       // We have to call this again here because startLoc may not be set...
       // This seems to be for performance reasons:
       // https://github.com/babel/babel/commit/acf2a10899f696a8aaf34df78bf9725b5ea7f2da
-      throw this.raise(Errors.UnterminatedComment, {
-        at: this.state.curPosition(),
-      });
+      throw this.raise(Errors.UnterminatedComment, this.state.curPosition());
     }
 
     this.state.pos = end + commentEnd.length;
@@ -501,9 +500,10 @@ export default abstract class Tokenizer extends CommentsParser {
     const nextPos = this.state.pos + 1;
     const next = this.codePointAtPos(nextPos);
     if (next >= charCodes.digit0 && next <= charCodes.digit9) {
-      throw this.raise(Errors.UnexpectedDigitAfterHash, {
-        at: this.state.curPosition(),
-      });
+      throw this.raise(
+        Errors.UnexpectedDigitAfterHash,
+        this.state.curPosition(),
+      );
     }
 
     if (
@@ -520,7 +520,7 @@ export default abstract class Tokenizer extends CommentsParser {
           next === charCodes.leftCurlyBrace
             ? Errors.RecordExpressionHashIncorrectStartSyntaxType
             : Errors.TupleExpressionHashIncorrectStartSyntaxType,
-          { at: this.state.curPosition() },
+          this.state.curPosition(),
         );
       }
 
@@ -644,9 +644,10 @@ export default abstract class Tokenizer extends CommentsParser {
         next === charCodes.rightCurlyBrace
       ) {
         if (this.getPluginOption("recordAndTuple", "syntaxType") !== "bar") {
-          throw this.raise(Errors.RecordExpressionBarIncorrectEndSyntaxType, {
-            at: this.state.curPosition(),
-          });
+          throw this.raise(
+            Errors.RecordExpressionBarIncorrectEndSyntaxType,
+            this.state.curPosition(),
+          );
         }
         this.state.pos += 2;
         this.finishToken(tt.braceBarR);
@@ -659,9 +660,10 @@ export default abstract class Tokenizer extends CommentsParser {
         next === charCodes.rightSquareBracket
       ) {
         if (this.getPluginOption("recordAndTuple", "syntaxType") !== "bar") {
-          throw this.raise(Errors.TupleExpressionBarIncorrectEndSyntaxType, {
-            at: this.state.curPosition(),
-          });
+          throw this.raise(
+            Errors.TupleExpressionBarIncorrectEndSyntaxType,
+            this.state.curPosition(),
+          );
         }
         this.state.pos += 2;
         this.finishToken(tt.bracketBarR);
@@ -876,7 +878,7 @@ export default abstract class Tokenizer extends CommentsParser {
           if (this.getPluginOption("recordAndTuple", "syntaxType") !== "bar") {
             throw this.raise(
               Errors.TupleExpressionBarIncorrectStartSyntaxType,
-              { at: this.state.curPosition() },
+              this.state.curPosition(),
             );
           }
 
@@ -900,7 +902,7 @@ export default abstract class Tokenizer extends CommentsParser {
           if (this.getPluginOption("recordAndTuple", "syntaxType") !== "bar") {
             throw this.raise(
               Errors.RecordExpressionBarIncorrectStartSyntaxType,
-              { at: this.state.curPosition() },
+              this.state.curPosition(),
             );
           }
 
@@ -1039,10 +1041,13 @@ export default abstract class Tokenizer extends CommentsParser {
         }
     }
 
-    throw this.raise(Errors.InvalidOrUnexpectedToken, {
-      at: this.state.curPosition(),
-      unexpected: String.fromCodePoint(code),
-    });
+    throw this.raise(
+      Errors.InvalidOrUnexpectedToken,
+      this.state.curPosition(),
+      {
+        unexpected: String.fromCodePoint(code),
+      },
+    );
   }
 
   finishOp(type: TokenType, size: number): void {
@@ -1059,15 +1064,17 @@ export default abstract class Tokenizer extends CommentsParser {
     for (; ; ++pos) {
       if (pos >= this.length) {
         // FIXME: explain
-        throw this.raise(Errors.UnterminatedRegExp, {
-          at: createPositionWithColumnOffset(startLoc, 1),
-        });
+        throw this.raise(
+          Errors.UnterminatedRegExp,
+          createPositionWithColumnOffset(startLoc, 1),
+        );
       }
       const ch = this.input.charCodeAt(pos);
       if (isNewLine(ch)) {
-        throw this.raise(Errors.UnterminatedRegExp, {
-          at: createPositionWithColumnOffset(startLoc, 1),
-        });
+        throw this.raise(
+          Errors.UnterminatedRegExp,
+          createPositionWithColumnOffset(startLoc, 1),
+        );
       }
       if (escaped) {
         escaped = false;
@@ -1100,18 +1107,18 @@ export default abstract class Tokenizer extends CommentsParser {
       if (VALID_REGEX_FLAGS.has(cp)) {
         if (cp === charCodes.lowercaseV) {
           if (mods.includes("u")) {
-            this.raise(Errors.IncompatibleRegExpUVFlags, { at: nextPos() });
+            this.raise(Errors.IncompatibleRegExpUVFlags, nextPos());
           }
         } else if (cp === charCodes.lowercaseU) {
           if (mods.includes("v")) {
-            this.raise(Errors.IncompatibleRegExpUVFlags, { at: nextPos() });
+            this.raise(Errors.IncompatibleRegExpUVFlags, nextPos());
           }
         }
         if (mods.includes(char)) {
-          this.raise(Errors.DuplicateRegExpFlags, { at: nextPos() });
+          this.raise(Errors.DuplicateRegExpFlags, nextPos());
         }
       } else if (isIdentifierChar(cp) || cp === charCodes.backslash) {
-        this.raise(Errors.MalformedRegExpFlags, { at: nextPos() });
+        this.raise(Errors.MalformedRegExpFlags, nextPos());
       } else {
         break;
       }
@@ -1165,11 +1172,14 @@ export default abstract class Tokenizer extends CommentsParser {
     this.state.pos += 2; // 0x
     const val = this.readInt(radix);
     if (val == null) {
-      this.raise(Errors.InvalidDigit, {
+      this.raise(
+        Errors.InvalidDigit,
         // Numeric literals can't have newlines, so this is safe to do.
-        at: createPositionWithColumnOffset(startLoc, 2),
-        radix,
-      });
+        createPositionWithColumnOffset(startLoc, 2),
+        {
+          radix,
+        },
+      );
     }
     const next = this.input.charCodeAt(this.state.pos);
 
@@ -1177,13 +1187,11 @@ export default abstract class Tokenizer extends CommentsParser {
       ++this.state.pos;
       isBigInt = true;
     } else if (next === charCodes.lowercaseM) {
-      throw this.raise(Errors.InvalidDecimal, { at: startLoc });
+      throw this.raise(Errors.InvalidDecimal, startLoc);
     }
 
     if (isIdentifierStart(this.codePointAtPos(this.state.pos))) {
-      throw this.raise(Errors.NumberIdentifier, {
-        at: this.state.curPosition(),
-      });
+      throw this.raise(Errors.NumberIdentifier, this.state.curPosition());
     }
 
     if (isBigInt) {
@@ -1209,7 +1217,7 @@ export default abstract class Tokenizer extends CommentsParser {
     let isOctal = false;
 
     if (!startsWithDot && this.readInt(10) === null) {
-      this.raise(Errors.InvalidNumber, { at: this.state.curPosition() });
+      this.raise(Errors.InvalidNumber, this.state.curPosition());
     }
     const hasLeadingZero =
       this.state.pos - start >= 2 &&
@@ -1217,15 +1225,16 @@ export default abstract class Tokenizer extends CommentsParser {
 
     if (hasLeadingZero) {
       const integer = this.input.slice(start, this.state.pos);
-      this.recordStrictModeErrors(Errors.StrictOctalLiteral, { at: startLoc });
+      this.recordStrictModeErrors(Errors.StrictOctalLiteral, startLoc);
       if (!this.state.strict) {
         // disallow numeric separators in non octal decimals and legacy octal likes
         const underscorePos = integer.indexOf("_");
         if (underscorePos > 0) {
           // Numeric literals can't have newlines, so this is safe to do.
-          this.raise(Errors.ZeroDigitNumericSeparator, {
-            at: createPositionWithColumnOffset(startLoc, underscorePos),
-          });
+          this.raise(
+            Errors.ZeroDigitNumericSeparator,
+            createPositionWithColumnOffset(startLoc, underscorePos),
+          );
         }
       }
       isOctal = hasLeadingZero && !/[89]/.test(integer);
@@ -1248,7 +1257,7 @@ export default abstract class Tokenizer extends CommentsParser {
         ++this.state.pos;
       }
       if (this.readInt(10) === null) {
-        this.raise(Errors.InvalidOrMissingExponent, { at: startLoc });
+        this.raise(Errors.InvalidOrMissingExponent, startLoc);
       }
       isFloat = true;
       hasExponent = true;
@@ -1259,7 +1268,7 @@ export default abstract class Tokenizer extends CommentsParser {
       // disallow floats, legacy octal syntax and non octal decimals
       // new style octal ("0o") is handled in this.readRadixNumber
       if (isFloat || hasLeadingZero) {
-        this.raise(Errors.InvalidBigIntLiteral, { at: startLoc });
+        this.raise(Errors.InvalidBigIntLiteral, startLoc);
       }
       ++this.state.pos;
       isBigInt = true;
@@ -1268,16 +1277,14 @@ export default abstract class Tokenizer extends CommentsParser {
     if (next === charCodes.lowercaseM) {
       this.expectPlugin("decimal", this.state.curPosition());
       if (hasExponent || hasLeadingZero) {
-        this.raise(Errors.InvalidDecimal, { at: startLoc });
+        this.raise(Errors.InvalidDecimal, startLoc);
       }
       ++this.state.pos;
       isDecimal = true;
     }
 
     if (isIdentifierStart(this.codePointAtPos(this.state.pos))) {
-      throw this.raise(Errors.NumberIdentifier, {
-        at: this.state.curPosition(),
-      });
+      throw this.raise(Errors.NumberIdentifier, this.state.curPosition());
     }
 
     // remove "_" for numeric literal separator, and trailing `m` or `n`
@@ -1375,14 +1382,11 @@ export default abstract class Tokenizer extends CommentsParser {
     }
   }
 
-  recordStrictModeErrors(
-    toParseError: DeferredStrictError,
-    { at }: { at: Position },
-  ) {
+  recordStrictModeErrors(toParseError: DeferredStrictError, at: Position) {
     const index = at.index;
 
     if (this.state.strict && !this.state.strictErrors.has(index)) {
-      this.raise(toParseError, { at });
+      this.raise(toParseError, at);
     } else {
       this.state.strictErrors.set(index, [toParseError, at]);
     }
@@ -1419,9 +1423,7 @@ export default abstract class Tokenizer extends CommentsParser {
           this.state.pos === start ? isIdentifierStart : isIdentifierChar;
 
         if (this.input.charCodeAt(++this.state.pos) !== charCodes.lowercaseU) {
-          this.raise(Errors.MissingUnicodeEscape, {
-            at: this.state.curPosition(),
-          });
+          this.raise(Errors.MissingUnicodeEscape, this.state.curPosition());
           chunkStart = this.state.pos - 1;
           continue;
         }
@@ -1430,7 +1432,7 @@ export default abstract class Tokenizer extends CommentsParser {
         const esc = this.readCodePoint(true);
         if (esc !== null) {
           if (!identifierCheck(esc)) {
-            this.raise(Errors.EscapedCharNotAnIdentifier, { at: escStart });
+            this.raise(Errors.EscapedCharNotAnIdentifier, escStart);
           }
 
           word += String.fromCodePoint(esc);
@@ -1461,8 +1463,7 @@ export default abstract class Tokenizer extends CommentsParser {
   checkKeywordEscapes(): void {
     const { type } = this.state;
     if (tokenIsKeyword(type) && this.state.containsEsc) {
-      this.raise(Errors.InvalidEscapedReservedWord, {
-        at: this.state.startLoc,
+      this.raise(Errors.InvalidEscapedReservedWord, this.state.startLoc, {
         reservedWord: tokenLabelName(type),
       });
     }
@@ -1479,12 +1480,11 @@ export default abstract class Tokenizer extends CommentsParser {
    */
   raise<ErrorDetails>(
     toParseError: ParseErrorConstructor<ErrorDetails>,
-    raiseProperties: RaiseProperties<ErrorDetails>,
+    at: Position | Undone<Node>,
+    details: ErrorDetails = {} as ErrorDetails,
   ): ParseError<ErrorDetails> {
-    const { at, ...details } = raiseProperties;
     const loc = at instanceof Position ? at : at.loc.start;
-    // @ts-expect-error: refine details typing
-    const error = toParseError({ loc, details });
+    const error = toParseError(loc, details);
 
     if (!this.options.errorRecovery) throw error;
     if (!this.isLookahead) this.state.errors.push(error);
@@ -1500,9 +1500,9 @@ export default abstract class Tokenizer extends CommentsParser {
    */
   raiseOverwrite<ErrorDetails>(
     toParseError: ParseErrorConstructor<ErrorDetails>,
-    raiseProperties: RaiseProperties<ErrorDetails>,
+    at: Position | Undone<Node>,
+    details: ErrorDetails = {} as ErrorDetails,
   ): ParseError<ErrorDetails> | never {
-    const { at, ...details } = raiseProperties;
     const loc = at instanceof Position ? at : at.loc.start;
     const pos = loc.index;
     const errors = this.state.errors;
@@ -1510,13 +1510,12 @@ export default abstract class Tokenizer extends CommentsParser {
     for (let i = errors.length - 1; i >= 0; i--) {
       const error = errors[i];
       if (error.loc.index === pos) {
-        // @ts-expect-error: refine details typing
-        return (errors[i] = toParseError({ loc, details }));
+        return (errors[i] = toParseError(loc, details));
       }
       if (error.loc.index < pos) break;
     }
 
-    return this.raise(toParseError, raiseProperties);
+    return this.raise(toParseError, at, details);
   }
 
   // updateContext is used by the jsx plugin
@@ -1525,10 +1524,13 @@ export default abstract class Tokenizer extends CommentsParser {
 
   // Raise an unexpected token error. Can take the expected token type.
   unexpected(loc?: Position | null, type?: TokenType): void {
-    throw this.raise(Errors.UnexpectedToken, {
-      expected: type ? tokenLabelName(type) : null,
-      at: loc != null ? loc : this.state.startLoc,
-    });
+    throw this.raise(
+      Errors.UnexpectedToken,
+      loc != null ? loc : this.state.startLoc,
+      {
+        expected: type ? tokenLabelName(type) : null,
+      },
+    );
   }
 
   expectPlugin(pluginName: Plugin, loc?: Position): true {
@@ -1536,16 +1538,18 @@ export default abstract class Tokenizer extends CommentsParser {
       return true;
     }
 
-    throw this.raise(Errors.MissingPlugin, {
-      at: loc != null ? loc : this.state.startLoc,
-      missingPlugin: [pluginName],
-    });
+    throw this.raise(
+      Errors.MissingPlugin,
+      loc != null ? loc : this.state.startLoc,
+      {
+        missingPlugin: [pluginName],
+      },
+    );
   }
 
   expectOnePlugin(pluginNames: Plugin[]): void {
     if (!pluginNames.some(name => this.hasPlugin(name))) {
-      throw this.raise(Errors.MissingOneOfPlugins, {
-        at: this.state.startLoc,
+      throw this.raise(Errors.MissingOneOfPlugins, this.state.startLoc, {
         missingPlugin: pluginNames,
       });
     }
@@ -1553,9 +1557,7 @@ export default abstract class Tokenizer extends CommentsParser {
 
   errorBuilder(error: ParseErrorConstructor<{}>) {
     return (pos: number, lineStart: number, curLine: number) => {
-      this.raise(error, {
-        at: buildPosition(pos, lineStart, curLine),
-      });
+      this.raise(error, buildPosition(pos, lineStart, curLine));
     };
   }
 
@@ -1563,8 +1565,7 @@ export default abstract class Tokenizer extends CommentsParser {
     invalidDigit: (pos, lineStart, curLine, radix) => {
       if (!this.options.errorRecovery) return false;
 
-      this.raise(Errors.InvalidDigit, {
-        at: buildPosition(pos, lineStart, curLine),
+      this.raise(Errors.InvalidDigit, buildPosition(pos, lineStart, curLine), {
         radix,
       });
       // Continue parsing the number as if there was no invalid digit.
@@ -1587,15 +1588,16 @@ export default abstract class Tokenizer extends CommentsParser {
   errorHandlers_readStringContents_string: StringContentsErrorHandlers = {
     ...this.errorHandlers_readCodePoint,
     strictNumericEscape: (pos, lineStart, curLine) => {
-      this.recordStrictModeErrors(Errors.StrictNumericEscape, {
-        at: buildPosition(pos, lineStart, curLine),
-      });
+      this.recordStrictModeErrors(
+        Errors.StrictNumericEscape,
+        buildPosition(pos, lineStart, curLine),
+      );
     },
     unterminated: (pos, lineStart, curLine) => {
-      throw this.raise(Errors.UnterminatedString, {
-        // Report the error at the string quote
-        at: buildPosition(pos - 1, lineStart, curLine),
-      });
+      throw this.raise(
+        Errors.UnterminatedString, // Report the error at the string quote
+        buildPosition(pos - 1, lineStart, curLine),
+      );
     },
   };
 
@@ -1603,9 +1605,10 @@ export default abstract class Tokenizer extends CommentsParser {
     ...this.errorHandlers_readCodePoint,
     strictNumericEscape: this.errorBuilder(Errors.StrictNumericEscape),
     unterminated: (pos, lineStart, curLine) => {
-      throw this.raise(Errors.UnterminatedTemplate, {
-        at: buildPosition(pos, lineStart, curLine),
-      });
+      throw this.raise(
+        Errors.UnterminatedTemplate,
+        buildPosition(pos, lineStart, curLine),
+      );
     },
   };
 }

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -94,6 +94,7 @@ export default abstract class Tokenizer extends CommentsParser {
     this.state.init(options);
     this.input = input;
     this.length = input.length;
+    this.comments = [];
     this.isLookahead = false;
   }
 
@@ -113,7 +114,6 @@ export default abstract class Tokenizer extends CommentsParser {
       this.pushToken(new Token(this.state));
     }
 
-    this.state.lastTokStart = this.state.start;
     this.state.lastTokEndLoc = this.state.endLoc;
     this.state.lastTokStartLoc = this.state.startLoc;
     this.nextToken();

--- a/packages/babel-parser/src/tokenizer/state.ts
+++ b/packages/babel-parser/src/tokenizer/state.ts
@@ -274,6 +274,11 @@ export default class State {
   // Tokens length in token store
   tokensLength: number = 0;
 
+  /**
+   * When we add a new property, we must manually update the `clone` method
+   * @see State#clone
+   */
+
   curPosition(): Position {
     return new Position(this.curLine, this.pos - this.lineStart, this.pos);
   }

--- a/packages/babel-parser/src/tokenizer/state.ts
+++ b/packages/babel-parser/src/tokenizer/state.ts
@@ -1,5 +1,4 @@
 import type { Options } from "../options.ts";
-import type * as N from "../types.ts";
 import type { CommentWhitespace } from "../parser/comments";
 import { Position } from "../util/location.ts";
 
@@ -24,8 +23,40 @@ type TopicContextState = {
   maxTopicIndex: null | 0;
 };
 
+const enum StateFlags {
+  None = 0,
+  Strict = 1 << 0,
+  maybeInArrowParameters = 1 << 1,
+  inType = 1 << 2,
+  noAnonFunctionType = 1 << 3,
+  hasFlowComment = 1 << 4,
+  isAmbientContext = 1 << 5,
+  inAbstractClass = 1 << 6,
+  inDisallowConditionalTypesContext = 1 << 7,
+  soloAwait = 1 << 8,
+  inFSharpPipelineDirectBody = 1 << 9,
+  canStartJSXElement = 1 << 10,
+  containsEsc = 1 << 11,
+}
+
+export const enum LoopLabelKind {
+  Loop = 1,
+  Switch = 2,
+}
+
 export default class State {
-  strict: boolean;
+  flags: number = StateFlags.canStartJSXElement;
+
+  get strict(): boolean {
+    return (this.flags & StateFlags.Strict) > 0;
+  }
+  set strict(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.Strict;
+    } else {
+      this.flags &= ~StateFlags.Strict;
+    }
+  }
   curLine: number;
   lineStart: number;
 
@@ -67,13 +98,76 @@ export default class State {
   noArrowParamsConversionAt: number[] = [];
 
   // Flags to track
-  maybeInArrowParameters: boolean = false;
-  inType: boolean = false;
-  noAnonFunctionType: boolean = false;
-  hasFlowComment: boolean = false;
-  isAmbientContext: boolean = false;
-  inAbstractClass: boolean = false;
-  inDisallowConditionalTypesContext: boolean = false;
+  get maybeInArrowParameters(): boolean {
+    return (this.flags & StateFlags.maybeInArrowParameters) > 0;
+  }
+  set maybeInArrowParameters(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.maybeInArrowParameters;
+    } else {
+      this.flags &= ~StateFlags.maybeInArrowParameters;
+    }
+  }
+  get inType(): boolean {
+    return (this.flags & StateFlags.inType) > 0;
+  }
+  set inType(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.inType;
+    } else {
+      this.flags &= ~StateFlags.inType;
+    }
+  }
+  get noAnonFunctionType(): boolean {
+    return (this.flags & StateFlags.noAnonFunctionType) > 0;
+  }
+  set noAnonFunctionType(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.noAnonFunctionType;
+    } else {
+      this.flags &= ~StateFlags.noAnonFunctionType;
+    }
+  }
+  get hasFlowComment(): boolean {
+    return (this.flags & StateFlags.hasFlowComment) > 0;
+  }
+  set hasFlowComment(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.hasFlowComment;
+    } else {
+      this.flags &= ~StateFlags.hasFlowComment;
+    }
+  }
+  get isAmbientContext(): boolean {
+    return (this.flags & StateFlags.isAmbientContext) > 0;
+  }
+  set isAmbientContext(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.isAmbientContext;
+    } else {
+      this.flags &= ~StateFlags.isAmbientContext;
+    }
+  }
+  get inAbstractClass(): boolean {
+    return (this.flags & StateFlags.inAbstractClass) > 0;
+  }
+  set inAbstractClass(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.inAbstractClass;
+    } else {
+      this.flags &= ~StateFlags.inAbstractClass;
+    }
+  }
+  get inDisallowConditionalTypesContext(): boolean {
+    return (this.flags & StateFlags.inDisallowConditionalTypesContext) > 0;
+  }
+  set inDisallowConditionalTypesContext(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.inDisallowConditionalTypesContext;
+    } else {
+      this.flags &= ~StateFlags.inDisallowConditionalTypesContext;
+    }
+  }
 
   // For the Hack-style pipelines plugin
   topicContext: TopicContextState = {
@@ -82,19 +176,35 @@ export default class State {
   };
 
   // For the F#-style pipelines plugin
-  soloAwait: boolean = false;
-  inFSharpPipelineDirectBody: boolean = false;
+  get soloAwait(): boolean {
+    return (this.flags & StateFlags.soloAwait) > 0;
+  }
+  set soloAwait(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.soloAwait;
+    } else {
+      this.flags &= ~StateFlags.soloAwait;
+    }
+  }
+  get inFSharpPipelineDirectBody(): boolean {
+    return (this.flags & StateFlags.inFSharpPipelineDirectBody) > 0;
+  }
+  set inFSharpPipelineDirectBody(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.inFSharpPipelineDirectBody;
+    } else {
+      this.flags &= ~StateFlags.inFSharpPipelineDirectBody;
+    }
+  }
 
   // Labels in scope.
   labels: Array<{
-    kind: "loop" | "switch" | undefined | null;
+    kind: LoopLabelKind;
     name?: string | null;
     statementStart?: number;
   }> = [];
 
-  // Comment store for Program.comments
-  comments: Array<N.Comment> = [];
-
+  commentsLen = 0;
   // Comment attachment store
   commentStack: Array<CommentWhitespace> = [];
 
@@ -117,18 +227,35 @@ export default class State {
   lastTokEndLoc: Position = null;
   // this is initialized when generating the second token.
   lastTokStartLoc: Position = null;
-  lastTokStart: number = 0;
 
   // The context stack is used to track whether the apostrophe "`" starts
   // or ends a string template
   context: Array<TokContext> = [ct.brace];
   // Used to track whether a JSX element is allowed to form
-  canStartJSXElement: boolean = true;
+  get canStartJSXElement(): boolean {
+    return (this.flags & StateFlags.canStartJSXElement) > 0;
+  }
+  set canStartJSXElement(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.canStartJSXElement;
+    } else {
+      this.flags &= ~StateFlags.canStartJSXElement;
+    }
+  }
 
   // Used to signal to callers of `readWord1` whether the word
   // contained any escape sequences. This is needed because words with
   // escape sequences must not be interpreted as keywords.
-  containsEsc: boolean = false;
+  get containsEsc(): boolean {
+    return (this.flags & StateFlags.containsEsc) > 0;
+  }
+  set containsEsc(value: boolean) {
+    if (value) {
+      this.flags |= StateFlags.containsEsc;
+    } else {
+      this.flags &= ~StateFlags.containsEsc;
+    }
+  }
 
   // Used to track invalid escape sequences in template literals,
   // that must be reported if the template is not tagged.
@@ -152,19 +279,35 @@ export default class State {
   }
 
   clone(skipArrays?: boolean): State {
-    const state = new State();
-    const keys = Object.keys(this) as (keyof State)[];
-    for (let i = 0, length = keys.length; i < length; i++) {
-      const key = keys[i];
-      let val = this[key];
-
-      if (!skipArrays && Array.isArray(val)) {
-        val = val.slice();
-      }
-
-      // @ts-expect-error val must conform to S[key]
-      state[key] = val;
+    function maybeCopy(val: any[]) {
+      return skipArrays ? val : val.slice();
     }
+
+    const state = new State();
+    state.flags = this.flags;
+    state.curLine = this.curLine;
+    state.lineStart = this.lineStart;
+    state.startLoc = this.startLoc;
+    state.endLoc = this.endLoc;
+    state.errors = maybeCopy(this.errors);
+    state.potentialArrowAt = this.potentialArrowAt;
+    state.noArrowAt = maybeCopy(this.noArrowAt);
+    state.noArrowParamsConversionAt = maybeCopy(this.noArrowParamsConversionAt);
+    state.topicContext = this.topicContext;
+    state.labels = maybeCopy(this.labels);
+    state.commentsLen = this.commentsLen;
+    state.commentStack = maybeCopy(this.commentStack);
+    state.pos = this.pos;
+    state.type = this.type;
+    state.value = this.value;
+    state.start = this.start;
+    state.end = this.end;
+    state.lastTokEndLoc = this.lastTokEndLoc;
+    state.lastTokStartLoc = this.lastTokStartLoc;
+    state.context = maybeCopy(this.context);
+    state.firstInvalidTemplateEscapePos = this.firstInvalidTemplateEscapePos;
+    state.strictErrors = this.strictErrors;
+    state.tokensLength = this.tokensLength;
 
     return state;
   }

--- a/packages/babel-parser/src/tokenizer/state.ts
+++ b/packages/babel-parser/src/tokenizer/state.ts
@@ -283,25 +283,21 @@ export default class State {
     return new Position(this.curLine, this.pos - this.lineStart, this.pos);
   }
 
-  clone(skipArrays?: boolean): State {
-    function maybeCopy(val: any[]) {
-      return skipArrays ? val : val.slice();
-    }
-
+  clone(): State {
     const state = new State();
     state.flags = this.flags;
     state.curLine = this.curLine;
     state.lineStart = this.lineStart;
     state.startLoc = this.startLoc;
     state.endLoc = this.endLoc;
-    state.errors = maybeCopy(this.errors);
+    state.errors = this.errors.slice();
     state.potentialArrowAt = this.potentialArrowAt;
-    state.noArrowAt = maybeCopy(this.noArrowAt);
-    state.noArrowParamsConversionAt = maybeCopy(this.noArrowParamsConversionAt);
+    state.noArrowAt = this.noArrowAt.slice();
+    state.noArrowParamsConversionAt = this.noArrowParamsConversionAt.slice();
     state.topicContext = this.topicContext;
-    state.labels = maybeCopy(this.labels);
+    state.labels = this.labels.slice();
     state.commentsLen = this.commentsLen;
-    state.commentStack = maybeCopy(this.commentStack);
+    state.commentStack = this.commentStack.slice();
     state.pos = this.pos;
     state.type = this.type;
     state.value = this.value;
@@ -309,7 +305,7 @@ export default class State {
     state.end = this.end;
     state.lastTokEndLoc = this.lastTokEndLoc;
     state.lastTokStartLoc = this.lastTokStartLoc;
-    state.context = maybeCopy(this.context);
+    state.context = this.context.slice();
     state.firstInvalidTemplateEscapePos = this.firstInvalidTemplateEscapePos;
     state.strictErrors = this.strictErrors;
     state.tokensLength = this.tokensLength;

--- a/packages/babel-parser/src/types.d.ts
+++ b/packages/babel-parser/src/types.d.ts
@@ -46,11 +46,11 @@ export interface NodeBase {
   start: number;
   end: number;
   loc: SourceLocation;
-  range: [number, number];
+  range?: [number, number];
   leadingComments?: Array<Comment>;
   trailingComments?: Array<Comment>;
   innerComments?: Array<Comment>;
-  extra: {
+  extra?: {
     [key: string]: any;
   };
 }

--- a/packages/babel-parser/src/util/class-scope.ts
+++ b/packages/babel-parser/src/util/class-scope.ts
@@ -47,8 +47,7 @@ export default class ClassScopeHandler {
           current.undefinedPrivateNames.set(name, loc);
         }
       } else {
-        this.parser.raise(Errors.InvalidPrivateFieldResolution, {
-          at: loc,
+        this.parser.raise(Errors.InvalidPrivateFieldResolution, loc, {
           identifierName: name,
         });
       }
@@ -85,8 +84,7 @@ export default class ClassScopeHandler {
     }
 
     if (redefined) {
-      this.parser.raise(Errors.PrivateNameRedeclaration, {
-        at: loc,
+      this.parser.raise(Errors.PrivateNameRedeclaration, loc, {
         identifierName: name,
       });
     }
@@ -105,8 +103,7 @@ export default class ClassScopeHandler {
       classScope.undefinedPrivateNames.set(name, loc);
     } else {
       // top-level
-      this.parser.raise(Errors.InvalidPrivateFieldResolution, {
-        at: loc,
+      this.parser.raise(Errors.InvalidPrivateFieldResolution, loc, {
         identifierName: name,
       });
     }

--- a/packages/babel-parser/src/util/expression-scope.ts
+++ b/packages/babel-parser/src/util/expression-scope.ts
@@ -93,11 +93,7 @@ class ArrowHeadParsingScope extends ExpressionScope {
   }
   recordDeclarationError(
     ParsingErrorClass: ParseErrorConstructor<{}>,
-    {
-      at,
-    }: {
-      at: Position;
-    },
+    at: Position,
   ) {
     const index = at.index;
 
@@ -137,13 +133,9 @@ export default class ExpressionScopeHandler {
    */
   recordParameterInitializerError(
     toParseError: ArrowHeadParsingParameterInitializerError,
-    {
-      at: node,
-    }: {
-      at: Node;
-    },
+    node: Node,
   ): void {
-    const origin = { at: node.loc.start };
+    const origin = node.loc.start;
     const { stack } = this;
     let i = stack.length - 1;
     let scope: ExpressionScope = stack[i];
@@ -181,15 +173,11 @@ export default class ExpressionScopeHandler {
    */
   recordArrowParameterBindingError(
     error: ParseErrorConstructor<{}>,
-    {
-      at: node,
-    }: {
-      at: Node;
-    },
+    node: Node,
   ): void {
     const { stack } = this;
     const scope: ExpressionScope = stack[stack.length - 1];
-    const origin = { at: node.loc.start };
+    const origin = node.loc.start;
     if (scope.isCertainlyParameterDeclaration()) {
       this.parser.raise(error, origin);
     } else if (scope.canBeArrowParameterDeclaration()) {
@@ -205,7 +193,7 @@ export default class ExpressionScopeHandler {
    * Errors will be recorded to any ancestry MaybeAsyncArrowParameterDeclaration
    * scope until an Expression scope is seen.
    */
-  recordAsyncArrowParametersError({ at }: { at: Position }): void {
+  recordAsyncArrowParametersError(at: Position): void {
     const { stack } = this;
     let i = stack.length - 1;
     let scope: ExpressionScope = stack[i];
@@ -213,7 +201,7 @@ export default class ExpressionScopeHandler {
       if (
         scope.type === ExpressionScopeType.kMaybeAsyncArrowParameterDeclaration
       ) {
-        scope.recordDeclarationError(Errors.AwaitBindingIdentifier, { at });
+        scope.recordDeclarationError(Errors.AwaitBindingIdentifier, at);
       }
       scope = stack[--i];
     }
@@ -224,7 +212,7 @@ export default class ExpressionScopeHandler {
     const currentScope = stack[stack.length - 1];
     if (!currentScope.canBeArrowParameterDeclaration()) return;
     currentScope.iterateErrors(([toParseError, loc]) => {
-      this.parser.raise(toParseError, { at: loc });
+      this.parser.raise(toParseError, loc);
       // iterate from parent scope
       let i = stack.length - 2;
       let scope = stack[i];

--- a/packages/babel-parser/src/util/scope.ts
+++ b/packages/babel-parser/src/util/scope.ts
@@ -194,12 +194,7 @@ export default class ScopeHandler<IScope extends Scope = Scope> {
   checkLocalExport(id: N.Identifier) {
     const { name } = id;
     const topLevelScope = this.scopeStack[0];
-    if (
-      !topLevelScope.names.has(name)
-      // In strict mode, scope.functions will always be empty.
-      // Modules are strict by default, but the `scriptMode` option
-      // can overwrite this behavior.
-    ) {
+    if (!topLevelScope.names.has(name)) {
       this.undefinedExports.set(name, id.loc.start);
     }
   }

--- a/packages/babel-parser/src/util/scope.ts
+++ b/packages/babel-parser/src/util/scope.ts
@@ -4,15 +4,20 @@ import type * as N from "../types.ts";
 import { Errors } from "../parse-error.ts";
 import type Tokenizer from "../tokenizer/index.ts";
 
+export const enum NameType {
+  // var-declared names in the current lexical scope
+  Var = 1 << 0,
+  // lexically-declared names in the current lexical scope
+  Lexical = 1 << 1,
+  // lexically-declared FunctionDeclaration names in the current lexical scope
+  Function = 1 << 2,
+}
+
 // Start an AST node, attaching a start offset.
 export class Scope {
-  declare flags: ScopeFlag;
-  // A set of var-declared names in the current lexical scope
-  var: Set<string> = new Set();
-  // A set of lexically-declared names in the current lexical scope
-  lexical: Set<string> = new Set();
-  // A set of lexically-declared FunctionDeclaration names in the current lexical scope
-  functions: Set<string> = new Set();
+  flags: ScopeFlag = 0;
+  names: Map<string, NameType> = new Map();
+  firstLexicalName = "";
 
   constructor(flags: ScopeFlag) {
     this.flags = flags;
@@ -103,11 +108,18 @@ export default class ScopeHandler<IScope extends Scope = Scope> {
     ) {
       this.checkRedeclarationInScope(scope, name, bindingType, loc);
 
+      let type = scope.names.get(name) || 0;
+
       if (bindingType & BindingFlag.SCOPE_FUNCTION) {
-        scope.functions.add(name);
+        type = type | NameType.Function;
       } else {
-        scope.lexical.add(name);
+        if (!scope.firstLexicalName) {
+          scope.firstLexicalName = name;
+        }
+        type = type | NameType.Lexical;
       }
+
+      scope.names.set(name, type);
 
       if (bindingType & BindingFlag.SCOPE_LEXICAL) {
         this.maybeExportDefined(scope, name);
@@ -116,7 +128,7 @@ export default class ScopeHandler<IScope extends Scope = Scope> {
       for (let i = this.scopeStack.length - 1; i >= 0; --i) {
         scope = this.scopeStack[i];
         this.checkRedeclarationInScope(scope, name, bindingType, loc);
-        scope.var.add(name);
+        scope.names.set(name, (scope.names.get(name) || 0) | NameType.Var);
         this.maybeExportDefined(scope, name);
 
         if (scope.flags & ScopeFlag.VAR) break;
@@ -155,29 +167,28 @@ export default class ScopeHandler<IScope extends Scope = Scope> {
     if (!(bindingType & BindingFlag.KIND_VALUE)) return false;
 
     if (bindingType & BindingFlag.SCOPE_LEXICAL) {
-      return (
-        scope.lexical.has(name) ||
-        scope.functions.has(name) ||
-        scope.var.has(name)
-      );
+      return scope.names.has(name);
     }
+
+    const type = scope.names.get(name);
 
     if (bindingType & BindingFlag.SCOPE_FUNCTION) {
       return (
-        scope.lexical.has(name) ||
-        (!this.treatFunctionsAsVarInScope(scope) && scope.var.has(name))
+        (type & NameType.Lexical) > 0 ||
+        (!this.treatFunctionsAsVarInScope(scope) && (type & NameType.Var) > 0)
       );
     }
 
     return (
-      (scope.lexical.has(name) &&
+      ((type & NameType.Lexical) > 0 &&
         // Annex B.3.4
         // https://tc39.es/ecma262/#sec-variablestatements-in-catch-blocks
         !(
           scope.flags & ScopeFlag.SIMPLE_CATCH &&
-          scope.lexical.values().next().value === name
+          scope.firstLexicalName === name
         )) ||
-      (!this.treatFunctionsAsVarInScope(scope) && scope.functions.has(name))
+      (!this.treatFunctionsAsVarInScope(scope) &&
+        (type & NameType.Function) > 0)
     );
   }
 
@@ -185,12 +196,10 @@ export default class ScopeHandler<IScope extends Scope = Scope> {
     const { name } = id;
     const topLevelScope = this.scopeStack[0];
     if (
-      !topLevelScope.lexical.has(name) &&
-      !topLevelScope.var.has(name) &&
+      !topLevelScope.names.has(name)
       // In strict mode, scope.functions will always be empty.
       // Modules are strict by default, but the `scriptMode` option
       // can overwrite this behavior.
-      !topLevelScope.functions.has(name)
     ) {
       this.undefinedExports.set(name, id.loc.start);
     }

--- a/packages/babel-parser/src/util/scope.ts
+++ b/packages/babel-parser/src/util/scope.ts
@@ -152,8 +152,7 @@ export default class ScopeHandler<IScope extends Scope = Scope> {
     loc: Position,
   ) {
     if (this.isRedeclaredInScope(scope, name, bindingType)) {
-      this.parser.raise(Errors.VarRedeclaration, {
-        at: loc,
+      this.parser.raise(Errors.VarRedeclaration, loc, {
         identifierName: name,
       });
     }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The ts parsing time is reduced by ~20%, and the general js parsing time is increased by ~2%.
If we want general js not to be affected, maybe we can manually replace all `getters/setters`.

```
PS F:\babel\benchmark\babel-parser\real-case-ts> node .\bench.mjs
current 1 typescript parser.ts: 67.9 ops/sec ±1.01% (15ms)
baseline 1 typescript parser.ts: 55.09 ops/sec ±1.22% (18ms)
current 1 typescript parser.ts: 68.58 ops/sec ±0.79% (15ms)
baseline 1 typescript parser.ts: 55.88 ops/sec ±0.84% (18ms)
PS F:\babel\benchmark\babel-parser\real-case-ts> node .\bench.mjs
current 1 typescript parser.ts: 66.91 ops/sec ±0.98% (15ms)
baseline 1 typescript parser.ts: 53.97 ops/sec ±1.14% (19ms)
current 1 typescript parser.ts: 68.01 ops/sec ±0.75% (15ms)
baseline 1 typescript parser.ts: 55.14 ops/sec ±0.81% (18ms)
```
```
PS F:\babel\benchmark\babel-parser\real-case> node .\bench.mjs
current 4 jquery 3.6: 24.43 ops/sec ±1.95% (41ms)
baseline 4 jquery 3.6: 25.48 ops/sec ±1.11% (39ms)
current 4 jquery 3.6: 25.01 ops/sec ±1.7% (40ms)
baseline 4 jquery 3.6: 25.2 ops/sec ±1.35% (40ms)
PS F:\babel\benchmark\babel-parser\real-case> node .\bench.mjs
current 4 jquery 3.6: 24.46 ops/sec ±1.78% (41ms)
baseline 4 jquery 3.6: 24.89 ops/sec ±1.46% (40ms)
current 4 jquery 3.6: 24.61 ops/sec ±1.67% (41ms)
baseline 4 jquery 3.6: 25.16 ops/sec ±1.26% (40ms)
```