### PR TITLE
Ensure the `[[@@toPrimitive]]` call of a decorated class member key is invoked once

### DIFF
--- a/packages/babel-plugin-proposal-decorators/src/transformer-2023-05.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-2023-05.ts
@@ -590,17 +590,13 @@ function transformClass(
 
       const newId = generateClassPrivateUid();
       const newField = generateClassProperty(newId, value, isStatic);
-
+      const keyPath = element.get("key");
       const [newPath] = element.replaceWith(newField);
-      const keyType = key.type;
+
       addProxyAccessorsFor(
         path.node.id,
         newPath,
-        computed &&
-          !scopeParent.isStatic(key) &&
-          keyType !== "StringLiteral" &&
-          keyType !== "NumericLiteral" &&
-          keyType !== "BigIntLiteral"
+        computed && !keyPath.isConstantExpression()
           ? memoiseExpression(key as t.Expression, "computedKey")
           : key,
         newId,
@@ -703,7 +699,7 @@ function transformClass(
       const isComputed =
         "computed" in element.node && element.node.computed === true;
       if (isComputed) {
-        if (!scopeParent.isStatic(node.key)) {
+        if (!element.get("key").isConstantExpression()) {
           node.key = memoiseExpression(node.key as t.Expression, "computedKey");
         }
       }

--- a/packages/babel-plugin-proposal-decorators/src/transformer-2023-05.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-2023-05.ts
@@ -525,6 +525,10 @@ function createSetFunctionNameCall(
   ]);
 }
 
+function createToPropertyKeyCall(state: PluginPass, propertyKey: t.Expression) {
+  return t.callExpression(state.addHelper("toPropertyKey"), [propertyKey]);
+}
+
 function transformClass(
   path: NodePath<t.ClassExpression | t.ClassDeclaration>,
   state: PluginPass,
@@ -597,7 +601,10 @@ function transformClass(
         path.node.id,
         newPath,
         computed && !keyPath.isConstantExpression()
-          ? memoiseExpression(key as t.Expression, "computedKey")
+          ? memoiseExpression(
+              createToPropertyKeyCall(state, key as t.Expression),
+              "computedKey",
+            )
           : key,
         newId,
         version,
@@ -700,7 +707,10 @@ function transformClass(
         "computed" in element.node && element.node.computed === true;
       if (isComputed) {
         if (!element.get("key").isConstantExpression()) {
-          node.key = memoiseExpression(node.key as t.Expression, "computedKey");
+          node.key = memoiseExpression(
+            createToPropertyKeyCall(state, node.key as t.Expression),
+            "computedKey",
+          );
         }
       }
 

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _initStatic, _class;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,10 +9,7 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
   constructor() {
@@ -33,10 +30,10 @@ class Foo {
   static set "b"(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _C, v);
   }
-  static get [_computedKey]() {
+  static get ["c"]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _D);
   }
-  static set [_computedKey](v) {
+  static set ["c"](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _D, v);
   }
   static get 0() {
@@ -45,10 +42,10 @@ class Foo {
   static set 0(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _E, v);
   }
-  static get [_computedKey2]() {
+  static get [1]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _F);
   }
-  static set [_computedKey2](v) {
+  static set [1](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _F, v);
   }
   static get 2n() {
@@ -57,16 +54,16 @@ class Foo {
   static set 2n(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _G, v);
   }
-  static get [_computedKey3]() {
+  static get [3n]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _H);
   }
-  static set [_computedKey3](v) {
+  static set [3n](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _H, v);
   }
-  static get [_computedKey4]() {
+  static get [_computedKey]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _I);
   }
-  static set [_computedKey4](v) {
+  static set [_computedKey](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _I, v);
   }
 }
@@ -82,7 +79,7 @@ function _get_a2() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _B);
   }, function (value) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _B, value);
-  }], [dec, 6, "b"], [dec, 6, _computedKey], [dec, 6, 0], [dec, 6, _computedKey2], [dec, 6, 2n], [dec, 6, _computedKey3], [dec, 6, _computedKey4]], []);
+  }], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []);
   _initStatic(_class);
 })();
 var _A = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
   constructor() {
@@ -118,4 +118,4 @@ var _I = {
   writable: true,
   value: _init_computedKey7(_class)
 };
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initProto, _class;
+var _init_a, _init_b, _init_computedKey, _initProto, _class;
 const dec = () => {};
-_computedKey = 'c';
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();
 var _C = /*#__PURE__*/new WeakMap();
@@ -31,12 +30,12 @@ class Foo {
   set b(v) {
     babelHelpers.classPrivateFieldSet(this, _B, v);
   }
-  get [_computedKey]() {
+  get ['c']() {
     return babelHelpers.classPrivateFieldGet(this, _C);
   }
-  set [_computedKey](v) {
+  set ['c'](v) {
     babelHelpers.classPrivateFieldSet(this, _C, v);
   }
 }
 _class = Foo;
-[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, _computedKey]], []);
+[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-public/output.js
@@ -1,6 +1,5 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initStatic, _class;
+var _init_a, _init_b, _init_computedKey, _initStatic, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static get a() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _A);
@@ -14,16 +13,16 @@ class Foo {
   static set b(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _B, v);
   }
-  static get [_computedKey]() {
+  static get ['c']() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _C);
   }
-  static set [_computedKey](v) {
+  static set ['c'](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _C, v);
   }
 }
 _class = Foo;
 (() => {
-  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, _computedKey]], []);
+  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []);
   _initStatic(_class);
 })();
 var _A = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name-debug/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name-debug/input.js
@@ -1,0 +1,8 @@
+const logs = [];
+const dec = (value, context) => { logs.push(context.name) };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
+class Foo {
+  @dec static accessor [f()];
+}
+
+expect(logs).toStrictEqual(["computing f", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name-debug/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name-debug/output.js
@@ -1,0 +1,26 @@
+var _computedKey, _init_computedKey, _initStatic;
+const logs = [];
+const dec = (value, context) => {
+  logs.push(context.name);
+};
+const f = () => {
+  logs.push("computing f");
+  return {
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
+  };
+};
+_computedKey = babelHelpers.toPropertyKey(f());
+class Foo {
+  static {
+    [_init_computedKey, _initStatic] = babelHelpers.applyDecs(this, [[dec, 6, _computedKey]], []);
+    _initStatic(this);
+  }
+  static #A = _init_computedKey(this);
+  static get [_computedKey]() {
+    return this.#A;
+  }
+  static set [_computedKey](v) {
+    this.#A = v;
+  }
+}
+expect(logs).toStrictEqual(["computing f", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs(this, [[dec, 6, "a"], [dec, 6, "a", function () {
@@ -83,4 +83,4 @@ class Foo {
     this.#I = v;
   }
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _initStatic;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,17 +9,14 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
     [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs(this, [[dec, 6, "a"], [dec, 6, "a", function () {
       return this.#B;
     }, function (value) {
       this.#B = value;
-    }], [dec, 6, "b"], [dec, 6, _computedKey], [dec, 6, 0], [dec, 6, _computedKey2], [dec, 6, 2n], [dec, 6, _computedKey3], [dec, 6, _computedKey4]], []);
+    }], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []);
     _initStatic(this);
   }
   static #A = _init_a(this);
@@ -44,10 +41,10 @@ class Foo {
     this.#C = v;
   }
   static #D = _init_computedKey2(this);
-  static get [_computedKey]() {
+  static get ["c"]() {
     return this.#D;
   }
-  static set [_computedKey](v) {
+  static set ["c"](v) {
     this.#D = v;
   }
   static #E = _init_computedKey3(this);
@@ -58,10 +55,10 @@ class Foo {
     this.#E = v;
   }
   static #F = _init_computedKey4(this);
-  static get [_computedKey2]() {
+  static get [1]() {
     return this.#F;
   }
-  static set [_computedKey2](v) {
+  static set [1](v) {
     this.#F = v;
   }
   static #G = _init_computedKey5(this);
@@ -72,17 +69,17 @@ class Foo {
     this.#G = v;
   }
   static #H = _init_computedKey6(this);
-  static get [_computedKey3]() {
+  static get [3n]() {
     return this.#H;
   }
-  static set [_computedKey3](v) {
+  static set [3n](v) {
     this.#H = v;
   }
   static #I = _init_computedKey7(this);
-  static get [_computedKey4]() {
+  static get [_computedKey]() {
     return this.#I;
   }
-  static set [_computedKey4](v) {
+  static set [_computedKey](v) {
     this.#I = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initProto;
+var _init_a, _init_b, _init_computedKey, _initProto;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs(this, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, _computedKey]], []);
+    [_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs(this, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []);
   }
   #A = (_initProto(this), _init_a(this));
   get a() {
@@ -20,10 +19,10 @@ class Foo {
     this.#B = v;
   }
   #C = _init_computedKey(this, 456);
-  get [_computedKey]() {
+  get ['c']() {
     return this.#C;
   }
-  set [_computedKey](v) {
+  set ['c'](v) {
     this.#C = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initStatic;
+var _init_a, _init_b, _init_computedKey, _initStatic;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs(this, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, _computedKey]], []);
+    [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs(this, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []);
     _initStatic(this);
   }
   static #A = _init_a(this);
@@ -21,10 +20,10 @@ class Foo {
     this.#B = v;
   }
   static #C = _init_computedKey(this, 456);
-  static get [_computedKey]() {
+  static get ['c']() {
     return this.#C;
   }
-  static set [_computedKey](v) {
+  static set ['c'](v) {
     this.#C = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto, _class;
 const dec = () => {};
-_computedKey = getKey();
-_computedKey2 = getKey();
+_computedKey = babelHelpers.toPropertyKey(getKey());
+_computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
   constructor(...args) {
     _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto, _class;
 const dec = () => {};
-_computedKey = getKeyI();
-_computedKey2 = getKeyJ();
+_computedKey = babelHelpers.toPropertyKey(getKeyI());
+_computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
   constructor(...args) {
     _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto;
 const dec = () => {};
-_computedKey = getKey();
-_computedKey2 = getKey();
+_computedKey = babelHelpers.toPropertyKey(getKey());
+_computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-value/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto;
 const dec = () => {};
-_computedKey = getKeyI();
-_computedKey2 = getKeyJ();
+_computedKey = babelHelpers.toPropertyKey(getKeyI());
+_computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _class;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,27 +9,24 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {}
 _class = Foo;
 [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs(_class, [[dec, 5, "a"], [dec, 5, "a", function () {
   return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _a);
 }, function (value) {
   babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _a, value);
-}], [dec, 5, "b"], [dec, 5, _computedKey], [dec, 5, 0], [dec, 5, _computedKey2], [dec, 5, 2n], [dec, 5, _computedKey3], [dec, 5, _computedKey4]], []);
+}], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []);
 babelHelpers.defineProperty(Foo, "a", _init_a(_class));
 var _a = {
   writable: true,
   value: _init_a2(_class)
 };
 babelHelpers.defineProperty(Foo, "b", _init_computedKey(_class));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey2(_class));
+babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_class));
 babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_class));
-babelHelpers.defineProperty(Foo, _computedKey2, _init_computedKey4(_class));
+babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
 babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
-babelHelpers.defineProperty(Foo, _computedKey3, _init_computedKey6(_class));
-babelHelpers.defineProperty(Foo, _computedKey4, _init_computedKey7(_class));
+babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
+babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {}
 _class = Foo;
 [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs(_class, [[dec, 5, "a"], [dec, 5, "a", function () {
@@ -29,4 +29,4 @@ babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
 babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
 babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
 babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/public/output.js
@@ -1,12 +1,11 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   constructor() {
     babelHelpers.defineProperty(this, "a", _init_a(this));
     babelHelpers.defineProperty(this, "b", _init_b(this, 123));
-    babelHelpers.defineProperty(this, _computedKey, _init_computedKey(this, 456));
+    babelHelpers.defineProperty(this, 'c', _init_computedKey(this, 456));
   }
 }
 _class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, _computedKey]], []);
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {}
 _class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(_class, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, _computedKey]], []);
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(_class, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []);
 babelHelpers.defineProperty(Foo, "a", _init_a(_class));
 babelHelpers.defineProperty(Foo, "b", _init_b(_class, 123));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey(_class, 456));
+babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_class, 456));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs(this, [[dec, 5, "a"], [dec, 5, "a", function () {
@@ -28,4 +28,4 @@ class Foo {
   static [3n] = _init_computedKey6(this);
   static [_computedKey] = _init_computedKey7(this);
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,26 +9,23 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
     [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs(this, [[dec, 5, "a"], [dec, 5, "a", function () {
       return this.#a;
     }, function (value) {
       this.#a = value;
-    }], [dec, 5, "b"], [dec, 5, _computedKey], [dec, 5, 0], [dec, 5, _computedKey2], [dec, 5, 2n], [dec, 5, _computedKey3], [dec, 5, _computedKey4]], []);
+    }], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []);
   }
   static a = _init_a(this);
   static #a = _init_a2(this);
   static "b" = _init_computedKey(this);
-  static [_computedKey] = _init_computedKey2(this);
+  static ["c"] = _init_computedKey2(this);
   static 0 = _init_computedKey3(this);
-  static [_computedKey2] = _init_computedKey4(this);
+  static [1] = _init_computedKey4(this);
   static 2n = _init_computedKey5(this);
-  static [_computedKey3] = _init_computedKey6(this);
-  static [_computedKey4] = _init_computedKey7(this);
+  static [3n] = _init_computedKey6(this);
+  static [_computedKey] = _init_computedKey7(this);
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/public/output.js
@@ -1,11 +1,10 @@
-var _init_a, _init_b, _computedKey, _init_computedKey;
+var _init_a, _init_b, _init_computedKey;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(this, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, _computedKey]], []);
+    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(this, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []);
   }
   a = _init_a(this);
   b = _init_b(this, 123);
-  [_computedKey] = _init_computedKey(this, 456);
+  ['c'] = _init_computedKey(this, 456);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/static-public/output.js
@@ -1,11 +1,10 @@
-var _init_a, _init_b, _computedKey, _init_computedKey;
+var _init_a, _init_b, _init_computedKey;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(this, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, _computedKey]], []);
+    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(this, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []);
   }
   static a = _init_a(this);
   static b = _init_b(this, 123);
-  static [_computedKey] = _init_computedKey(this, 456);
+  static ['c'] = _init_computedKey(this, 456);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,19 +9,16 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static get a() {}
   static get "b"() {}
-  static get [_computedKey]() {}
+  static get ["c"]() {}
   static get 0() {}
-  static get [_computedKey2]() {}
+  static get [1]() {}
   static get 2n() {}
-  static get [_computedKey3]() {}
-  static get [_computedKey4]() {}
+  static get [3n]() {}
+  static get [_computedKey]() {}
 }
 _class = Foo;
 function _get_a() {
@@ -32,7 +29,7 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, _computedKey], [dec, 8, 0], [dec, 8, _computedKey2], [dec, 8, 2n], [dec, 8, _computedKey3], [dec, 8, _computedKey4]], []);
+  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []);
   _initStatic(_class);
 })();
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static get a() {}
   static get "b"() {}
