### PR TITLE
chore: Enable `useProjectService`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -88,7 +88,8 @@ module.exports = [
           parser: parserTypeScriptESLint,
           parserOptions: {
             allowAutomaticSingleRunInference: true,
-            project: "./tsconfig.eslint.json",
+            project: true,
+            EXPERIMENTAL_useProjectService: true,
           },
         },
         plugins: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -88,7 +88,6 @@ module.exports = [
           parser: parserTypeScriptESLint,
           parserOptions: {
             allowAutomaticSingleRunInference: true,
-            project: true,
             EXPERIMENTAL_useProjectService: true,
           },
         },

--- a/packages/babel-helpers/src/helpers/setFunctionName.ts
+++ b/packages/babel-helpers/src/helpers/setFunctionName.ts
@@ -8,7 +8,7 @@ export default function setFunctionName<T extends Function>(
 ): T {
   if (typeof name === "symbol") {
     name = name.description;
-    name = name ? "[" + (name as string) + "]" : "";
+    name = name ? "[" + name + "]" : "";
   }
   // In some older browsers .name was non-configurable, here we catch any
   // errors thrown by defineProperty.

--- a/packages/babel-plugin-proposal-import-defer/src/index.ts
+++ b/packages/babel-plugin-proposal-import-defer/src/index.ts
@@ -95,7 +95,7 @@ export default declare(api => {
             (child.isExportNamedDeclaration() && child.node.source !== null) ||
             child.isExportAllDeclaration()
           ) {
-            const specifier = child.node.source!.value;
+            const specifier = child.node.source.value;
             if (!eagerImports.has(specifier)) {
               eagerImports.add(specifier);
             }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "strict": true
-  }
-}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
https://github.com/typescript-eslint/typescript-eslint/pull/8031
The overall lint time is reduced from 38 seconds to 36 seconds.