### PR TITLE
[eslint] Fix `no-use-before-define` for class ref in fields

### DIFF
--- a/eslint/babel-eslint-parser/src/analyze-scope.cjs
+++ b/eslint/babel-eslint-parser/src/analyze-scope.cjs
@@ -213,8 +213,30 @@ class Referencer extends OriginalReferencer {
   }
 
   _visitClassProperty(node) {
-    this._visitTypeAnnotation(node.typeAnnotation);
-    this.visitProperty(node);
+    const { computed, key, typeAnnotation, value } = node;
+
+    if (computed) this.visit(key);
+    this._visitTypeAnnotation(typeAnnotation);
+
+    if (value) {
+      if (this.scopeManager.__nestClassFieldInitializerScope) {
+        this.scopeManager.__nestClassFieldInitializerScope(value);
+      } else {
+        // Given that ESLint 7 didn't have a "class field initializer" scope,
+        // we create a plain method scope. Semantics are the same.
+        this.scopeManager.__nestScope(
+          new Scope(
+            this.scopeManager,
+            "function",
+            this.scopeManager.__currentScope,
+            value,
+            true,
+          ),
+        );
+      }
+      this.visit(value);
+      this.close(value);
+    }
   }
 
   _visitDeclareX(node) {

--- a/eslint/babel-eslint-tests/test/integration/eslint/verify.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/verify.js
@@ -1749,6 +1749,17 @@ describe("verify", () => {
           { "no-unused-vars": 1 },
         );
       });
+
+      it("no-use-before-define allows referencing the class in a field", () => {
+        verifyAndAssertMessages(
+          `
+            class C {
+              d = C.name;
+            }
+          `,
+          { "no-use-before-define": 1 },
+        );
+      });
     });
 
     describe("private field declarations", () => {
@@ -1771,6 +1782,17 @@ describe("verify", () => {
               }
           `,
           { "no-unused-vars": 1 },
+        );
+      });
+
+      it("no-use-before-define allows referencing the class in a field", () => {
+        verifyAndAssertMessages(
+          `
+            class C {
+              #d = C.name;
+            }
+          `,
+          { "no-use-before-define": 1 },
         );
       });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The underlying problem is that we are using a different `eslint-scope` version than ESLint. This is fixed for Babel 8, but ideally it should also work in Babel 7.

Our `analyze-scope.cjs` will  need a big cleanup after we drop support for ESLint 7, since a lot of logic is duplicate with the ESLint 8 scope implementation.