@@ -32,4 +32,4 @@ var _a = {
   [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []);
   _initStatic(_class);
 })();
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   get a() {
     return this.value;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs(_class, [[dec, 3, "a"], [dec, 3, _computedKey]], []);
+[_initProto] = babelHelpers.applyDecs(_class, [[dec, 3, "a"], [dec, 3, 'b']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static get a() {
     return this.value;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a"], [dec, 8, _computedKey]], []);
+  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a"], [dec, 8, 'b']], []);
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
@@ -1,7 +1,5 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -13,12 +11,12 @@ class Foo {
   set a(v) {
     this.value = v;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
-  set [_computedKey2](v) {
+  set ['b'](v) {
     this.value = v;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, _computedKey], [dec, 4, _computedKey2]], []);
+[_initProto] = babelHelpers.applyDecs(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-public/output.js
@@ -1,7 +1,5 @@
-var _computedKey, _computedKey2, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static get a() {
     return this.value;
@@ -9,16 +7,16 @@ class Foo {
   static set a(v) {
     this.value = v;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
-  static set [_computedKey2](v) {
+  static set ['b'](v) {
     this.value = v;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, _computedKey], [dec, 9, _computedKey2]], []);
+  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []);
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/public/output.js
@@ -1,10 +1,8 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, _computedKey], [dec, 4, _computedKey2]], []);
+    [_initProto] = babelHelpers.applyDecs(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []);
   }
   constructor(...args) {
     _initProto(this);
@@ -16,10 +14,10 @@ class Foo {
   set a(v) {
     this.value = v;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
-  set [_computedKey2](v) {
+  set ['b'](v) {
     this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/static-public/output.js
@@ -1,10 +1,8 @@
-var _computedKey, _computedKey2, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs(this, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, _computedKey], [dec, 9, _computedKey2]], []);
+    [_initStatic] = babelHelpers.applyDecs(this, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []);
     _initStatic(this);
   }
   static value = 1;
@@ -14,10 +12,10 @@ class Foo {
   static set a(v) {
     this.value = v;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
-  static set [_computedKey2](v) {
+  static set ['b'](v) {
     this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,13 +9,10 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs(this, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, _computedKey], [dec, 8, 0], [dec, 8, _computedKey2], [dec, 8, 2n], [dec, 8, _computedKey3], [dec, 8, _computedKey4]], []);
+    [_call_a, _initStatic] = babelHelpers.applyDecs(this, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []);
     _initStatic(this);
   }
   static get a() {}
@@ -23,11 +20,11 @@ class Foo {
     return _call_a(this);
   }
   static get "b"() {}
-  static get [_computedKey]() {}
+  static get ["c"]() {}
   static get 0() {}
-  static get [_computedKey2]() {}
+  static get [1]() {}
   static get 2n() {}
-  static get [_computedKey3]() {}
-  static get [_computedKey4]() {}
+  static get [3n]() {}
+  static get [_computedKey]() {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs(this, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []);
@@ -27,4 +27,4 @@ class Foo {
   static get [3n]() {}
   static get [_computedKey]() {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs(this, [[dec, 3, "a"], [dec, 3, _computedKey]], []);
+    [_initProto] = babelHelpers.applyDecs(this, [[dec, 3, "a"], [dec, 3, 'b']], []);
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   get a() {
     return this.value;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs(this, [[dec, 8, "a"], [dec, 8, _computedKey]], []);
+    [_initStatic] = babelHelpers.applyDecs(this, [[dec, 8, "a"], [dec, 8, 'b']], []);
     _initStatic(this);
   }
   static value = 1;
   static get a() {
     return this.value;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,23 +9,20 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static a() {}
   static "b"() {}
-  static [_computedKey]() {}
+  static ["c"]() {}
   static 0() {}
-  static [_computedKey2]() {}
+  static [1]() {}
   static 2n() {}
-  static [_computedKey3]() {}
-  static [_computedKey4]() {}
+  static [3n]() {}
+  static [_computedKey]() {}
 }
 _class = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, _computedKey], [dec, 7, 0], [dec, 7, _computedKey2], [dec, 7, 2n], [dec, 7, _computedKey3], [dec, 7, _computedKey4]], []);
+  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []);
   _initStatic(_class);
 })();
 var _a = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static a() {}
   static "b"() {}
@@ -29,4 +29,4 @@ var _a = {
   writable: true,
   value: _call_a
 };
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   a() {
     return this.value;
   }
-  [_computedKey]() {
+  ['b']() {
     return this.value;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs(_class, [[dec, 2, "a"], [dec, 2, _computedKey]], []);
+[_initProto] = babelHelpers.applyDecs(_class, [[dec, 2, "a"], [dec, 2, 'b']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static a() {
     return this.value;
   }
-  static [_computedKey]() {
+  static ['b']() {
     return this.value;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 7, "a"], [dec, 7, _computedKey]], []);
+  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 7, "a"], [dec, 7, 'b']], []);
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,23 +9,20 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs(this, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, _computedKey], [dec, 7, 0], [dec, 7, _computedKey2], [dec, 7, 2n], [dec, 7, _computedKey3], [dec, 7, _computedKey4]], []);
+    [_call_a, _initStatic] = babelHelpers.applyDecs(this, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []);
     _initStatic(this);
   }
   static #a = _call_a;
   static a() {}
   static "b"() {}
-  static [_computedKey]() {}
+  static ["c"]() {}
   static 0() {}
-  static [_computedKey2]() {}
+  static [1]() {}
   static 2n() {}
-  static [_computedKey3]() {}
-  static [_computedKey4]() {}
+  static [3n]() {}
+  static [_computedKey]() {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs(this, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []);
@@ -25,4 +25,4 @@ class Foo {
   static [3n]() {}
   static [_computedKey]() {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs(this, [[dec, 2, "a"], [dec, 2, _computedKey]], []);
+    [_initProto] = babelHelpers.applyDecs(this, [[dec, 2, "a"], [dec, 2, 'b']], []);
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   a() {
     return this.value;
   }
-  [_computedKey]() {
+  ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs(this, [[dec, 7, "a"], [dec, 7, _computedKey]], []);
+    [_initStatic] = babelHelpers.applyDecs(this, [[dec, 7, "a"], [dec, 7, 'b']], []);
     _initStatic(this);
   }
   static value = 1;
   static a() {
     return this.value;
   }
-  static [_computedKey]() {
+  static ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,19 +9,16 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static set a(v) {}
   static set "b"(v) {}
-  static set [_computedKey](v) {}
+  static set ["c"](v) {}
   static set 0(v) {}
-  static set [_computedKey2](v) {}
+  static set [1](v) {}
   static set 2n(v) {}
-  static set [_computedKey3](v) {}
-  static set [_computedKey4](v) {}
+  static set [3n](v) {}
+  static set [_computedKey](v) {}
 }
 _class = Foo;
 function _set_a(v) {
@@ -32,7 +29,7 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, _computedKey], [dec, 9, 0], [dec, 9, _computedKey2], [dec, 9, 2n], [dec, 9, _computedKey3], [dec, 9, _computedKey4]], []);
+  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []);
   _initStatic(_class);
 })();
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static set a(v) {}
   static set "b"(v) {}
@@ -32,4 +32,4 @@ var _a = {
   [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []);
   _initStatic(_class);
 })();
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   set a(v) {
     return this.value = v;
   }
-  set [_computedKey](v) {
+  set ['b'](v) {
     return this.value = v;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs(_class, [[dec, 4, "a"], [dec, 4, _computedKey]], []);
+[_initProto] = babelHelpers.applyDecs(_class, [[dec, 4, "a"], [dec, 4, 'b']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static set a(v) {
     return this.value = v;
   }
-  static set [_computedKey](v) {
+  static set ['b'](v) {
     return this.value = v;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 9, "a"], [dec, 9, _computedKey]], []);
+  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 9, "a"], [dec, 9, 'b']], []);
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs(this, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []);
@@ -27,4 +27,4 @@ class Foo {
   static set [3n](v) {}
   static set [_computedKey](v) {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,13 +9,10 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs(this, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, _computedKey], [dec, 9, 0], [dec, 9, _computedKey2], [dec, 9, 2n], [dec, 9, _computedKey3], [dec, 9, _computedKey4]], []);
