### PR TITLE
Patch psl to use punycode from node_modules

### DIFF
--- a/.yarn/patches/psl-npm-1.9.0-a546edad1a.patch
+++ b/.yarn/patches/psl-npm-1.9.0-a546edad1a.patch
@@ -1,0 +1,13 @@
+diff --git a/index.js b/index.js
+index da7bc12136cbbe0c4b1794a31ab315b903a80a4d..f2dc8991c89fea00128aea438a2293b810fa30b9 100644
+--- a/index.js
++++ b/index.js
+@@ -2,7 +2,7 @@
+ 'use strict';
+ 
+ 
+-var Punycode = require('punycode');
++var Punycode = require('punycode/');
+ 
+ 
+ var internals = {};

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -74,6 +74,9 @@ packageExtensions:
   "@babel/plugin-syntax-unicode-sets-regex@*":
     peerDependencies:
       "@babel/core": null
+  psl@*:
+    dependencies:
+      punycode: "^2.3.0"
 
 plugins:
   - checksum: 0f9f9afc8fdd7275b8c61b00ae8e74f7c23ac91533bacd242cc9478f6d20792335145d9b68abe8d01b6e50844bbb6a777097cc85973990fe4badf2c9a2b6ae11

--- a/package.json
+++ b/package.json
@@ -103,7 +103,9 @@
     "@babel/plugin-syntax-unicode-sets-regex/@babel/helper-create-regexp-features-plugin": "workspace:*",
     "babel-plugin-polyfill-corejs2/@babel/compat-data": "workspace:*",
     "chokidar@^3.4.0": "patch:chokidar@npm%3A3.5.3#./.yarn/patches/chokidar-npm-3.5.3-c5f9b0a56a.patch",
-    "chokidar@^3.4.1": "patch:chokidar@npm%3A3.5.3#./.yarn/patches/chokidar-npm-3.5.3-c5f9b0a56a.patch"
+    "chokidar@^3.4.1": "patch:chokidar@npm%3A3.5.3#./.yarn/patches/chokidar-npm-3.5.3-c5f9b0a56a.patch",
+    "psl@npm:^1.1.28": "patch:psl@npm%3A1.9.0#~/.yarn/patches/psl-npm-1.9.0-a546edad1a.patch",
+    "psl@npm:^1.1.33": "patch:psl@npm%3A1.9.0#~/.yarn/patches/psl-npm-1.9.0-a546edad1a.patch"
   },
   "engines": {
     "yarn": ">=1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14077,10 +14077,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"psl@npm:^1.1.28, psl@npm:^1.1.33":
+"psl@npm:1.9.0":
   version: 1.9.0
   resolution: "psl@npm:1.9.0"
   checksum: d07879d4bfd0ac74796306a8e5a36a93cfb9c4f4e8ee8e63fbb909066c192fe1008cd8f12abd8ba2f62ca28247949a20c8fb32e1d18831d9e71285a1569720f9
+  languageName: node
+  linkType: hard
+
+"psl@patch:psl@npm%3A1.9.0#~/.yarn/patches/psl-npm-1.9.0-a546edad1a.patch":
+  version: 1.9.0
+  resolution: "psl@patch:psl@npm%3A1.9.0#~/.yarn/patches/psl-npm-1.9.0-a546edad1a.patch::version=1.9.0&hash=b8389b"
+  checksum: eeaa6ceacea9ca95bc81441cafec8cd588901e2de24f20189f089024c9650859bb15a092924796eed185dd3d870af01c6b3c1c416fde9784f5db0ef4387310e6
   languageName: node
   linkType: hard
 
@@ -16026,14 +16033,14 @@ __metadata:
   linkType: hard
 
 "tough-cookie@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "tough-cookie@npm:4.1.2"
+  version: 4.1.3
+  resolution: "tough-cookie@npm:4.1.3"
   dependencies:
     psl: "npm:^1.1.33"
     punycode: "npm:^2.1.1"
     universalify: "npm:^0.2.0"
     url-parse: "npm:^1.5.3"
-  checksum: 7c42b332ad1e89ed97e6c725618140eade6b104a006857b1605daed18f47bef2b0e9b5684025d1a50b879de5af3ed84eb602a571d308cec7c9514956cab93a77
+  checksum: cf148c359b638a7069fc3ba9a5257bdc9616a6948a98736b92c3570b3f8401cf9237a42bf716878b656f372a1fb65b74dd13a46ccff8eceba14ffd053d33f72a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Deprecation message with respect to the `punycode` usage on Node.js 21: https://github.com/babel/babel/actions/runs/6911116250/job/18805227329#step:5:86
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Running `yarn jest babel-standalone` on Node.js 21 produces a deprecation message "[DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead."

In this PR we patch the `psl` so that it can import the `punycode` installed on node_modules. We can remove the patch when the upstream issue https://github.com/lupomontero/psl/issues/296 is resolved.