### PR TITLE
`using`: Allow looking up `Symbol.dispose` on a function

### DIFF
--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -111,7 +111,7 @@ export default Object.freeze({
   ),
   using: helper(
     "7.22.0",
-    'export default function _using(o,e,n){if(null==e)return e;if("object"!=typeof e)throw new TypeError("using declarations can only be used with objects, null, or undefined.");if(n)var r=e[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==r&&(r=e[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof r)throw new TypeError("Property [Symbol.dispose] is not a function.");return o.push({v:e,d:r,a:n}),e}',
+    'export default function _using(o,n,e){if(null==n)return n;if(Object(n)!==n)throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");if(e)var r=n[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==r&&(r=n[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof r)throw new TypeError("Property [Symbol.dispose] is not a function.");return o.push({v:n,d:r,a:e}),n}',
   ),
   wrapRegExp: helper(
     "7.19.0",

--- a/packages/babel-helpers/src/helpers/using.js
+++ b/packages/babel-helpers/src/helpers/using.js
@@ -2,9 +2,9 @@
 
 export default function _using(stack, value, isAwait) {
   if (value === null || value === void 0) return value;
-  if (typeof value !== "object") {
+  if (Object(value) !== value) {
     throw new TypeError(
-      "using declarations can only be used with objects, null, or undefined."
+      "using declarations can only be used with objects, functions, null, or undefined."
     );
   }
   // core-js-pure uses Symbol.for for polyfilling well-known symbols

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/using-function.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/using-function.js
@@ -1,0 +1,15 @@
+return async function () {
+  let log = [];
+  async function getDisposable() {
+    function disposable() { log.push('call') }
+    disposable[Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")] = () => { log.push('dispose') };
+    return disposable;
+  }
+
+  {
+    await using x = getDisposable();
+    x();
+  }
+
+  expect(log).toEqual(['call', 'dispose']);
+}

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync/using-function.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync/using-function.js
@@ -1,0 +1,10 @@
+let log = [];
+function disposable() { log.push('call') }
+disposable[Symbol.dispose || Symbol.for("Symbol.dispose")] = () => { log.push('dispose') };
+
+{
+  using x = disposable;
+  x();
+}
+
+expect(log).toEqual(['call', 'dispose']);


### PR DESCRIPTION
This works with browsers and it allows the nice pattern of returning a function that allows you to do something directly with what you used.

I'm just using this to do early 'unpause'-ing of undo functionality.

```javascript
{
  using unpause = pauseUndo();
  code.doThings();
  if (weAreSomehowDone) unpause();
  code.doOtherThing();
}
```

It doesn't seem so restrictive in the spec, as a function is also an object, but it has a different `typeof` name.