+    [_call_a, _initStatic] = babelHelpers.applyDecs(this, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []);
     _initStatic(this);
   }
   static set a(v) {}
@@ -23,11 +20,11 @@ class Foo {
     _call_a(this, v);
   }
   static set "b"(v) {}
-  static set [_computedKey](v) {}
+  static set ["c"](v) {}
   static set 0(v) {}
-  static set [_computedKey2](v) {}
+  static set [1](v) {}
   static set 2n(v) {}
-  static set [_computedKey3](v) {}
-  static set [_computedKey4](v) {}
+  static set [3n](v) {}
+  static set [_computedKey](v) {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs(this, [[dec, 4, "a"], [dec, 4, _computedKey]], []);
+    [_initProto] = babelHelpers.applyDecs(this, [[dec, 4, "a"], [dec, 4, 'b']], []);
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   set a(v) {
     return this.value = v;
   }
-  set [_computedKey](v) {
+  set ['b'](v) {
     return this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs(this, [[dec, 9, "a"], [dec, 9, _computedKey]], []);
+    [_initStatic] = babelHelpers.applyDecs(this, [[dec, 9, "a"], [dec, 9, 'b']], []);
     _initStatic(this);
   }
   static value = 1;
   static set a(v) {
     return this.value = v;
   }
-  static set [_computedKey](v) {
+  static set ['b'](v) {
     return this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
   constructor() {
@@ -118,4 +118,4 @@ var _I = {
   writable: true,
   value: _init_computedKey7(_class)
 };
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _initStatic, _class;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,10 +9,7 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
   constructor() {
@@ -33,10 +30,10 @@ class Foo {
   static set "b"(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _C, v);
   }
-  static get [_computedKey]() {
+  static get ["c"]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _D);
   }
-  static set [_computedKey](v) {
+  static set ["c"](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _D, v);
   }
   static get 0() {
@@ -45,10 +42,10 @@ class Foo {
   static set 0(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _E, v);
   }
-  static get [_computedKey2]() {
+  static get [1]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _F);
   }
-  static set [_computedKey2](v) {
+  static set [1](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _F, v);
   }
   static get 2n() {
@@ -57,16 +54,16 @@ class Foo {
   static set 2n(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _G, v);
   }
-  static get [_computedKey3]() {
+  static get [3n]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _H);
   }
-  static set [_computedKey3](v) {
+  static set [3n](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _H, v);
   }
-  static get [_computedKey4]() {
+  static get [_computedKey]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _I);
   }
-  static set [_computedKey4](v) {
+  static set [_computedKey](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _I, v);
   }
 }
@@ -82,7 +79,7 @@ function _get_a2() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _B);
   }, function (value) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _B, value);
-  }], [dec, 6, "b"], [dec, 6, _computedKey], [dec, 6, 0], [dec, 6, _computedKey2], [dec, 6, 2n], [dec, 6, _computedKey3], [dec, 6, _computedKey4]], []).e;
+  }], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []).e;
   _initStatic(_class);
 })();
 var _A = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initProto, _class;
+var _init_a, _init_b, _init_computedKey, _initProto, _class;
 const dec = () => {};
-_computedKey = 'c';
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();
 var _C = /*#__PURE__*/new WeakMap();
@@ -31,12 +30,12 @@ class Foo {
   set b(v) {
     babelHelpers.classPrivateFieldSet(this, _B, v);
   }
-  get [_computedKey]() {
+  get ['c']() {
     return babelHelpers.classPrivateFieldGet(this, _C);
   }
-  set [_computedKey](v) {
+  set ['c'](v) {
     babelHelpers.classPrivateFieldSet(this, _C, v);
   }
 }
 _class = Foo;
-[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, _computedKey]], []).e;
+[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-public/output.js
@@ -1,6 +1,5 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initStatic, _class;
+var _init_a, _init_b, _init_computedKey, _initStatic, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static get a() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _A);
@@ -14,16 +13,16 @@ class Foo {
   static set b(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _B, v);
   }
-  static get [_computedKey]() {
+  static get ['c']() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _C);
   }
-  static set [_computedKey](v) {
+  static set ['c'](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _C, v);
   }
 }
 _class = Foo;
 (() => {
-  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, _computedKey]], []).e;
+  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []).e;
   _initStatic(_class);
 })();
 var _A = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 6, "a"], [dec, 6, "a", function () {
@@ -83,4 +83,4 @@ class Foo {
     this.#I = v;
   }
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _initStatic;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,17 +9,14 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
     [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 6, "a"], [dec, 6, "a", function () {
       return this.#B;
     }, function (value) {
       this.#B = value;
-    }], [dec, 6, "b"], [dec, 6, _computedKey], [dec, 6, 0], [dec, 6, _computedKey2], [dec, 6, 2n], [dec, 6, _computedKey3], [dec, 6, _computedKey4]], []).e;
+    }], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []).e;
     _initStatic(this);
   }
   static #A = _init_a(this);
@@ -44,10 +41,10 @@ class Foo {
     this.#C = v;
   }
   static #D = _init_computedKey2(this);
-  static get [_computedKey]() {
+  static get ["c"]() {
     return this.#D;
   }
-  static set [_computedKey](v) {
+  static set ["c"](v) {
     this.#D = v;
   }
   static #E = _init_computedKey3(this);
@@ -58,10 +55,10 @@ class Foo {
     this.#E = v;
   }
   static #F = _init_computedKey4(this);
-  static get [_computedKey2]() {
+  static get [1]() {
     return this.#F;
   }
-  static set [_computedKey2](v) {
+  static set [1](v) {
     this.#F = v;
   }
   static #G = _init_computedKey5(this);
@@ -72,17 +69,17 @@ class Foo {
     this.#G = v;
   }
   static #H = _init_computedKey6(this);
-  static get [_computedKey3]() {
+  static get [3n]() {
     return this.#H;
   }
-  static set [_computedKey3](v) {
+  static set [3n](v) {
     this.#H = v;
   }
   static #I = _init_computedKey7(this);
-  static get [_computedKey4]() {
+  static get [_computedKey]() {
     return this.#I;
   }
-  static set [_computedKey4](v) {
+  static set [_computedKey](v) {
     this.#I = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initProto;
+var _init_a, _init_b, _init_computedKey, _initProto;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2203R(this, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2203R(this, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;
   }
   #A = (_initProto(this), _init_a(this));
   get a() {
@@ -20,10 +19,10 @@ class Foo {
     this.#B = v;
   }
   #C = _init_computedKey(this, 456);
-  get [_computedKey]() {
+  get ['c']() {
     return this.#C;
   }
-  set [_computedKey](v) {
+  set ['c'](v) {
     this.#C = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initStatic;
+var _init_a, _init_b, _init_computedKey, _initStatic;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []).e;
     _initStatic(this);
   }
   static #A = _init_a(this);
@@ -21,10 +20,10 @@ class Foo {
     this.#B = v;
   }
   static #C = _init_computedKey(this, 456);
-  static get [_computedKey]() {
+  static get ['c']() {
     return this.#C;
   }
-  static set [_computedKey](v) {
+  static set ['c'](v) {
     this.#C = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto, _class;
 const dec = () => {};
-_computedKey = getKey();
-_computedKey2 = getKey();
+_computedKey = babelHelpers.toPropertyKey(getKey());
+_computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
   constructor(...args) {
     _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto, _class;
 const dec = () => {};
-_computedKey = getKeyI();
-_computedKey2 = getKeyJ();
+_computedKey = babelHelpers.toPropertyKey(getKeyI());
+_computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
   constructor(...args) {
     _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto;
 const dec = () => {};
-_computedKey = getKey();
-_computedKey2 = getKey();
+_computedKey = babelHelpers.toPropertyKey(getKey());
+_computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-value/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto;
 const dec = () => {};
-_computedKey = getKeyI();
-_computedKey2 = getKeyJ();
+_computedKey = babelHelpers.toPropertyKey(getKeyI());
+_computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _class;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,27 +9,24 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {}
 _class = Foo;
 [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2203R(_class, [[dec, 5, "a"], [dec, 5, "a", function () {
   return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _a);
 }, function (value) {
   babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _a, value);
-}], [dec, 5, "b"], [dec, 5, _computedKey], [dec, 5, 0], [dec, 5, _computedKey2], [dec, 5, 2n], [dec, 5, _computedKey3], [dec, 5, _computedKey4]], []).e;
+}], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []).e;
 babelHelpers.defineProperty(Foo, "a", _init_a(_class));
 var _a = {
   writable: true,
   value: _init_a2(_class)
 };
 babelHelpers.defineProperty(Foo, "b", _init_computedKey(_class));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey2(_class));
+babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_class));
 babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_class));
-babelHelpers.defineProperty(Foo, _computedKey2, _init_computedKey4(_class));
+babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
 babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
-babelHelpers.defineProperty(Foo, _computedKey3, _init_computedKey6(_class));
-babelHelpers.defineProperty(Foo, _computedKey4, _init_computedKey7(_class));
+babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
+babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {}
 _class = Foo;
 [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2203R(_class, [[dec, 5, "a"], [dec, 5, "a", function () {
@@ -29,4 +29,4 @@ babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
 babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
 babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
 babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/public/output.js
@@ -1,12 +1,11 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   constructor() {
     babelHelpers.defineProperty(this, "a", _init_a(this));
     babelHelpers.defineProperty(this, "b", _init_b(this, 123));
-    babelHelpers.defineProperty(this, _computedKey, _init_computedKey(this, 456));
+    babelHelpers.defineProperty(this, 'c', _init_computedKey(this, 456));
   }
 }
 _class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, _computedKey]], []).e;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/static-public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {}
 _class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(_class, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, _computedKey]], []).e;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(_class, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []).e;
 babelHelpers.defineProperty(Foo, "a", _init_a(_class));
 babelHelpers.defineProperty(Foo, "b", _init_b(_class, 123));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey(_class, 456));
+babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_class, 456));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2203R(this, [[dec, 5, "a"], [dec, 5, "a", function () {
@@ -28,4 +28,4 @@ class Foo {
   static [3n] = _init_computedKey6(this);
   static [_computedKey] = _init_computedKey7(this);
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,26 +9,23 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
     [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2203R(this, [[dec, 5, "a"], [dec, 5, "a", function () {
       return this.#a;
     }, function (value) {
       this.#a = value;
-    }], [dec, 5, "b"], [dec, 5, _computedKey], [dec, 5, 0], [dec, 5, _computedKey2], [dec, 5, 2n], [dec, 5, _computedKey3], [dec, 5, _computedKey4]], []).e;
+    }], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []).e;
   }
   static a = _init_a(this);
   static #a = _init_a2(this);
   static "b" = _init_computedKey(this);
-  static [_computedKey] = _init_computedKey2(this);
+  static ["c"] = _init_computedKey2(this);
   static 0 = _init_computedKey3(this);
-  static [_computedKey2] = _init_computedKey4(this);
+  static [1] = _init_computedKey4(this);
   static 2n = _init_computedKey5(this);
-  static [_computedKey3] = _init_computedKey6(this);
-  static [_computedKey4] = _init_computedKey7(this);
+  static [3n] = _init_computedKey6(this);
+  static [_computedKey] = _init_computedKey7(this);
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/public/output.js
@@ -1,11 +1,10 @@
-var _init_a, _init_b, _computedKey, _init_computedKey;
+var _init_a, _init_b, _init_computedKey;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(this, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(this, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;
   }
   a = _init_a(this);
   b = _init_b(this, 123);
-  [_computedKey] = _init_computedKey(this, 456);
+  ['c'] = _init_computedKey(this, 456);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/static-public/output.js
@@ -1,11 +1,10 @@
-var _init_a, _init_b, _computedKey, _init_computedKey;
+var _init_a, _init_b, _init_computedKey;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(this, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(this, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []).e;
   }
   static a = _init_a(this);
   static b = _init_b(this, 123);
-  static [_computedKey] = _init_computedKey(this, 456);
+  static ['c'] = _init_computedKey(this, 456);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,19 +9,16 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static get a() {}
   static get "b"() {}
-  static get [_computedKey]() {}
+  static get ["c"]() {}
   static get 0() {}
-  static get [_computedKey2]() {}
+  static get [1]() {}
   static get 2n() {}
-  static get [_computedKey3]() {}
-  static get [_computedKey4]() {}
+  static get [3n]() {}
+  static get [_computedKey]() {}
 }
 _class = Foo;
 function _get_a() {
@@ -32,7 +29,7 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, _computedKey], [dec, 8, 0], [dec, 8, _computedKey2], [dec, 8, 2n], [dec, 8, _computedKey3], [dec, 8, _computedKey4]], []).e;
+  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
   _initStatic(_class);
 })();
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static get a() {}
   static get "b"() {}
@@ -32,4 +32,4 @@ var _a = {
   [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
   _initStatic(_class);
 })();
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   get a() {
     return this.value;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 3, "a"], [dec, 3, _computedKey]], []).e;
