### PR TITLE
Revert "chore: Update artifact tools (#16184)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Prepare artifacts
         run: |
           ./scripts/get-artifact-files.sh | tar --null -cvf babel-artifact.tar --files-from=-
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: babel-artifact
           path: babel-artifact.tar
@@ -188,7 +188,7 @@ jobs:
           cache: "yarn"
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: babel-artifact
       - name: Extract artifacts
@@ -239,7 +239,7 @@ jobs:
           # Deduplicate dependencies, because duplicate copies of graceful-fs cause
           # problems with the "path" module: https://github.com/facebook/jest/issues/9656
           yarn dedupe
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: babel-artifact
       - name: Extract artifacts
@@ -295,7 +295,7 @@ jobs:
       - name: Prepare artifacts
         run: |
           ./scripts/get-artifact-files.sh | tar --null -cvf babel-artifact.tar --files-from=-
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: babel8-artifact
           path: babel-artifact.tar
@@ -321,7 +321,7 @@ jobs:
       - name: Install
         run: |
           yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: babel8-artifact
       - name: Extract artifacts
@@ -353,7 +353,7 @@ jobs:
           cache: "yarn"
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: babel-artifact
       - name: Extract artifacts
@@ -379,7 +379,7 @@ jobs:
           cache: "yarn"
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: babel-artifact
       - name: Extract artifacts
@@ -427,7 +427,7 @@ jobs:
           # The "Support self-references on old Node.js" step mutates the
           # package.json file, causing a yarn.lock update.
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: babel-artifact
       - name: Extract artifacts
@@ -514,7 +514,7 @@ jobs:
           cache: "yarn"
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: babel-artifact
       - name: Extract artifacts
@@ -552,7 +552,7 @@ jobs:
         env:
           TEST262_PATH: ../build/test262
       - name: Upload chunks artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test262-chunks
           path: ~/test262-chunks.json
@@ -575,7 +575,7 @@ jobs:
           check-latest: true
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: babel-artifact
       - name: Extract artifacts
@@ -594,7 +594,7 @@ jobs:
       - name: Download test262
         run: make bootstrap-test262
       - name: Download chunks file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: test262-chunks
       - name: Run test262
@@ -608,7 +608,7 @@ jobs:
           CHUNKS_FILE: ../test262-chunks.json
           CHUNK: ${{ matrix.chunk }}
       - name: Create artifact with report results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test262-result-${{ matrix.chunk }}
           path: ~/test262-${{ matrix.chunk }}.tap
@@ -619,21 +619,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: test262
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with: { name: test262-result-0 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with: { name: test262-result-1 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with: { name: test262-result-2 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with: { name: test262-result-3 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with: { name: test262-result-4 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with: { name: test262-result-5 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with: { name: test262-result-6 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with: { name: test262-result-7 }
       - name: Merge chunk results
         run: |
@@ -641,7 +641,7 @@ jobs:
               test262-4.tap test262-5.tap test262-6.tap test262-7.tap \
             | npx tap-merge > test262.tap
       - name: Create artifact with report results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test262-result
           path: test262.tap

--- a/.github/workflows/e2e-tests-breaking-esm.yml
+++ b/.github/workflows/e2e-tests-breaking-esm.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Pack published packages
         working-directory: /tmp
         run: tar -cvf verdaccio-workspace.tar verdaccio-workspace
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: verdaccio-workspace
           path: /tmp/verdaccio-workspace.tar
@@ -92,7 +92,7 @@ jobs:
         run: |
           rm -rf ${{ steps.yarn1-cache-dir-path.outputs.dir }}/*babel*
           rm -rf ${{ steps.yarn-cache-dir-path.outputs.dir }}/*babel*
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: verdaccio-workspace
           path: /tmp

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Pack published packages
         working-directory: /tmp
         run: tar -cvf verdaccio-workspace.tar verdaccio-workspace
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: verdaccio-workspace
           path: /tmp/verdaccio-workspace.tar
@@ -85,7 +85,7 @@ jobs:
         run: |
           rm -rf ${{ steps.yarn1-cache-dir-path.outputs.dir }}/*babel*
           rm -rf ${{ steps.yarn-cache-dir-path.outputs.dir }}/*babel*
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: verdaccio-workspace
           path: /tmp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload babel-types docs
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: babel-types-docs
           path: build/types.md
@@ -298,7 +298,7 @@ jobs:
         with:
           repository: babel/website
       - name: Download babel-types docs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: babel-types-docs
           # Downloaded as ./docs/types.md


### PR DESCRIPTION
This reverts commit 60c94d9f32c09ea52e2358968d01ca099b15053b.

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Frequent request timeout in {upload,download} action v4, https://github.com/actions/download-artifact/issues/249
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
We can reland the update when the upstream issue is resolved. At this moment let's see if CI can be green again.