### PR TITLE
[babel 8] Remove `CodeGenerator` from `@babel/generator`

### DIFF
--- a/packages/babel-generator/src/index.ts
+++ b/packages/babel-generator/src/index.ts
@@ -225,15 +225,17 @@ if (!process.env.BABEL_8_BREAKING && !USE_ESM) {
   // eslint-disable-next-line no-restricted-globals
   exports.CodeGenerator = class CodeGenerator {
     private _ast: t.Node;
-    private _opts: GeneratorOptions | undefined;
-    private _code: string | undefined;
-    constructor(ast: t.Node, opts?: GeneratorOptions, code?: string) {
+    private _format: Format | undefined;
+    private _map: SourceMap | null;
+    constructor(ast: t.Node, opts: GeneratorOptions = {}, code?: string) {
       this._ast = ast;
-      this._opts = opts;
-      this._code = code;
+      this._format = normalizeOptions(code, opts);
+      this._map = opts.sourceMaps ? new SourceMap(opts, code) : null;
     }
     generate(): GeneratorResult {
-      return generate(this._ast, this._opts, this._code);
+      const printer = new Printer(this._format, this._map);
+
+      return printer.generate(this._ast);
     }
   };
 }

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -4,13 +4,13 @@ import fs from "fs";
 import path from "path";
 import fixtures from "@babel/helper-fixtures";
 import { TraceMap, originalPositionFor } from "@jridgewell/trace-mapping";
-import { commonJS } from "$repo-utils";
+import { commonJS, describeBabel7NoESM } from "$repo-utils";
 import { encode } from "@jridgewell/sourcemap-codec";
 
-import _generate, { CodeGenerator } from "../lib/index.js";
+import _generate from "../lib/index.js";
 const generate = _generate.default || _generate;
 
-const { __dirname } = commonJS(import.meta.url);
+const { __dirname, require } = commonJS(import.meta.url);
 
 describe("generation", function () {
   it("multiple sources", function () {
@@ -1515,8 +1515,9 @@ describe("programmatic generation", function () {
   });
 });
 
-describe("CodeGenerator", function () {
+describeBabel7NoESM("CodeGenerator", function () {
   it("generate", function () {
+    const CodeGenerator = require("../lib/index.js").CodeGenerator;
     const codeGen = new CodeGenerator(t.numericLiteral(123));
     const code = codeGen.generate().code;
     expect(parse(code).program.body[0].expression.value).toBe(123);

--- a/packages/babel-types/test/cloning.js
+++ b/packages/babel-types/test/cloning.js
@@ -1,6 +1,7 @@
 import * as t from "../lib/index.js";
 import { parse } from "@babel/parser";
-import { CodeGenerator } from "@babel/generator";
+import _generate from "@babel/generator";
+const generate = _generate.default || _generate;
 
 describe("cloneNode", function () {
   it("should handle undefined", function () {
@@ -159,16 +160,14 @@ describe("cloneNode", function () {
     //test6
     var b;
     `;
-    code = new CodeGenerator(parse(code), { retainLines: true }).generate()
-      .code;
+    code = generate(parse(code), { retainLines: true }).code;
 
     const ast = t.cloneNode(
       parse(code),
       /* deep */ true,
       /* withoutLoc */ false,
     );
-    const newCode = new CodeGenerator(ast, { retainLines: true }).generate()
-      .code;
+    const newCode = generate(ast, { retainLines: true }).code;
 
     expect(newCode).toBe(code);
   });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2851<!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`class Generator extends Printer` is actually useless and I removed it for performance and code cleanliness.