### PR TITLE
fix: support module expression scopes

### DIFF
--- a/eslint/babel-eslint-parser/src/analyze-scope.cjs
+++ b/eslint/babel-eslint-parser/src/analyze-scope.cjs
@@ -67,10 +67,27 @@ class PatternVisitor extends OriginalPatternVisitor {
 
 class Referencer extends OriginalReferencer {
   #client;
+  visitedTopLevel = false;
 
   constructor(options, scopeManager, client) {
     super(options, scopeManager);
     this.#client = client;
+  }
+
+  Program(node) {
+    if (this.visitedTopLevel) {
+      // Program nodes are also currently used nested in module expressions, leading to an error as only one global scope can exist
+      return;
+    }
+
+    this.visitedTopLevel = true;
+    super.Program(node);
+  }
+
+  ModuleExpression(node) {
+    this.scopeManager.__nestModuleScope(node);
+    this.visitChildren(node);
+    this.close(node);
   }
 
   // inherits.

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -987,3 +987,19 @@ describe("Babel and Espree", () => {
     });
   });
 });
+
+describe("scope", () => {
+  it("should nest a module scope for module expressions", () => {
+    const code = "(module {})";
+    const options = {
+      babelOptions: { parserOpts: { plugins: ["moduleBlocks"] } },
+    };
+    const { ast, scopeManager } = parseForESLint(code, options);
+    const moduleExpression = ast.body[0].expression;
+    scopeManager.acquire(moduleExpression);
+
+    expect(scopeManager.acquire(moduleExpression)).toMatchObject({
+      type: "module",
+    });
+  });
+});


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16037 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

The `Program` visitor can now only be called once for the top-level (cannot access the `parent` property on node, so I added a class field).
Also added a visitor for `ModuleExpression` nesting a module scope.
