### PR TITLE
Do not remove bindings when removing assignment expression path

### DIFF
--- a/packages/babel-traverse/src/path/removal.ts
+++ b/packages/babel-traverse/src/path/removal.ts
@@ -4,6 +4,7 @@ import { hooks } from "./lib/removal-hooks.ts";
 import { getCachedPaths } from "../cache.ts";
 import type NodePath from "./index.ts";
 import { REMOVED, SHOULD_SKIP } from "./index.ts";
+import { getBindingIdentifiers } from "@babel/types";
 
 export function remove(this: NodePath) {
   this._assertUnremoved();
@@ -24,7 +25,7 @@ export function remove(this: NodePath) {
 }
 
 export function _removeFromScope(this: NodePath) {
-  const bindings = this.getBindingIdentifiers();
+  const bindings = getBindingIdentifiers(this.node, false, false, true);
   Object.keys(bindings).forEach(name => this.scope.removeBinding(name));
 }
 

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -144,4 +144,12 @@ describe("removal", function () {
       expect(ifPath.get("alternate").node).toBeNull();
     });
   });
+
+  it("of AssignmentExpression does not remove binding", function () {
+    const rootPath = getPath("var x; x = 1;");
+    const path = rootPath.get("body.1.expression");
+    path.remove();
+
+    expect(rootPath.scope.hasBinding("x")).toBe(true);
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I found this bug (see the new test) while working on rebasing https://github.com/babel/babel/pull/14883.

It's very weird that `getBindingIdentifiers` returns `x` in `x = 1` assignment expressions. I tried fixing it, but we have multiple plugins relying on this property so for now I just worked it around.