+[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 3, "a"], [dec, 3, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static get a() {
     return this.value;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a"], [dec, 8, _computedKey]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a"], [dec, 8, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/public/output.js
@@ -1,7 +1,5 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -13,12 +11,12 @@ class Foo {
   set a(v) {
     this.value = v;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
-  set [_computedKey2](v) {
+  set ['b'](v) {
     this.value = v;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, _computedKey], [dec, 4, _computedKey2]], []).e;
+[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-public/output.js
@@ -1,7 +1,5 @@
-var _computedKey, _computedKey2, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static get a() {
     return this.value;
@@ -9,16 +7,16 @@ class Foo {
   static set a(v) {
     this.value = v;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
-  static set [_computedKey2](v) {
+  static set ['b'](v) {
     this.value = v;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, _computedKey], [dec, 9, _computedKey2]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/public/output.js
@@ -1,10 +1,8 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, _computedKey], [dec, 4, _computedKey2]], []).e;
+    [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -16,10 +14,10 @@ class Foo {
   set a(v) {
     this.value = v;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
-  set [_computedKey2](v) {
+  set ['b'](v) {
     this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/static-public/output.js
@@ -1,10 +1,8 @@
-var _computedKey, _computedKey2, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, _computedKey], [dec, 9, _computedKey2]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
@@ -14,10 +12,10 @@ class Foo {
   static set a(v) {
     this.value = v;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
-  static set [_computedKey2](v) {
+  static set ['b'](v) {
     this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,13 +9,10 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, _computedKey], [dec, 8, 0], [dec, 8, _computedKey2], [dec, 8, 2n], [dec, 8, _computedKey3], [dec, 8, _computedKey4]], []).e;
+    [_call_a, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
     _initStatic(this);
   }
   static get a() {}
@@ -23,11 +20,11 @@ class Foo {
     return _call_a(this);
   }
   static get "b"() {}
-  static get [_computedKey]() {}
+  static get ["c"]() {}
   static get 0() {}
-  static get [_computedKey2]() {}
+  static get [1]() {}
   static get 2n() {}
-  static get [_computedKey3]() {}
-  static get [_computedKey4]() {}
+  static get [3n]() {}
+  static get [_computedKey]() {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
@@ -27,4 +27,4 @@ class Foo {
   static get [3n]() {}
   static get [_computedKey]() {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 3, "a"], [dec, 3, _computedKey]], []).e;
+    [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   get a() {
     return this.value;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 8, "a"], [dec, 8, _computedKey]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 8, "a"], [dec, 8, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
   static get a() {
     return this.value;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,23 +9,20 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static a() {}
   static "b"() {}
-  static [_computedKey]() {}
+  static ["c"]() {}
   static 0() {}
-  static [_computedKey2]() {}
+  static [1]() {}
   static 2n() {}
-  static [_computedKey3]() {}
-  static [_computedKey4]() {}
+  static [3n]() {}
+  static [_computedKey]() {}
 }
 _class = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, _computedKey], [dec, 7, 0], [dec, 7, _computedKey2], [dec, 7, 2n], [dec, 7, _computedKey3], [dec, 7, _computedKey4]], []).e;
+  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []).e;
   _initStatic(_class);
 })();
 var _a = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static a() {}
   static "b"() {}
@@ -29,4 +29,4 @@ var _a = {
   writable: true,
   value: _call_a
 };
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   a() {
     return this.value;
   }
-  [_computedKey]() {
+  ['b']() {
     return this.value;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 2, "a"], [dec, 2, _computedKey]], []).e;
+[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 2, "a"], [dec, 2, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static a() {
     return this.value;
   }
-  static [_computedKey]() {
+  static ['b']() {
     return this.value;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 7, "a"], [dec, 7, _computedKey]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 7, "a"], [dec, 7, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,23 +9,20 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, _computedKey], [dec, 7, 0], [dec, 7, _computedKey2], [dec, 7, 2n], [dec, 7, _computedKey3], [dec, 7, _computedKey4]], []).e;
+    [_call_a, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []).e;
     _initStatic(this);
   }
   static #a = _call_a;
   static a() {}
   static "b"() {}
-  static [_computedKey]() {}
+  static ["c"]() {}
   static 0() {}
-  static [_computedKey2]() {}
+  static [1]() {}
   static 2n() {}
-  static [_computedKey3]() {}
-  static [_computedKey4]() {}
+  static [3n]() {}
+  static [_computedKey]() {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []).e;
@@ -25,4 +25,4 @@ class Foo {
   static [3n]() {}
   static [_computedKey]() {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 2, "a"], [dec, 2, _computedKey]], []).e;
+    [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   a() {
     return this.value;
   }
-  [_computedKey]() {
+  ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 7, "a"], [dec, 7, _computedKey]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 7, "a"], [dec, 7, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
   static a() {
     return this.value;
   }
-  static [_computedKey]() {
+  static ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,19 +9,16 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static set a(v) {}
   static set "b"(v) {}
-  static set [_computedKey](v) {}
+  static set ["c"](v) {}
   static set 0(v) {}
-  static set [_computedKey2](v) {}
+  static set [1](v) {}
   static set 2n(v) {}
-  static set [_computedKey3](v) {}
-  static set [_computedKey4](v) {}
+  static set [3n](v) {}
+  static set [_computedKey](v) {}
 }
 _class = Foo;
 function _set_a(v) {
@@ -32,7 +29,7 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, _computedKey], [dec, 9, 0], [dec, 9, _computedKey2], [dec, 9, 2n], [dec, 9, _computedKey3], [dec, 9, _computedKey4]], []).e;
+  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
   _initStatic(_class);
 })();
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static set a(v) {}
   static set "b"(v) {}
@@ -32,4 +32,4 @@ var _a = {
   [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
   _initStatic(_class);
 })();
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   set a(v) {
     return this.value = v;
   }
-  set [_computedKey](v) {
+  set ['b'](v) {
     return this.value = v;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 4, "a"], [dec, 4, _computedKey]], []).e;
+[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 4, "a"], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static set a(v) {
     return this.value = v;
   }
-  static set [_computedKey](v) {
+  static set ['b'](v) {
     return this.value = v;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 9, "a"], [dec, 9, _computedKey]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 9, "a"], [dec, 9, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
@@ -27,4 +27,4 @@ class Foo {
   static set [3n](v) {}
   static set [_computedKey](v) {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,13 +9,10 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, _computedKey], [dec, 9, 0], [dec, 9, _computedKey2], [dec, 9, 2n], [dec, 9, _computedKey3], [dec, 9, _computedKey4]], []).e;
+    [_call_a, _initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
     _initStatic(this);
   }
   static set a(v) {}
@@ -23,11 +20,11 @@ class Foo {
     _call_a(this, v);
   }
   static set "b"(v) {}
-  static set [_computedKey](v) {}
+  static set ["c"](v) {}
   static set 0(v) {}
-  static set [_computedKey2](v) {}
+  static set [1](v) {}
   static set 2n(v) {}
