### PR TITLE
Simplify class fields injetion after `super()`

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -213,7 +213,11 @@ export function buildDecoratedClass(
   }
 
   return {
-    instanceNodes: [template.statement.ast`${t.cloneNode(initializeId)}(this)`],
+    instanceNodes: [
+      template.statement.ast`
+        ${t.cloneNode(initializeId)}(this)
+      ` as t.ExpressionStatement,
+    ],
     wrapClass(path: NodePath<t.Class>) {
       path.replaceWith(replacement);
       return path.get(classPathDesc) as NodePath;

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -238,7 +238,8 @@ export function createClassFeaturePlugin({
 
         let keysNodes: t.Statement[],
           staticNodes: t.Statement[],
-          instanceNodes: t.Statement[],
+          instanceNodes: t.ExpressionStatement[],
+          lastInstanceNodeReturnsThis: boolean,
           pureStaticNodes: t.FunctionDeclaration[],
           classBindingNode: t.Statement | null,
           wrapClass: (path: NodePath<t.Class>) => NodePath;
@@ -258,6 +259,7 @@ export function createClassFeaturePlugin({
               staticNodes,
               pureStaticNodes,
               instanceNodes,
+              lastInstanceNodeReturnsThis,
               classBindingNode,
               wrapClass,
             } = buildFieldsInitNodes(
@@ -278,6 +280,7 @@ export function createClassFeaturePlugin({
             staticNodes,
             pureStaticNodes,
             instanceNodes,
+            lastInstanceNodeReturnsThis,
             classBindingNode,
             wrapClass,
           } = buildFieldsInitNodes(
@@ -308,6 +311,7 @@ export function createClassFeaturePlugin({
                 prop.traverse(referenceVisitor, state);
               }
             },
+            lastInstanceNodeReturnsThis,
           );
         }
 

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-complex/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-complex/output.js
@@ -1,3 +1,3 @@
 class Foo extends Bar {
-  constructor(x = test ? (() => (super(), babelHelpers.defineProperty(this, "bar", "foo"), this))() : 0) {}
+  constructor(x = test ? (super(), babelHelpers.defineProperty(this, "bar", "foo")) : 0) {}
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params-in-arrow/output.js
@@ -1,5 +1,5 @@
 class Foo extends Bar {
   constructor(x = () => {
-    check((super(), babelHelpers.defineProperty(this, "bar", "foo"), this));
+    check((super(), babelHelpers.defineProperty(this, "bar", "foo")));
   }) {}
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/derived-super-in-default-params/output.js
@@ -1,3 +1,3 @@
 class Foo extends Bar {
-  constructor(x = (() => (super(), babelHelpers.defineProperty(this, "bar", "foo"), this))()) {}
+  constructor(x = (super(), babelHelpers.defineProperty(this, "bar", "foo"))) {}
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/super-expression/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/super-expression/output.js
@@ -6,7 +6,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
   function Foo() {
     var _this;
     babelHelpers.classCallCheck(this, Foo);
-    foo((_this = _super.call(this), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo"), babelHelpers.assertThisInitialized(_this)));
+    foo((_this = _super.call(this), babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo")));
     return _this;
   }
   return babelHelpers.createClass(Foo);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/7371/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/7371/output.js
@@ -45,7 +45,7 @@ class ComputedMethod extends Obj {
         super();
         expect(this.field).toBeUndefined();
       }
-      [(super(), babelHelpers.defineProperty(this, "field", 1), this)]() {}
+      [(super(), babelHelpers.defineProperty(this, "field", 1))]() {}
     }
     expect(this.field).toBe(1);
     new B();
@@ -57,7 +57,7 @@ new ComputedMethod();
 class ComputedField extends Obj {
   constructor() {
     let _ref;
-    _ref = (super(), babelHelpers.defineProperty(this, "field", 1), this);
+    _ref = (super(), babelHelpers.defineProperty(this, "field", 1));
     class B extends Obj {
       constructor() {
         super();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/input.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/input.js
@@ -1,0 +1,6 @@
+class A extends B {
+  x = 2;
+  constructor() {
+    x ? super(a) : super(b)
+  }
+}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/options.json
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-class-properties"]
+}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/output.js
@@ -1,5 +1,5 @@
 class A extends B {
   constructor() {
-    x ? (super(a), babelHelpers.defineProperty(this, "x", 2), this) : (super(b), super(a), babelHelpers.defineProperty(this, "x", 2), this, this);
+    x ? (super(a), babelHelpers.defineProperty(this, "x", 2)) : (super(b), babelHelpers.defineProperty(this, "x", 2));
   }
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/multiple-super-in-termary/output.js
@@ -1,0 +1,5 @@
+class A extends B {
+  constructor() {
+    x ? (super(a), babelHelpers.defineProperty(this, "x", 2), this) : (super(b), super(a), babelHelpers.defineProperty(this, "x", 2), this, this);
+  }
+}

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -205,7 +205,7 @@ export default declare((api, opts: Options) => {
       // property is only added once. This is necessary for cases like
       // using `transform-classes`, which causes this visitor to run
       // twice.
-      const assigns = [];
+      const assigns: t.ExpressionStatement[] = [];
       const { scope } = path;
       for (const paramPath of path.get("params")) {
         const param = paramPath.node;
@@ -226,8 +226,11 @@ export default declare((api, opts: Options) => {
               "Parameter properties can not be destructuring patterns.",
             );
           }
-          assigns.push(template.statement.ast`
-          this.${t.cloneNode(id)} = ${t.cloneNode(id)}`);
+          assigns.push(
+            template.statement.ast`
+              this.${t.cloneNode(id)} = ${t.cloneNode(id)}
+            ` as t.ExpressionStatement,
+          );
 
           paramPath.replaceWith(paramPath.get("parameter"));
           scope.registerBinding("param", paramPath);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16121
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The issue was caused by some missing cloning of nodes. This PR avoids the problem by simplifying how we inject nodes after `super()` in expressions, so that cloning is not needed at all.