### PR TITLE
Avoid unpreventable `unhandledRejection` events

### DIFF
--- a/packages/babel-core/src/gensync-utils/functional.ts
+++ b/packages/babel-core/src/gensync-utils/functional.ts
@@ -3,29 +3,48 @@ import type { Handler } from "gensync";
 import { isAsync, waitFor } from "./async.ts";
 
 export function once<R>(fn: () => Handler<R>): () => Handler<R> {
-  let result: R;
+  let result: { ok: true; value: R } | { ok: false; value: unknown };
   let resultP: Promise<R>;
+  let promiseReferenced = false;
   return function* () {
-    if (result) return result;
-    if (!(yield* isAsync())) return (result = yield* fn());
-    if (resultP) return yield* waitFor(resultP);
+    if (!result) {
+      if (resultP) {
+        promiseReferenced = true;
+        return yield* waitFor(resultP);
+      }
 
-    let resolve: (result: R) => void, reject: (error: unknown) => void;
-    resultP = new Promise((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
+      if (!(yield* isAsync())) {
+        try {
+          result = { ok: true, value: yield* fn() };
+        } catch (error) {
+          result = { ok: false, value: error };
+        }
+      } else {
+        let resolve: (result: R) => void, reject: (error: unknown) => void;
+        resultP = new Promise((res, rej) => {
+          resolve = res;
+          reject = rej;
+        });
 
-    try {
-      result = yield* fn();
-      // Avoid keeping the promise around
-      // now that we have the result.
-      resultP = null;
-      resolve(result);
-      return result;
-    } catch (error) {
-      reject(error);
-      throw error;
+        try {
+          result = { ok: true, value: yield* fn() };
+          // Avoid keeping the promise around
+          // now that we have the result.
+          resultP = null;
+          // We only resolve/reject the promise if it has been actually
+          // referenced. If there are no listeners we can forget about it.
+          // In the reject case, this avoid uncatchable unhandledRejection
+          // events.
+          if (promiseReferenced) resolve(result.value);
+        } catch (error) {
+          result = { ok: false, value: error };
+          resultP = null;
+          if (promiseReferenced) reject(error);
+        }
+      }
     }
+
+    if (result.ok) return result.value;
+    else throw result.value;
   };
 }

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -306,4 +306,24 @@ describe("asynchronicity", () => {
       });
     });
   });
+
+  describe("misc", () => {
+    it("unknown preset in config file does not trigget unhandledRejection if caught", async () => {
+      process.chdir("unknown-preset");
+      const handler = jest.fn();
+
+      process.on("unhandledRejection", handler);
+
+      await babel.loadPartialConfigAsync().catch(() => {});
+
+      // unhandledRejection is triggered at the end of the current microtask
+      // queue. Wait for the event loop to spin to make sure that, if it were to
+      // be triggered, it would have already happened.
+      await new Promise(r => setTimeout(r, 0));
+
+      process.off("unhandledRejection", handler);
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -312,7 +312,7 @@ describe("asynchronicity", () => {
       process.chdir("unknown-preset");
       const handler = jest.fn();
 
-      process.on("unhandledRejection", handler);
+      process.addListener("unhandledRejection", handler);
 
       await babel.loadPartialConfigAsync().catch(() => {});
 
@@ -321,7 +321,7 @@ describe("asynchronicity", () => {
       // be triggered, it would have already happened.
       await new Promise(r => setTimeout(r, 0));
 
-      process.off("unhandledRejection", handler);
+      process.removeListener("unhandledRejection", handler);
 
       expect(handler).not.toHaveBeenCalled();
     });

--- a/packages/babel-core/test/fixtures/async/unknown-preset/babel.config.json
+++ b/packages/babel-core/test/fixtures/async/unknown-preset/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": ["unknown"]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16163
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The main fix is to only reject the `resultP` "cache" if that promise is has actually been exposed to a caller. If it hasn't, then there is nobody using it and thus there is no need to reject it (and no way to handle that rejection).

In order to do this, we have to replace `resultP` with a "synchronous result" (an object with `ok` and `value` properties) once it's completion is known, so that when the operation throws we can synchronously throw without waiting on `resultP`.