-  static set [_computedKey3](v) {}
-  static set [_computedKey4](v) {}
+  static set [3n](v) {}
+  static set [_computedKey](v) {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 4, "a"], [dec, 4, _computedKey]], []).e;
+    [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   set a(v) {
     return this.value = v;
   }
-  set [_computedKey](v) {
+  set ['b'](v) {
     return this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 9, "a"], [dec, 9, _computedKey]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2203R(this, [[dec, 9, "a"], [dec, 9, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
   static set a(v) {
     return this.value = v;
   }
-  static set [_computedKey](v) {
+  static set ['b'](v) {
     return this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _initStatic, _class;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,10 +9,7 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
   constructor() {
@@ -33,10 +30,10 @@ class Foo {
   static set "b"(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _C, v);
   }
-  static get [_computedKey]() {
+  static get ["c"]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _D);
   }
-  static set [_computedKey](v) {
+  static set ["c"](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _D, v);
   }
   static get 0() {
@@ -45,10 +42,10 @@ class Foo {
   static set 0(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _E, v);
   }
-  static get [_computedKey2]() {
+  static get [1]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _F);
   }
-  static set [_computedKey2](v) {
+  static set [1](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _F, v);
   }
   static get 2n() {
@@ -57,16 +54,16 @@ class Foo {
   static set 2n(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _G, v);
   }
-  static get [_computedKey3]() {
+  static get [3n]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _H);
   }
-  static set [_computedKey3](v) {
+  static set [3n](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _H, v);
   }
-  static get [_computedKey4]() {
+  static get [_computedKey]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _I);
   }
-  static set [_computedKey4](v) {
+  static set [_computedKey](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _I, v);
   }
 }
@@ -78,7 +75,7 @@ function _get_a2() {
   return _get_a(this);
 }
 (() => {
-  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 6, "a"], [dec, 6, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _B, v)], [dec, 6, "b"], [dec, 6, _computedKey], [dec, 6, 0], [dec, 6, _computedKey2], [dec, 6, 2n], [dec, 6, _computedKey3], [dec, 6, _computedKey4]], []).e;
+  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 6, "a"], [dec, 6, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _B, v)], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []).e;
   _initStatic(_class);
 })();
 var _A = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
   constructor() {
@@ -114,4 +114,4 @@ var _I = {
   writable: true,
   value: _init_computedKey7(_class)
 };
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initProto, _class;
+var _init_a, _init_b, _init_computedKey, _initProto, _class;
 const dec = () => {};
-_computedKey = 'c';
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();
 var _C = /*#__PURE__*/new WeakMap();
@@ -31,12 +30,12 @@ class Foo {
   set b(v) {
     babelHelpers.classPrivateFieldSet(this, _B, v);
   }
-  get [_computedKey]() {
+  get ['c']() {
     return babelHelpers.classPrivateFieldGet(this, _C);
   }
-  set [_computedKey](v) {
+  set ['c'](v) {
     babelHelpers.classPrivateFieldSet(this, _C, v);
   }
 }
 _class = Foo;
-[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2301(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, _computedKey]], []).e;
+[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2301(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-public/output.js
@@ -1,6 +1,5 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initStatic, _class;
+var _init_a, _init_b, _init_computedKey, _initStatic, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static get a() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _A);
@@ -14,16 +13,16 @@ class Foo {
   static set b(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _B, v);
   }
-  static get [_computedKey]() {
+  static get ['c']() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _C);
   }
-  static set [_computedKey](v) {
+  static set ['c'](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _C, v);
   }
 }
 _class = Foo;
 (() => {
-  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, _computedKey]], []).e;
+  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []).e;
   _initStatic(_class);
 })();
 var _A = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 6, "a"], [dec, 6, "a", o => o.#B, (o, v) => o.#B = v], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []).e;
@@ -79,4 +79,4 @@ class Foo {
     this.#I = v;
   }
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _initStatic;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,13 +9,10 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 6, "a"], [dec, 6, "a", o => o.#B, (o, v) => o.#B = v], [dec, 6, "b"], [dec, 6, _computedKey], [dec, 6, 0], [dec, 6, _computedKey2], [dec, 6, 2n], [dec, 6, _computedKey3], [dec, 6, _computedKey4]], []).e;
+    [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 6, "a"], [dec, 6, "a", o => o.#B, (o, v) => o.#B = v], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []).e;
     _initStatic(this);
   }
   static #A = _init_a(this);
@@ -40,10 +37,10 @@ class Foo {
     this.#C = v;
   }
   static #D = _init_computedKey2(this);
-  static get [_computedKey]() {
+  static get ["c"]() {
     return this.#D;
   }
-  static set [_computedKey](v) {
+  static set ["c"](v) {
     this.#D = v;
   }
   static #E = _init_computedKey3(this);
@@ -54,10 +51,10 @@ class Foo {
     this.#E = v;
   }
   static #F = _init_computedKey4(this);
-  static get [_computedKey2]() {
+  static get [1]() {
     return this.#F;
   }
-  static set [_computedKey2](v) {
+  static set [1](v) {
     this.#F = v;
   }
   static #G = _init_computedKey5(this);
@@ -68,17 +65,17 @@ class Foo {
     this.#G = v;
   }
   static #H = _init_computedKey6(this);
-  static get [_computedKey3]() {
+  static get [3n]() {
     return this.#H;
   }
-  static set [_computedKey3](v) {
+  static set [3n](v) {
     this.#H = v;
   }
   static #I = _init_computedKey7(this);
-  static get [_computedKey4]() {
+  static get [_computedKey]() {
     return this.#I;
   }
-  static set [_computedKey4](v) {
+  static set [_computedKey](v) {
     this.#I = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initProto;
+var _init_a, _init_b, _init_computedKey, _initProto;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2301(this, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2301(this, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;
   }
   #A = (_initProto(this), _init_a(this));
   get a() {
@@ -20,10 +19,10 @@ class Foo {
     this.#B = v;
   }
   #C = _init_computedKey(this, 456);
-  get [_computedKey]() {
+  get ['c']() {
     return this.#C;
   }
-  set [_computedKey](v) {
+  set ['c'](v) {
     this.#C = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initStatic;
+var _init_a, _init_b, _init_computedKey, _initStatic;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []).e;
     _initStatic(this);
   }
   static #A = _init_a(this);
@@ -21,10 +20,10 @@ class Foo {
     this.#B = v;
   }
   static #C = _init_computedKey(this, 456);
-  static get [_computedKey]() {
+  static get ['c']() {
     return this.#C;
   }
-  static set [_computedKey](v) {
+  static set ['c'](v) {
     this.#C = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto, _class;
 const dec = () => {};
-_computedKey = getKey();
-_computedKey2 = getKey();
+_computedKey = babelHelpers.toPropertyKey(getKey());
+_computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
   constructor(...args) {
     _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto, _class;
 const dec = () => {};
-_computedKey = getKeyI();
-_computedKey2 = getKeyJ();
+_computedKey = babelHelpers.toPropertyKey(getKeyI());
+_computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
   constructor(...args) {
     _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto;
 const dec = () => {};
-_computedKey = getKey();
-_computedKey2 = getKey();
+_computedKey = babelHelpers.toPropertyKey(getKey());
+_computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-value/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto;
 const dec = () => {};
-_computedKey = getKeyI();
-_computedKey2 = getKeyJ();
+_computedKey = babelHelpers.toPropertyKey(getKeyI());
+_computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _class;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,23 +9,20 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {}
 _class = Foo;
-[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2301(_class, [[dec, 5, "a"], [dec, 5, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _a, v)], [dec, 5, "b"], [dec, 5, _computedKey], [dec, 5, 0], [dec, 5, _computedKey2], [dec, 5, 2n], [dec, 5, _computedKey3], [dec, 5, _computedKey4]], []).e;
+[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2301(_class, [[dec, 5, "a"], [dec, 5, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _a, v)], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []).e;
 babelHelpers.defineProperty(Foo, "a", _init_a(_class));
 var _a = {
   writable: true,
   value: _init_a2(_class)
 };
 babelHelpers.defineProperty(Foo, "b", _init_computedKey(_class));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey2(_class));
+babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_class));
 babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_class));
-babelHelpers.defineProperty(Foo, _computedKey2, _init_computedKey4(_class));
+babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
 babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
-babelHelpers.defineProperty(Foo, _computedKey3, _init_computedKey6(_class));
-babelHelpers.defineProperty(Foo, _computedKey4, _init_computedKey7(_class));
+babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
+babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {}
 _class = Foo;
 [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2301(_class, [[dec, 5, "a"], [dec, 5, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _a, v)], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []).e;
@@ -25,4 +25,4 @@ babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
 babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
 babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
 babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/public/output.js
@@ -1,12 +1,11 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   constructor() {
     babelHelpers.defineProperty(this, "a", _init_a(this));
     babelHelpers.defineProperty(this, "b", _init_b(this, 123));
-    babelHelpers.defineProperty(this, _computedKey, _init_computedKey(this, 456));
+    babelHelpers.defineProperty(this, 'c', _init_computedKey(this, 456));
   }
 }
 _class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, _computedKey]], []).e;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/static-public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {}
 _class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(_class, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, _computedKey]], []).e;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(_class, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []).e;
 babelHelpers.defineProperty(Foo, "a", _init_a(_class));
 babelHelpers.defineProperty(Foo, "b", _init_b(_class, 123));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey(_class, 456));
+babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_class, 456));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2301(this, [[dec, 5, "a"], [dec, 5, "a", o => o.#a, (o, v) => o.#a = v], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []).e;
@@ -24,4 +24,4 @@ class Foo {
   static [3n] = _init_computedKey6(this);
   static [_computedKey] = _init_computedKey7(this);
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,22 +9,19 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2301(this, [[dec, 5, "a"], [dec, 5, "a", o => o.#a, (o, v) => o.#a = v], [dec, 5, "b"], [dec, 5, _computedKey], [dec, 5, 0], [dec, 5, _computedKey2], [dec, 5, 2n], [dec, 5, _computedKey3], [dec, 5, _computedKey4]], []).e;
+    [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2301(this, [[dec, 5, "a"], [dec, 5, "a", o => o.#a, (o, v) => o.#a = v], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []).e;
   }
   static a = _init_a(this);
   static #a = _init_a2(this);
   static "b" = _init_computedKey(this);
-  static [_computedKey] = _init_computedKey2(this);
+  static ["c"] = _init_computedKey2(this);
   static 0 = _init_computedKey3(this);
-  static [_computedKey2] = _init_computedKey4(this);
+  static [1] = _init_computedKey4(this);
   static 2n = _init_computedKey5(this);
-  static [_computedKey3] = _init_computedKey6(this);
-  static [_computedKey4] = _init_computedKey7(this);
+  static [3n] = _init_computedKey6(this);
+  static [_computedKey] = _init_computedKey7(this);
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/public/output.js
@@ -1,11 +1,10 @@
-var _init_a, _init_b, _computedKey, _init_computedKey;
+var _init_a, _init_b, _init_computedKey;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(this, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(this, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;
   }
   a = _init_a(this);
   b = _init_b(this, 123);
-  [_computedKey] = _init_computedKey(this, 456);
+  ['c'] = _init_computedKey(this, 456);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/static-public/output.js
@@ -1,11 +1,10 @@
-var _init_a, _init_b, _computedKey, _init_computedKey;
+var _init_a, _init_b, _init_computedKey;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(this, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(this, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []).e;
   }
   static a = _init_a(this);
   static b = _init_b(this, 123);
-  static [_computedKey] = _init_computedKey(this, 456);
+  static ['c'] = _init_computedKey(this, 456);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,19 +9,16 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static get a() {}
   static get "b"() {}
-  static get [_computedKey]() {}
+  static get ["c"]() {}
   static get 0() {}
-  static get [_computedKey2]() {}
+  static get [1]() {}
   static get 2n() {}
-  static get [_computedKey3]() {}
-  static get [_computedKey4]() {}
+  static get [3n]() {}
+  static get [_computedKey]() {}
 }
 _class = Foo;
 function _get_a() {
@@ -32,7 +29,7 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, _computedKey], [dec, 8, 0], [dec, 8, _computedKey2], [dec, 8, 2n], [dec, 8, _computedKey3], [dec, 8, _computedKey4]], []).e;
+  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
   _initStatic(_class);
 })();
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static get a() {}
   static get "b"() {}
@@ -32,4 +32,4 @@ var _a = {
   [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
   _initStatic(_class);
 })();
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   get a() {
     return this.value;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 3, "a"], [dec, 3, _computedKey]], []).e;
+[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 3, "a"], [dec, 3, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static get a() {
     return this.value;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a"], [dec, 8, _computedKey]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a"], [dec, 8, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/public/output.js
@@ -1,7 +1,5 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -13,12 +11,12 @@ class Foo {
   set a(v) {
     this.value = v;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
-  set [_computedKey2](v) {
+  set ['b'](v) {
     this.value = v;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, _computedKey], [dec, 4, _computedKey2]], []).e;
+[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-public/output.js
@@ -1,7 +1,5 @@
-var _computedKey, _computedKey2, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static get a() {
     return this.value;
@@ -9,16 +7,16 @@ class Foo {
   static set a(v) {
     this.value = v;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
-  static set [_computedKey2](v) {
+  static set ['b'](v) {
     this.value = v;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, _computedKey], [dec, 9, _computedKey2]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/public/output.js
@@ -1,10 +1,8 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, _computedKey], [dec, 4, _computedKey2]], []).e;
+    [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -16,10 +14,10 @@ class Foo {
   set a(v) {
     this.value = v;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
-  set [_computedKey2](v) {
+  set ['b'](v) {
     this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/static-public/output.js
@@ -1,10 +1,8 @@
-var _computedKey, _computedKey2, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2301(this, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, _computedKey], [dec, 9, _computedKey2]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2301(this, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
@@ -14,10 +12,10 @@ class Foo {
   static set a(v) {
     this.value = v;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
-  static set [_computedKey2](v) {
+  static set ['b'](v) {
     this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,13 +9,10 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, _computedKey], [dec, 8, 0], [dec, 8, _computedKey2], [dec, 8, 2n], [dec, 8, _computedKey3], [dec, 8, _computedKey4]], []).e;
+    [_call_a, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
     _initStatic(this);
   }
   static get a() {}
@@ -23,11 +20,11 @@ class Foo {
     return _call_a(this);
   }
   static get "b"() {}
-  static get [_computedKey]() {}
+  static get ["c"]() {}
   static get 0() {}
-  static get [_computedKey2]() {}
+  static get [1]() {}
   static get 2n() {}
-  static get [_computedKey3]() {}
-  static get [_computedKey4]() {}
+  static get [3n]() {}
+  static get [_computedKey]() {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
@@ -27,4 +27,4 @@ class Foo {
   static get [3n]() {}
   static get [_computedKey]() {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 3, "a"], [dec, 3, _computedKey]], []).e;
+    [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   get a() {
     return this.value;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2301(this, [[dec, 8, "a"], [dec, 8, _computedKey]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2301(this, [[dec, 8, "a"], [dec, 8, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
   static get a() {
     return this.value;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,23 +9,20 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static a() {}
   static "b"() {}
-  static [_computedKey]() {}
+  static ["c"]() {}
   static 0() {}
-  static [_computedKey2]() {}
+  static [1]() {}
   static 2n() {}
-  static [_computedKey3]() {}
-  static [_computedKey4]() {}
+  static [3n]() {}
+  static [_computedKey]() {}
 }
 _class = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, _computedKey], [dec, 7, 0], [dec, 7, _computedKey2], [dec, 7, 2n], [dec, 7, _computedKey3], [dec, 7, _computedKey4]], []).e;
+  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []).e;
   _initStatic(_class);
 })();
 var _a = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static a() {}
   static "b"() {}
@@ -29,4 +29,4 @@ var _a = {
   writable: true,
   value: _call_a
 };
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   a() {
     return this.value;
   }
-  [_computedKey]() {
+  ['b']() {
     return this.value;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 2, "a"], [dec, 2, _computedKey]], []).e;
+[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 2, "a"], [dec, 2, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static a() {
     return this.value;
   }
-  static [_computedKey]() {
+  static ['b']() {
     return this.value;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 7, "a"], [dec, 7, _computedKey]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 7, "a"], [dec, 7, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,23 +9,20 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, _computedKey], [dec, 7, 0], [dec, 7, _computedKey2], [dec, 7, 2n], [dec, 7, _computedKey3], [dec, 7, _computedKey4]], []).e;
+    [_call_a, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []).e;
     _initStatic(this);
   }
   static #a = _call_a;
   static a() {}
   static "b"() {}
-  static [_computedKey]() {}
+  static ["c"]() {}
   static 0() {}
-  static [_computedKey2]() {}
+  static [1]() {}
   static 2n() {}
-  static [_computedKey3]() {}
-  static [_computedKey4]() {}
+  static [3n]() {}
+  static [_computedKey]() {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []).e;
@@ -25,4 +25,4 @@ class Foo {
   static [3n]() {}
   static [_computedKey]() {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 2, "a"], [dec, 2, _computedKey]], []).e;
+    [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   a() {
     return this.value;
   }
-  [_computedKey]() {
+  ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2301(this, [[dec, 7, "a"], [dec, 7, _computedKey]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2301(this, [[dec, 7, "a"], [dec, 7, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
   static a() {
     return this.value;
   }
-  static [_computedKey]() {
+  static ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static set a(v) {}
   static set "b"(v) {}
@@ -32,4 +32,4 @@ var _a = {
   [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
   _initStatic(_class);
 })();
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,19 +9,16 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static set a(v) {}
   static set "b"(v) {}
-  static set [_computedKey](v) {}
+  static set ["c"](v) {}
   static set 0(v) {}
-  static set [_computedKey2](v) {}
+  static set [1](v) {}
   static set 2n(v) {}
-  static set [_computedKey3](v) {}
-  static set [_computedKey4](v) {}
+  static set [3n](v) {}
+  static set [_computedKey](v) {}
 }
 _class = Foo;
 function _set_a(v) {
@@ -32,7 +29,7 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, _computedKey], [dec, 9, 0], [dec, 9, _computedKey2], [dec, 9, 2n], [dec, 9, _computedKey3], [dec, 9, _computedKey4]], []).e;
+  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
   _initStatic(_class);
 })();
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   set a(v) {
     return this.value = v;
   }
-  set [_computedKey](v) {
+  set ['b'](v) {
     return this.value = v;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 4, "a"], [dec, 4, _computedKey]], []).e;
+[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 4, "a"], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static set a(v) {
     return this.value = v;
   }
-  static set [_computedKey](v) {
+  static set ['b'](v) {
     return this.value = v;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 9, "a"], [dec, 9, _computedKey]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 9, "a"], [dec, 9, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,13 +9,10 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, _computedKey], [dec, 9, 0], [dec, 9, _computedKey2], [dec, 9, 2n], [dec, 9, _computedKey3], [dec, 9, _computedKey4]], []).e;
+    [_call_a, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
     _initStatic(this);
   }
   static set a(v) {}
@@ -23,11 +20,11 @@ class Foo {
     _call_a(this, v);
   }
   static set "b"(v) {}
-  static set [_computedKey](v) {}
+  static set ["c"](v) {}
   static set 0(v) {}
-  static set [_computedKey2](v) {}
+  static set [1](v) {}
   static set 2n(v) {}
-  static set [_computedKey3](v) {}
-  static set [_computedKey4](v) {}
+  static set [3n](v) {}
+  static set [_computedKey](v) {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs2301(this, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
@@ -27,4 +27,4 @@ class Foo {
   static set [3n](v) {}
   static set [_computedKey](v) {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 4, "a"], [dec, 4, _computedKey]], []).e;
+    [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   set a(v) {
     return this.value = v;
   }
-  set [_computedKey](v) {
+  set ['b'](v) {
     return this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2301(this, [[dec, 9, "a"], [dec, 9, _computedKey]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2301(this, [[dec, 9, "a"], [dec, 9, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
   static set a(v) {
     return this.value = v;
   }
-  static set [_computedKey](v) {
+  static set ['b'](v) {
     return this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
   constructor() {
@@ -114,4 +114,4 @@ var _I = {
   writable: true,
   value: _init_computedKey7(_class)
 };
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _initStatic, _class;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,10 +9,7 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
   constructor() {
@@ -33,10 +30,10 @@ class Foo {
   static set "b"(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(Foo, Foo, _C, v);
   }
-  static get [_computedKey]() {
+  static get ["c"]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _D);
   }
-  static set [_computedKey](v) {
+  static set ["c"](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(Foo, Foo, _D, v);
   }
   static get 0() {
@@ -45,10 +42,10 @@ class Foo {
   static set 0(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(Foo, Foo, _E, v);
   }
-  static get [_computedKey2]() {
+  static get [1]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _F);
   }
-  static set [_computedKey2](v) {
+  static set [1](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(Foo, Foo, _F, v);
   }
   static get 2n() {
@@ -57,16 +54,16 @@ class Foo {
   static set 2n(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(Foo, Foo, _G, v);
   }
-  static get [_computedKey3]() {
+  static get [3n]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _H);
   }
-  static set [_computedKey3](v) {
+  static set [3n](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(Foo, Foo, _H, v);
   }
-  static get [_computedKey4]() {
+  static get [_computedKey]() {
     return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _I);
   }
-  static set [_computedKey4](v) {
+  static set [_computedKey](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(Foo, Foo, _I, v);
   }
 }
@@ -78,7 +75,7 @@ function _get_a2() {
   return _get_a(this);
 }
 (() => {
-  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 9, "a"], [dec, 9, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _B, v)], [dec, 9, "b"], [dec, 9, _computedKey], [dec, 9, 0], [dec, 9, _computedKey2], [dec, 9, 2n], [dec, 9, _computedKey3], [dec, 9, _computedKey4]], []).e;
+  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 9, "a"], [dec, 9, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _B, v)], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
   _initStatic(_class);
 })();
 var _A = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initProto, _class;
+var _init_a, _init_b, _init_computedKey, _initProto, _class;
 const dec = () => {};
-_computedKey = 'c';
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();
 var _C = /*#__PURE__*/new WeakMap();
@@ -31,12 +30,12 @@ class Foo {
   set b(v) {
     babelHelpers.classPrivateFieldSet(this, _B, v);
   }
-  get [_computedKey]() {
+  get ['c']() {
     return babelHelpers.classPrivateFieldGet(this, _C);
   }
-  set [_computedKey](v) {
+  set ['c'](v) {
     babelHelpers.classPrivateFieldSet(this, _C, v);
   }
 }
 _class = Foo;
-[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2305(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, _computedKey]], []).e;
+[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2305(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-public/output.js
@@ -1,6 +1,5 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initStatic, _class;
+var _init_a, _init_b, _init_computedKey, _initStatic, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static get a() {
     return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _A);
@@ -14,16 +13,16 @@ class Foo {
   static set b(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(Foo, Foo, _B, v);
   }
-  static get [_computedKey]() {
+  static get ['c']() {
     return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _C);
   }
-  static set [_computedKey](v) {
+  static set ['c'](v) {
     babelHelpers.classStaticPrivateFieldSpecSet(Foo, Foo, _C, v);
   }
 }
 _class = Foo;
 (() => {
-  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 9, "a"], [dec, 9, "b"], [dec, 9, _computedKey]], []).e;
+  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 9, "a"], [dec, 9, "b"], [dec, 9, 'c']], []).e;
   _initStatic(_class);
 })();
 var _A = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static accessor a;
   @dec static accessor #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static accessor [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 9, "a"], [dec, 9, "a", o => o.#B, (o, v) => o.#B = v], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
@@ -79,4 +79,4 @@ class Foo {
     Foo.#I = v;
   }
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _initStatic;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,13 +9,10 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 9, "a"], [dec, 9, "a", o => o.#B, (o, v) => o.#B = v], [dec, 9, "b"], [dec, 9, _computedKey], [dec, 9, 0], [dec, 9, _computedKey2], [dec, 9, 2n], [dec, 9, _computedKey3], [dec, 9, _computedKey4]], []).e;
+    [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 9, "a"], [dec, 9, "a", o => o.#B, (o, v) => o.#B = v], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
     _initStatic(this);
   }
   static #A = _init_a(this);
@@ -40,10 +37,10 @@ class Foo {
     Foo.#C = v;
   }
   static #D = _init_computedKey2(this);
-  static get [_computedKey]() {
+  static get ["c"]() {
     return Foo.#D;
   }
-  static set [_computedKey](v) {
+  static set ["c"](v) {
     Foo.#D = v;
   }
   static #E = _init_computedKey3(this);
@@ -54,10 +51,10 @@ class Foo {
     Foo.#E = v;
   }
   static #F = _init_computedKey4(this);
-  static get [_computedKey2]() {
+  static get [1]() {
     return Foo.#F;
   }
-  static set [_computedKey2](v) {
+  static set [1](v) {
     Foo.#F = v;
   }
   static #G = _init_computedKey5(this);
@@ -68,17 +65,17 @@ class Foo {
     Foo.#G = v;
   }
   static #H = _init_computedKey6(this);
-  static get [_computedKey3]() {
+  static get [3n]() {
     return Foo.#H;
   }
-  static set [_computedKey3](v) {
+  static set [3n](v) {
     Foo.#H = v;
   }
   static #I = _init_computedKey7(this);
-  static get [_computedKey4]() {
+  static get [_computedKey]() {
     return Foo.#I;
   }
-  static set [_computedKey4](v) {
+  static set [_computedKey](v) {
     Foo.#I = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initProto;
+var _init_a, _init_b, _init_computedKey, _initProto;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2305(this, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2305(this, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;
   }
   #A = (_initProto(this), _init_a(this));
   get a() {
@@ -20,10 +19,10 @@ class Foo {
     this.#B = v;
   }
   #C = _init_computedKey(this, 456);
-  get [_computedKey]() {
+  get ['c']() {
     return this.#C;
   }
-  set [_computedKey](v) {
+  set ['c'](v) {
     this.#C = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _initStatic;
+var _init_a, _init_b, _init_computedKey, _initStatic;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 9, "a"], [dec, 9, "b"], [dec, 9, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 9, "a"], [dec, 9, "b"], [dec, 9, 'c']], []).e;
     _initStatic(this);
   }
   static #A = _init_a(this);
@@ -21,10 +20,10 @@ class Foo {
     Foo.#B = v;
   }
   static #C = _init_computedKey(this, 456);
-  static get [_computedKey]() {
+  static get ['c']() {
     return Foo.#C;
   }
-  static set [_computedKey](v) {
+  static set ['c'](v) {
     Foo.#C = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto, _class;
 const dec = () => {};
-_computedKey = getKey();
-_computedKey2 = getKey();
+_computedKey = babelHelpers.toPropertyKey(getKey());
+_computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
   constructor(...args) {
     _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto, _class;
 const dec = () => {};
-_computedKey = getKeyI();
-_computedKey2 = getKeyJ();
+_computedKey = babelHelpers.toPropertyKey(getKeyI());
+_computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
   constructor(...args) {
     _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto;
 const dec = () => {};
-_computedKey = getKey();
-_computedKey2 = getKey();
+_computedKey = babelHelpers.toPropertyKey(getKey());
+_computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-value/output.js
@@ -1,7 +1,7 @@
 var _computedKey, _computedKey2, _initProto;
 const dec = () => {};
-_computedKey = getKeyI();
-_computedKey2 = getKeyJ();
+_computedKey = babelHelpers.toPropertyKey(getKeyI());
+_computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {}
 _class = Foo;
 [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2305(_class, [[dec, 8, "a"], [dec, 8, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _a, v)], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
@@ -25,4 +25,4 @@ babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
 babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
 babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
 babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7, _class;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,23 +9,20 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {}
 _class = Foo;
-[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2305(_class, [[dec, 8, "a"], [dec, 8, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _a, v)], [dec, 8, "b"], [dec, 8, _computedKey], [dec, 8, 0], [dec, 8, _computedKey2], [dec, 8, 2n], [dec, 8, _computedKey3], [dec, 8, _computedKey4]], []).e;
+[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2305(_class, [[dec, 8, "a"], [dec, 8, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _a, v)], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
 babelHelpers.defineProperty(Foo, "a", _init_a(_class));
 var _a = {
   writable: true,
   value: _init_a2(_class)
 };
 babelHelpers.defineProperty(Foo, "b", _init_computedKey(_class));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey2(_class));
+babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_class));
 babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_class));
-babelHelpers.defineProperty(Foo, _computedKey2, _init_computedKey4(_class));
+babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
 babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
-babelHelpers.defineProperty(Foo, _computedKey3, _init_computedKey6(_class));
-babelHelpers.defineProperty(Foo, _computedKey4, _init_computedKey7(_class));
+babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
+babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/public/output.js
@@ -1,12 +1,11 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   constructor() {
     babelHelpers.defineProperty(this, "a", _init_a(this));
     babelHelpers.defineProperty(this, "b", _init_b(this, 123));
-    babelHelpers.defineProperty(this, _computedKey, _init_computedKey(this, 456));
+    babelHelpers.defineProperty(this, 'c', _init_computedKey(this, 456));
   }
 }
 _class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, _computedKey]], []).e;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/static-public/output.js
@@ -1,9 +1,8 @@
-var _init_a, _init_b, _computedKey, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _class;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {}
 _class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(_class, [[dec, 8, "a"], [dec, 8, "b"], [dec, 8, _computedKey]], []).e;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(_class, [[dec, 8, "a"], [dec, 8, "b"], [dec, 8, 'c']], []).e;
 babelHelpers.defineProperty(Foo, "a", _init_a(_class));
 babelHelpers.defineProperty(Foo, "b", _init_b(_class, 123));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey(_class, 456));
+babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_class, 456));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a;
   @dec static #a;
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()];
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2305(this, [[dec, 8, "a"], [dec, 8, "a", o => o.#a, (o, v) => o.#a = v], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
@@ -24,4 +24,4 @@ class Foo {
   static [3n] = _init_computedKey6(this);
   static [_computedKey] = _init_computedKey7(this);
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _computedKey, _init_computedKey2, _init_computedKey3, _computedKey2, _init_computedKey4, _init_computedKey5, _computedKey3, _init_computedKey6, _computedKey4, _init_computedKey7;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,22 +9,19 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2305(this, [[dec, 8, "a"], [dec, 8, "a", o => o.#a, (o, v) => o.#a = v], [dec, 8, "b"], [dec, 8, _computedKey], [dec, 8, 0], [dec, 8, _computedKey2], [dec, 8, 2n], [dec, 8, _computedKey3], [dec, 8, _computedKey4]], []).e;
+    [_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2305(this, [[dec, 8, "a"], [dec, 8, "a", o => o.#a, (o, v) => o.#a = v], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
   }
   static a = _init_a(this);
   static #a = _init_a2(this);
   static "b" = _init_computedKey(this);
-  static [_computedKey] = _init_computedKey2(this);
+  static ["c"] = _init_computedKey2(this);
   static 0 = _init_computedKey3(this);
-  static [_computedKey2] = _init_computedKey4(this);
+  static [1] = _init_computedKey4(this);
   static 2n = _init_computedKey5(this);
-  static [_computedKey3] = _init_computedKey6(this);
-  static [_computedKey4] = _init_computedKey7(this);
+  static [3n] = _init_computedKey6(this);
+  static [_computedKey] = _init_computedKey7(this);
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/public/output.js
@@ -1,11 +1,10 @@
-var _init_a, _init_b, _computedKey, _init_computedKey;
+var _init_a, _init_b, _init_computedKey;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(this, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(this, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;
   }
   a = _init_a(this);
   b = _init_b(this, 123);
-  [_computedKey] = _init_computedKey(this, 456);
+  ['c'] = _init_computedKey(this, 456);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/static-public/output.js
@@ -1,11 +1,10 @@
-var _init_a, _init_b, _computedKey, _init_computedKey;
+var _init_a, _init_b, _init_computedKey;
 const dec = () => {};
-_computedKey = 'c';
 class Foo {
   static {
-    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(this, [[dec, 8, "a"], [dec, 8, "b"], [dec, 8, _computedKey]], []).e;
+    [_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(this, [[dec, 8, "a"], [dec, 8, "b"], [dec, 8, 'c']], []).e;
   }
   static a = _init_a(this);
   static b = _init_b(this, 123);
-  static [_computedKey] = _init_computedKey(this, 456);
+  static ['c'] = _init_computedKey(this, 456);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static get a() {}
   static get "b"() {}
@@ -32,4 +32,4 @@ var _a = {
   [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a"], [dec, 11, "a", function () {}], [dec, 11, "b"], [dec, 11, "c"], [dec, 11, 0], [dec, 11, 1], [dec, 11, 2n], [dec, 11, 3n], [dec, 11, _computedKey]], []).e;
   _initStatic(_class);
 })();
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,19 +9,16 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static get a() {}
   static get "b"() {}
-  static get [_computedKey]() {}
+  static get ["c"]() {}
   static get 0() {}
-  static get [_computedKey2]() {}
+  static get [1]() {}
   static get 2n() {}
-  static get [_computedKey3]() {}
-  static get [_computedKey4]() {}
+  static get [3n]() {}
+  static get [_computedKey]() {}
 }
 _class = Foo;
 function _get_a() {
@@ -32,7 +29,7 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a"], [dec, 11, "a", function () {}], [dec, 11, "b"], [dec, 11, _computedKey], [dec, 11, 0], [dec, 11, _computedKey2], [dec, 11, 2n], [dec, 11, _computedKey3], [dec, 11, _computedKey4]], []).e;
+  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a"], [dec, 11, "a", function () {}], [dec, 11, "b"], [dec, 11, "c"], [dec, 11, 0], [dec, 11, 1], [dec, 11, 2n], [dec, 11, 3n], [dec, 11, _computedKey]], []).e;
   _initStatic(_class);
 })();
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   get a() {
     return this.value;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 3, "a"], [dec, 3, _computedKey]], []).e;
+[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 3, "a"], [dec, 3, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static get a() {
     return this.value;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a"], [dec, 11, _computedKey]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a"], [dec, 11, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/public/output.js
@@ -1,7 +1,5 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -13,12 +11,12 @@ class Foo {
   set a(v) {
     this.value = v;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
-  set [_computedKey2](v) {
+  set ['b'](v) {
     this.value = v;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, _computedKey], [dec, 4, _computedKey2]], []).e;
+[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-public/output.js
@@ -1,7 +1,5 @@
-var _computedKey, _computedKey2, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static get a() {
     return this.value;
@@ -9,16 +7,16 @@ class Foo {
   static set a(v) {
     this.value = v;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
-  static set [_computedKey2](v) {
+  static set ['b'](v) {
     this.value = v;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a"], [dec, 12, "a"], [dec, 11, _computedKey], [dec, 12, _computedKey2]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a"], [dec, 12, "a"], [dec, 11, 'b'], [dec, 12, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/public/output.js
@@ -1,10 +1,8 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, _computedKey], [dec, 4, _computedKey2]], []).e;
+    [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -16,10 +14,10 @@ class Foo {
   set a(v) {
     this.value = v;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
-  set [_computedKey2](v) {
+  set ['b'](v) {
     this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/static-public/output.js
@@ -1,10 +1,8 @@
-var _computedKey, _computedKey2, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
-_computedKey2 = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2305(this, [[dec, 11, "a"], [dec, 12, "a"], [dec, 11, _computedKey], [dec, 12, _computedKey2]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2305(this, [[dec, 11, "a"], [dec, 12, "a"], [dec, 11, 'b'], [dec, 12, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
@@ -14,10 +12,10 @@ class Foo {
   static set a(v) {
     this.value = v;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
-  static set [_computedKey2](v) {
+  static set ['b'](v) {
     this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static get a() {};
   @dec static get #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static get [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 11, "a"], [dec, 11, "a", function () {}], [dec, 11, "b"], [dec, 11, "c"], [dec, 11, 0], [dec, 11, 1], [dec, 11, 2n], [dec, 11, 3n], [dec, 11, _computedKey]], []).e;
@@ -27,4 +27,4 @@ class Foo {
   static get [3n]() {}
   static get [_computedKey]() {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,13 +9,10 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 11, "a"], [dec, 11, "a", function () {}], [dec, 11, "b"], [dec, 11, _computedKey], [dec, 11, 0], [dec, 11, _computedKey2], [dec, 11, 2n], [dec, 11, _computedKey3], [dec, 11, _computedKey4]], []).e;
+    [_call_a, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 11, "a"], [dec, 11, "a", function () {}], [dec, 11, "b"], [dec, 11, "c"], [dec, 11, 0], [dec, 11, 1], [dec, 11, 2n], [dec, 11, 3n], [dec, 11, _computedKey]], []).e;
     _initStatic(this);
   }
   static get a() {}
@@ -23,11 +20,11 @@ class Foo {
     return _call_a(this);
   }
   static get "b"() {}
-  static get [_computedKey]() {}
+  static get ["c"]() {}
   static get 0() {}
-  static get [_computedKey2]() {}
+  static get [1]() {}
   static get 2n() {}
-  static get [_computedKey3]() {}
-  static get [_computedKey4]() {}
+  static get [3n]() {}
+  static get [_computedKey]() {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 3, "a"], [dec, 3, _computedKey]], []).e;
+    [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   get a() {
     return this.value;
   }
-  get [_computedKey]() {
+  get ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2305(this, [[dec, 11, "a"], [dec, 11, _computedKey]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2305(this, [[dec, 11, "a"], [dec, 11, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
   static get a() {
     return this.value;
   }
-  static get [_computedKey]() {
+  static get ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,23 +9,20 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static a() {}
   static "b"() {}
-  static [_computedKey]() {}
+  static ["c"]() {}
   static 0() {}
-  static [_computedKey2]() {}
+  static [1]() {}
   static 2n() {}
-  static [_computedKey3]() {}
-  static [_computedKey4]() {}
+  static [3n]() {}
+  static [_computedKey]() {}
 }
 _class = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 10, "a"], [dec, 10, "a", function () {}], [dec, 10, "b"], [dec, 10, _computedKey], [dec, 10, 0], [dec, 10, _computedKey2], [dec, 10, 2n], [dec, 10, _computedKey3], [dec, 10, _computedKey4]], []).e;
+  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 10, "a"], [dec, 10, "a", function () {}], [dec, 10, "b"], [dec, 10, "c"], [dec, 10, 0], [dec, 10, 1], [dec, 10, 2n], [dec, 10, 3n], [dec, 10, _computedKey]], []).e;
   _initStatic(_class);
 })();
 var _a = {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static a() {}
   static "b"() {}
@@ -29,4 +29,4 @@ var _a = {
   writable: true,
   value: _call_a
 };
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   a() {
     return this.value;
   }
-  [_computedKey]() {
+  ['b']() {
     return this.value;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 2, "a"], [dec, 2, _computedKey]], []).e;
+[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 2, "a"], [dec, 2, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static a() {
     return this.value;
   }
-  static [_computedKey]() {
+  static ['b']() {
     return this.value;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 10, "a"], [dec, 10, _computedKey]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 10, "a"], [dec, 10, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static a() {};
   @dec static #a() {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static [f()]() {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,23 +9,20 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 10, "a"], [dec, 10, "a", function () {}], [dec, 10, "b"], [dec, 10, _computedKey], [dec, 10, 0], [dec, 10, _computedKey2], [dec, 10, 2n], [dec, 10, _computedKey3], [dec, 10, _computedKey4]], []).e;
+    [_call_a, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 10, "a"], [dec, 10, "a", function () {}], [dec, 10, "b"], [dec, 10, "c"], [dec, 10, 0], [dec, 10, 1], [dec, 10, 2n], [dec, 10, 3n], [dec, 10, _computedKey]], []).e;
     _initStatic(this);
   }
   static #a = _call_a;
   static a() {}
   static "b"() {}
-  static [_computedKey]() {}
+  static ["c"]() {}
   static 0() {}
-  static [_computedKey2]() {}
+  static [1]() {}
   static 2n() {}
-  static [_computedKey3]() {}
-  static [_computedKey4]() {}
+  static [3n]() {}
+  static [_computedKey]() {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 10, "a"], [dec, 10, "a", function () {}], [dec, 10, "b"], [dec, 10, "c"], [dec, 10, 0], [dec, 10, 1], [dec, 10, 2n], [dec, 10, 3n], [dec, 10, _computedKey]], []).e;
@@ -25,4 +25,4 @@ class Foo {
   static [3n]() {}
   static [_computedKey]() {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 2, "a"], [dec, 2, _computedKey]], []).e;
+    [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   a() {
     return this.value;
   }
-  [_computedKey]() {
+  ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2305(this, [[dec, 10, "a"], [dec, 10, _computedKey]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2305(this, [[dec, 10, "a"], [dec, 10, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
   static a() {
     return this.value;
   }
-  static [_computedKey]() {
+  static ['b']() {
     return this.value;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static set a(v) {}
   static set "b"(v) {}
@@ -32,4 +32,4 @@ var _a = {
   [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 12, "a"], [dec, 12, "a", function (v) {}], [dec, 12, "b"], [dec, 12, "c"], [dec, 12, 0], [dec, 12, 1], [dec, 12, 2n], [dec, 12, 3n], [dec, 12, _computedKey]], []).e;
   _initStatic(_class);
 })();
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _class;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,19 +9,16 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static set a(v) {}
   static set "b"(v) {}
-  static set [_computedKey](v) {}
+  static set ["c"](v) {}
   static set 0(v) {}
-  static set [_computedKey2](v) {}
+  static set [1](v) {}
   static set 2n(v) {}
-  static set [_computedKey3](v) {}
-  static set [_computedKey4](v) {}
+  static set [3n](v) {}
+  static set [_computedKey](v) {}
 }
 _class = Foo;
 function _set_a(v) {
@@ -32,7 +29,7 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 12, "a"], [dec, 12, "a", function (v) {}], [dec, 12, "b"], [dec, 12, _computedKey], [dec, 12, 0], [dec, 12, _computedKey2], [dec, 12, 2n], [dec, 12, _computedKey3], [dec, 12, _computedKey4]], []).e;
+  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 12, "a"], [dec, 12, "a", function (v) {}], [dec, 12, "b"], [dec, 12, "c"], [dec, 12, 0], [dec, 12, 1], [dec, 12, 2n], [dec, 12, 3n], [dec, 12, _computedKey]], []).e;
   _initStatic(_class);
 })();
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/public/output.js
@@ -1,6 +1,5 @@
-var _computedKey, _initProto, _class;
+var _initProto, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   constructor(...args) {
     babelHelpers.defineProperty(this, "value", 1);
@@ -9,9 +8,9 @@ class Foo {
   set a(v) {
     return this.value = v;
   }
-  set [_computedKey](v) {
+  set ['b'](v) {
     return this.value = v;
   }
 }
 _class = Foo;
-[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 4, "a"], [dec, 4, _computedKey]], []).e;
+[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 4, "a"], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-public/output.js
@@ -1,17 +1,16 @@
-var _computedKey, _initStatic, _class;
+var _initStatic, _class;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static set a(v) {
     return this.value = v;
   }
-  static set [_computedKey](v) {
+  static set ['b'](v) {
     return this.value = v;
   }
 }
 _class = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 12, "a"], [dec, 12, _computedKey]], []).e;
+  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 12, "a"], [dec, 12, 'b']], []).e;
   _initStatic(_class);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/exec.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/input.js
@@ -1,6 +1,6 @@
 const logs = [];
 const dec = (value, context) => { logs.push(context.name) };
-const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => "f()" }; };
+const f = () => { logs.push("computing f"); return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
 class Foo {
   @dec static set a(v) {};
   @dec static set #a(v) {};
@@ -17,4 +17,4 @@ class Foo {
   @dec static set [f()](v) {};
 }
 
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _computedKey2, _computedKey3, _computedKey4, _initStatic;
+var _call_a, _computedKey, _initStatic;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -9,13 +9,10 @@ const f = () => {
     [Symbol.toPrimitive]: () => "f()"
   };
 };
-_computedKey = "c";
-_computedKey2 = 1;
-_computedKey3 = 3n;
-_computedKey4 = f();
+_computedKey = f();
 class Foo {
   static {
-    [_call_a, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 12, "a"], [dec, 12, "a", function (v) {}], [dec, 12, "b"], [dec, 12, _computedKey], [dec, 12, 0], [dec, 12, _computedKey2], [dec, 12, 2n], [dec, 12, _computedKey3], [dec, 12, _computedKey4]], []).e;
+    [_call_a, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 12, "a"], [dec, 12, "a", function (v) {}], [dec, 12, "b"], [dec, 12, "c"], [dec, 12, 0], [dec, 12, 1], [dec, 12, 2n], [dec, 12, 3n], [dec, 12, _computedKey]], []).e;
     _initStatic(this);
   }
   static set a(v) {}
@@ -23,11 +20,11 @@ class Foo {
     _call_a(this, v);
   }
   static set "b"(v) {}
-  static set [_computedKey](v) {}
+  static set ["c"](v) {}
   static set 0(v) {}
-  static set [_computedKey2](v) {}
+  static set [1](v) {}
   static set 2n(v) {}
-  static set [_computedKey3](v) {}
-  static set [_computedKey4](v) {}
+  static set [3n](v) {}
+  static set [_computedKey](v) {}
 }
 expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/output.js
@@ -6,10 +6,10 @@ const dec = (value, context) => {
 const f = () => {
   logs.push("computing f");
   return {
-    [Symbol.toPrimitive]: () => "f()"
+    [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()")
   };
 };
-_computedKey = f();
+_computedKey = babelHelpers.toPropertyKey(f());
 class Foo {
   static {
     [_call_a, _initStatic] = babelHelpers.applyDecs2305(this, [[dec, 12, "a"], [dec, 12, "a", function (v) {}], [dec, 12, "b"], [dec, 12, "c"], [dec, 12, 0], [dec, 12, 1], [dec, 12, 2n], [dec, 12, 3n], [dec, 12, _computedKey]], []).e;
@@ -27,4 +27,4 @@ class Foo {
   static set [3n](v) {}
   static set [_computedKey](v) {}
 }
-expect(logs).toStrictEqual(["computing f", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);
+expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/public/output.js
@@ -1,9 +1,8 @@
-var _computedKey, _initProto;
+var _initProto;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 4, "a"], [dec, 4, _computedKey]], []).e;
+    [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
   }
   constructor(...args) {
     _initProto(this);
@@ -12,7 +11,7 @@ class Foo {
   set a(v) {
     return this.value = v;
   }
-  set [_computedKey](v) {
+  set ['b'](v) {
     return this.value = v;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/static-public/output.js
@@ -1,16 +1,15 @@
-var _computedKey, _initStatic;
+var _initStatic;
 const dec = () => {};
-_computedKey = 'b';
 class Foo {
   static {
-    [_initStatic] = babelHelpers.applyDecs2305(this, [[dec, 12, "a"], [dec, 12, _computedKey]], []).e;
+    [_initStatic] = babelHelpers.applyDecs2305(this, [[dec, 12, "a"], [dec, 12, 'b']], []).e;
     _initStatic(this);
   }
   static value = 1;
   static set a(v) {
     return this.value = v;
   }
-  static set [_computedKey](v) {
+  static set ['b'](v) {
     return this.value = v;
   }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The [[@@toPrimitive]] call is invoked more than once for the decorated accessor keys [REPL](https://babel.dev/repl#?browsers=chrome%2072&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYewdgzgLgBANiA5hGBeGBtAugbgFCiSwAmApsGjABQBuAhnAK6kA0MhUpAHlAJRoA-GAG8AvvkLQYAM0pV-qIcJgAnUlEYqwIzAGUAngFsARiDgA6KCAAKKgJaG7UOzVJYAXNQVCqCZOYAHRggACyoAImAGODswRBgrWwcnF1Jw3jZw6Xl0mHE8iTg6CBQAMRAQETwYGAABMgpoOmcKOmBgUhKQFUxs3lw8UTwCcAgzUnM_XyQIXnwgA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=true&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact&prettier=false&targets=&version=7.23.5&externalPlugins=%40babel%2Fplugin-proposal-decorators%407.23.3&assumptions=%7B%7D)
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In the following example,
```js
const logs = [];
const dec = (value, context) => {};
const f = () => { return { [Symbol.toPrimitive]: () => (logs.push("calling toPrimitive"), "f()") }; };
class Foo {
  @dec static accessor [f()];
}

console.log(logs);
```
The `[[@@toPrimitive]]` should be invoked only once during the ClassElementNameEvaluation, however, the transpiled code shows that it is run for 4 times.

In this PR we first unify the criteria of memoising computed keys, aligning it with the class properties transform here.

https://github.com/babel/babel/blob/380d186b77d32734c595652a40cbda5e4e109c5c/packages/babel-helper-create-class-features-plugin/src/misc.ts#L142-L160

In the second commit we emit the `toPropertyKey` call when the caching the computed key and hardened out test suites.