### PR TITLE
Reuse computed key memoiser

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/misc.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/misc.ts
@@ -142,21 +142,37 @@ export function extractComputedKeys(
     // Make sure computed property names are only evaluated once (upon class definition)
     // and in the right order in combination with static properties
     if (!computedKey.isConstantExpression()) {
-      const ident = path.scope.generateUidIdentifierBasedOnNode(
-        computedNode.key,
-      );
-      // Declaring in the same block scope
-      // Ref: https://github.com/babel/babel/pull/10029/files#diff-fbbdd83e7a9c998721c1484529c2ce92
-      path.scope.push({
-        id: ident,
-        kind: "let",
-      });
-      declarations.push(
-        t.expressionStatement(
-          t.assignmentExpression("=", t.cloneNode(ident), computedNode.key),
-        ),
-      );
-      computedNode.key = t.cloneNode(ident);
+      const scope = path.scope;
+      const isUidReference =
+        t.isIdentifier(computedKey.node) && scope.hasUid(computedKey.node.name);
+      const isMemoiseAssignment =
+        computedKey.isAssignmentExpression({ operator: "=" }) &&
+        t.isIdentifier(computedKey.node.left) &&
+        scope.hasUid(computedKey.node.left.name);
+      if (isUidReference) {
+        continue;
+      } else if (isMemoiseAssignment) {
+        declarations.push(t.expressionStatement(t.cloneNode(computedNode.key)));
+        computedNode.key = t.cloneNode(
+          (computedNode.key as t.AssignmentExpression).left as t.Identifier,
+        );
+      } else {
+        const ident = path.scope.generateUidIdentifierBasedOnNode(
+          computedNode.key,
+        );
+        // Declaring in the same block scope
+        // Ref: https://github.com/babel/babel/pull/10029/files#diff-fbbdd83e7a9c998721c1484529c2ce92
+        scope.push({
+          id: ident,
+          kind: "let",
+        });
+        declarations.push(
+          t.expressionStatement(
+            t.assignmentExpression("=", t.cloneNode(ident), computedNode.key),
+          ),
+        );
+        computedNode.key = t.cloneNode(ident);
+      }
     }
   }
 

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-call-in-key/output.js
@@ -12,13 +12,12 @@ let Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
   var _super = babelHelpers.createSuper(Outer);
   function Outer() {
-    let _this2;
     var _this;
     babelHelpers.classCallCheck(this, Outer);
-    _this2 = _this = _super.call(this);
+    _this = _super.call(this);
     let Inner = /*#__PURE__*/babelHelpers.createClass(function Inner() {
       babelHelpers.classCallCheck(this, Inner);
-      babelHelpers.defineProperty(this, _this2, "hello");
+      babelHelpers.defineProperty(this, _this, "hello");
     });
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N.A.
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we reuse the memoising expression of the computed class element key when transforming class fields. This optimizing trick can be applied to other plugins that requires memoising an expression, such as optional chaining and nullish coalescing as well.

I think eventually we should create a new helper for such purpose. For any given expression, an optimized memoising procedure can be
1) If the expression is a uid reference, treat it as a constant binding and thus it is ["static"](https://github.com/babel/babel/blob/380d186b77d32734c595652a40cbda5e4e109c5c/packages/babel-traverse/src/scope/index.ts#L557) within the scope
2) If the expression is an assignment `uid = expression`, treat `uid` as the memoiser id, and re-use the `uid = expression` assignment
3) Otherwise create a new `uid` for `expression` and construct the assignment `uid = expression`

Currently we only did the step 3 by `scope.maybeGenerateMemoised`, so Babel will create quite a few redundant memoisers if various transforms are applied to a given expression that needs memoising. For example, transforming a computed class accessor down to ES5 require 3 plugins: decorators, class properties and class transforms.