### PR TITLE
Pass `repository` to the create PR action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,13 +312,12 @@ jobs:
           git push --force origin update-types-docs
       - name: Create Pull Request
         uses: babel/actions/create-pull-request@v2
-        env:
-          GITHUB_REPOSITORY: babel/website
         with:
           token: ${{ secrets.BOT_TOKEN }}
+          repository: babel/website
           branch: update-types-docs
           title: Update Babel types docs
-          description: Updated `@babel/types` docs for [Babel v${{ needs.github-release.outputs.version }}](https://github.com/babel/babel/releases/tag/${{ needs.github-release.outputs.version }}).
+          description: Updated `@babel/types` docs for [Babel ${{ needs.github-release.outputs.version }}](https://github.com/babel/babel/releases/tag/${{ needs.github-release.outputs.version }}).
           labels: |
             docs
             repo automation :robot:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Hopefully the last blocking issue of the types docs update workflow
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Previously we pass `babel/website` via the `GITHUB_REPOSITORY` env. It seems that it is reserved by the actions runner and thus overwritten as `babel/babel` as we can see the validation error in the last run https://github.com/babel/babel/actions/runs/7451677773/job/20273644894#step:5:50

We add `repository` input support in https://github.com/babel/actions/pull/26. Now we pass the `babel/website` to the workflow.