### PR TITLE
Fix types.md update in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v3
         with:
-          name: babel-types.md
+          name: babel-types-docs
           path: build/types.md
           retention-days: 3
 
@@ -300,10 +300,11 @@ jobs:
       - name: Download babel-types docs
         uses: actions/download-artifact@v3
         with:
-          name: babel-types.md
+          name: babel-types-docs
+          # Downloaded as ./docs/types.md
+          path: docs
       - name: Commit Babel website changes
         run: |
-          mv babel-types.md docs/types.md
           git config user.name "Babel Bot"
           git config user.email "babel-bot@users.noreply.github.com"
           git checkout -b update-types-docs


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The recent release workflow is still failing on the types docs update step: https://github.com/babel/babel/actions/runs/6931271205/job/18853120241
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The downloaded artifact will be named as `types.md` as is named in the upload step. Here we download it directly to the `docs` folder of the `website` repo.