### PR TITLE
Improve temporary variables for decorators

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -648,7 +648,7 @@ function transformClass(
   const decoratorsThis = new Map<t.Decorator, t.Expression>();
   const maybeExtractDecorators = (
     decorators: t.Decorator[],
-    memoise = false,
+    memoiseInPlace: boolean,
   ) => {
     let needMemoise = false;
     for (const decorator of decorators) {
@@ -660,7 +660,7 @@ function transformClass(
           t.isThisExpression(expression.object)
         ) {
           needMemoise = true;
-          if (memoise) {
+          if (memoiseInPlace) {
             object = memoiseExpression(t.thisExpression(), "obj");
           } else {
             object = t.thisExpression();
@@ -668,7 +668,7 @@ function transformClass(
         } else {
           if (!scopeParent.isStatic(expression.object)) {
             needMemoise = true;
-            if (memoise) {
+            if (memoiseInPlace) {
               expression.object = memoiseExpression(expression.object, "obj");
             }
           }
@@ -678,12 +678,12 @@ function transformClass(
       }
       if (!scopeParent.isStatic(expression)) {
         needMemoise = true;
-        if (memoise) {
+        if (memoiseInPlace) {
           decorator.expression = memoiseExpression(expression, "dec");
         }
       }
     }
-    return needMemoise;
+    return needMemoise && !memoiseInPlace;
   };
 
   let needsDeclaraionForClassBinding = false;
@@ -697,7 +697,7 @@ function transformClass(
 
     path.node.decorators = null;
 
-    const needMemoise = maybeExtractDecorators(classDecorators);
+    const needMemoise = maybeExtractDecorators(classDecorators, false);
 
     const { hasThis, decs } = generateDecorationList(
       classDecorators.map(el => el.expression),

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -1110,7 +1110,8 @@ export function buildFieldsInitNodes(
       };
 
   const classRefForInnerBinding =
-    ref ?? props[0].scope.generateUidIdentifier("class");
+    ref ??
+    props[0].scope.generateUidIdentifier(innerBindingRef?.name || "Class");
   ref ??= t.cloneNode(innerBindingRef);
 
   for (const prop of props) {

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -230,7 +230,7 @@ export function createClassFeaturePlugin({
         let ref: t.Identifier | null;
         if (!innerBinding || !pathIsClassDeclaration) {
           nameFunction(path);
-          ref = path.scope.generateUidIdentifier("class");
+          ref = path.scope.generateUidIdentifier(innerBinding?.name || "Class");
         }
         const classRefForDefine = ref ?? t.cloneNode(innerBinding);
 

--- a/packages/babel-helper-create-class-features-plugin/test/fixtures/replace-supers/method/output.js
+++ b/packages/babel-helper-create-class-features-plugin/test/fixtures/replace-supers/method/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _A;
 var _foo = /*#__PURE__*/new WeakSet();
 class A extends B {
   constructor(...args) {
@@ -6,8 +6,8 @@ class A extends B {
     babelHelpers.classPrivateMethodInitSpec(this, _foo);
   }
 }
-_class = A;
+_A = A;
 function _foo2() {
-  let _A;
-  babelHelpers.get(babelHelpers.getPrototypeOf(_class.prototype), "x", this);
+  let _A2;
+  babelHelpers.get(babelHelpers.getPrototypeOf(_A.prototype), "x", this);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-transformation/export-default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-transformation/export-default-anonymous/output.mjs
@@ -1,11 +1,11 @@
 export default babelHelpers.decorate([dec()], function (_initialize) {
-  class _class {
+  class _Class {
     constructor() {
       _initialize(this);
     }
   }
   return {
-    F: _class,
+    F: _Class,
     d: []
   };
 });

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-transformation/expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2018-09-transformation/expression/output.js
@@ -1,13 +1,13 @@
 babelHelpers.decorate([dec()], function (_initialize) {
   "use strict";
 
-  class _class {
+  class _Class {
     constructor() {
       _initialize(this);
     }
   }
   return {
-    F: _class,
+    F: _Class,
     d: []
   };
 });

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _class;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -67,7 +67,7 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _I, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -75,47 +75,47 @@ function _get_a2() {
   return _get_a(this);
 }
 (() => {
-  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 6, "a"], [dec, 6, "a", function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _B);
+  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 6, "a"], [dec, 6, "a", function () {
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _B);
   }, function (value) {
-    babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _B, value);
+    babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _B, value);
   }], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []);
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_a2(_class)
+  value: _init_a2(_Foo)
 };
 var _C = {
   writable: true,
-  value: _init_computedKey(_class)
+  value: _init_computedKey(_Foo)
 };
 var _D = {
   writable: true,
-  value: _init_computedKey2(_class)
+  value: _init_computedKey2(_Foo)
 };
 var _E = {
   writable: true,
-  value: _init_computedKey3(_class)
+  value: _init_computedKey3(_Foo)
 };
 var _F = {
   writable: true,
-  value: _init_computedKey4(_class)
+  value: _init_computedKey4(_Foo)
 };
 var _G = {
   writable: true,
-  value: _init_computedKey5(_class)
+  value: _init_computedKey5(_Foo)
 };
 var _H = {
   writable: true,
-  value: _init_computedKey6(_class)
+  value: _init_computedKey6(_Foo)
 };
 var _I = {
   writable: true,
-  value: _init_computedKey7(_class)
+  value: _init_computedKey7(_Foo)
 };
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _class;
+var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _a = /*#__PURE__*/new WeakMap();
@@ -24,7 +24,7 @@ class Foo {
     });
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -37,7 +37,7 @@ function _set_b2(v) {
 function _get_b2() {
   return _get_b(this);
 }
-[_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs(_class, [[dec, 1, "a", function () {
+[_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs(_Foo, [[dec, 1, "a", function () {
   return babelHelpers.classPrivateFieldGet(this, _A);
 }, function (value) {
   babelHelpers.classPrivateFieldSet(this, _A, value);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto, _class;
+var _init_a, _init_b, _init_computedKey, _initProto, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();
@@ -37,5 +37,5 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _C, v);
   }
 }
-_class = Foo;
-[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []);
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs(_Foo, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _class;
+var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();
@@ -14,7 +14,7 @@ class Foo {
     });
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -28,22 +28,22 @@ function _get_b2() {
   return _get_b(this);
 }
 (() => {
-  [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 6, "a", function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _A);
+  [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 6, "a", function () {
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _A);
   }, function (value) {
-    babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _A, value);
+    babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _A, value);
   }], [dec, 6, "b", function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _B);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _B);
   }, function (value) {
-    babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _B, value);
+    babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _B, value);
   }]], []);
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic, _class;
+var _init_a, _init_b, _init_computedKey, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -20,20 +20,20 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _C, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []);
-  _initStatic(_class);
+  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []);
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };
 var _C = {
   writable: true,
-  value: _init_computedKey(_class, 456)
+  value: _init_computedKey(_Foo, 456)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/undecorated-static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/undecorated-static-private/output.js
@@ -1,18 +1,18 @@
-var _class;
+var _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _A);
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _A);
 }
 function _set_a(v) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _A, v);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _A, v);
 }
 function _get_b() {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _B);
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _B);
 }
 function _set_b(v) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _B, v);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _B, v);
 }
 var _b = {
   get: _get_b,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions-static-blocks/output.js
@@ -1,73 +1,73 @@
-var _initClass, _A, _temp, _initClass2, _C, _temp2, _initClass3, _D, _temp3, _initClass4, _decorated_class, _temp4, _class5, _initClass5, _G, _temp5, _initClass6, _decorated_class2, _temp6, _class7, _initClass7, _H, _temp7, _initClass8, _K, _temp8;
+var _initClass, _A, _temp, _initClass2, _C, _temp2, _initClass3, _D, _temp3, _initClass4, _decorated_class, _temp4, _Class2, _initClass5, _G, _temp5, _initClass6, _decorated_class2, _temp6, _Class3, _initClass7, _H, _temp7, _initClass8, _K, _temp8;
 const dec = () => {};
 const A = (new (_temp = class extends babelHelpers.identity {
   constructor() {
     super(_A), (() => {})(), _initClass();
   }
-}, (_class2 => {
+}, (_A2 => {
   class A {}
-  _class2 = A;
-  [_A, _initClass] = babelHelpers.applyDecs(_class2, [], [dec]);
+  _A2 = A;
+  [_A, _initClass] = babelHelpers.applyDecs(_A2, [], [dec]);
 })(), _temp)(), _A);
 const B = (new (_temp2 = class extends babelHelpers.identity {
   constructor() {
     super(_C), (() => {})(), _initClass2();
   }
-}, (_class3 => {
+}, (_C2 => {
   class C {}
-  _class3 = C;
-  [_C, _initClass2] = babelHelpers.applyDecs(_class3, [], [dec]);
+  _C2 = C;
+  [_C, _initClass2] = babelHelpers.applyDecs(_C2, [], [dec]);
 })(), _temp2)(), _C);
 const D = (new (_temp3 = class extends babelHelpers.identity {
   constructor() {
     super(_D), (() => {})(), _initClass3();
   }
-}, (_class4 => {
+}, (_D2 => {
   class D {}
-  _class4 = D;
-  [_D, _initClass3] = babelHelpers.applyDecs(_class4, [], [dec]);
+  _D2 = D;
+  [_D, _initClass3] = babelHelpers.applyDecs(_D2, [], [dec]);
 })(), _temp3)(), _D);
 const E = ((new (_temp4 = class extends babelHelpers.identity {
   constructor() {
     super(_decorated_class), (() => {})(), _initClass4();
   }
-}, (_class5 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs(_class5, [], [dec])), _temp4)(), _decorated_class), 123);
+}, (_Class2 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs(_Class2, [], [dec])), _temp4)(), _decorated_class), 123);
 const F = [(new (_temp5 = class extends babelHelpers.identity {
   constructor() {
     super(_G), (() => {})(), _initClass5();
   }
-}, (_class6 => {
+}, (_G2 => {
   class G {}
-  _class6 = G;
-  [_G, _initClass5] = babelHelpers.applyDecs(_class6, [], [dec]);
+  _G2 = G;
+  [_G, _initClass5] = babelHelpers.applyDecs(_G2, [], [dec]);
 })(), _temp5)(), _G), (new (_temp6 = class extends babelHelpers.identity {
   constructor() {
     super(_decorated_class2), (() => {})(), _initClass6();
   }
-}, (_class7 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs(_class7, [], [dec])), _temp6)(), _decorated_class2)];
+}, (_Class3 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs(_Class3, [], [dec])), _temp6)(), _decorated_class2)];
 const H = (new (_temp7 = class extends babelHelpers.identity {
   constructor() {
     super(_H), (() => {})(), _initClass7();
   }
-}, (_class8 => {
+}, (_H2 => {
   class H extends I {}
-  _class8 = H;
-  [_H, _initClass7] = babelHelpers.applyDecs(_class8, [], [dec]);
+  _H2 = H;
+  [_H, _initClass7] = babelHelpers.applyDecs(_H2, [], [dec]);
 })(), _temp7)(), _H);
 const J = (new (_temp8 = class extends babelHelpers.identity {
   constructor() {
     super(_K), (() => {})(), _initClass8();
   }
-}, (_class9 => {
+}, (_K2 => {
   class K extends L {}
-  _class9 = K;
-  [_K, _initClass8] = babelHelpers.applyDecs(_class9, [], [dec]);
+  _K2 = K;
+  [_K, _initClass8] = babelHelpers.applyDecs(_K2, [], [dec]);
 })(), _temp8)(), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _temp9, _class11;
+  var _initClass9, _decorated_class3, _temp9, _Class5;
   return new (_temp9 = class extends babelHelpers.identity {
     constructor() {
       super(_decorated_class3), (() => {})(), _initClass9();
     }
-  }, (_class11 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs(_class11, [], [dec])), _temp9)(), _decorated_class3;
+  }, (_Class5 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs(_Class5, [], [dec])), _temp9)(), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions/output.js
@@ -1,13 +1,13 @@
-var _initClass, _A, _class, _initClass2, _C, _class2, _initClass3, _D, _class3, _initClass4, _decorated_class, _class4, _initClass5, _G, _class5, _initClass6, _decorated_class2, _class6, _initClass7, _H, _class7, _initClass8, _K, _class8;
+var _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _Class, _initClass5, _G, _G2, _initClass6, _decorated_class2, _Class2, _initClass7, _H, _H2, _initClass8, _K, _K2;
 const dec = () => {};
-const A = ((_class = class A {}, [_A, _initClass] = babelHelpers.applyDecs(_class, [], [dec]), _initClass()), _A);
-const B = ((_class2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs(_class2, [], [dec]), _initClass2()), _C);
-const D = ((_class3 = class D {}, [_D, _initClass3] = babelHelpers.applyDecs(_class3, [], [dec]), _initClass3()), _D);
-const E = (((_class4 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs(_class4, [], [dec]), _initClass4()), _decorated_class), 123);
-const F = [((_class5 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs(_class5, [], [dec]), _initClass5()), _G), ((_class6 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs(_class6, [], [dec]), _initClass6()), _decorated_class2)];
-const H = ((_class7 = class H extends I {}, [_H, _initClass7] = babelHelpers.applyDecs(_class7, [], [dec]), _initClass7()), _H);
-const J = ((_class8 = class K extends L {}, [_K, _initClass8] = babelHelpers.applyDecs(_class8, [], [dec]), _initClass8()), _K);
+const A = ((_A2 = class A {}, [_A, _initClass] = babelHelpers.applyDecs(_A2, [], [dec]), _initClass()), _A);
+const B = ((_C2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs(_C2, [], [dec]), _initClass2()), _C);
+const D = ((_D2 = class D {}, [_D, _initClass3] = babelHelpers.applyDecs(_D2, [], [dec]), _initClass3()), _D);
+const E = (((_Class = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs(_Class, [], [dec]), _initClass4()), _decorated_class), 123);
+const F = [((_G2 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs(_G2, [], [dec]), _initClass5()), _G), ((_Class2 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs(_Class2, [], [dec]), _initClass6()), _decorated_class2)];
+const H = ((_H2 = class H extends I {}, [_H, _initClass7] = babelHelpers.applyDecs(_H2, [], [dec]), _initClass7()), _H);
+const J = ((_K2 = class K extends L {}, [_K, _initClass8] = babelHelpers.applyDecs(_K2, [], [dec]), _initClass8()), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _class9;
-  return (_class9 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs(_class9, [], [dec]), _initClass9()), _decorated_class3;
+  var _initClass9, _decorated_class3, _Class3;
+  return (_Class3 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs(_Class3, [], [dec]), _initClass9()), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/inheritance/output.js
@@ -1,13 +1,13 @@
-var _initClass, _class, _initClass2, _class2;
+var _initClass, _Bar2, _initClass2, _Foo2;
 const dec1 = () => {};
 const dec2 = () => {};
 let _Bar;
 class Bar {}
-_class = Bar;
-[_Bar, _initClass] = babelHelpers.applyDecs(_class, [], [dec1]);
+_Bar2 = Bar;
+[_Bar, _initClass] = babelHelpers.applyDecs(_Bar2, [], [dec1]);
 _initClass();
 let _Foo;
 class Foo extends _Bar {}
-_class2 = Foo;
-[_Foo, _initClass2] = babelHelpers.applyDecs(_class2, [], [dec2]);
+_Foo2 = Foo;
+[_Foo, _initClass2] = babelHelpers.applyDecs(_Foo2, [], [dec2]);
 _initClass2();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/initializers/output.js
@@ -5,10 +5,10 @@ new (_temp = class extends babelHelpers.identity {
   constructor() {
     (super(_Foo), babelHelpers.defineProperty(this, "field", 123)), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs(_class2, [], [dec]);
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs(_Foo2, [], [dec]);
 })(), _temp)();
 let _Bar;
 new (_temp2 = class extends babelHelpers.identity {
@@ -17,8 +17,8 @@ new (_temp2 = class extends babelHelpers.identity {
       this.otherField = 456;
     })(), 123))), _initClass2();
   }
-}, (_class3 => {
+}, (_Bar2 => {
   class Bar extends _Foo {}
-  _class3 = Bar;
-  [_Bar, _initClass2] = babelHelpers.applyDecs(_class3, [], [dec]);
+  _Bar2 = Bar;
+  [_Bar, _initClass2] = babelHelpers.applyDecs(_Bar2, [], [dec]);
 })(), _temp2)();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -12,11 +12,11 @@ new (_x = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), (_temp = 
       hasM = o => _m.has(babelHelpers.checkInRHS(o));
     })(), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {
     static m() {}
   }
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs(_class2, [], [dec]);
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs(_Foo2, [], [dec]);
 })(), _temp))();
 function _m2() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-this/output.js
@@ -9,8 +9,8 @@ new (_temp = class extends babelHelpers.identity {
       this;
     })(), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs(_class2, [], [dec]);
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs(_Foo2, [], [dec]);
 })(), _temp)();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-with-expr/output.js
@@ -1,8 +1,8 @@
-var _initClass, _Bar, _class;
+var _initClass, _Bar, _Bar2;
 const dec = () => {};
-const Foo = ((_class = class Bar {
+const Foo = ((_Bar2 = class Bar {
   constructor() {
     babelHelpers.defineProperty(this, "bar", new _Bar());
   }
-}, [_Bar, _initClass] = babelHelpers.applyDecs(_class, [], [dec]), _initClass()), _Bar);
+}, [_Bar, _initClass] = babelHelpers.applyDecs(_Bar2, [], [dec]), _initClass()), _Bar);
 const foo = new Foo();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement/output.js
@@ -5,9 +5,9 @@ new (_temp = class extends babelHelpers.identity {
   constructor() {
     (super(_Foo), babelHelpers.defineProperty(this, "foo", new _Foo())), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs(_class2, [], [dec]);
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs(_Foo2, [], [dec]);
 })(), _temp)();
 const foo = new _Foo();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/inheritance/output.js
@@ -1,20 +1,20 @@
-var _initClass, _dec, _initClass2, _dec2;
+var _initClass, _classDecs, _initClass2, _classDecs2;
 const dec = () => {};
-_dec = dec1;
+_classDecs = [dec1];
 let _Bar;
 class Bar {
   static {
-    [_Bar, _initClass] = babelHelpers.applyDecs(this, [], [_dec]);
+    [_Bar, _initClass] = babelHelpers.applyDecs(this, [], _classDecs);
   }
   static {
     _initClass();
   }
 }
-_dec2 = dec2;
+_classDecs2 = [dec2];
 let _Foo;
 class Foo extends _Bar {
   static {
-    [_Foo, _initClass2] = babelHelpers.applyDecs(this, [], [_dec2]);
+    [_Foo, _initClass2] = babelHelpers.applyDecs(this, [], _classDecs2);
   }
   static {
     _initClass2();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,9 +1,9 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _computedKey, _computedKey2, _initProto, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {
@@ -13,5 +13,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs(_class, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs(_Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,9 +1,9 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _computedKey, _computedKey2, _initProto, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {
@@ -13,5 +13,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs(_class, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs(_Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto, _class;
+var _init_a, _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
@@ -8,5 +8,5 @@ class Foo {
     return 1;
   }
 }
-_class = Foo;
-[_init_a, _initProto] = babelHelpers.applyDecs(_class, [[dec, 2, "a"], [dec, 0, "a"]], []);
+_Foo = Foo;
+[_init_a, _initProto] = babelHelpers.applyDecs(_Foo, [[dec, 2, "a"], [dec, 0, "a"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/methods-with-same-key/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   a() {
@@ -11,5 +11,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs(_class, [[dec, 2, "a"], [dec, 2, "a"]], []);
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs(_Foo, [[dec, 2, "a"], [dec, 2, "a"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-ast/output.js
@@ -6,7 +6,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-value/output.js
@@ -6,7 +6,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/methods-with-same-key/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 2, "a"], [dec, 2, "a"]], []);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-anonymous/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _A;
 class A {
   static {
-    [_A, _initClass] = babelHelpers.applyDecs(this, [], [_dec]);
+    [_A, _initClass] = babelHelpers.applyDecs(this, [], _classDecs);
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-named/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _default2;
 class _default {
   static {
-    [_default2, _initClass] = babelHelpers.applyDecs(babelHelpers.setFunctionName(this, "default"), [], [_dec]);
+    [_default2, _initClass] = babelHelpers.applyDecs(babelHelpers.setFunctionName(this, "default"), [], _classDecs);
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/named/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _A;
 class A {
   static {
-    [_A, _initClass] = babelHelpers.applyDecs(this, [], [_dec]);
+    [_A, _initClass] = babelHelpers.applyDecs(this, [], _classDecs);
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _class;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -11,22 +11,22 @@ const f = () => {
 };
 _computedKey = babelHelpers.toPropertyKey(f());
 class Foo {}
-_class = Foo;
-[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs(_class, [[dec, 5, "a"], [dec, 5, "a", function () {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _a);
+_Foo = Foo;
+[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs(_Foo, [[dec, 5, "a"], [dec, 5, "a", function () {
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _a);
 }, function (value) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _a, value);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _a, value);
 }], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []);
-babelHelpers.defineProperty(Foo, "a", _init_a(_class));
+babelHelpers.defineProperty(Foo, "a", _init_a(_Foo));
 var _a = {
   writable: true,
-  value: _init_a2(_class)
+  value: _init_a2(_Foo)
 };
-babelHelpers.defineProperty(Foo, "b", _init_computedKey(_class));
-babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_class));
-babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_class));
-babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
-babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
-babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
+babelHelpers.defineProperty(Foo, "b", _init_computedKey(_Foo));
+babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_Foo));
+babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_Foo));
+babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_Foo));
+babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_Foo));
+babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_Foo));
+babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_Foo));
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _class;
+var _init_a, _init_b, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();
@@ -14,8 +14,8 @@ class Foo {
     });
   }
 }
-_class = Foo;
-[_init_a, _init_b] = babelHelpers.applyDecs(_class, [[dec, 0, "a", function () {
+_Foo = Foo;
+[_init_a, _init_b] = babelHelpers.applyDecs(_Foo, [[dec, 0, "a", function () {
   return babelHelpers.classPrivateFieldGet(this, _a);
 }, function (value) {
   babelHelpers.classPrivateFieldSet(this, _a, value);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
@@ -7,5 +7,5 @@ class Foo {
     babelHelpers.defineProperty(this, 'c', _init_computedKey(this, 456));
   }
 }
-_class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []);
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(_Foo, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-private/output.js
@@ -1,21 +1,21 @@
-var _init_a, _init_b, _class;
+var _init_a, _init_b, _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
-[_init_a, _init_b] = babelHelpers.applyDecs(_class, [[dec, 5, "a", function () {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _a);
+_Foo = Foo;
+[_init_a, _init_b] = babelHelpers.applyDecs(_Foo, [[dec, 5, "a", function () {
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _a);
 }, function (value) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _a, value);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _a, value);
 }], [dec, 5, "b", function () {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _b);
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _b);
 }, function (value) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _b, value);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _b, value);
 }]], []);
 var _a = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _b = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-public/output.js
@@ -1,8 +1,8 @@
-var _init_a, _init_b, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(_class, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []);
-babelHelpers.defineProperty(Foo, "a", _init_a(_class));
-babelHelpers.defineProperty(Foo, "b", _init_b(_class, 123));
-babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_class, 456));
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs(_Foo, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []);
+babelHelpers.defineProperty(Foo, "a", _init_a(_Foo));
+babelHelpers.defineProperty(Foo, "b", _init_b(_Foo, 123));
+babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_Foo, 456));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,7 +20,7 @@ class Foo {
   static get [3n]() {}
   static get [_computedKey]() {}
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -29,7 +29,7 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []);
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []);
+  _initStatic(_Foo);
 })();
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: _get_a,
       set: void 0
@@ -14,10 +14,10 @@ class Foo {
     return babelHelpers.classPrivateFieldGet(this, _a);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
-[_call_a, _initProto] = babelHelpers.applyDecs(_class, [[dec, 3, "a", function () {
+[_call_a, _initProto] = babelHelpers.applyDecs(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs(_class, [[dec, 3, "a"], [dec, 3, 'b']], []);
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs(_Foo, [[dec, 3, "a"], [dec, 3, 'b']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-private/output.js
@@ -1,11 +1,11 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _a);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -14,9 +14,9 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a", function () {
+  [_call_a, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 8, "a", function () {
     return this.value;
   }]], []);
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -8,9 +8,9 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a"], [dec, 8, 'b']], []);
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 8, "a"], [dec, 8, 'b']], []);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _call_a2, _initProto, _class;
+var _call_a, _call_a2, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: _get_a,
       set: _set_a
@@ -17,14 +17,14 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
 function _set_a(v) {
   _call_a2(this, v);
 }
-[_call_a, _call_a2, _initProto] = babelHelpers.applyDecs(_class, [[dec, 3, "a", function () {
+[_call_a, _call_a2, _initProto] = babelHelpers.applyDecs(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }], [dec, 4, "a", function (v) {
   this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -18,5 +18,5 @@ class Foo {
     this.value = v;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []);
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs(_Foo, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic, _class;
+var _call_a, _call_a2, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
@@ -8,7 +8,7 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -20,11 +20,11 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a", function () {
+  [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 8, "a", function () {
     return this.value;
   }], [dec, 9, "a", function (v) {
     this.value = v;
   }]], []);
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -14,9 +14,9 @@ class Foo {
     this.value = v;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []);
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/private/output.js
@@ -8,7 +8,7 @@ class Foo {
       this.value = v;
     }]], []);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value;
     }]], []);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 3, "a"], [dec, 3, 'b']], []);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,10 +20,10 @@ class Foo {
   static [3n]() {}
   static [_computedKey]() {}
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []);
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []);
+  _initStatic(_Foo);
 })();
 var _a = {
   writable: true,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
       value: _call_a
@@ -14,7 +14,7 @@ class Foo {
     return babelHelpers.classPrivateFieldGet(this, _a).call(this);
   }
 }
-_class = Foo;
-[_call_a, _initProto] = babelHelpers.applyDecs(_class, [[dec, 2, "a", function () {
+_Foo = Foo;
+[_call_a, _initProto] = babelHelpers.applyDecs(_Foo, [[dec, 2, "a", function () {
   return this.value;
 }]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs(_class, [[dec, 2, "a"], [dec, 2, 'b']], []);
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs(_Foo, [[dec, 2, "a"], [dec, 2, 'b']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-private/output.js
@@ -1,16 +1,16 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static callA() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _a).call(this);
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 7, "a", function () {
+  [_call_a, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 7, "a", function () {
     return this.value;
   }]], []);
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 var _a = {
   writable: true,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static a() {
@@ -8,9 +8,9 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 7, "a"], [dec, 7, 'b']], []);
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 7, "a"], [dec, 7, 'b']], []);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value;
     }]], []);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   #a = _call_a;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 2, "a"], [dec, 2, 'b']], []);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -1,4 +1,4 @@
-var _dec, _initProto, _class;
+var _dec, _initProto, _A;
 const dec = () => {};
 _dec = deco;
 class A extends B {
@@ -9,5 +9,5 @@ class A extends B {
   }
   method() {}
 }
-_class = A;
-[_initProto] = babelHelpers.applyDecs(_class, [[_dec, 2, "method"]], []);
+_A = A;
+[_initProto] = babelHelpers.applyDecs(_A, [[_dec, 2, "method"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
@@ -1,17 +1,14 @@
-var _initClass, _dec, _dec2, _dec3, _dec4, _dec5, _dec6, _dec7, _dec8, _initProto, _class;
+var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto, _Foo2;
 const dec = () => {};
+_classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
 _dec4 = array[expr];
-_dec5 = call();
-_dec6 = chain.expr();
-_dec7 = arbitrary + expr;
-_dec8 = array[expr];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
       value: void 0
@@ -20,14 +17,14 @@ class Foo {
   }
   method() {}
   makeClass() {
-    var _dec9, _init_bar, _class2;
-    return _dec9 = babelHelpers.classPrivateFieldGet(this, _a), (_class2 = class Nested {
+    var _dec5, _init_bar, _Nested;
+    return _dec5 = babelHelpers.classPrivateFieldGet(this, _a), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, "bar", _init_bar(this));
       }
-    }, [_init_bar] = babelHelpers.applyDecs(_class2, [[_dec9, 0, "bar"]], []), _class2);
+    }, [_init_bar] = babelHelpers.applyDecs(_Nested, [[_dec5, 0, "bar"]], []), _Nested);
   }
 }
-_class = Foo;
-[_initProto, _Foo, _initClass] = babelHelpers.applyDecs(_class, [[[dec, _dec5, _dec6, _dec7, _dec8], 2, "method"]], [dec, _dec, _dec2, _dec3, _dec4]);
+_Foo2 = Foo;
+[_initProto, _Foo, _initClass] = babelHelpers.applyDecs(_Foo2, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs);
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
@@ -1,28 +1,25 @@
-var _initClass, _dec, _dec2, _dec3, _dec4, _dec5, _dec6, _dec7, _dec8, _initProto;
+var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto;
 const dec = () => {};
+_classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
 _dec4 = array[expr];
-_dec5 = call();
-_dec6 = chain.expr();
-_dec7 = arbitrary + expr;
-_dec8 = array[expr];
 let _Foo;
 class Foo {
   static {
-    [_initProto, _Foo, _initClass] = babelHelpers.applyDecs(this, [[[dec, _dec5, _dec6, _dec7, _dec8], 2, "method"]], [dec, _dec, _dec2, _dec3, _dec4]);
+    [_initProto, _Foo, _initClass] = babelHelpers.applyDecs(this, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   #a;
   method() {}
   makeClass() {
-    var _dec9, _init_bar;
-    return _dec9 = this.#a, class Nested {
+    var _dec5, _init_bar;
+    return _dec5 = this.#a, class Nested {
       static {
-        [_init_bar] = babelHelpers.applyDecs(this, [[_dec9, 0, "bar"]], []);
+        [_init_bar] = babelHelpers.applyDecs(this, [[_dec5, 0, "bar"]], []);
       }
       bar = _init_bar(this);
     };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,7 +20,7 @@ class Foo {
   static set [3n](v) {}
   static set [_computedKey](v) {}
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
@@ -29,7 +29,7 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []);
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []);
+  _initStatic(_Foo);
 })();
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: void 0,
       set: _set_a
@@ -14,10 +14,10 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
-[_call_a, _initProto] = babelHelpers.applyDecs(_class, [[dec, 4, "a", function (v) {
+[_call_a, _initProto] = babelHelpers.applyDecs(_Foo, [[dec, 4, "a", function (v) {
   return this.value = v;
 }]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value = v;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs(_class, [[dec, 4, "a"], [dec, 4, 'b']], []);
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs(_Foo, [[dec, 4, "a"], [dec, 4, 'b']], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-private/output.js
@@ -1,11 +1,11 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
@@ -14,9 +14,9 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs(_class, [[dec, 9, "a", function (v) {
+  [_call_a, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 9, "a", function (v) {
     return this.value = v;
   }]], []);
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static set a(v) {
@@ -8,9 +8,9 @@ class Foo {
     return this.value = v;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs(_class, [[dec, 9, "a"], [dec, 9, 'b']], []);
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 9, "a"], [dec, 9, 'b']], []);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value = v;
     }]], []);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 4, "a"], [dec, 4, 'b']], []);
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _class;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -67,7 +67,7 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _I, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -75,47 +75,47 @@ function _get_a2() {
   return _get_a(this);
 }
 (() => {
-  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 6, "a"], [dec, 6, "a", function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _B);
+  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 6, "a"], [dec, 6, "a", function () {
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _B);
   }, function (value) {
-    babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _B, value);
+    babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _B, value);
   }], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_a2(_class)
+  value: _init_a2(_Foo)
 };
 var _C = {
   writable: true,
-  value: _init_computedKey(_class)
+  value: _init_computedKey(_Foo)
 };
 var _D = {
   writable: true,
-  value: _init_computedKey2(_class)
+  value: _init_computedKey2(_Foo)
 };
 var _E = {
   writable: true,
-  value: _init_computedKey3(_class)
+  value: _init_computedKey3(_Foo)
 };
 var _F = {
   writable: true,
-  value: _init_computedKey4(_class)
+  value: _init_computedKey4(_Foo)
 };
 var _G = {
   writable: true,
-  value: _init_computedKey5(_class)
+  value: _init_computedKey5(_Foo)
 };
 var _H = {
   writable: true,
-  value: _init_computedKey6(_class)
+  value: _init_computedKey6(_Foo)
 };
 var _I = {
   writable: true,
-  value: _init_computedKey7(_class)
+  value: _init_computedKey7(_Foo)
 };
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _class;
+var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _a = /*#__PURE__*/new WeakMap();
@@ -24,7 +24,7 @@ class Foo {
     });
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -37,7 +37,7 @@ function _set_b2(v) {
 function _get_b2() {
   return _get_b(this);
 }
-[_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 1, "a", function () {
+[_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 1, "a", function () {
   return babelHelpers.classPrivateFieldGet(this, _A);
 }, function (value) {
   babelHelpers.classPrivateFieldSet(this, _A, value);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto, _class;
+var _init_a, _init_b, _init_computedKey, _initProto, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();
@@ -37,5 +37,5 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _C, v);
   }
 }
-_class = Foo;
-[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _class;
+var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();
@@ -14,7 +14,7 @@ class Foo {
     });
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -28,22 +28,22 @@ function _get_b2() {
   return _get_b(this);
 }
 (() => {
-  [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 6, "a", function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _A);
+  [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 6, "a", function () {
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _A);
   }, function (value) {
-    babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _A, value);
+    babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _A, value);
   }], [dec, 6, "b", function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _B);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _B);
   }, function (value) {
-    babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _B, value);
+    babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _B, value);
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic, _class;
+var _init_a, _init_b, _init_computedKey, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -20,20 +20,20 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _C, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []).e;
-  _initStatic(_class);
+  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []).e;
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };
 var _C = {
   writable: true,
-  value: _init_computedKey(_class, 456)
+  value: _init_computedKey(_Foo, 456)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/undecorated-static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/undecorated-static-private/output.js
@@ -1,18 +1,18 @@
-var _class;
+var _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _A);
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _A);
 }
 function _set_a(v) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _A, v);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _A, v);
 }
 function _get_b() {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _B);
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _B);
 }
 function _set_b(v) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _B, v);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _B, v);
 }
 var _b = {
   get: _get_b,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/decorator-access-modified-fields/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/decorator-access-modified-fields/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_m, _class;
+var _initClass, _init_m, _C2;
 var value;
 const classDec = Class => {
   value = new Class().p;
@@ -11,9 +11,9 @@ class C {
     babelHelpers.defineProperty(this, "m", _init_m(this));
   }
 }
-_class = C;
+_C2 = C;
 ({
   e: [_init_m],
   c: [_C, _initClass]
-} = babelHelpers.applyDecs2203R(_class, [[memberDec, 0, "m"]], [classDec]));
+} = babelHelpers.applyDecs2203R(_C2, [[memberDec, 0, "m"]], [classDec]));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initProto, _class;
+var _initClass, _initProto, _C2;
 var value;
 const classDec = Class => {
   value = new Class().m();
@@ -7,14 +7,14 @@ const classDec = Class => {
 const memberDec = () => () => 42;
 let _C;
 class C {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   m() {}
 }
-_class = C;
+_C2 = C;
 ({
   e: [_initProto],
   c: [_C, _initClass]
-} = babelHelpers.applyDecs2203R(_class, [[memberDec, 2, "m"]], [classDec]));
+} = babelHelpers.applyDecs2203R(_C2, [[memberDec, 2, "m"]], [classDec]));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions-static-blocks/output.js
@@ -1,73 +1,73 @@
-var _initClass, _A, _temp, _initClass2, _C, _temp2, _initClass3, _D, _temp3, _initClass4, _decorated_class, _temp4, _class5, _initClass5, _G, _temp5, _initClass6, _decorated_class2, _temp6, _class7, _initClass7, _H, _temp7, _initClass8, _K, _temp8;
+var _initClass, _A, _temp, _initClass2, _C, _temp2, _initClass3, _D, _temp3, _initClass4, _decorated_class, _temp4, _Class2, _initClass5, _G, _temp5, _initClass6, _decorated_class2, _temp6, _Class3, _initClass7, _H, _temp7, _initClass8, _K, _temp8;
 const dec = () => {};
 const A = (new (_temp = class extends babelHelpers.identity {
   constructor() {
     super(_A), (() => {})(), _initClass();
   }
-}, (_class2 => {
+}, (_A2 => {
   class A {}
-  _class2 = A;
-  [_A, _initClass] = babelHelpers.applyDecs2203R(_class2, [], [dec]).c;
+  _A2 = A;
+  [_A, _initClass] = babelHelpers.applyDecs2203R(_A2, [], [dec]).c;
 })(), _temp)(), _A);
 const B = (new (_temp2 = class extends babelHelpers.identity {
   constructor() {
     super(_C), (() => {})(), _initClass2();
   }
-}, (_class3 => {
+}, (_C2 => {
   class C {}
-  _class3 = C;
-  [_C, _initClass2] = babelHelpers.applyDecs2203R(_class3, [], [dec]).c;
+  _C2 = C;
+  [_C, _initClass2] = babelHelpers.applyDecs2203R(_C2, [], [dec]).c;
 })(), _temp2)(), _C);
 const D = (new (_temp3 = class extends babelHelpers.identity {
   constructor() {
     super(_D), (() => {})(), _initClass3();
   }
-}, (_class4 => {
+}, (_D2 => {
   class D {}
-  _class4 = D;
-  [_D, _initClass3] = babelHelpers.applyDecs2203R(_class4, [], [dec]).c;
+  _D2 = D;
+  [_D, _initClass3] = babelHelpers.applyDecs2203R(_D2, [], [dec]).c;
 })(), _temp3)(), _D);
 const E = ((new (_temp4 = class extends babelHelpers.identity {
   constructor() {
     super(_decorated_class), (() => {})(), _initClass4();
   }
-}, (_class5 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2203R(_class5, [], [dec]).c), _temp4)(), _decorated_class), 123);
+}, (_Class2 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2203R(_Class2, [], [dec]).c), _temp4)(), _decorated_class), 123);
 const F = [(new (_temp5 = class extends babelHelpers.identity {
   constructor() {
     super(_G), (() => {})(), _initClass5();
   }
-}, (_class6 => {
+}, (_G2 => {
   class G {}
-  _class6 = G;
-  [_G, _initClass5] = babelHelpers.applyDecs2203R(_class6, [], [dec]).c;
+  _G2 = G;
+  [_G, _initClass5] = babelHelpers.applyDecs2203R(_G2, [], [dec]).c;
 })(), _temp5)(), _G), (new (_temp6 = class extends babelHelpers.identity {
   constructor() {
     super(_decorated_class2), (() => {})(), _initClass6();
   }
-}, (_class7 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2203R(_class7, [], [dec]).c), _temp6)(), _decorated_class2)];
+}, (_Class3 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2203R(_Class3, [], [dec]).c), _temp6)(), _decorated_class2)];
 const H = (new (_temp7 = class extends babelHelpers.identity {
   constructor() {
     super(_H), (() => {})(), _initClass7();
   }
-}, (_class8 => {
+}, (_H2 => {
   class H extends I {}
-  _class8 = H;
-  [_H, _initClass7] = babelHelpers.applyDecs2203R(_class8, [], [dec]).c;
+  _H2 = H;
+  [_H, _initClass7] = babelHelpers.applyDecs2203R(_H2, [], [dec]).c;
 })(), _temp7)(), _H);
 const J = (new (_temp8 = class extends babelHelpers.identity {
   constructor() {
     super(_K), (() => {})(), _initClass8();
   }
-}, (_class9 => {
+}, (_K2 => {
   class K extends L {}
-  _class9 = K;
-  [_K, _initClass8] = babelHelpers.applyDecs2203R(_class9, [], [dec]).c;
+  _K2 = K;
+  [_K, _initClass8] = babelHelpers.applyDecs2203R(_K2, [], [dec]).c;
 })(), _temp8)(), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _temp9, _class11;
+  var _initClass9, _decorated_class3, _temp9, _Class5;
   return new (_temp9 = class extends babelHelpers.identity {
     constructor() {
       super(_decorated_class3), (() => {})(), _initClass9();
     }
-  }, (_class11 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2203R(_class11, [], [dec]).c), _temp9)(), _decorated_class3;
+  }, (_Class5 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2203R(_Class5, [], [dec]).c), _temp9)(), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions/output.js
@@ -1,13 +1,13 @@
-var _initClass, _A, _class, _initClass2, _C, _class2, _initClass3, _D, _class3, _initClass4, _decorated_class, _class4, _initClass5, _G, _class5, _initClass6, _decorated_class2, _class6, _initClass7, _H, _class7, _initClass8, _K, _class8;
+var _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _Class, _initClass5, _G, _G2, _initClass6, _decorated_class2, _Class2, _initClass7, _H, _H2, _initClass8, _K, _K2;
 const dec = () => {};
-const A = ((_class = class A {}, [_A, _initClass] = babelHelpers.applyDecs2203R(_class, [], [dec]).c, _initClass()), _A);
-const B = ((_class2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs2203R(_class2, [], [dec]).c, _initClass2()), _C);
-const D = ((_class3 = class D {}, [_D, _initClass3] = babelHelpers.applyDecs2203R(_class3, [], [dec]).c, _initClass3()), _D);
-const E = (((_class4 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2203R(_class4, [], [dec]).c, _initClass4()), _decorated_class), 123);
-const F = [((_class5 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs2203R(_class5, [], [dec]).c, _initClass5()), _G), ((_class6 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2203R(_class6, [], [dec]).c, _initClass6()), _decorated_class2)];
-const H = ((_class7 = class H extends I {}, [_H, _initClass7] = babelHelpers.applyDecs2203R(_class7, [], [dec]).c, _initClass7()), _H);
-const J = ((_class8 = class K extends L {}, [_K, _initClass8] = babelHelpers.applyDecs2203R(_class8, [], [dec]).c, _initClass8()), _K);
+const A = ((_A2 = class A {}, [_A, _initClass] = babelHelpers.applyDecs2203R(_A2, [], [dec]).c, _initClass()), _A);
+const B = ((_C2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs2203R(_C2, [], [dec]).c, _initClass2()), _C);
+const D = ((_D2 = class D {}, [_D, _initClass3] = babelHelpers.applyDecs2203R(_D2, [], [dec]).c, _initClass3()), _D);
+const E = (((_Class = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2203R(_Class, [], [dec]).c, _initClass4()), _decorated_class), 123);
+const F = [((_G2 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs2203R(_G2, [], [dec]).c, _initClass5()), _G), ((_Class2 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2203R(_Class2, [], [dec]).c, _initClass6()), _decorated_class2)];
+const H = ((_H2 = class H extends I {}, [_H, _initClass7] = babelHelpers.applyDecs2203R(_H2, [], [dec]).c, _initClass7()), _H);
+const J = ((_K2 = class K extends L {}, [_K, _initClass8] = babelHelpers.applyDecs2203R(_K2, [], [dec]).c, _initClass8()), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _class9;
-  return (_class9 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2203R(_class9, [], [dec]).c, _initClass9()), _decorated_class3;
+  var _initClass9, _decorated_class3, _Class3;
+  return (_Class3 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2203R(_Class3, [], [dec]).c, _initClass9()), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/inheritance/output.js
@@ -1,13 +1,13 @@
-var _initClass, _class, _initClass2, _class2;
+var _initClass, _Bar2, _initClass2, _Foo2;
 const dec1 = () => {};
 const dec2 = () => {};
 let _Bar;
 class Bar {}
-_class = Bar;
-[_Bar, _initClass] = babelHelpers.applyDecs2203R(_class, [], [dec1]).c;
+_Bar2 = Bar;
+[_Bar, _initClass] = babelHelpers.applyDecs2203R(_Bar2, [], [dec1]).c;
 _initClass();
 let _Foo;
 class Foo extends _Bar {}
-_class2 = Foo;
-[_Foo, _initClass2] = babelHelpers.applyDecs2203R(_class2, [], [dec2]).c;
+_Foo2 = Foo;
+[_Foo, _initClass2] = babelHelpers.applyDecs2203R(_Foo2, [], [dec2]).c;
 _initClass2();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/initializers/output.js
@@ -5,10 +5,10 @@ new (_temp = class extends babelHelpers.identity {
   constructor() {
     (super(_Foo), babelHelpers.defineProperty(this, "field", 123)), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2203R(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2203R(_Foo2, [], [dec]).c;
 })(), _temp)();
 let _Bar;
 new (_temp2 = class extends babelHelpers.identity {
@@ -17,8 +17,8 @@ new (_temp2 = class extends babelHelpers.identity {
       this.otherField = 456;
     })(), 123))), _initClass2();
   }
-}, (_class3 => {
+}, (_Bar2 => {
   class Bar extends _Foo {}
-  _class3 = Bar;
-  [_Bar, _initClass2] = babelHelpers.applyDecs2203R(_class3, [], [dec]).c;
+  _Bar2 = Bar;
+  [_Bar, _initClass2] = babelHelpers.applyDecs2203R(_Bar2, [], [dec]).c;
 })(), _temp2)();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -12,11 +12,11 @@ new (_x = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), (_temp = 
       hasM = o => _m.has(babelHelpers.checkInRHS(o));
     })(), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {
     static m() {}
   }
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2203R(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2203R(_Foo2, [], [dec]).c;
 })(), _temp))();
 function _m2() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-this/output.js
@@ -9,8 +9,8 @@ new (_temp = class extends babelHelpers.identity {
       this;
     })(), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2203R(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2203R(_Foo2, [], [dec]).c;
 })(), _temp)();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-with-expr/output.js
@@ -1,8 +1,8 @@
-var _initClass, _Bar, _class;
+var _initClass, _Bar, _Bar2;
 const dec = () => {};
-const Foo = ((_class = class Bar {
+const Foo = ((_Bar2 = class Bar {
   constructor() {
     babelHelpers.defineProperty(this, "bar", new _Bar());
   }
-}, [_Bar, _initClass] = babelHelpers.applyDecs2203R(_class, [], [dec]).c, _initClass()), _Bar);
+}, [_Bar, _initClass] = babelHelpers.applyDecs2203R(_Bar2, [], [dec]).c, _initClass()), _Bar);
 const foo = new Foo();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement/output.js
@@ -5,9 +5,9 @@ new (_temp = class extends babelHelpers.identity {
   constructor() {
     (super(_Foo), babelHelpers.defineProperty(this, "foo", new _Foo())), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2203R(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2203R(_Foo2, [], [dec]).c;
 })(), _temp)();
 const foo = new _Foo();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/decorator-access-modified-methods/output.js
@@ -13,7 +13,7 @@ class C {
       c: [_C, _initClass]
     } = babelHelpers.applyDecs2203R(this, [[memberDec, 2, "m"]], [classDec]));
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   m() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/inheritance/output.js
@@ -1,20 +1,20 @@
-var _initClass, _dec, _initClass2, _dec2;
+var _initClass, _classDecs, _initClass2, _classDecs2;
 const dec = () => {};
-_dec = dec1;
+_classDecs = [dec1];
 let _Bar;
 class Bar {
   static {
-    [_Bar, _initClass] = babelHelpers.applyDecs2203R(this, [], [_dec]).c;
+    [_Bar, _initClass] = babelHelpers.applyDecs2203R(this, [], _classDecs).c;
   }
   static {
     _initClass();
   }
 }
-_dec2 = dec2;
+_classDecs2 = [dec2];
 let _Foo;
 class Foo extends _Bar {
   static {
-    [_Foo, _initClass2] = babelHelpers.applyDecs2203R(this, [], [_dec2]).c;
+    [_Foo, _initClass2] = babelHelpers.applyDecs2203R(this, [], _classDecs2).c;
   }
   static {
     _initClass2();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,9 +1,9 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _computedKey, _computedKey2, _initProto, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {
@@ -13,5 +13,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,9 +1,9 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _computedKey, _computedKey2, _initProto, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {
@@ -13,5 +13,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto, _class;
+var _init_a, _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
@@ -8,5 +8,5 @@ class Foo {
     return 1;
   }
 }
-_class = Foo;
-[_init_a, _initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 2, "a"], [dec, 0, "a"]], []).e;
+_Foo = Foo;
+[_init_a, _initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 2, "a"], [dec, 0, "a"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/methods-with-same-key/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   a() {
@@ -11,5 +11,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 2, "a"], [dec, 2, "a"]], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 2, "a"], [dec, 2, "a"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-ast/output.js
@@ -6,7 +6,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-value/output.js
@@ -6,7 +6,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/methods-with-same-key/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 2, "a"], [dec, 2, "a"]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/default-anonymous/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _A;
 class A {
   static {
-    [_A, _initClass] = babelHelpers.applyDecs2203R(this, [], [_dec]).c;
+    [_A, _initClass] = babelHelpers.applyDecs2203R(this, [], _classDecs).c;
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/default-named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/default-named/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _default2;
 class _default {
   static {
-    [_default2, _initClass] = babelHelpers.applyDecs2203R(babelHelpers.setFunctionName(this, "default"), [], [_dec]).c;
+    [_default2, _initClass] = babelHelpers.applyDecs2203R(babelHelpers.setFunctionName(this, "default"), [], _classDecs).c;
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/named/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _A;
 class A {
   static {
-    [_A, _initClass] = babelHelpers.applyDecs2203R(this, [], [_dec]).c;
+    [_A, _initClass] = babelHelpers.applyDecs2203R(this, [], _classDecs).c;
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _class;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -11,22 +11,22 @@ const f = () => {
 };
 _computedKey = babelHelpers.toPropertyKey(f());
 class Foo {}
-_class = Foo;
-[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2203R(_class, [[dec, 5, "a"], [dec, 5, "a", function () {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _a);
+_Foo = Foo;
+[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2203R(_Foo, [[dec, 5, "a"], [dec, 5, "a", function () {
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _a);
 }, function (value) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _a, value);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _a, value);
 }], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []).e;
-babelHelpers.defineProperty(Foo, "a", _init_a(_class));
+babelHelpers.defineProperty(Foo, "a", _init_a(_Foo));
 var _a = {
   writable: true,
-  value: _init_a2(_class)
+  value: _init_a2(_Foo)
 };
-babelHelpers.defineProperty(Foo, "b", _init_computedKey(_class));
-babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_class));
-babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_class));
-babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
-babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
-babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
+babelHelpers.defineProperty(Foo, "b", _init_computedKey(_Foo));
+babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_Foo));
+babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_Foo));
+babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_Foo));
+babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_Foo));
+babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_Foo));
+babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_Foo));
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _class;
+var _init_a, _init_b, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();
@@ -14,8 +14,8 @@ class Foo {
     });
   }
 }
-_class = Foo;
-[_init_a, _init_b] = babelHelpers.applyDecs2203R(_class, [[dec, 0, "a", function () {
+_Foo = Foo;
+[_init_a, _init_b] = babelHelpers.applyDecs2203R(_Foo, [[dec, 0, "a", function () {
   return babelHelpers.classPrivateFieldGet(this, _a);
 }, function (value) {
   babelHelpers.classPrivateFieldSet(this, _a, value);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
@@ -7,5 +7,5 @@ class Foo {
     babelHelpers.defineProperty(this, 'c', _init_computedKey(this, 456));
   }
 }
-_class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(_Foo, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/static-private/output.js
@@ -1,21 +1,21 @@
-var _init_a, _init_b, _class;
+var _init_a, _init_b, _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
-[_init_a, _init_b] = babelHelpers.applyDecs2203R(_class, [[dec, 5, "a", function () {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _a);
+_Foo = Foo;
+[_init_a, _init_b] = babelHelpers.applyDecs2203R(_Foo, [[dec, 5, "a", function () {
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _a);
 }, function (value) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _a, value);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _a, value);
 }], [dec, 5, "b", function () {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _b);
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _b);
 }, function (value) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _b, value);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _b, value);
 }]], []).e;
 var _a = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _b = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/static-public/output.js
@@ -1,8 +1,8 @@
-var _init_a, _init_b, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(_class, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []).e;
-babelHelpers.defineProperty(Foo, "a", _init_a(_class));
-babelHelpers.defineProperty(Foo, "b", _init_b(_class, 123));
-babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_class, 456));
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2203R(_Foo, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []).e;
+babelHelpers.defineProperty(Foo, "a", _init_a(_Foo));
+babelHelpers.defineProperty(Foo, "b", _init_b(_Foo, 123));
+babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_Foo, 456));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,7 +20,7 @@ class Foo {
   static get [3n]() {}
   static get [_computedKey]() {}
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -29,7 +29,7 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
+  _initStatic(_Foo);
 })();
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: _get_a,
       set: void 0
@@ -14,10 +14,10 @@ class Foo {
     return babelHelpers.classPrivateFieldGet(this, _a);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
-[_call_a, _initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 3, "a", function () {
+[_call_a, _initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 3, "a"], [dec, 3, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-private/output.js
@@ -1,11 +1,11 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _a);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -14,9 +14,9 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a", function () {
+  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 8, "a", function () {
     return this.value;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -8,9 +8,9 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a"], [dec, 8, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 8, "a"], [dec, 8, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _call_a2, _initProto, _class;
+var _call_a, _call_a2, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: _get_a,
       set: _set_a
@@ -17,14 +17,14 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
 function _set_a(v) {
   _call_a2(this, v);
 }
-[_call_a, _call_a2, _initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 3, "a", function () {
+[_call_a, _call_a2, _initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }], [dec, 4, "a", function (v) {
   this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -18,5 +18,5 @@ class Foo {
     this.value = v;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic, _class;
+var _call_a, _call_a2, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
@@ -8,7 +8,7 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -20,11 +20,11 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a", function () {
+  [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 8, "a", function () {
     return this.value;
   }], [dec, 9, "a", function (v) {
     this.value = v;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -14,9 +14,9 @@ class Foo {
     this.value = v;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/private/output.js
@@ -8,7 +8,7 @@ class Foo {
       this.value = v;
     }]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value;
     }]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,10 +20,10 @@ class Foo {
   static [3n]() {}
   static [_computedKey]() {}
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []).e;
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []).e;
+  _initStatic(_Foo);
 })();
 var _a = {
   writable: true,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
       value: _call_a
@@ -14,7 +14,7 @@ class Foo {
     return babelHelpers.classPrivateFieldGet(this, _a).call(this);
   }
 }
-_class = Foo;
-[_call_a, _initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 2, "a", function () {
+_Foo = Foo;
+[_call_a, _initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 2, "a", function () {
   return this.value;
 }]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 2, "a"], [dec, 2, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-private/output.js
@@ -1,16 +1,16 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static callA() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _a).call(this);
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 7, "a", function () {
+  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 7, "a", function () {
     return this.value;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 var _a = {
   writable: true,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static a() {
@@ -8,9 +8,9 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 7, "a"], [dec, 7, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 7, "a"], [dec, 7, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value;
     }]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   #a = _call_a;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,5 @@
 {
-  var _initProto, _class;
+  var _initProto, _A;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -18,8 +18,8 @@
     }
     method() {}
   }
-  _class = A;
-  [_initProto] = babelHelpers.applyDecs2203R(_class, [[deco, 2, "method"]], []).e;
+  _A = A;
+  [_initProto] = babelHelpers.applyDecs2203R(_A, [[deco, 2, "method"]], []).e;
   let instance = new A();
   expect(self).toBe(instance);
   expect(a).toBe(2);
@@ -40,7 +40,7 @@
     }
   }
   {
-    var _initProto2, _class2;
+    var _initProto2, _A2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -56,8 +56,8 @@
         return this.a;
       }
     }
-    _class2 = A;
-    [_initProto2] = babelHelpers.applyDecs2203R(_class2, [[dec, 2, "method"]], []).e;
+    _A2 = A;
+    [_initProto2] = babelHelpers.applyDecs2203R(_A2, [[dec, 2, "method"]], []).e;
     new A();
     expect(log + "").toBe("103,4");
   }
@@ -66,7 +66,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        var _computedKey, _initProto3, _class3;
+        var _computedKey, _initProto3, _A3;
         let key;
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
@@ -77,8 +77,8 @@
             return this.a;
           }
         }
-        _class3 = A;
-        [_initProto3] = babelHelpers.applyDecs2203R(_class3, [[dec, 2, "method"]], []).e;
+        _A3 = A;
+        [_initProto3] = babelHelpers.applyDecs2203R(_A3, [[dec, 2, "method"]], []).e;
         new A();
       }
     }();
@@ -90,7 +90,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _dec, _initProto4, _class4;
+        var _dec, _initProto4, _A4;
         _dec = noop(log.push(super(7).method()));
         class A extends B {
           constructor() {
@@ -101,15 +101,15 @@
           }
           noop() {}
         }
-        _class4 = A;
-        [_initProto4] = babelHelpers.applyDecs2203R(_class4, [[dec, 2, "method"], [_dec, 2, "noop"]], []).e;
+        _A4 = A;
+        [_initProto4] = babelHelpers.applyDecs2203R(_A4, [[dec, 2, "method"], [_dec, 2, "noop"]], []).e;
         new A();
       }
     }();
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5, _class5;
+    var _initProto5, _A5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -126,32 +126,32 @@
         return this.a;
       }
     }
-    _class5 = A;
-    [_initProto5] = babelHelpers.applyDecs2203R(_class5, [[dec, 2, "method"]], []).e;
+    _A5 = A;
+    [_initProto5] = babelHelpers.applyDecs2203R(_A5, [[dec, 2, "method"]], []).e;
     new A();
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6, _class7;
+    var _initProto6, _A6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        var _dec2, _initProto7, _class8;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_class8 = class Dummy extends B {
+        var _dec2, _initProto7, _Dummy2;
+        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());
           }
           noop() {}
-        }, [_initProto7] = babelHelpers.applyDecs2203R(_class8, [[_dec2, 2, "noop"]], []).e, _class8))();
+        }, [_initProto7] = babelHelpers.applyDecs2203R(_Dummy2, [[_dec2, 2, "noop"]], []).e, _Dummy2))();
       }
       method() {
         return this.a;
       }
     }
-    _class7 = A;
-    [_initProto6] = babelHelpers.applyDecs2203R(_class7, [[dec, 2, "method"]], []).e;
+    _A6 = A;
+    [_initProto6] = babelHelpers.applyDecs2203R(_A6, [[dec, 2, "method"]], []).e;
     new A();
     expect(log + "").toBe("111,12");
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/valid-expression-formats/output.js
@@ -1,17 +1,14 @@
-var _initClass, _dec, _dec2, _dec3, _dec4, _dec5, _dec6, _dec7, _dec8, _initProto, _class;
+var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto, _Foo2;
 const dec = () => {};
+_classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
 _dec4 = array[expr];
-_dec5 = call();
-_dec6 = chain.expr();
-_dec7 = arbitrary + expr;
-_dec8 = array[expr];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
       value: void 0
@@ -20,17 +17,17 @@ class Foo {
   }
   method() {}
   makeClass() {
-    var _dec9, _init_bar, _class2;
-    return _dec9 = babelHelpers.classPrivateFieldGet(this, _a), (_class2 = class Nested {
+    var _dec5, _init_bar, _Nested;
+    return _dec5 = babelHelpers.classPrivateFieldGet(this, _a), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, "bar", _init_bar(this));
       }
-    }, [_init_bar] = babelHelpers.applyDecs2203R(_class2, [[_dec9, 0, "bar"]], []).e, _class2);
+    }, [_init_bar] = babelHelpers.applyDecs2203R(_Nested, [[_dec5, 0, "bar"]], []).e, _Nested);
   }
 }
-_class = Foo;
+_Foo2 = Foo;
 ({
   e: [_initProto],
   c: [_Foo, _initClass]
-} = babelHelpers.applyDecs2203R(_class, [[[dec, _dec5, _dec6, _dec7, _dec8], 2, "method"]], [dec, _dec, _dec2, _dec3, _dec4]));
+} = babelHelpers.applyDecs2203R(_Foo2, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/valid-expression-formats/output.js
@@ -1,31 +1,28 @@
-var _initClass, _dec, _dec2, _dec3, _dec4, _dec5, _dec6, _dec7, _dec8, _initProto;
+var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto;
 const dec = () => {};
+_classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
 _dec4 = array[expr];
-_dec5 = call();
-_dec6 = chain.expr();
-_dec7 = arbitrary + expr;
-_dec8 = array[expr];
 let _Foo;
 class Foo {
   static {
     ({
       e: [_initProto],
       c: [_Foo, _initClass]
-    } = babelHelpers.applyDecs2203R(this, [[[dec, _dec5, _dec6, _dec7, _dec8], 2, "method"]], [dec, _dec, _dec2, _dec3, _dec4]));
+    } = babelHelpers.applyDecs2203R(this, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs));
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   #a;
   method() {}
   makeClass() {
-    var _dec9, _init_bar;
-    return _dec9 = this.#a, class Nested {
+    var _dec5, _init_bar;
+    return _dec5 = this.#a, class Nested {
       static {
-        [_init_bar] = babelHelpers.applyDecs2203R(this, [[_dec9, 0, "bar"]], []).e;
+        [_init_bar] = babelHelpers.applyDecs2203R(this, [[_dec5, 0, "bar"]], []).e;
       }
       bar = _init_bar(this);
     };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,7 +20,7 @@ class Foo {
   static set [3n](v) {}
   static set [_computedKey](v) {}
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
@@ -29,7 +29,7 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
+  _initStatic(_Foo);
 })();
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: void 0,
       set: _set_a
@@ -14,10 +14,10 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
-[_call_a, _initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 4, "a", function (v) {
+[_call_a, _initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 4, "a", function (v) {
   return this.value = v;
 }]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value = v;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2203R(_class, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 4, "a"], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-private/output.js
@@ -1,11 +1,11 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
@@ -14,9 +14,9 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 9, "a", function (v) {
+  [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 9, "a", function (v) {
     return this.value = v;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static set a(v) {
@@ -8,9 +8,9 @@ class Foo {
     return this.value = v;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2203R(_class, [[dec, 9, "a"], [dec, 9, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 9, "a"], [dec, 9, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value = v;
     }]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _class;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -67,7 +67,7 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _I, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -75,43 +75,43 @@ function _get_a2() {
   return _get_a(this);
 }
 (() => {
-  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 6, "a"], [dec, 6, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _B, v)], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []).e;
-  _initStatic(_class);
+  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 6, "a"], [dec, 6, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _B, v)], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []).e;
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_a2(_class)
+  value: _init_a2(_Foo)
 };
 var _C = {
   writable: true,
-  value: _init_computedKey(_class)
+  value: _init_computedKey(_Foo)
 };
 var _D = {
   writable: true,
-  value: _init_computedKey2(_class)
+  value: _init_computedKey2(_Foo)
 };
 var _E = {
   writable: true,
-  value: _init_computedKey3(_class)
+  value: _init_computedKey3(_Foo)
 };
 var _F = {
   writable: true,
-  value: _init_computedKey4(_class)
+  value: _init_computedKey4(_Foo)
 };
 var _G = {
   writable: true,
-  value: _init_computedKey5(_class)
+  value: _init_computedKey5(_Foo)
 };
 var _H = {
   writable: true,
-  value: _init_computedKey6(_class)
+  value: _init_computedKey6(_Foo)
 };
 var _I = {
   writable: true,
-  value: _init_computedKey7(_class)
+  value: _init_computedKey7(_Foo)
 };
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _class;
+var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _a = /*#__PURE__*/new WeakMap();
@@ -24,7 +24,7 @@ class Foo {
     });
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -37,4 +37,4 @@ function _set_b2(v) {
 function _get_b2() {
   return _get_b(this);
 }
-[_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs2301(_class, [[dec, 1, "a", o => babelHelpers.classPrivateFieldGet(o, _A), (o, v) => babelHelpers.classPrivateFieldSet(o, _A, v)], [dec, 1, "b", o => babelHelpers.classPrivateFieldGet(o, _B), (o, v) => babelHelpers.classPrivateFieldSet(o, _B, v)]], [], _ => _a.has(babelHelpers.checkInRHS(_))).e;
+[_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 1, "a", o => babelHelpers.classPrivateFieldGet(o, _A), (o, v) => babelHelpers.classPrivateFieldSet(o, _A, v)], [dec, 1, "b", o => babelHelpers.classPrivateFieldGet(o, _B), (o, v) => babelHelpers.classPrivateFieldSet(o, _B, v)]], [], _ => _a.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto, _class;
+var _init_a, _init_b, _init_computedKey, _initProto, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();
@@ -37,5 +37,5 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _C, v);
   }
 }
-_class = Foo;
-[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2301(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _class;
+var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();
@@ -14,7 +14,7 @@ class Foo {
     });
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -28,14 +28,14 @@ function _get_b2() {
   return _get_b(this);
 }
 (() => {
-  [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 6, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _A), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _A, v)], [dec, 6, "b", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _B, v)]], []).e;
-  _initStatic(_class);
+  [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 6, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _A), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _A, v)], [dec, 6, "b", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _B, v)]], []).e;
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic, _class;
+var _init_a, _init_b, _init_computedKey, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -20,20 +20,20 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _C, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []).e;
-  _initStatic(_class);
+  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 6, "a"], [dec, 6, "b"], [dec, 6, 'c']], []).e;
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };
 var _C = {
   writable: true,
-  value: _init_computedKey(_class, 456)
+  value: _init_computedKey(_Foo, 456)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/undecorated-static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/undecorated-static-private/output.js
@@ -1,18 +1,18 @@
-var _class;
+var _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _A);
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _A);
 }
 function _set_a(v) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _A, v);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _A, v);
 }
 function _get_b() {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _B);
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _B);
 }
 function _set_b(v) {
-  babelHelpers.classStaticPrivateFieldSpecSet(this, _class, _B, v);
+  babelHelpers.classStaticPrivateFieldSpecSet(this, _Foo, _B, v);
 }
 var _b = {
   get: _get_b,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/decorator-access-modified-fields/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/decorator-access-modified-fields/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_m, _class;
+var _initClass, _init_m, _C2;
 var value;
 const classDec = Class => {
   value = new Class().p;
@@ -11,9 +11,9 @@ class C {
     babelHelpers.defineProperty(this, "m", _init_m(this));
   }
 }
-_class = C;
+_C2 = C;
 ({
   e: [_init_m],
   c: [_C, _initClass]
-} = babelHelpers.applyDecs2301(_class, [[memberDec, 0, "m"]], [classDec]));
+} = babelHelpers.applyDecs2301(_C2, [[memberDec, 0, "m"]], [classDec]));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initProto, _class;
+var _initClass, _initProto, _C2;
 var value;
 const classDec = Class => {
   value = new Class().m();
@@ -7,14 +7,14 @@ const classDec = Class => {
 const memberDec = () => () => 42;
 let _C;
 class C {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   m() {}
 }
-_class = C;
+_C2 = C;
 ({
   e: [_initProto],
   c: [_C, _initClass]
-} = babelHelpers.applyDecs2301(_class, [[memberDec, 2, "m"]], [classDec]));
+} = babelHelpers.applyDecs2301(_C2, [[memberDec, 2, "m"]], [classDec]));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/expressions-static-blocks/output.js
@@ -1,73 +1,73 @@
-var _initClass, _A, _temp, _initClass2, _C, _temp2, _initClass3, _D, _temp3, _initClass4, _decorated_class, _temp4, _class5, _initClass5, _G, _temp5, _initClass6, _decorated_class2, _temp6, _class7, _initClass7, _H, _temp7, _initClass8, _K, _temp8;
+var _initClass, _A, _temp, _initClass2, _C, _temp2, _initClass3, _D, _temp3, _initClass4, _decorated_class, _temp4, _Class2, _initClass5, _G, _temp5, _initClass6, _decorated_class2, _temp6, _Class3, _initClass7, _H, _temp7, _initClass8, _K, _temp8;
 const dec = () => {};
 const A = (new (_temp = class extends babelHelpers.identity {
   constructor() {
     super(_A), (() => {})(), _initClass();
   }
-}, (_class2 => {
+}, (_A2 => {
   class A {}
-  _class2 = A;
-  [_A, _initClass] = babelHelpers.applyDecs2301(_class2, [], [dec]).c;
+  _A2 = A;
+  [_A, _initClass] = babelHelpers.applyDecs2301(_A2, [], [dec]).c;
 })(), _temp)(), _A);
 const B = (new (_temp2 = class extends babelHelpers.identity {
   constructor() {
     super(_C), (() => {})(), _initClass2();
   }
-}, (_class3 => {
+}, (_C2 => {
   class C {}
-  _class3 = C;
-  [_C, _initClass2] = babelHelpers.applyDecs2301(_class3, [], [dec]).c;
+  _C2 = C;
+  [_C, _initClass2] = babelHelpers.applyDecs2301(_C2, [], [dec]).c;
 })(), _temp2)(), _C);
 const D = (new (_temp3 = class extends babelHelpers.identity {
   constructor() {
     super(_D), (() => {})(), _initClass3();
   }
-}, (_class4 => {
+}, (_D2 => {
   class D {}
-  _class4 = D;
-  [_D, _initClass3] = babelHelpers.applyDecs2301(_class4, [], [dec]).c;
+  _D2 = D;
+  [_D, _initClass3] = babelHelpers.applyDecs2301(_D2, [], [dec]).c;
 })(), _temp3)(), _D);
 const E = ((new (_temp4 = class extends babelHelpers.identity {
   constructor() {
     super(_decorated_class), (() => {})(), _initClass4();
   }
-}, (_class5 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2301(_class5, [], [dec]).c), _temp4)(), _decorated_class), 123);
+}, (_Class2 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2301(_Class2, [], [dec]).c), _temp4)(), _decorated_class), 123);
 const F = [(new (_temp5 = class extends babelHelpers.identity {
   constructor() {
     super(_G), (() => {})(), _initClass5();
   }
-}, (_class6 => {
+}, (_G2 => {
   class G {}
-  _class6 = G;
-  [_G, _initClass5] = babelHelpers.applyDecs2301(_class6, [], [dec]).c;
+  _G2 = G;
+  [_G, _initClass5] = babelHelpers.applyDecs2301(_G2, [], [dec]).c;
 })(), _temp5)(), _G), (new (_temp6 = class extends babelHelpers.identity {
   constructor() {
     super(_decorated_class2), (() => {})(), _initClass6();
   }
-}, (_class7 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2301(_class7, [], [dec]).c), _temp6)(), _decorated_class2)];
+}, (_Class3 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2301(_Class3, [], [dec]).c), _temp6)(), _decorated_class2)];
 const H = (new (_temp7 = class extends babelHelpers.identity {
   constructor() {
     super(_H), (() => {})(), _initClass7();
   }
-}, (_class8 => {
+}, (_H2 => {
   class H extends I {}
-  _class8 = H;
-  [_H, _initClass7] = babelHelpers.applyDecs2301(_class8, [], [dec]).c;
+  _H2 = H;
+  [_H, _initClass7] = babelHelpers.applyDecs2301(_H2, [], [dec]).c;
 })(), _temp7)(), _H);
 const J = (new (_temp8 = class extends babelHelpers.identity {
   constructor() {
     super(_K), (() => {})(), _initClass8();
   }
-}, (_class9 => {
+}, (_K2 => {
   class K extends L {}
-  _class9 = K;
-  [_K, _initClass8] = babelHelpers.applyDecs2301(_class9, [], [dec]).c;
+  _K2 = K;
+  [_K, _initClass8] = babelHelpers.applyDecs2301(_K2, [], [dec]).c;
 })(), _temp8)(), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _temp9, _class11;
+  var _initClass9, _decorated_class3, _temp9, _Class5;
   return new (_temp9 = class extends babelHelpers.identity {
     constructor() {
       super(_decorated_class3), (() => {})(), _initClass9();
     }
-  }, (_class11 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2301(_class11, [], [dec]).c), _temp9)(), _decorated_class3;
+  }, (_Class5 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2301(_Class5, [], [dec]).c), _temp9)(), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/expressions/output.js
@@ -1,13 +1,13 @@
-var _initClass, _A, _class, _initClass2, _C, _class2, _initClass3, _D, _class3, _initClass4, _decorated_class, _class4, _initClass5, _G, _class5, _initClass6, _decorated_class2, _class6, _initClass7, _H, _class7, _initClass8, _K, _class8;
+var _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _Class, _initClass5, _G, _G2, _initClass6, _decorated_class2, _Class2, _initClass7, _H, _H2, _initClass8, _K, _K2;
 const dec = () => {};
-const A = ((_class = class A {}, [_A, _initClass] = babelHelpers.applyDecs2301(_class, [], [dec]).c, _initClass()), _A);
-const B = ((_class2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs2301(_class2, [], [dec]).c, _initClass2()), _C);
-const D = ((_class3 = class D {}, [_D, _initClass3] = babelHelpers.applyDecs2301(_class3, [], [dec]).c, _initClass3()), _D);
-const E = (((_class4 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2301(_class4, [], [dec]).c, _initClass4()), _decorated_class), 123);
-const F = [((_class5 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs2301(_class5, [], [dec]).c, _initClass5()), _G), ((_class6 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2301(_class6, [], [dec]).c, _initClass6()), _decorated_class2)];
-const H = ((_class7 = class H extends I {}, [_H, _initClass7] = babelHelpers.applyDecs2301(_class7, [], [dec]).c, _initClass7()), _H);
-const J = ((_class8 = class K extends L {}, [_K, _initClass8] = babelHelpers.applyDecs2301(_class8, [], [dec]).c, _initClass8()), _K);
+const A = ((_A2 = class A {}, [_A, _initClass] = babelHelpers.applyDecs2301(_A2, [], [dec]).c, _initClass()), _A);
+const B = ((_C2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs2301(_C2, [], [dec]).c, _initClass2()), _C);
+const D = ((_D2 = class D {}, [_D, _initClass3] = babelHelpers.applyDecs2301(_D2, [], [dec]).c, _initClass3()), _D);
+const E = (((_Class = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2301(_Class, [], [dec]).c, _initClass4()), _decorated_class), 123);
+const F = [((_G2 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs2301(_G2, [], [dec]).c, _initClass5()), _G), ((_Class2 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2301(_Class2, [], [dec]).c, _initClass6()), _decorated_class2)];
+const H = ((_H2 = class H extends I {}, [_H, _initClass7] = babelHelpers.applyDecs2301(_H2, [], [dec]).c, _initClass7()), _H);
+const J = ((_K2 = class K extends L {}, [_K, _initClass8] = babelHelpers.applyDecs2301(_K2, [], [dec]).c, _initClass8()), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _class9;
-  return (_class9 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2301(_class9, [], [dec]).c, _initClass9()), _decorated_class3;
+  var _initClass9, _decorated_class3, _Class3;
+  return (_Class3 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2301(_Class3, [], [dec]).c, _initClass9()), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/inheritance/output.js
@@ -1,13 +1,13 @@
-var _initClass, _class, _initClass2, _class2;
+var _initClass, _Bar2, _initClass2, _Foo2;
 const dec1 = () => {};
 const dec2 = () => {};
 let _Bar;
 class Bar {}
-_class = Bar;
-[_Bar, _initClass] = babelHelpers.applyDecs2301(_class, [], [dec1]).c;
+_Bar2 = Bar;
+[_Bar, _initClass] = babelHelpers.applyDecs2301(_Bar2, [], [dec1]).c;
 _initClass();
 let _Foo;
 class Foo extends _Bar {}
-_class2 = Foo;
-[_Foo, _initClass2] = babelHelpers.applyDecs2301(_class2, [], [dec2]).c;
+_Foo2 = Foo;
+[_Foo, _initClass2] = babelHelpers.applyDecs2301(_Foo2, [], [dec2]).c;
 _initClass2();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/initializers/output.js
@@ -5,10 +5,10 @@ new (_temp = class extends babelHelpers.identity {
   constructor() {
     (super(_Foo), babelHelpers.defineProperty(this, "field", 123)), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2301(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2301(_Foo2, [], [dec]).c;
 })(), _temp)();
 let _Bar;
 new (_temp2 = class extends babelHelpers.identity {
@@ -17,8 +17,8 @@ new (_temp2 = class extends babelHelpers.identity {
       this.otherField = 456;
     })(), 123))), _initClass2();
   }
-}, (_class3 => {
+}, (_Bar2 => {
   class Bar extends _Foo {}
-  _class3 = Bar;
-  [_Bar, _initClass2] = babelHelpers.applyDecs2301(_class3, [], [dec]).c;
+  _Bar2 = Bar;
+  [_Bar, _initClass2] = babelHelpers.applyDecs2301(_Bar2, [], [dec]).c;
 })(), _temp2)();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -12,11 +12,11 @@ new (_x = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), (_temp = 
       hasM = o => _m.has(babelHelpers.checkInRHS(o));
     })(), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {
     static m() {}
   }
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2301(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2301(_Foo2, [], [dec]).c;
 })(), _temp))();
 function _m2() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-this/output.js
@@ -9,8 +9,8 @@ new (_temp = class extends babelHelpers.identity {
       this;
     })(), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2301(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2301(_Foo2, [], [dec]).c;
 })(), _temp)();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-with-expr/output.js
@@ -1,8 +1,8 @@
-var _initClass, _Bar, _class;
+var _initClass, _Bar, _Bar2;
 const dec = () => {};
-const Foo = ((_class = class Bar {
+const Foo = ((_Bar2 = class Bar {
   constructor() {
     babelHelpers.defineProperty(this, "bar", new _Bar());
   }
-}, [_Bar, _initClass] = babelHelpers.applyDecs2301(_class, [], [dec]).c, _initClass()), _Bar);
+}, [_Bar, _initClass] = babelHelpers.applyDecs2301(_Bar2, [], [dec]).c, _initClass()), _Bar);
 const foo = new Foo();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement/output.js
@@ -5,9 +5,9 @@ new (_temp = class extends babelHelpers.identity {
   constructor() {
     (super(_Foo), babelHelpers.defineProperty(this, "foo", new _Foo())), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2301(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2301(_Foo2, [], [dec]).c;
 })(), _temp)();
 const foo = new _Foo();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/decorator-access-modified-methods/output.js
@@ -13,7 +13,7 @@ class C {
       c: [_C, _initClass]
     } = babelHelpers.applyDecs2301(this, [[memberDec, 2, "m"]], [classDec]));
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   m() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/inheritance/output.js
@@ -1,20 +1,20 @@
-var _initClass, _dec, _initClass2, _dec2;
+var _initClass, _classDecs, _initClass2, _classDecs2;
 const dec = () => {};
-_dec = dec1;
+_classDecs = [dec1];
 let _Bar;
 class Bar {
   static {
-    [_Bar, _initClass] = babelHelpers.applyDecs2301(this, [], [_dec]).c;
+    [_Bar, _initClass] = babelHelpers.applyDecs2301(this, [], _classDecs).c;
   }
   static {
     _initClass();
   }
 }
-_dec2 = dec2;
+_classDecs2 = [dec2];
 let _Foo;
 class Foo extends _Bar {
   static {
-    [_Foo, _initClass2] = babelHelpers.applyDecs2301(this, [], [_dec2]).c;
+    [_Foo, _initClass2] = babelHelpers.applyDecs2301(this, [], _classDecs2).c;
   }
   static {
     _initClass2();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,9 +1,9 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _computedKey, _computedKey2, _initProto, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {
@@ -13,5 +13,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,9 +1,9 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _computedKey, _computedKey2, _initProto, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {
@@ -13,5 +13,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto, _class;
+var _init_a, _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
@@ -8,5 +8,5 @@ class Foo {
     return 1;
   }
 }
-_class = Foo;
-[_init_a, _initProto] = babelHelpers.applyDecs2301(_class, [[dec, 2, "a"], [dec, 0, "a"]], []).e;
+_Foo = Foo;
+[_init_a, _initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 2, "a"], [dec, 0, "a"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/methods-with-same-key/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   a() {
@@ -11,5 +11,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 2, "a"], [dec, 2, "a"]], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 2, "a"], [dec, 2, "a"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-ast/output.js
@@ -6,7 +6,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-value/output.js
@@ -6,7 +6,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/methods-with-same-key/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 2, "a"], [dec, 2, "a"]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/default-anonymous/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _A;
 class A {
   static {
-    [_A, _initClass] = babelHelpers.applyDecs2301(this, [], [_dec]).c;
+    [_A, _initClass] = babelHelpers.applyDecs2301(this, [], _classDecs).c;
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/default-named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/default-named/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _default2;
 class _default {
   static {
-    [_default2, _initClass] = babelHelpers.applyDecs2301(babelHelpers.setFunctionName(this, "default"), [], [_dec]).c;
+    [_default2, _initClass] = babelHelpers.applyDecs2301(babelHelpers.setFunctionName(this, "default"), [], _classDecs).c;
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/named/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _A;
 class A {
   static {
-    [_A, _initClass] = babelHelpers.applyDecs2301(this, [], [_dec]).c;
+    [_A, _initClass] = babelHelpers.applyDecs2301(this, [], _classDecs).c;
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _class;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -11,18 +11,18 @@ const f = () => {
 };
 _computedKey = babelHelpers.toPropertyKey(f());
 class Foo {}
-_class = Foo;
-[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2301(_class, [[dec, 5, "a"], [dec, 5, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _a, v)], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []).e;
-babelHelpers.defineProperty(Foo, "a", _init_a(_class));
+_Foo = Foo;
+[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2301(_Foo, [[dec, 5, "a"], [dec, 5, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _a, v)], [dec, 5, "b"], [dec, 5, "c"], [dec, 5, 0], [dec, 5, 1], [dec, 5, 2n], [dec, 5, 3n], [dec, 5, _computedKey]], []).e;
+babelHelpers.defineProperty(Foo, "a", _init_a(_Foo));
 var _a = {
   writable: true,
-  value: _init_a2(_class)
+  value: _init_a2(_Foo)
 };
-babelHelpers.defineProperty(Foo, "b", _init_computedKey(_class));
-babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_class));
-babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_class));
-babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
-babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
-babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
+babelHelpers.defineProperty(Foo, "b", _init_computedKey(_Foo));
+babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_Foo));
+babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_Foo));
+babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_Foo));
+babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_Foo));
+babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_Foo));
+babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_Foo));
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _class;
+var _init_a, _init_b, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();
@@ -14,5 +14,5 @@ class Foo {
     });
   }
 }
-_class = Foo;
-[_init_a, _init_b] = babelHelpers.applyDecs2301(_class, [[dec, 0, "a", o => babelHelpers.classPrivateFieldGet(o, _a), (o, v) => babelHelpers.classPrivateFieldSet(o, _a, v)], [dec, 0, "b", o => babelHelpers.classPrivateFieldGet(o, _b), (o, v) => babelHelpers.classPrivateFieldSet(o, _b, v)]], [], _ => _b.has(babelHelpers.checkInRHS(_))).e;
+_Foo = Foo;
+[_init_a, _init_b] = babelHelpers.applyDecs2301(_Foo, [[dec, 0, "a", o => babelHelpers.classPrivateFieldGet(o, _a), (o, v) => babelHelpers.classPrivateFieldSet(o, _a, v)], [dec, 0, "b", o => babelHelpers.classPrivateFieldGet(o, _b), (o, v) => babelHelpers.classPrivateFieldSet(o, _b, v)]], [], _ => _b.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
@@ -7,5 +7,5 @@ class Foo {
     babelHelpers.defineProperty(this, 'c', _init_computedKey(this, 456));
   }
 }
-_class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(_Foo, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/static-private/output.js
@@ -1,13 +1,13 @@
-var _init_a, _init_b, _class;
+var _init_a, _init_b, _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
-[_init_a, _init_b] = babelHelpers.applyDecs2301(_class, [[dec, 5, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _a, v)], [dec, 5, "b", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _b), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _b, v)]], []).e;
+_Foo = Foo;
+[_init_a, _init_b] = babelHelpers.applyDecs2301(_Foo, [[dec, 5, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _a, v)], [dec, 5, "b", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _b), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _b, v)]], []).e;
 var _a = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _b = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/static-public/output.js
@@ -1,8 +1,8 @@
-var _init_a, _init_b, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(_class, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []).e;
-babelHelpers.defineProperty(Foo, "a", _init_a(_class));
-babelHelpers.defineProperty(Foo, "b", _init_b(_class, 123));
-babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_class, 456));
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2301(_Foo, [[dec, 5, "a"], [dec, 5, "b"], [dec, 5, 'c']], []).e;
+babelHelpers.defineProperty(Foo, "a", _init_a(_Foo));
+babelHelpers.defineProperty(Foo, "b", _init_b(_Foo, 123));
+babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_Foo, 456));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,7 +20,7 @@ class Foo {
   static get [3n]() {}
   static get [_computedKey]() {}
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -29,7 +29,7 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
+  _initStatic(_Foo);
 })();
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: _get_a,
       set: void 0
@@ -14,10 +14,10 @@ class Foo {
     return babelHelpers.classPrivateFieldGet(this, _a);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
-[_call_a, _initProto] = babelHelpers.applyDecs2301(_class, [[dec, 3, "a", function () {
+[_call_a, _initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }]], [], _ => _a.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 3, "a"], [dec, 3, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-private/output.js
@@ -1,11 +1,11 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _a);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -14,9 +14,9 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a", function () {
+  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 8, "a", function () {
     return this.value;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -8,9 +8,9 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a"], [dec, 8, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 8, "a"], [dec, 8, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _call_a2, _initProto, _class;
+var _call_a, _call_a2, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: _get_a,
       set: _set_a
@@ -17,14 +17,14 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
 function _set_a(v) {
   _call_a2(this, v);
 }
-[_call_a, _call_a2, _initProto] = babelHelpers.applyDecs2301(_class, [[dec, 3, "a", function () {
+[_call_a, _call_a2, _initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }], [dec, 4, "a", function (v) {
   this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -18,5 +18,5 @@ class Foo {
     this.value = v;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic, _class;
+var _call_a, _call_a2, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
@@ -8,7 +8,7 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -20,11 +20,11 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a", function () {
+  [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 8, "a", function () {
     return this.value;
   }], [dec, 9, "a", function (v) {
     this.value = v;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -14,9 +14,9 @@ class Foo {
     this.value = v;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 8, "a"], [dec, 9, "a"], [dec, 8, 'b'], [dec, 9, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/private/output.js
@@ -8,7 +8,7 @@ class Foo {
       this.value = v;
     }]], [], _ => #a in _).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value;
     }]], [], _ => #a in _).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,10 +20,10 @@ class Foo {
   static [3n]() {}
   static [_computedKey]() {}
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []).e;
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 7, "a"], [dec, 7, "a", function () {}], [dec, 7, "b"], [dec, 7, "c"], [dec, 7, 0], [dec, 7, 1], [dec, 7, 2n], [dec, 7, 3n], [dec, 7, _computedKey]], []).e;
+  _initStatic(_Foo);
 })();
 var _a = {
   writable: true,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
       value: _call_a
@@ -14,7 +14,7 @@ class Foo {
     return babelHelpers.classPrivateFieldGet(this, _a).call(this);
   }
 }
-_class = Foo;
-[_call_a, _initProto] = babelHelpers.applyDecs2301(_class, [[dec, 2, "a", function () {
+_Foo = Foo;
+[_call_a, _initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 2, "a", function () {
   return this.value;
 }]], [], _ => _a.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 2, "a"], [dec, 2, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-private/output.js
@@ -1,16 +1,16 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static callA() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _a).call(this);
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 7, "a", function () {
+  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 7, "a", function () {
     return this.value;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 var _a = {
   writable: true,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static a() {
@@ -8,9 +8,9 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 7, "a"], [dec, 7, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 7, "a"], [dec, 7, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value;
     }]], [], _ => #a in _).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   #a = _call_a;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,5 @@
 {
-  var _initProto, _class;
+  var _initProto, _A;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -18,8 +18,8 @@
     }
     method() {}
   }
-  _class = A;
-  [_initProto] = babelHelpers.applyDecs2301(_class, [[deco, 2, "method"]], []).e;
+  _A = A;
+  [_initProto] = babelHelpers.applyDecs2301(_A, [[deco, 2, "method"]], []).e;
   let instance = new A();
   expect(self).toBe(instance);
   expect(a).toBe(2);
@@ -40,7 +40,7 @@
     }
   }
   {
-    var _initProto2, _class2;
+    var _initProto2, _A2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -56,8 +56,8 @@
         return this.a;
       }
     }
-    _class2 = A;
-    [_initProto2] = babelHelpers.applyDecs2301(_class2, [[dec, 2, "method"]], []).e;
+    _A2 = A;
+    [_initProto2] = babelHelpers.applyDecs2301(_A2, [[dec, 2, "method"]], []).e;
     new A();
     expect(log + "").toBe("103,4");
   }
@@ -66,7 +66,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        var _computedKey, _initProto3, _class3;
+        var _computedKey, _initProto3, _A3;
         let key;
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
@@ -77,8 +77,8 @@
             return this.a;
           }
         }
-        _class3 = A;
-        [_initProto3] = babelHelpers.applyDecs2301(_class3, [[dec, 2, "method"]], []).e;
+        _A3 = A;
+        [_initProto3] = babelHelpers.applyDecs2301(_A3, [[dec, 2, "method"]], []).e;
         new A();
       }
     }();
@@ -90,7 +90,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _dec, _initProto4, _class4;
+        var _dec, _initProto4, _A4;
         _dec = noop(log.push(super(7).method()));
         class A extends B {
           constructor() {
@@ -101,15 +101,15 @@
           }
           noop() {}
         }
-        _class4 = A;
-        [_initProto4] = babelHelpers.applyDecs2301(_class4, [[dec, 2, "method"], [_dec, 2, "noop"]], []).e;
+        _A4 = A;
+        [_initProto4] = babelHelpers.applyDecs2301(_A4, [[dec, 2, "method"], [_dec, 2, "noop"]], []).e;
         new A();
       }
     }();
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5, _class5;
+    var _initProto5, _A5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -126,32 +126,32 @@
         return this.a;
       }
     }
-    _class5 = A;
-    [_initProto5] = babelHelpers.applyDecs2301(_class5, [[dec, 2, "method"]], []).e;
+    _A5 = A;
+    [_initProto5] = babelHelpers.applyDecs2301(_A5, [[dec, 2, "method"]], []).e;
     new A();
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6, _class7;
+    var _initProto6, _A6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        var _dec2, _initProto7, _class8;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_class8 = class Dummy extends B {
+        var _dec2, _initProto7, _Dummy2;
+        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());
           }
           noop() {}
-        }, [_initProto7] = babelHelpers.applyDecs2301(_class8, [[_dec2, 2, "noop"]], []).e, _class8))();
+        }, [_initProto7] = babelHelpers.applyDecs2301(_Dummy2, [[_dec2, 2, "noop"]], []).e, _Dummy2))();
       }
       method() {
         return this.a;
       }
     }
-    _class7 = A;
-    [_initProto6] = babelHelpers.applyDecs2301(_class7, [[dec, 2, "method"]], []).e;
+    _A6 = A;
+    [_initProto6] = babelHelpers.applyDecs2301(_A6, [[dec, 2, "method"]], []).e;
     new A();
     expect(log + "").toBe("111,12");
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/valid-expression-formats/output.js
@@ -1,17 +1,14 @@
-var _initClass, _dec, _dec2, _dec3, _dec4, _dec5, _dec6, _dec7, _dec8, _initProto, _class;
+var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto, _Foo2;
 const dec = () => {};
+_classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
 _dec4 = array[expr];
-_dec5 = call();
-_dec6 = chain.expr();
-_dec7 = arbitrary + expr;
-_dec8 = array[expr];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
       value: void 0
@@ -20,17 +17,17 @@ class Foo {
   }
   method() {}
   makeClass() {
-    var _dec9, _init_bar, _class2;
-    return _dec9 = babelHelpers.classPrivateFieldGet(this, _a), (_class2 = class Nested {
+    var _dec5, _init_bar, _Nested;
+    return _dec5 = babelHelpers.classPrivateFieldGet(this, _a), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, "bar", _init_bar(this));
       }
-    }, [_init_bar] = babelHelpers.applyDecs2301(_class2, [[_dec9, 0, "bar"]], []).e, _class2);
+    }, [_init_bar] = babelHelpers.applyDecs2301(_Nested, [[_dec5, 0, "bar"]], []).e, _Nested);
   }
 }
-_class = Foo;
+_Foo2 = Foo;
 ({
   e: [_initProto],
   c: [_Foo, _initClass]
-} = babelHelpers.applyDecs2301(_class, [[[dec, _dec5, _dec6, _dec7, _dec8], 2, "method"]], [dec, _dec, _dec2, _dec3, _dec4]));
+} = babelHelpers.applyDecs2301(_Foo2, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/valid-expression-formats/output.js
@@ -1,31 +1,28 @@
-var _initClass, _dec, _dec2, _dec3, _dec4, _dec5, _dec6, _dec7, _dec8, _initProto;
+var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto;
 const dec = () => {};
+_classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
 _dec4 = array[expr];
-_dec5 = call();
-_dec6 = chain.expr();
-_dec7 = arbitrary + expr;
-_dec8 = array[expr];
 let _Foo;
 class Foo {
   static {
     ({
       e: [_initProto],
       c: [_Foo, _initClass]
-    } = babelHelpers.applyDecs2301(this, [[[dec, _dec5, _dec6, _dec7, _dec8], 2, "method"]], [dec, _dec, _dec2, _dec3, _dec4]));
+    } = babelHelpers.applyDecs2301(this, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs));
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   #a;
   method() {}
   makeClass() {
-    var _dec9, _init_bar;
-    return _dec9 = this.#a, class Nested {
+    var _dec5, _init_bar;
+    return _dec5 = this.#a, class Nested {
       static {
-        [_init_bar] = babelHelpers.applyDecs2301(this, [[_dec9, 0, "bar"]], []).e;
+        [_init_bar] = babelHelpers.applyDecs2301(this, [[_dec5, 0, "bar"]], []).e;
       }
       bar = _init_bar(this);
     };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,7 +20,7 @@ class Foo {
   static set [3n](v) {}
   static set [_computedKey](v) {}
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
@@ -29,7 +29,7 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
+  _initStatic(_Foo);
 })();
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: void 0,
       set: _set_a
@@ -14,10 +14,10 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
-[_call_a, _initProto] = babelHelpers.applyDecs2301(_class, [[dec, 4, "a", function (v) {
+[_call_a, _initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 4, "a", function (v) {
   return this.value = v;
 }]], [], _ => _a.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value = v;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2301(_class, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 4, "a"], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-private/output.js
@@ -1,11 +1,11 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
@@ -14,9 +14,9 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 9, "a", function (v) {
+  [_call_a, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 9, "a", function (v) {
     return this.value = v;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static set a(v) {
@@ -8,9 +8,9 @@ class Foo {
     return this.value = v;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2301(_class, [[dec, 9, "a"], [dec, 9, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 9, "a"], [dec, 9, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value = v;
     }]], [], _ => #a in _).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _class;
+var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -67,7 +67,7 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(Foo, Foo, _I, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -75,43 +75,43 @@ function _get_a2() {
   return _get_a(this);
 }
 (() => {
-  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 9, "a"], [dec, 9, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _B, v)], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
-  _initStatic(_class);
+  [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 9, "a"], [dec, 9, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _B, v)], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_a2(_class)
+  value: _init_a2(_Foo)
 };
 var _C = {
   writable: true,
-  value: _init_computedKey(_class)
+  value: _init_computedKey(_Foo)
 };
 var _D = {
   writable: true,
-  value: _init_computedKey2(_class)
+  value: _init_computedKey2(_Foo)
 };
 var _E = {
   writable: true,
-  value: _init_computedKey3(_class)
+  value: _init_computedKey3(_Foo)
 };
 var _F = {
   writable: true,
-  value: _init_computedKey4(_class)
+  value: _init_computedKey4(_Foo)
 };
 var _G = {
   writable: true,
-  value: _init_computedKey5(_class)
+  value: _init_computedKey5(_Foo)
 };
 var _H = {
   writable: true,
-  value: _init_computedKey6(_class)
+  value: _init_computedKey6(_Foo)
 };
 var _I = {
   writable: true,
-  value: _init_computedKey7(_class)
+  value: _init_computedKey7(_Foo)
 };
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _class;
+var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _a = /*#__PURE__*/new WeakMap();
@@ -24,7 +24,7 @@ class Foo {
     });
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -37,4 +37,4 @@ function _set_b2(v) {
 function _get_b2() {
   return _get_b(this);
 }
-[_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs2305(_class, [[dec, 1, "a", o => babelHelpers.classPrivateFieldGet(o, _A), (o, v) => babelHelpers.classPrivateFieldSet(o, _A, v)], [dec, 1, "b", o => babelHelpers.classPrivateFieldGet(o, _B), (o, v) => babelHelpers.classPrivateFieldSet(o, _B, v)]], [], 0, _ => _a.has(babelHelpers.checkInRHS(_))).e;
+[_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 1, "a", o => babelHelpers.classPrivateFieldGet(o, _A), (o, v) => babelHelpers.classPrivateFieldSet(o, _A, v)], [dec, 1, "b", o => babelHelpers.classPrivateFieldGet(o, _B), (o, v) => babelHelpers.classPrivateFieldSet(o, _B, v)]], [], 0, _ => _a.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto, _class;
+var _init_a, _init_b, _init_computedKey, _initProto, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();
@@ -37,5 +37,5 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _C, v);
   }
 }
-_class = Foo;
-[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2305(_class, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey, _initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 1, "a"], [dec, 1, "b"], [dec, 1, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _class;
+var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();
@@ -14,7 +14,7 @@ class Foo {
     });
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
 }
@@ -28,14 +28,14 @@ function _get_b2() {
   return _get_b(this);
 }
 (() => {
-  [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 9, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _A), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _A, v)], [dec, 9, "b", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _B, v)]], []).e;
-  _initStatic(_class);
+  [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 9, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _A), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _A, v)], [dec, 9, "b", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _B, v)]], []).e;
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic, _class;
+var _init_a, _init_b, _init_computedKey, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -20,20 +20,20 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(Foo, Foo, _C, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 9, "a"], [dec, 9, "b"], [dec, 9, 'c']], []).e;
-  _initStatic(_class);
+  [_init_a, _init_b, _init_computedKey, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 9, "a"], [dec, 9, "b"], [dec, 9, 'c']], []).e;
+  _initStatic(_Foo);
 })();
 var _A = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _B = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };
 var _C = {
   writable: true,
-  value: _init_computedKey(_class, 456)
+  value: _init_computedKey(_Foo, 456)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/undecorated-static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/undecorated-static-private/output.js
@@ -1,18 +1,18 @@
-var _class;
+var _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
-  return babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _A);
+  return babelHelpers.classStaticPrivateFieldSpecGet(_Foo, _Foo, _A);
 }
 function _set_a(v) {
-  babelHelpers.classStaticPrivateFieldSpecSet(_class, _class, _A, v);
+  babelHelpers.classStaticPrivateFieldSpecSet(_Foo, _Foo, _A, v);
 }
 function _get_b() {
-  return babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _B);
+  return babelHelpers.classStaticPrivateFieldSpecGet(_Foo, _Foo, _B);
 }
 function _set_b(v) {
-  babelHelpers.classStaticPrivateFieldSpecSet(_class, _class, _B, v);
+  babelHelpers.classStaticPrivateFieldSpecSet(_Foo, _Foo, _B, v);
 }
 var _b = {
   get: _get_b,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/decorator-access-modified-fields/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/decorator-access-modified-fields/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_m, _class;
+var _initClass, _init_m, _C2;
 var value;
 const classDec = Class => {
   value = new Class().p;
@@ -11,9 +11,9 @@ class C {
     babelHelpers.defineProperty(this, "m", _init_m(this));
   }
 }
-_class = C;
+_C2 = C;
 ({
   e: [_init_m],
   c: [_C, _initClass]
-} = babelHelpers.applyDecs2305(_class, [[memberDec, 0, "m"]], [classDec]));
+} = babelHelpers.applyDecs2305(_C2, [[memberDec, 0, "m"]], [classDec]));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initProto, _class;
+var _initClass, _initProto, _C2;
 var value;
 const classDec = Class => {
   value = new Class().m();
@@ -7,14 +7,14 @@ const classDec = Class => {
 const memberDec = () => () => 42;
 let _C;
 class C {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   m() {}
 }
-_class = C;
+_C2 = C;
 ({
   e: [_initProto],
   c: [_C, _initClass]
-} = babelHelpers.applyDecs2305(_class, [[memberDec, 2, "m"]], [classDec]));
+} = babelHelpers.applyDecs2305(_C2, [[memberDec, 2, "m"]], [classDec]));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/expressions-static-blocks/output.js
@@ -1,73 +1,73 @@
-var _initClass, _A, _temp, _initClass2, _C, _temp2, _initClass3, _D, _temp3, _initClass4, _decorated_class, _temp4, _class5, _initClass5, _G, _temp5, _initClass6, _decorated_class2, _temp6, _class7, _initClass7, _H, _I, _temp7, _initClass8, _K, _L, _temp8;
+var _initClass, _A, _temp, _initClass2, _C, _temp2, _initClass3, _D, _temp3, _initClass4, _decorated_class, _temp4, _Class2, _initClass5, _G, _temp5, _initClass6, _decorated_class2, _temp6, _Class3, _initClass7, _H, _I, _temp7, _initClass8, _K, _L, _temp8;
 const dec = () => {};
 const A = (new (_temp = class extends babelHelpers.identity {
   constructor() {
     super(_A), (() => {})(), _initClass();
   }
-}, (_class2 => {
+}, (_A2 => {
   class A {}
-  _class2 = A;
-  [_A, _initClass] = babelHelpers.applyDecs2305(_class2, [], [dec]).c;
+  _A2 = A;
+  [_A, _initClass] = babelHelpers.applyDecs2305(_A2, [], [dec]).c;
 })(), _temp)(), _A);
 const B = (new (_temp2 = class extends babelHelpers.identity {
   constructor() {
     super(_C), (() => {})(), _initClass2();
   }
-}, (_class3 => {
+}, (_C2 => {
   class C {}
-  _class3 = C;
-  [_C, _initClass2] = babelHelpers.applyDecs2305(_class3, [], [dec]).c;
+  _C2 = C;
+  [_C, _initClass2] = babelHelpers.applyDecs2305(_C2, [], [dec]).c;
 })(), _temp2)(), _C);
 const D = (new (_temp3 = class extends babelHelpers.identity {
   constructor() {
     super(_D), (() => {})(), _initClass3();
   }
-}, (_class4 => {
+}, (_D2 => {
   class D {}
-  _class4 = D;
-  [_D, _initClass3] = babelHelpers.applyDecs2305(_class4, [], [dec]).c;
+  _D2 = D;
+  [_D, _initClass3] = babelHelpers.applyDecs2305(_D2, [], [dec]).c;
 })(), _temp3)(), _D);
 const E = ((new (_temp4 = class extends babelHelpers.identity {
   constructor() {
     super(_decorated_class), (() => {})(), _initClass4();
   }
-}, (_class5 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2305(_class5, [], [dec]).c), _temp4)(), _decorated_class), 123);
+}, (_Class2 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2305(_Class2, [], [dec]).c), _temp4)(), _decorated_class), 123);
 const F = [(new (_temp5 = class extends babelHelpers.identity {
   constructor() {
     super(_G), (() => {})(), _initClass5();
   }
-}, (_class6 => {
+}, (_G2 => {
   class G {}
-  _class6 = G;
-  [_G, _initClass5] = babelHelpers.applyDecs2305(_class6, [], [dec]).c;
+  _G2 = G;
+  [_G, _initClass5] = babelHelpers.applyDecs2305(_G2, [], [dec]).c;
 })(), _temp5)(), _G), (new (_temp6 = class extends babelHelpers.identity {
   constructor() {
     super(_decorated_class2), (() => {})(), _initClass6();
   }
-}, (_class7 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2305(_class7, [], [dec]).c), _temp6)(), _decorated_class2)];
+}, (_Class3 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2305(_Class3, [], [dec]).c), _temp6)(), _decorated_class2)];
 const H = (new (_temp7 = class extends babelHelpers.identity {
   constructor() {
     super(_H), (() => {})(), _initClass7();
   }
-}, (_class8 => {
+}, (_H2 => {
   class H extends (_I = I) {}
-  _class8 = H;
-  [_H, _initClass7] = babelHelpers.applyDecs2305(_class8, [], [dec], 0, void 0, _I).c;
+  _H2 = H;
+  [_H, _initClass7] = babelHelpers.applyDecs2305(_H2, [], [dec], 0, void 0, _I).c;
 })(), _temp7)(), _H);
 const J = (new (_temp8 = class extends babelHelpers.identity {
   constructor() {
     super(_K), (() => {})(), _initClass8();
   }
-}, (_class9 => {
+}, (_K2 => {
   class K extends (_L = L) {}
-  _class9 = K;
-  [_K, _initClass8] = babelHelpers.applyDecs2305(_class9, [], [dec], 0, void 0, _L).c;
+  _K2 = K;
+  [_K, _initClass8] = babelHelpers.applyDecs2305(_K2, [], [dec], 0, void 0, _L).c;
 })(), _temp8)(), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _temp9, _class11;
+  var _initClass9, _decorated_class3, _temp9, _Class5;
   return new (_temp9 = class extends babelHelpers.identity {
     constructor() {
       super(_decorated_class3), (() => {})(), _initClass9();
     }
-  }, (_class11 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2305(_class11, [], [dec]).c), _temp9)(), _decorated_class3;
+  }, (_Class5 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2305(_Class5, [], [dec]).c), _temp9)(), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/expressions/output.js
@@ -1,13 +1,13 @@
-var _initClass, _A, _class, _initClass2, _C, _class2, _initClass3, _D, _class3, _initClass4, _decorated_class, _class4, _initClass5, _G, _class5, _initClass6, _decorated_class2, _class6, _initClass7, _H, _I, _class7, _initClass8, _K, _L, _class8;
+var _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _Class, _initClass5, _G, _G2, _initClass6, _decorated_class2, _Class2, _initClass7, _H, _I, _H2, _initClass8, _K, _L, _K2;
 const dec = () => {};
-const A = ((_class = class A {}, [_A, _initClass] = babelHelpers.applyDecs2305(_class, [], [dec]).c, _initClass()), _A);
-const B = ((_class2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs2305(_class2, [], [dec]).c, _initClass2()), _C);
-const D = ((_class3 = class D {}, [_D, _initClass3] = babelHelpers.applyDecs2305(_class3, [], [dec]).c, _initClass3()), _D);
-const E = (((_class4 = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2305(_class4, [], [dec]).c, _initClass4()), _decorated_class), 123);
-const F = [((_class5 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs2305(_class5, [], [dec]).c, _initClass5()), _G), ((_class6 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2305(_class6, [], [dec]).c, _initClass6()), _decorated_class2)];
-const H = ((_class7 = class H extends (_I = I) {}, [_H, _initClass7] = babelHelpers.applyDecs2305(_class7, [], [dec], 0, void 0, _I).c, _initClass7()), _H);
-const J = ((_class8 = class K extends (_L = L) {}, [_K, _initClass8] = babelHelpers.applyDecs2305(_class8, [], [dec], 0, void 0, _L).c, _initClass8()), _K);
+const A = ((_A2 = class A {}, [_A, _initClass] = babelHelpers.applyDecs2305(_A2, [], [dec]).c, _initClass()), _A);
+const B = ((_C2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs2305(_C2, [], [dec]).c, _initClass2()), _C);
+const D = ((_D2 = class D {}, [_D, _initClass3] = babelHelpers.applyDecs2305(_D2, [], [dec]).c, _initClass3()), _D);
+const E = (((_Class = class {}, [_decorated_class, _initClass4] = babelHelpers.applyDecs2305(_Class, [], [dec]).c, _initClass4()), _decorated_class), 123);
+const F = [((_G2 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs2305(_G2, [], [dec]).c, _initClass5()), _G), ((_Class2 = class {}, [_decorated_class2, _initClass6] = babelHelpers.applyDecs2305(_Class2, [], [dec]).c, _initClass6()), _decorated_class2)];
+const H = ((_H2 = class H extends (_I = I) {}, [_H, _initClass7] = babelHelpers.applyDecs2305(_H2, [], [dec], 0, void 0, _I).c, _initClass7()), _H);
+const J = ((_K2 = class K extends (_L = L) {}, [_K, _initClass8] = babelHelpers.applyDecs2305(_K2, [], [dec], 0, void 0, _L).c, _initClass8()), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _class9;
-  return (_class9 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2305(_class9, [], [dec]).c, _initClass9()), _decorated_class3;
+  var _initClass9, _decorated_class3, _Class3;
+  return (_Class3 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2305(_Class3, [], [dec]).c, _initClass9()), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/inheritance/output.js
@@ -1,13 +1,13 @@
-var _initClass, _class, _initClass2, _Bar2, _class2;
+var _initClass, _Bar2, _initClass2, _Bar3, _Foo2;
 const dec1 = () => {};
 const dec2 = () => {};
 let _Bar;
 class Bar {}
-_class = Bar;
-[_Bar, _initClass] = babelHelpers.applyDecs2305(_class, [], [dec1]).c;
+_Bar2 = Bar;
+[_Bar, _initClass] = babelHelpers.applyDecs2305(_Bar2, [], [dec1]).c;
 _initClass();
 let _Foo;
-class Foo extends (_Bar2 = _Bar) {}
-_class2 = Foo;
-[_Foo, _initClass2] = babelHelpers.applyDecs2305(_class2, [], [dec2], 0, void 0, _Bar2).c;
+class Foo extends (_Bar3 = _Bar) {}
+_Foo2 = Foo;
+[_Foo, _initClass2] = babelHelpers.applyDecs2305(_Foo2, [], [dec2], 0, void 0, _Bar3).c;
 _initClass2();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/initializers/output.js
@@ -1,14 +1,14 @@
-var _initClass, _temp, _initClass2, _Foo2, _temp2;
+var _initClass, _temp, _initClass2, _Foo3, _temp2;
 const dec = () => {};
 let _Foo;
 new (_temp = class extends babelHelpers.identity {
   constructor() {
     (super(_Foo), babelHelpers.defineProperty(this, "field", 123)), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2305(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2305(_Foo2, [], [dec]).c;
 })(), _temp)();
 let _Bar;
 new (_temp2 = class extends babelHelpers.identity {
@@ -17,8 +17,8 @@ new (_temp2 = class extends babelHelpers.identity {
       this.otherField = 456;
     })(), 123))), _initClass2();
   }
-}, (_class3 => {
-  class Bar extends (_Foo2 = _Foo) {}
-  _class3 = Bar;
-  [_Bar, _initClass2] = babelHelpers.applyDecs2305(_class3, [], [dec], 0, void 0, _Foo2).c;
+}, (_Bar2 => {
+  class Bar extends (_Foo3 = _Foo) {}
+  _Bar2 = Bar;
+  [_Bar, _initClass2] = babelHelpers.applyDecs2305(_Bar2, [], [dec], 0, void 0, _Foo3).c;
 })(), _temp2)();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -12,11 +12,11 @@ new (_x = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), (_temp = 
       hasM = o => _m.has(babelHelpers.checkInRHS(o));
     })(), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {
     static m() {}
   }
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2305(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2305(_Foo2, [], [dec]).c;
 })(), _temp))();
 function _m2() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-this/output.js
@@ -9,8 +9,8 @@ new (_temp = class extends babelHelpers.identity {
       this;
     })(), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2305(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2305(_Foo2, [], [dec]).c;
 })(), _temp)();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-with-expr/output.js
@@ -1,8 +1,8 @@
-var _initClass, _Bar, _class;
+var _initClass, _Bar, _Bar2;
 const dec = () => {};
-const Foo = ((_class = class Bar {
+const Foo = ((_Bar2 = class Bar {
   constructor() {
     babelHelpers.defineProperty(this, "bar", new _Bar());
   }
-}, [_Bar, _initClass] = babelHelpers.applyDecs2305(_class, [], [dec]).c, _initClass()), _Bar);
+}, [_Bar, _initClass] = babelHelpers.applyDecs2305(_Bar2, [], [dec]).c, _initClass()), _Bar);
 const foo = new Foo();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement/output.js
@@ -5,9 +5,9 @@ new (_temp = class extends babelHelpers.identity {
   constructor() {
     (super(_Foo), babelHelpers.defineProperty(this, "foo", new _Foo())), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   class Foo {}
-  _class2 = Foo;
-  [_Foo, _initClass] = babelHelpers.applyDecs2305(_class2, [], [dec]).c;
+  _Foo2 = Foo;
+  [_Foo, _initClass] = babelHelpers.applyDecs2305(_Foo2, [], [dec]).c;
 })(), _temp)();
 const foo = new _Foo();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/decorator-access-modified-methods/output.js
@@ -13,7 +13,7 @@ class C {
       c: [_C, _initClass]
     } = babelHelpers.applyDecs2305(this, [[memberDec, 2, "m"]], [classDec]));
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   m() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/inheritance/output.js
@@ -1,20 +1,20 @@
-var _initClass, _dec, _initClass2, _dec2, _Bar2;
+var _initClass, _classDecs, _initClass2, _classDecs2, _Bar2;
 const dec = () => {};
-_dec = dec1;
+_classDecs = [dec1];
 let _Bar;
 class Bar {
   static {
-    [_Bar, _initClass] = babelHelpers.applyDecs2305(this, [], [_dec]).c;
+    [_Bar, _initClass] = babelHelpers.applyDecs2305(this, [], _classDecs).c;
   }
   static {
     _initClass();
   }
 }
-_dec2 = dec2;
+_classDecs2 = [dec2];
 let _Foo;
 class Foo extends (_Bar2 = _Bar) {
   static {
-    [_Foo, _initClass2] = babelHelpers.applyDecs2305(this, [], [_dec2], 0, void 0, _Bar2).c;
+    [_Foo, _initClass2] = babelHelpers.applyDecs2305(this, [], _classDecs2, 0, void 0, _Bar2).c;
   }
   static {
     _initClass2();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,9 +1,9 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _computedKey, _computedKey2, _initProto, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {
@@ -13,5 +13,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,9 +1,9 @@
-var _computedKey, _computedKey2, _initProto, _class;
+var _computedKey, _computedKey2, _initProto, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {
@@ -13,5 +13,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto, _class;
+var _init_a, _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
@@ -8,5 +8,5 @@ class Foo {
     return 1;
   }
 }
-_class = Foo;
-[_init_a, _initProto] = babelHelpers.applyDecs2305(_class, [[dec, 2, "a"], [dec, 0, "a"]], []).e;
+_Foo = Foo;
+[_init_a, _initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 2, "a"], [dec, 0, "a"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/methods-with-same-key/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   a() {
@@ -11,5 +11,5 @@ class Foo {
     return 2;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 2, "a"], [dec, 2, "a"]], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 2, "a"], [dec, 2, "a"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-ast/output.js
@@ -6,7 +6,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-value/output.js
@@ -6,7 +6,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 2, _computedKey], [dec, 2, _computedKey2]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   [_computedKey]() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/methods-with-same-key/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 2, "a"], [dec, 2, "a"]], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/default-anonymous/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _A;
 class A {
   static {
-    [_A, _initClass] = babelHelpers.applyDecs2305(this, [], [_dec]).c;
+    [_A, _initClass] = babelHelpers.applyDecs2305(this, [], _classDecs).c;
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/default-named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/default-named/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _default2;
 class _default {
   static {
-    [_default2, _initClass] = babelHelpers.applyDecs2305(babelHelpers.setFunctionName(this, "default"), [], [_dec]).c;
+    [_default2, _initClass] = babelHelpers.applyDecs2305(babelHelpers.setFunctionName(this, "default"), [], _classDecs).c;
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/named/output.mjs
@@ -1,9 +1,9 @@
-var _initClass, _dec;
-_dec = dec;
+var _initClass, _classDecs;
+_classDecs = [dec];
 let _A;
 class A {
   static {
-    [_A, _initClass] = babelHelpers.applyDecs2305(this, [], [_dec]).c;
+    [_A, _initClass] = babelHelpers.applyDecs2305(this, [], _classDecs).c;
   }
   static {
     _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _class;
+var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -11,18 +11,18 @@ const f = () => {
 };
 _computedKey = babelHelpers.toPropertyKey(f());
 class Foo {}
-_class = Foo;
-[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2305(_class, [[dec, 8, "a"], [dec, 8, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _a, v)], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
-babelHelpers.defineProperty(Foo, "a", _init_a(_class));
+_Foo = Foo;
+[_init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7] = babelHelpers.applyDecs2305(_Foo, [[dec, 8, "a"], [dec, 8, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _a, v)], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
+babelHelpers.defineProperty(Foo, "a", _init_a(_Foo));
 var _a = {
   writable: true,
-  value: _init_a2(_class)
+  value: _init_a2(_Foo)
 };
-babelHelpers.defineProperty(Foo, "b", _init_computedKey(_class));
-babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_class));
-babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_class));
-babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_class));
-babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_class));
-babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_class));
-babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_class));
+babelHelpers.defineProperty(Foo, "b", _init_computedKey(_Foo));
+babelHelpers.defineProperty(Foo, "c", _init_computedKey2(_Foo));
+babelHelpers.defineProperty(Foo, 0, _init_computedKey3(_Foo));
+babelHelpers.defineProperty(Foo, 1, _init_computedKey4(_Foo));
+babelHelpers.defineProperty(Foo, 2n, _init_computedKey5(_Foo));
+babelHelpers.defineProperty(Foo, 3n, _init_computedKey6(_Foo));
+babelHelpers.defineProperty(Foo, _computedKey, _init_computedKey7(_Foo));
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _class;
+var _init_a, _init_b, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();
@@ -14,5 +14,5 @@ class Foo {
     });
   }
 }
-_class = Foo;
-[_init_a, _init_b] = babelHelpers.applyDecs2305(_class, [[dec, 0, "a", o => babelHelpers.classPrivateFieldGet(o, _a), (o, v) => babelHelpers.classPrivateFieldSet(o, _a, v)], [dec, 0, "b", o => babelHelpers.classPrivateFieldGet(o, _b), (o, v) => babelHelpers.classPrivateFieldSet(o, _b, v)]], [], 0, _ => _b.has(babelHelpers.checkInRHS(_))).e;
+_Foo = Foo;
+[_init_a, _init_b] = babelHelpers.applyDecs2305(_Foo, [[dec, 0, "a", o => babelHelpers.classPrivateFieldGet(o, _a), (o, v) => babelHelpers.classPrivateFieldSet(o, _a, v)], [dec, 0, "b", o => babelHelpers.classPrivateFieldGet(o, _b), (o, v) => babelHelpers.classPrivateFieldSet(o, _b, v)]], [], 0, _ => _b.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
@@ -7,5 +7,5 @@ class Foo {
     babelHelpers.defineProperty(this, 'c', _init_computedKey(this, 456));
   }
 }
-_class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(_class, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(_Foo, [[dec, 0, "a"], [dec, 0, "b"], [dec, 0, 'c']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/static-private/output.js
@@ -1,13 +1,13 @@
-var _init_a, _init_b, _class;
+var _init_a, _init_b, _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
-[_init_a, _init_b] = babelHelpers.applyDecs2305(_class, [[dec, 8, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _a, v)], [dec, 8, "b", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _class, _b), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _class, _b, v)]], []).e;
+_Foo = Foo;
+[_init_a, _init_b] = babelHelpers.applyDecs2305(_Foo, [[dec, 8, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _a), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _a, v)], [dec, 8, "b", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _b), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _b, v)]], []).e;
 var _a = {
   writable: true,
-  value: _init_a(_class)
+  value: _init_a(_Foo)
 };
 var _b = {
   writable: true,
-  value: _init_b(_class, 123)
+  value: _init_b(_Foo, 123)
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/static-public/output.js
@@ -1,8 +1,8 @@
-var _init_a, _init_b, _init_computedKey, _class;
+var _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {}
-_class = Foo;
-[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(_class, [[dec, 8, "a"], [dec, 8, "b"], [dec, 8, 'c']], []).e;
-babelHelpers.defineProperty(Foo, "a", _init_a(_class));
-babelHelpers.defineProperty(Foo, "b", _init_b(_class, 123));
-babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_class, 456));
+_Foo = Foo;
+[_init_a, _init_b, _init_computedKey] = babelHelpers.applyDecs2305(_Foo, [[dec, 8, "a"], [dec, 8, "b"], [dec, 8, 'c']], []).e;
+babelHelpers.defineProperty(Foo, "a", _init_a(_Foo));
+babelHelpers.defineProperty(Foo, "b", _init_b(_Foo, 123));
+babelHelpers.defineProperty(Foo, 'c', _init_computedKey(_Foo, 456));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,7 +20,7 @@ class Foo {
   static get [3n]() {}
   static get [_computedKey]() {}
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -29,7 +29,7 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a"], [dec, 11, "a", function () {}], [dec, 11, "b"], [dec, 11, "c"], [dec, 11, 0], [dec, 11, 1], [dec, 11, 2n], [dec, 11, 3n], [dec, 11, _computedKey]], []).e;
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 11, "a"], [dec, 11, "a", function () {}], [dec, 11, "b"], [dec, 11, "c"], [dec, 11, 0], [dec, 11, 1], [dec, 11, 2n], [dec, 11, 3n], [dec, 11, _computedKey]], []).e;
+  _initStatic(_Foo);
 })();
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: _get_a,
       set: void 0
@@ -14,10 +14,10 @@ class Foo {
     return babelHelpers.classPrivateFieldGet(this, _a);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
-[_call_a, _initProto] = babelHelpers.applyDecs2305(_class, [[dec, 3, "a", function () {
+[_call_a, _initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }]], [], 0, _ => _a.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 3, "a"], [dec, 3, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-private/output.js
@@ -1,11 +1,11 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _a);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -14,9 +14,9 @@ var _a = {
   set: void 0
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a", function () {
+  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 11, "a", function () {
     return this.value;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -8,9 +8,9 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a"], [dec, 11, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 11, "a"], [dec, 11, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _call_a2, _initProto, _class;
+var _call_a, _call_a2, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: _get_a,
       set: _set_a
@@ -17,14 +17,14 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
 function _set_a(v) {
   _call_a2(this, v);
 }
-[_call_a, _call_a2, _initProto] = babelHelpers.applyDecs2305(_class, [[dec, 3, "a", function () {
+[_call_a, _call_a2, _initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }], [dec, 4, "a", function (v) {
   this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -18,5 +18,5 @@ class Foo {
     this.value = v;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic, _class;
+var _call_a, _call_a2, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
@@ -8,7 +8,7 @@ class Foo {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _get_a() {
   return _call_a(this);
 }
@@ -20,11 +20,11 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a", function () {
+  [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 11, "a", function () {
     return this.value;
   }], [dec, 12, "a", function (v) {
     this.value = v;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {
@@ -14,9 +14,9 @@ class Foo {
     this.value = v;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 11, "a"], [dec, 12, "a"], [dec, 11, 'b'], [dec, 12, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 11, "a"], [dec, 12, "a"], [dec, 11, 'b'], [dec, 12, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/private/output.js
@@ -8,7 +8,7 @@ class Foo {
       this.value = v;
     }]], [], 0, _ => #a in _).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value;
     }]], [], 0, _ => #a in _).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,10 +20,10 @@ class Foo {
   static [3n]() {}
   static [_computedKey]() {}
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 10, "a"], [dec, 10, "a", function () {}], [dec, 10, "b"], [dec, 10, "c"], [dec, 10, 0], [dec, 10, 1], [dec, 10, 2n], [dec, 10, 3n], [dec, 10, _computedKey]], []).e;
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 10, "a"], [dec, 10, "a", function () {}], [dec, 10, "b"], [dec, 10, "c"], [dec, 10, 0], [dec, 10, 1], [dec, 10, 2n], [dec, 10, 3n], [dec, 10, _computedKey]], []).e;
+  _initStatic(_Foo);
 })();
 var _a = {
   writable: true,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
       value: _call_a
@@ -14,7 +14,7 @@ class Foo {
     return babelHelpers.classPrivateFieldGet(this, _a).call(this);
   }
 }
-_class = Foo;
-[_call_a, _initProto] = babelHelpers.applyDecs2305(_class, [[dec, 2, "a", function () {
+_Foo = Foo;
+[_call_a, _initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 2, "a", function () {
   return this.value;
 }]], [], 0, _ => _a.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 2, "a"], [dec, 2, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-private/output.js
@@ -1,16 +1,16 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static callA() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _a).call(this);
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 10, "a", function () {
+  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 10, "a", function () {
     return this.value;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 var _a = {
   writable: true,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static a() {
@@ -8,9 +8,9 @@ class Foo {
     return this.value;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 10, "a"], [dec, 10, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 10, "a"], [dec, 10, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value;
     }]], [], 0, _ => #a in _).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   #a = _call_a;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,5 @@
 {
-  var _initProto, _class;
+  var _initProto, _A;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -18,8 +18,8 @@
     }
     method() {}
   }
-  _class = A;
-  [_initProto] = babelHelpers.applyDecs2305(_class, [[deco, 2, "method"]], [], 0, void 0, B).e;
+  _A = A;
+  [_initProto] = babelHelpers.applyDecs2305(_A, [[deco, 2, "method"]], [], 0, void 0, B).e;
   let instance = new A();
   expect(self).toBe(instance);
   expect(a).toBe(2);
@@ -40,7 +40,7 @@
     }
   }
   {
-    var _initProto2, _class2;
+    var _initProto2, _A2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -56,8 +56,8 @@
         return this.a;
       }
     }
-    _class2 = A;
-    [_initProto2] = babelHelpers.applyDecs2305(_class2, [[dec, 2, "method"]], [], 0, void 0, B).e;
+    _A2 = A;
+    [_initProto2] = babelHelpers.applyDecs2305(_A2, [[dec, 2, "method"]], [], 0, void 0, B).e;
     new A();
     expect(log + "").toBe("103,4");
   }
@@ -66,7 +66,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        var _computedKey, _initProto3, _class3;
+        var _computedKey, _initProto3, _A3;
         let key;
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
@@ -77,8 +77,8 @@
             return this.a;
           }
         }
-        _class3 = A;
-        [_initProto3] = babelHelpers.applyDecs2305(_class3, [[dec, 2, "method"]], [], 0, void 0, B).e;
+        _A3 = A;
+        [_initProto3] = babelHelpers.applyDecs2305(_A3, [[dec, 2, "method"]], [], 0, void 0, B).e;
         new A();
       }
     }();
@@ -90,7 +90,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _dec, _initProto4, _class4;
+        var _dec, _initProto4, _A4;
         _dec = noop(log.push(super(7).method()));
         class A extends B {
           constructor() {
@@ -101,15 +101,15 @@
           }
           noop() {}
         }
-        _class4 = A;
-        [_initProto4] = babelHelpers.applyDecs2305(_class4, [[dec, 2, "method"], [_dec, 2, "noop"]], [], 0, void 0, B).e;
+        _A4 = A;
+        [_initProto4] = babelHelpers.applyDecs2305(_A4, [[dec, 2, "method"], [_dec, 2, "noop"]], [], 0, void 0, B).e;
         new A();
       }
     }();
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5, _class5;
+    var _initProto5, _A5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -126,32 +126,32 @@
         return this.a;
       }
     }
-    _class5 = A;
-    [_initProto5] = babelHelpers.applyDecs2305(_class5, [[dec, 2, "method"]], [], 0, void 0, B).e;
+    _A5 = A;
+    [_initProto5] = babelHelpers.applyDecs2305(_A5, [[dec, 2, "method"]], [], 0, void 0, B).e;
     new A();
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6, _class7;
+    var _initProto6, _A6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        var _dec2, _initProto7, _class8;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_class8 = class Dummy extends B {
+        var _dec2, _initProto7, _Dummy2;
+        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());
           }
           noop() {}
-        }, [_initProto7] = babelHelpers.applyDecs2305(_class8, [[_dec2, 2, "noop"]], [], 0, void 0, B).e, _class8))();
+        }, [_initProto7] = babelHelpers.applyDecs2305(_Dummy2, [[_dec2, 2, "noop"]], [], 0, void 0, B).e, _Dummy2))();
       }
       method() {
         return this.a;
       }
     }
-    _class7 = A;
-    [_initProto6] = babelHelpers.applyDecs2305(_class7, [[dec, 2, "method"]], [], 0, void 0, B).e;
+    _A6 = A;
+    [_initProto6] = babelHelpers.applyDecs2305(_A6, [[dec, 2, "method"]], [], 0, void 0, B).e;
     new A();
     expect(log + "").toBe("111,12");
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
@@ -1,22 +1,21 @@
 class A extends B {
   m() {
-    var _initClass, _obj, _dec, _obj2, _dec2, _initProto, _class;
+    var _initClass, _classDecs, _obj, _dec, _initProto, _C2;
+    _classDecs = [this, super.dec1];
     _obj = this;
-    _dec = super.dec1;
-    _obj2 = this;
-    _dec2 = super.dec2;
+    _dec = super.dec2;
     let _C;
     class C {
-      constructor(...args) {
+      constructor() {
         _initProto(this);
       }
       m2() {}
     }
-    _class = C;
+    _C2 = C;
     ({
       e: [_initProto],
       c: [_C, _initClass]
-    } = babelHelpers.applyDecs2305(_class, [[[_obj2, _dec2], 18, "m2"]], [_obj, _dec], 1));
+    } = babelHelpers.applyDecs2305(_C2, [[[_obj, _dec], 18, "m2"]], _classDecs, 1));
     _initClass();
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
@@ -1,16 +1,12 @@
-var _initClass, _obj, _dec, _dec2, _obj2, _dec3, _obj3, _dec4, _obj4, _dec5, _init_x, _obj5, _dec6, _dec7, _init_y, _class;
-_obj = o1;
+var _initClass, _classDecs, _obj, _dec, _obj2, _dec2, _init_x, _obj3, _dec3, _dec4, _init_y, _A2;
+_classDecs = [o1, o1.dec, void 0, dec, o2, o2.dec];
+_obj = o2;
 _dec = _obj.dec;
-_dec2 = dec;
-_obj2 = o2;
-_dec3 = _obj2.dec;
+_obj2 = o3.o;
+_dec2 = _obj2.dec;
 _obj3 = o2;
-_dec4 = _obj3.dec;
-_obj4 = o3.o;
-_dec5 = _obj4.dec;
-_obj5 = o2;
-_dec6 = _obj5.dec;
-_dec7 = dec;
+_dec3 = _obj3.dec;
+_dec4 = dec;
 let _A;
 class A {
   constructor() {
@@ -18,9 +14,9 @@ class A {
     babelHelpers.defineProperty(this, "y", _init_y(this));
   }
 }
-_class = A;
+_A2 = A;
 ({
   e: [_init_x, _init_y],
   c: [_A, _initClass]
-} = babelHelpers.applyDecs2305(_class, [[[_obj3, _dec4, _obj4, _dec5], 16, "x"], [[_obj5, _dec6, void 0, _dec7], 16, "y"]], [_obj, _dec, void 0, _dec2, _obj2, _dec3], 1));
+} = babelHelpers.applyDecs2305(_A2, [[[_obj, _dec, _obj2, _dec2], 16, "x"], [[_obj3, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
@@ -1,19 +1,15 @@
-var _initClass, _dec, _dec2, _dec3, _obj, _dec4, _dec5, _dec6, _dec7, _obj2, _dec8, _initProto, _class;
+var _initClass, _classDecs, _dec, _dec2, _dec3, _obj, _dec4, _initProto, _Foo2;
 const dec = () => {};
+_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, array, array[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
 _obj = array;
 _dec4 = _obj[expr];
-_dec5 = call();
-_dec6 = chain.expr();
-_dec7 = arbitrary + expr;
-_obj2 = array;
-_dec8 = _obj2[expr];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
       value: void 0
@@ -22,17 +18,17 @@ class Foo {
   }
   method() {}
   makeClass() {
-    var _dec9, _init_bar, _class2;
-    return _dec9 = babelHelpers.classPrivateFieldGet(this, _a), (_class2 = class Nested {
+    var _dec5, _init_bar, _Nested;
+    return _dec5 = babelHelpers.classPrivateFieldGet(this, _a), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, "bar", _init_bar(this));
       }
-    }, [_init_bar] = babelHelpers.applyDecs2305(_class2, [[_dec9, 0, "bar"]], []).e, _class2);
+    }, [_init_bar] = babelHelpers.applyDecs2305(_Nested, [[_dec5, 0, "bar"]], []).e, _Nested);
   }
 }
-_class = Foo;
+_Foo2 = Foo;
 ({
   e: [_initProto],
   c: [_Foo, _initClass]
-} = babelHelpers.applyDecs2305(_class, [[[void 0, dec, void 0, _dec5, void 0, _dec6, void 0, _dec7, _obj2, _dec8], 18, "method"]], [void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj, _dec4], 1));
+} = babelHelpers.applyDecs2305(_Foo2, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj, _dec4], 18, "method"]], _classDecs, 1));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
@@ -1,19 +1,18 @@
 class A extends B {
   m() {
-    var _initClass, _obj, _dec, _obj2, _dec2, _initProto;
+    var _initClass, _classDecs, _obj, _dec, _initProto;
+    _classDecs = [this, super.dec1];
     _obj = this;
-    _dec = super.dec1;
-    _obj2 = this;
-    _dec2 = super.dec2;
+    _dec = super.dec2;
     let _C;
     class C {
       static {
         ({
           e: [_initProto],
           c: [_C, _initClass]
-        } = babelHelpers.applyDecs2305(this, [[[_obj2, _dec2], 18, "m2"]], [_obj, _dec], 1));
+        } = babelHelpers.applyDecs2305(this, [[[_obj, _dec], 18, "m2"]], _classDecs, 1));
       }
-      constructor(...args) {
+      constructor() {
         _initProto(this);
       }
       m2() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
@@ -1,23 +1,19 @@
-var _initClass, _obj, _dec, _dec2, _obj2, _dec3, _obj3, _dec4, _obj4, _dec5, _init_x, _obj5, _dec6, _dec7, _init_y;
-_obj = o1;
+var _initClass, _classDecs, _obj, _dec, _obj2, _dec2, _init_x, _obj3, _dec3, _dec4, _init_y;
+_classDecs = [o1, o1.dec, void 0, dec, o2, o2.dec];
+_obj = o2;
 _dec = _obj.dec;
-_dec2 = dec;
-_obj2 = o2;
-_dec3 = _obj2.dec;
+_obj2 = o3.o;
+_dec2 = _obj2.dec;
 _obj3 = o2;
-_dec4 = _obj3.dec;
-_obj4 = o3.o;
-_dec5 = _obj4.dec;
-_obj5 = o2;
-_dec6 = _obj5.dec;
-_dec7 = dec;
+_dec3 = _obj3.dec;
+_dec4 = dec;
 let _A;
 class A {
   static {
     ({
       e: [_init_x, _init_y],
       c: [_A, _initClass]
-    } = babelHelpers.applyDecs2305(this, [[[_obj3, _dec4, _obj4, _dec5], 16, "x"], [[_obj5, _dec6, void 0, _dec7], 16, "y"]], [_obj, _dec, void 0, _dec2, _obj2, _dec3], 1));
+    } = babelHelpers.applyDecs2305(this, [[[_obj, _dec, _obj2, _dec2], 16, "x"], [[_obj3, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
   }
   x = _init_x(this);
   y = _init_y(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
@@ -1,33 +1,29 @@
-var _initClass, _dec, _dec2, _dec3, _obj, _dec4, _dec5, _dec6, _dec7, _obj2, _dec8, _initProto;
+var _initClass, _classDecs, _dec, _dec2, _dec3, _obj, _dec4, _initProto;
 const dec = () => {};
+_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, array, array[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
 _obj = array;
 _dec4 = _obj[expr];
-_dec5 = call();
-_dec6 = chain.expr();
-_dec7 = arbitrary + expr;
-_obj2 = array;
-_dec8 = _obj2[expr];
 let _Foo;
 class Foo {
   static {
     ({
       e: [_initProto],
       c: [_Foo, _initClass]
-    } = babelHelpers.applyDecs2305(this, [[[void 0, dec, void 0, _dec5, void 0, _dec6, void 0, _dec7, _obj2, _dec8], 18, "method"]], [void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj, _dec4], 1));
+    } = babelHelpers.applyDecs2305(this, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj, _dec4], 18, "method"]], _classDecs, 1));
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   #a;
   method() {}
   makeClass() {
-    var _obj3, _dec9, _init_bar;
-    return _obj3 = this, _dec9 = this.#a, class Nested {
+    var _obj2, _dec5, _init_bar;
+    return _obj2 = this, _dec5 = this.#a, class Nested {
       static {
-        [_init_bar] = babelHelpers.applyDecs2305(this, [[[_obj3, _dec9], 16, "bar"]], []).e;
+        [_init_bar] = babelHelpers.applyDecs2305(this, [[[_obj2, _dec5], 16, "bar"]], []).e;
       }
       bar = _init_bar(this);
     };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering--to-es2015/initializers-and-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering--to-es2015/initializers-and-static-blocks/output.js
@@ -155,7 +155,7 @@ new (_B = /*#__PURE__*/new WeakMap(), (_temp = class extends babelHelpers.identi
       log.push("static:end");
     })(), _initClass();
   }
-}, (_class2 => {
+}, (_Foo2 => {
   var _A = /*#__PURE__*/new WeakMap();
   class Foo extends (_ref = (log.push("extends"), Object)) {
     constructor() {
@@ -191,13 +191,13 @@ new (_B = /*#__PURE__*/new WeakMap(), (_temp = class extends babelHelpers.identi
       babelHelpers.classPrivateFieldSet(Foo, _B, v);
     }
   }
-  _class2 = Foo;
+  _Foo2 = Foo;
   (() => {
     ({
       e: [_init_accessor2, _init_accessor, _init_field2, _init_field, _initProto, _initStatic],
       c: [_Foo, _initClass]
-    } = babelHelpers.applyDecs2305(_class2, [[[staticMethodDec1, staticMethodDec2], 10, "method"], [[staticGetterDec1, staticGetterDec2], 11, "getter"], [[staticSetterDec1, staticSetterDec2], 12, "getter"], [[staticAccessorDec1, staticAccessorDec2], 9, "accessor"], [[methodDec1, methodDec2], 2, "method"], [[getterDec1, getterDec2], 3, "getter"], [[setterDec1, setterDec2], 4, "setter"], [[accessorDec1, accessorDec2], 1, "accessor"], [[staticFieldDec1, staticFieldDec2], 8, "field"], [[fieldDec1, fieldDec2], 0, "field"]], [classDec1, classDec2], 0, void 0, _ref));
-    _initStatic(_class2);
+    } = babelHelpers.applyDecs2305(_Foo2, [[[staticMethodDec1, staticMethodDec2], 10, "method"], [[staticGetterDec1, staticGetterDec2], 11, "getter"], [[staticSetterDec1, staticSetterDec2], 12, "getter"], [[staticAccessorDec1, staticAccessorDec2], 9, "accessor"], [[methodDec1, methodDec2], 2, "method"], [[getterDec1, getterDec2], 3, "getter"], [[setterDec1, setterDec2], 4, "setter"], [[accessorDec1, accessorDec2], 1, "accessor"], [[staticFieldDec1, staticFieldDec2], 8, "field"], [[fieldDec1, fieldDec2], 0, "field"]], [classDec1, classDec2], 0, void 0, _ref));
+    _initStatic(_Foo2);
   })();
 })(), _temp))();
 log.push("after");

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _class;
+var _call_a, _computedKey, _initStatic, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);
@@ -20,7 +20,7 @@ class Foo {
   static set [3n](v) {}
   static set [_computedKey](v) {}
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
@@ -29,7 +29,7 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 12, "a"], [dec, 12, "a", function (v) {}], [dec, 12, "b"], [dec, 12, "c"], [dec, 12, 0], [dec, 12, 1], [dec, 12, 2n], [dec, 12, 3n], [dec, 12, _computedKey]], []).e;
-  _initStatic(_class);
+  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 12, "a"], [dec, 12, "a", function (v) {}], [dec, 12, "b"], [dec, 12, "c"], [dec, 12, 0], [dec, 12, 1], [dec, 12, 2n], [dec, 12, 3n], [dec, 12, _computedKey]], []).e;
+  _initStatic(_Foo);
 })();
 expect(logs).toStrictEqual(["computing f", "calling toPrimitive", "a", "#a", "b", "c", "0", "1", "2", "3", "f()"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/private/output.js
@@ -1,8 +1,8 @@
-var _call_a, _initProto, _class;
+var _call_a, _initProto, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       get: void 0,
       set: _set_a
@@ -14,10 +14,10 @@ class Foo {
     babelHelpers.classPrivateFieldSet(this, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
-[_call_a, _initProto] = babelHelpers.applyDecs2305(_class, [[dec, 4, "a", function (v) {
+[_call_a, _initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 4, "a", function (v) {
   return this.value = v;
 }]], [], 0, _ => _a.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/public/output.js
@@ -1,7 +1,7 @@
-var _initProto, _class;
+var _initProto, _Foo;
 const dec = () => {};
 class Foo {
-  constructor(...args) {
+  constructor() {
     babelHelpers.defineProperty(this, "value", 1);
     _initProto(this);
   }
@@ -12,5 +12,5 @@ class Foo {
     return this.value = v;
   }
 }
-_class = Foo;
-[_initProto] = babelHelpers.applyDecs2305(_class, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
+_Foo = Foo;
+[_initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 4, "a"], [dec, 4, 'b']], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-private/output.js
@@ -1,11 +1,11 @@
-var _call_a, _initStatic, _class;
+var _call_a, _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {
     babelHelpers.classStaticPrivateFieldSpecSet(this, Foo, _a, v);
   }
 }
-_class = Foo;
+_Foo = Foo;
 function _set_a(v) {
   _call_a(this, v);
 }
@@ -14,9 +14,9 @@ var _a = {
   set: _set_a
 };
 (() => {
-  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 12, "a", function (v) {
+  [_call_a, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 12, "a", function (v) {
     return this.value = v;
   }]], []).e;
-  _initStatic(_class);
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _class;
+var _initStatic, _Foo;
 const dec = () => {};
 class Foo {
   static set a(v) {
@@ -8,9 +8,9 @@ class Foo {
     return this.value = v;
   }
 }
-_class = Foo;
+_Foo = Foo;
 (() => {
-  [_initStatic] = babelHelpers.applyDecs2305(_class, [[dec, 12, "a"], [dec, 12, 'b']], []).e;
-  _initStatic(_class);
+  [_initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 12, "a"], [dec, 12, 'b']], []).e;
+  _initStatic(_Foo);
 })();
 babelHelpers.defineProperty(Foo, "value", 1);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/private/output.js
@@ -6,7 +6,7 @@ class Foo {
       return this.value = v;
     }]], [], 0, _ => #a in _).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/public/output.js
@@ -4,7 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
   }
-  constructor(...args) {
+  constructor() {
     _initProto(this);
   }
   value = 1;

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/array-rest-destructuring-middle/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/array-rest-destructuring-middle/output.js
@@ -1,7 +1,7 @@
-var _class;
+var _C;
 let x, y, z;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: void 0
@@ -12,5 +12,5 @@ var _x = {
     y
   }, _p, ..._p2] = [{
     y: 1
-  }, _class], _m = babelHelpers.classStaticPrivateFieldSpecGet(_p, _class, _x), x = _m === void 0 ? y : _m, z = _p2;
+  }, _C], _m = babelHelpers.classStaticPrivateFieldSpecGet(_p, _C, _x), x = _m === void 0 ? y : _m, z = _p2;
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/array-rest-only/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/array-rest-only/output.js
@@ -1,8 +1,8 @@
-var _class;
+var _C;
 const _excluded = ["0"];
 let result;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: void 0
@@ -10,7 +10,7 @@ var _x = {
 (() => {
   var _p, _m;
   var x, z;
-  [..._p] = [_class], _m = babelHelpers.classStaticPrivateFieldSpecGet(_p[0], _class, _x), x = _m === void 0 ? 1 : _m, z = babelHelpers.objectWithoutProperties(_p, _excluded);
+  [..._p] = [_C], _m = babelHelpers.classStaticPrivateFieldSpecGet(_p[0], _C, _x), x = _m === void 0 ? 1 : _m, z = babelHelpers.objectWithoutProperties(_p, _excluded);
   result = {
     x,
     z

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/array-rest/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/array-rest/output.js
@@ -1,12 +1,12 @@
-var _class;
+var _C;
 let x, z;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: void 0
 };
 (() => {
   var _p, _p2, _m;
-  [_p, ..._p2] = [_class], _m = babelHelpers.classStaticPrivateFieldSpecGet(_p, _class, _x), x = _m === void 0 ? 1 : _m, z = _p2;
+  [_p, ..._p2] = [_C], _m = babelHelpers.classStaticPrivateFieldSpecGet(_p, _C, _x), x = _m === void 0 ? 1 : _m, z = _p2;
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/basic/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/basic/output.js
@@ -1,7 +1,7 @@
-var _class;
+var _C;
 let a, x, b;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: void 0
@@ -10,7 +10,7 @@ var _x = {
   var _m;
   ({
     a = 1
-  } = _class), _m = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x), x = _m === void 0 ? 2 : _m, ({
+  } = _C), _m = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x), x = _m === void 0 ? 2 : _m, ({
     b = 3
-  } = _class);
+  } = _C);
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/completion-do-expression/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/completion-do-expression/output.js
@@ -1,12 +1,12 @@
-var _class;
+var _C;
 var result;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: void 0
 };
 ((_m, _m2) => {
   var x;
-  result = (_m = _class, _m2 = babelHelpers.classStaticPrivateFieldSpecGet(_m, _class, _x), x = _m2 === void 0 ? 2 : _m2, _m);
+  result = (_m = _C, _m2 = babelHelpers.classStaticPrivateFieldSpecGet(_m, _C, _x), x = _m2 === void 0 ? 2 : _m2, _m);
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/member-expression/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/member-expression/output.js
@@ -1,7 +1,7 @@
-var _class;
+var _C;
 let x;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: void 0
@@ -17,5 +17,5 @@ var _z = {
 (() => {
   var _p, _p2;
   let z;
-  [babelHelpers.classStaticPrivateFieldDestructureSet(_class, _class, _x).value, _p, ..._p2] = [0, _class], x = babelHelpers.classStaticPrivateFieldSpecGet(_p, _class, _x), z = _p2;
+  [babelHelpers.classStaticPrivateFieldDestructureSet(_C, _C, _x).value, _p, ..._p2] = [0, _C], x = babelHelpers.classStaticPrivateFieldSpecGet(_p, _C, _x), z = _p2;
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/nested-under-array-pattern/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/nested-under-array-pattern/output.js
@@ -1,8 +1,8 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 function _self() {
-  return _class;
+  return _C;
 }
 var _x = {
   writable: true,
@@ -16,9 +16,9 @@ var _z = {
   writable: true,
   value: void 0
 };
-babelHelpers.defineProperty(C, "self", _class);
+babelHelpers.defineProperty(C, "self", _C);
 (() => {
   var _p, _p2, _p3, _p4, _m;
   let x, y, z;
-  [_p, _p2,, _p3] = [_class, _class], x = babelHelpers.classStaticPrivateFieldSpecGet(_p === void 0 ? _class.self : _p, _class, _x), [, _p4] = babelHelpers.classStaticPrivateFieldSpecGet(_p2, _class, _y), _m = babelHelpers.classStaticPrivateFieldSpecGet(_p4 === void 0 ? _class.self : _p4, _class, _z), y = _m === void 0 ? babelHelpers.classStaticPrivateMethodGet(_class, _class, _self).call(_class) : _m, z = _p3 === void 0 ? babelHelpers.classStaticPrivateFieldSpecGet(y, _class, _y) : _p3;
+  [_p, _p2,, _p3] = [_C, _C], x = babelHelpers.classStaticPrivateFieldSpecGet(_p === void 0 ? _C.self : _p, _C, _x), [, _p4] = babelHelpers.classStaticPrivateFieldSpecGet(_p2, _C, _y), _m = babelHelpers.classStaticPrivateFieldSpecGet(_p4 === void 0 ? _C.self : _p4, _C, _z), y = _m === void 0 ? babelHelpers.classStaticPrivateMethodGet(_C, _C, _self).call(_C) : _m, z = _p3 === void 0 ? babelHelpers.classStaticPrivateFieldSpecGet(y, _C, _y) : _p3;
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/nested/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/nested/output.js
@@ -1,6 +1,6 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 var _y = {
   writable: true,
   value: "y"
@@ -14,17 +14,17 @@ var _x = {
   value: void 0
 };
 babelHelpers.defineProperty(C, "b", "b");
-babelHelpers.defineProperty(C, "self", _class);
+babelHelpers.defineProperty(C, "self", _C);
 var _self = {
   writable: true,
-  value: _class
+  value: _C
 };
 (() => {
   var _m, _m2, _m3, _m4, _m5;
   let cloned, b, y, yy, yy2;
-  _m = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x), _m2 = _m === void 0 ? babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _self) : _m, _m3 = _m2[babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _z)], ({
+  _m = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x), _m2 = _m === void 0 ? babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _self) : _m, _m3 = _m2[babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _z)], ({
     b
-  } = _m3), _m4 = babelHelpers.classStaticPrivateFieldSpecGet(_m3, _class, _x), y = _m4 === void 0 ? (_class.b = "bb", babelHelpers.classStaticPrivateFieldSpecGet(babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _self), _class, _y)) : _m4, _m5 = babelHelpers.classStaticPrivateFieldSpecGet(_m2, _class, _x), yy = _m5 === void 0 ? (delete _class.self, ({
+  } = _m3), _m4 = babelHelpers.classStaticPrivateFieldSpecGet(_m3, _C, _x), y = _m4 === void 0 ? (_C.b = "bb", babelHelpers.classStaticPrivateFieldSpecGet(babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _self), _C, _y)) : _m4, _m5 = babelHelpers.classStaticPrivateFieldSpecGet(_m2, _C, _x), yy = _m5 === void 0 ? (delete _C.self, ({
     ...cloned
-  } = _class), babelHelpers.classStaticPrivateFieldSpecSet(_class, _class, _y, "yy")) : _m5, yy2 = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _y);
+  } = _C), babelHelpers.classStaticPrivateFieldSpecSet(_C, _C, _y, "yy")) : _m5, yy2 = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _y);
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-and-keys/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-and-keys/output.js
@@ -1,8 +1,8 @@
 const _excluded = ["y"];
-var _class;
+var _C;
 let result;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: "#x"
@@ -14,11 +14,11 @@ var _y = {
 babelHelpers.defineProperty(C, "a", "a");
 babelHelpers.defineProperty(C, "b", "b");
 babelHelpers.defineProperty(C, "c", "c");
-(_class2 => {
+(_C2 => {
   let x, y, z;
-  x = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x), (_class2 = _class, ({
+  x = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x), (_C2 = _C, ({
     y
-  } = _class2), z = babelHelpers.objectWithoutProperties(_class2, _excluded), _class2);
+  } = _C2), z = babelHelpers.objectWithoutProperties(_C2, _excluded), _C2);
   result = {
     x,
     y,

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-and-private-keys/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-and-private-keys/output.js
@@ -1,7 +1,7 @@
-var _class;
+var _C;
 let result;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: "#x"
@@ -13,9 +13,9 @@ var _y = {
 babelHelpers.defineProperty(C, "a", "a");
 babelHelpers.defineProperty(C, "b", "b");
 babelHelpers.defineProperty(C, "c", "c");
-(_class2 => {
+(_C2 => {
   let x, y, z;
-  x = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x), y = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _y), (_class2 = _class, ({} = _class2), z = Object.assign({}, (babelHelpers.objectDestructuringEmpty(_class2), _class2)), _class2);
+  x = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x), y = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _y), (_C2 = _C, ({} = _C2), z = Object.assign({}, (babelHelpers.objectDestructuringEmpty(_C2), _C2)), _C2);
   result = {
     x,
     y,

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-under-private/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest-under-private/output.js
@@ -1,20 +1,20 @@
 const _excluded = ["y"];
-var _class;
+var _C;
 let result;
 class C {}
-_class = C;
+_C = C;
 babelHelpers.defineProperty(C, "x", "x");
 babelHelpers.defineProperty(C, "y", "y");
 babelHelpers.defineProperty(C, "z", "z");
 var _x = {
   writable: true,
-  value: _class
+  value: _C
 };
 (_babelHelpers$classSt => {
   var x, y, z;
   ({
     x
-  } = _class), (_babelHelpers$classSt = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x), ({
+  } = _C), (_babelHelpers$classSt = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x), ({
     y
   } = _babelHelpers$classSt), z = babelHelpers.objectWithoutProperties(_babelHelpers$classSt, _excluded), _babelHelpers$classSt);
   result = {

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/object-rest/output.js
@@ -1,7 +1,7 @@
-var _class;
+var _C;
 let result;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: "#x"
@@ -17,10 +17,10 @@ babelHelpers.defineProperty(C, "c", "c");
   var _m, _m2;
   var a, b, x, y, z;
   ({
-    [_m = _class.a]: a
-  } = _class), x = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x), ({
-    [_m2 = _class.b]: b
-  } = _class), y = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _y), z = babelHelpers.objectWithoutProperties(_class, [_m, _m2].map(babelHelpers.toPropertyKey));
+    [_m = _C.a]: a
+  } = _C), x = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x), ({
+    [_m2 = _C.b]: b
+  } = _C), y = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _y), z = babelHelpers.objectWithoutProperties(_C, [_m, _m2].map(babelHelpers.toPropertyKey));
   result = {
     a,
     b,

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/under-param-initializer/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assignment--es2015/under-param-initializer/output.js
@@ -1,11 +1,11 @@
-var _m2, _class;
+var _m2, _C;
 let a;
 class C {
   static m(r = (_m2 = C, ({
     a
   } = babelHelpers.classStaticPrivateFieldSpecGet(_m2, C, _x)), _m2)) {}
 }
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: {
@@ -16,8 +16,8 @@ var _x = {
 (() => {
   var _m;
   let b;
-  (function f(r = (_m = _class, ({
+  (function f(r = (_m = _C, ({
     b
-  } = babelHelpers.classStaticPrivateFieldSpecGet(_m, _class, _x)), _m)) {})();
+  } = babelHelpers.classStaticPrivateFieldSpecGet(_m, _C, _x)), _m)) {})();
 })();
 C.m();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assumption-objectRestNoSymbols/variable-declaration/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/assumption-objectRestNoSymbols/variable-declaration/output.js
@@ -1,7 +1,7 @@
-var _class;
+var _C;
 let result;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: "#x"
@@ -16,14 +16,14 @@ babelHelpers.defineProperty(C, "c", "c");
 (() => {
   var _m, _m2;
   var {
-      [_m = _class.a]: a
-    } = _class,
-    x = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x),
+      [_m = _C.a]: a
+    } = _C,
+    x = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x),
     {
-      [_m2 = _class.b]: b
-    } = _class,
-    y = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _y),
-    z = babelHelpers.objectWithoutPropertiesLoose(_class, [_m, _m2].map(babelHelpers.toPropertyKey));
+      [_m2 = _C.b]: b
+    } = _C,
+    y = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _y),
+    z = babelHelpers.objectWithoutPropertiesLoose(_C, [_m, _m2].map(babelHelpers.toPropertyKey));
   result = {
     a,
     b,

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/catch-param--es2015/no-shadowed-params/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/catch-param--es2015/no-shadowed-params/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _C;
 var x;
 var _x = /*#__PURE__*/new WeakMap();
 class C {
@@ -9,11 +9,11 @@ class C {
     });
   }
 }
-_class = C;
+_C = C;
 (() => {
   x = "x";
   try {
-    throw new _class();
+    throw new _C();
   } catch (_e) {
     let x = babelHelpers.classPrivateFieldGet(_e, _x);
   }

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-init--es2015/lhs-with-assign/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-init--es2015/lhs-with-assign/output.js
@@ -1,13 +1,13 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: 42
 };
 (() => {
   let x, y;
-  for (_m = (_m2 = _class, y = babelHelpers.classStaticPrivateFieldSpecGet(_m2, _class, _x), _m2), x = babelHelpers.classStaticPrivateFieldSpecGet(_m, _class, _x), _m;;) {
+  for (_m = (_m2 = _C, y = babelHelpers.classStaticPrivateFieldSpecGet(_m2, _C, _x), _m2), x = babelHelpers.classStaticPrivateFieldSpecGet(_m, _C, _x), _m;;) {
     var _m, _m2;
     break;
   }

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-init--es2015/lhs/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-init--es2015/lhs/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _C;
 var _x = /*#__PURE__*/new WeakMap();
 class C {
   constructor() {
@@ -8,9 +8,9 @@ class C {
     });
   }
 }
-_class = C;
+_C = C;
 (() => {
-  for (_m = _class, x = babelHelpers.classPrivateFieldGet(_m, _x), _m;;) {
+  for (_m = _C, x = babelHelpers.classPrivateFieldGet(_m, _x), _m;;) {
     var _m;
     break;
   }

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-init--es2015/variable-declaration-with-assign/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-init--es2015/variable-declaration-with-assign/output.js
@@ -1,13 +1,13 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: 42
 };
 (() => {
   let y;
-  for (let x = babelHelpers.classStaticPrivateFieldSpecGet((_m = _class, y = babelHelpers.classStaticPrivateFieldSpecGet(_m, _class, _x), _m), _class, _x);;) {
+  for (let x = babelHelpers.classStaticPrivateFieldSpecGet((_m = _C, y = babelHelpers.classStaticPrivateFieldSpecGet(_m, _C, _x), _m), _C, _x);;) {
     var _m;
     break;
   }

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-init--es2015/variable-declaration/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-init--es2015/variable-declaration/output.js
@@ -1,12 +1,12 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: void 0
 };
 (() => {
-  for (let x = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x);;) {
+  for (let x = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x);;) {
     break;
   }
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-of--es2015/lhs-with-shadowed-block-scoped/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-of--es2015/lhs-with-shadowed-block-scoped/output.js
@@ -1,6 +1,6 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 babelHelpers.defineProperty(C, "a", "a");
 var _x = {
   writable: true,
@@ -9,8 +9,8 @@ var _x = {
 (() => {
   var x,
     a = "a";
-  for (const _ref of [_class]) {
-    x = babelHelpers.classStaticPrivateFieldSpecGet(_ref, _class, _x), ({
+  for (const _ref of [_C]) {
+    x = babelHelpers.classStaticPrivateFieldSpecGet(_ref, _C, _x), ({
       [a]: a
     } = _ref);
     {

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-of--es2015/lhs/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-of--es2015/lhs/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _C;
 var _x = /*#__PURE__*/new WeakMap();
 class C {
   constructor() {
@@ -8,9 +8,9 @@ class C {
     });
   }
 }
-_class = C;
+_C = C;
 (() => {
-  for (const _ref of [_class]) {
+  for (const _ref of [_C]) {
     x = babelHelpers.classPrivateFieldGet(_ref, _x);
     ;
   }

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-of--es2015/variable-declaration-block-scoped/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-of--es2015/variable-declaration-block-scoped/output.js
@@ -1,6 +1,6 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 babelHelpers.defineProperty(C, "a", "a");
 var _x = {
   writable: true,
@@ -8,8 +8,8 @@ var _x = {
 };
 (() => {
   const a = "a";
-  for (const _ref of [_class]) {
-    const x = babelHelpers.classStaticPrivateFieldSpecGet(_ref, _class, _x),
+  for (const _ref of [_C]) {
+    const x = babelHelpers.classStaticPrivateFieldSpecGet(_ref, _C, _x),
       {
         [a]: _
       } = _ref;

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-of--es2015/variable-declaration/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/for-of--es2015/variable-declaration/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _C;
 var _x = /*#__PURE__*/new WeakMap();
 class C {
   constructor() {
@@ -8,9 +8,9 @@ class C {
     });
   }
 }
-_class = C;
+_C = C;
 (() => {
-  for (const _ref of [_class]) {
+  for (const _ref of [_C]) {
     const x = babelHelpers.classPrivateFieldGet(_ref, _x);
     ;
   }

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/array-rest-only/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/array-rest-only/output.js
@@ -1,15 +1,15 @@
-var _class;
+var _C;
 const _excluded = ["0"];
 let result;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: void 0
 };
 (() => {
-  var [..._p] = [_class],
-    _m = babelHelpers.classStaticPrivateFieldSpecGet(_p[0], _class, _x),
+  var [..._p] = [_C],
+    _m = babelHelpers.classStaticPrivateFieldSpecGet(_p[0], _C, _x),
     x = _m === void 0 ? 1 : _m,
     z = babelHelpers.objectWithoutProperties(_p, _excluded);
   result = {

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/array-rest/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/array-rest/output.js
@@ -1,13 +1,13 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: void 0
 };
 (() => {
-  var [_p, ..._p2] = [_class],
-    _m = babelHelpers.classStaticPrivateFieldSpecGet(_p, _class, _x),
+  var [_p, ..._p2] = [_C],
+    _m = babelHelpers.classStaticPrivateFieldSpecGet(_p, _C, _x),
     x = _m === void 0 ? 1 : _m,
     z = _p2;
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/basic/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/basic/output.js
@@ -1,6 +1,6 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: void 0
@@ -8,10 +8,10 @@ var _x = {
 (() => {
   var {
       a = 1
-    } = _class,
-    _m = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x),
+    } = _C,
+    _m = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x),
     x = _m === void 0 ? 2 : _m,
     {
       b = 3
-    } = _class;
+    } = _C;
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/nested-under-array-pattern/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/nested-under-array-pattern/output.js
@@ -1,8 +1,8 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 function _self() {
-  return _class;
+  return _C;
 }
 var _x = {
   writable: true,
@@ -16,12 +16,12 @@ var _z = {
   writable: true,
   value: void 0
 };
-babelHelpers.defineProperty(C, "self", _class);
+babelHelpers.defineProperty(C, "self", _C);
 (() => {
-  var [_p, _p2,, _p3] = [_class, _class],
-    x = babelHelpers.classStaticPrivateFieldSpecGet(_p === void 0 ? _class.self : _p, _class, _x),
-    [, _p4] = babelHelpers.classStaticPrivateFieldSpecGet(_p2, _class, _y),
-    _m = babelHelpers.classStaticPrivateFieldSpecGet(_p4 === void 0 ? _class.self : _p4, _class, _z),
-    y = _m === void 0 ? babelHelpers.classStaticPrivateMethodGet(_class, _class, _self).call(_class) : _m,
-    z = _p3 === void 0 ? babelHelpers.classStaticPrivateFieldSpecGet(y, _class, _y) : _p3;
+  var [_p, _p2,, _p3] = [_C, _C],
+    x = babelHelpers.classStaticPrivateFieldSpecGet(_p === void 0 ? _C.self : _p, _C, _x),
+    [, _p4] = babelHelpers.classStaticPrivateFieldSpecGet(_p2, _C, _y),
+    _m = babelHelpers.classStaticPrivateFieldSpecGet(_p4 === void 0 ? _C.self : _p4, _C, _z),
+    y = _m === void 0 ? babelHelpers.classStaticPrivateMethodGet(_C, _C, _self).call(_C) : _m,
+    z = _p3 === void 0 ? babelHelpers.classStaticPrivateFieldSpecGet(y, _C, _y) : _p3;
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/nested/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/nested/output.js
@@ -1,6 +1,6 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 var _y = {
   writable: true,
   value: "y"
@@ -14,24 +14,24 @@ var _x = {
   value: void 0
 };
 babelHelpers.defineProperty(C, "b", "b");
-babelHelpers.defineProperty(C, "self", _class);
+babelHelpers.defineProperty(C, "self", _C);
 var _self = {
   writable: true,
-  value: _class
+  value: _C
 };
 (() => {
   let cloned;
-  var _m = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x),
-    _m2 = _m === void 0 ? babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _self) : _m,
-    _m3 = _m2[babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _z)],
+  var _m = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x),
+    _m2 = _m === void 0 ? babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _self) : _m,
+    _m3 = _m2[babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _z)],
     {
       b
     } = _m3,
-    _m4 = babelHelpers.classStaticPrivateFieldSpecGet(_m3, _class, _x),
-    y = _m4 === void 0 ? (_class.b = "bb", babelHelpers.classStaticPrivateFieldSpecGet(babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _self), _class, _y)) : _m4,
-    _m5 = babelHelpers.classStaticPrivateFieldSpecGet(_m2, _class, _x),
-    yy = _m5 === void 0 ? (delete _class.self, ({
+    _m4 = babelHelpers.classStaticPrivateFieldSpecGet(_m3, _C, _x),
+    y = _m4 === void 0 ? (_C.b = "bb", babelHelpers.classStaticPrivateFieldSpecGet(babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _self), _C, _y)) : _m4,
+    _m5 = babelHelpers.classStaticPrivateFieldSpecGet(_m2, _C, _x),
+    yy = _m5 === void 0 ? (delete _C.self, ({
       ...cloned
-    } = _class), babelHelpers.classStaticPrivateFieldSpecSet(_class, _class, _y, "yy")) : _m5,
-    yy2 = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _y);
+    } = _C), babelHelpers.classStaticPrivateFieldSpecSet(_C, _C, _y, "yy")) : _m5,
+    yy2 = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _y);
 })();

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/object-rest-and-keys/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/object-rest-and-keys/output.js
@@ -1,8 +1,8 @@
 const _excluded = ["y"];
-var _class;
+var _C;
 let result;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: "#x"
@@ -12,11 +12,11 @@ babelHelpers.defineProperty(C, "a", "a");
 babelHelpers.defineProperty(C, "b", "b");
 babelHelpers.defineProperty(C, "c", "c");
 (() => {
-  var x = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x),
+  var x = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x),
     {
       y
-    } = _class,
-    z = babelHelpers.objectWithoutProperties(_class, _excluded);
+    } = _C,
+    z = babelHelpers.objectWithoutProperties(_C, _excluded);
   result = {
     x,
     y,

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/object-rest-and-private-keys/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/object-rest-and-private-keys/output.js
@@ -1,7 +1,7 @@
-var _class;
+var _C;
 let result;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: "#x"
@@ -14,9 +14,9 @@ babelHelpers.defineProperty(C, "a", "a");
 babelHelpers.defineProperty(C, "b", "b");
 babelHelpers.defineProperty(C, "c", "c");
 (() => {
-  var x = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x),
-    y = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _y),
-    z = Object.assign({}, (babelHelpers.objectDestructuringEmpty(_class), _class));
+  var x = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x),
+    y = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _y),
+    z = Object.assign({}, (babelHelpers.objectDestructuringEmpty(_C), _C));
   result = {
     x,
     y,

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/object-rest-under-private/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/object-rest-under-private/output.js
@@ -1,20 +1,20 @@
 const _excluded = ["y"];
-var _class;
+var _C;
 let result;
 class C {}
-_class = C;
+_C = C;
 babelHelpers.defineProperty(C, "x", "x");
 babelHelpers.defineProperty(C, "y", "y");
 babelHelpers.defineProperty(C, "z", "z");
 var _x = {
   writable: true,
-  value: _class
+  value: _C
 };
 (() => {
   var {
       x
-    } = _class,
-    _babelHelpers$classSt = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x),
+    } = _C,
+    _babelHelpers$classSt = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x),
     {
       y
     } = _babelHelpers$classSt,

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/object-rest/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration--es2015/object-rest/output.js
@@ -1,7 +1,7 @@
-var _class;
+var _C;
 let result;
 class C {}
-_class = C;
+_C = C;
 var _x = {
   writable: true,
   value: "#x"
@@ -16,14 +16,14 @@ babelHelpers.defineProperty(C, "c", "c");
 (() => {
   var _m, _m2;
   var {
-      [_m = _class.a]: a
-    } = _class,
-    x = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _x),
+      [_m = _C.a]: a
+    } = _C,
+    x = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _x),
     {
-      [_m2 = _class.b]: b
-    } = _class,
-    y = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _y),
-    z = babelHelpers.objectWithoutProperties(_class, [_m, _m2].map(babelHelpers.toPropertyKey));
+      [_m2 = _C.b]: b
+    } = _C,
+    y = babelHelpers.classStaticPrivateFieldSpecGet(_C, _C, _y),
+    z = babelHelpers.objectWithoutProperties(_C, [_m, _m2].map(babelHelpers.toPropertyKey));
   result = {
     a,
     b,

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/class-decorator/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/class-decorator/output.js
@@ -1,12 +1,12 @@
-var _initClass, _decorated_class, _class;
+var _initClass, _decorated_class, _Class;
 const expectedValue = 42;
 function decorator(target) {
   target.decoratorValue = expectedValue;
 }
-const result = ((_class = class {
+const result = ((_Class = class {
   constructor() {
     this.value = expectedValue;
   }
-}, [_decorated_class, _initClass] = babelHelpers.applyDecs2305(_class, [], [decorator]).c, _initClass()), _decorated_class);
+}, [_decorated_class, _initClass] = babelHelpers.applyDecs2305(_Class, [], [decorator]).c, _initClass()), _decorated_class);
 expect(result.decoratorValue).toBe(expectedValue);
 expect(new result().value).toBe(expectedValue);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/class-decorator/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/class-decorator/output.js
@@ -1,12 +1,12 @@
-var _initClass, _decorated_class, _class;
+var _initClass, _decorated_class, _Class;
 const expectedValue = 42;
 function decorator(target) {
   target.decoratorValue = expectedValue;
 }
-const result = ((_class = class {
+const result = ((_Class = class {
   constructor() {
     this.value = expectedValue;
   }
-}, [_decorated_class, _initClass] = babelHelpers.applyDecs2305(_class, [], [decorator]).c, _initClass()), _decorated_class);
+}, [_decorated_class, _initClass] = babelHelpers.applyDecs2305(_Class, [], [decorator]).c, _initClass()), _decorated_class);
 expect(result.decoratorValue).toBe(expectedValue);
 expect(new result().value).toBe(expectedValue);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-noDocumentAll/optional-chain-before-member-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-noDocumentAll/optional-chain-before-member-call/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -59,7 +59,7 @@ class Foo {
     (_getSelf6 = (fn == null ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self))?.getSelf?.()) == null ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf6$self = _getSelf6.self, Foo, _m).call(_getSelf6$self);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
@@ -67,12 +67,12 @@ var _x = {
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/non-block-arrow-func/output.mjs
@@ -1,11 +1,11 @@
 export default (param => {
-  var _class;
-  return _class = class App {
+  var _App;
+  return _App = class App {
     getParam() {
       return param;
     }
-  }, _class.props = {
+  }, _App.props = {
     prop1: 'prop1',
     prop2: 'prop2'
-  }, _class;
+  }, _App;
 });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T2983/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T2983/output.mjs
@@ -1,5 +1,5 @@
-var _class;
-call((_class = class {}, _class.test = true, _class));
-export default class _class2 {}
-_class2.test = true;
+var _Class;
+call((_Class = class {}, _Class.test = true, _Class));
+export default class _Class2 {}
+_Class2.test = true;
 ;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T6719/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T6719/output.js
@@ -1,10 +1,10 @@
 function withContext(ComposedComponent) {
-  var _class;
-  return _class = class WithContext extends Component {}, _class.propTypes = {
+  var _WithContext;
+  return _WithContext = class WithContext extends Component {}, _WithContext.propTypes = {
     context: PropTypes.shape({
       addCss: PropTypes.func,
       setTitle: PropTypes.func,
       setMeta: PropTypes.func
     })
-  }, _class;
+  }, _WithContext;
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/static-class-binding/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/static-class-binding/output.js
@@ -1,5 +1,5 @@
-var _class;
+var _A;
 class A {}
-_class = A;
-A.self = _class;
-A.getA = () => _class;
+_A = A;
+A.self = _A;
+A.getA = () => _A;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/static-infer-name/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/static-infer-name/output.js
@@ -1,2 +1,2 @@
-var _class;
-var Foo = (_class = class Foo {}, _class.num = 0, _class);
+var _Class;
+var Foo = (_Class = class Foo {}, _Class.num = 0, _Class);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/static-super/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/static-super/output.js
@@ -1,8 +1,8 @@
-var _class2;
+var _B;
 class A {}
 A.prop = 1;
 class B extends A {}
-_class2 = B;
+_B = B;
 B.prop = 2;
-B.propA = babelHelpers.get(babelHelpers.getPrototypeOf(_class2), "prop", _class2);
-B.getPropA = () => babelHelpers.get(babelHelpers.getPrototypeOf(_class2), "prop", _class2);
+B.propA = babelHelpers.get(babelHelpers.getPrototypeOf(_B), "prop", _B);
+B.getPropA = () => babelHelpers.get(babelHelpers.getPrototypeOf(_B), "prop", _B);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/static-this/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/static-this/output.js
@@ -1,5 +1,5 @@
-var _class;
+var _A;
 class A {}
-_class = A;
-A.self = _class;
-A.getA = () => _class;
+_A = A;
+A.self = _A;
+A.getA = () => _A;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
@@ -7,7 +7,7 @@ let Hello = /*#__PURE__*/babelHelpers.createClass(function Hello() {
 let Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
   function Outer() {
-    var _dec, _init_hello, _class;
+    var _dec, _init_hello, _Inner;
     var _this;
     babelHelpers.classCallCheck(this, Outer);
     _dec = _this = babelHelpers.callSuper(this, Outer);
@@ -15,8 +15,8 @@ let Outer = /*#__PURE__*/function (_Hello) {
       babelHelpers.classCallCheck(this, Inner);
       babelHelpers.defineProperty(this, "hello", _init_hello(this));
     });
-    _class = Inner;
-    [_init_hello] = babelHelpers.applyDecs2305(_class, [[_dec, 0, "hello"]], []).e;
+    _Inner = Inner;
+    [_init_hello] = babelHelpers.applyDecs2305(_Inner, [[_dec, 0, "hello"]], []).e;
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
   return babelHelpers.createClass(Outer);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
@@ -15,7 +15,7 @@ let Hello = /*#__PURE__*/function () {
 let Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
   function Outer() {
-    var _dec, _init_hello, _class;
+    var _dec, _init_hello, _Inner;
     var _thisSuper, _this;
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.callSuper(this, Outer);
@@ -24,8 +24,8 @@ let Outer = /*#__PURE__*/function (_Hello) {
       babelHelpers.classCallCheck(this, Inner);
       babelHelpers.defineProperty(this, "hello", _init_hello(this));
     });
-    _class = Inner;
-    [_init_hello] = babelHelpers.applyDecs2305(_class, [[_dec, 0, "hello"]], []).e;
+    _Inner = Inner;
+    [_init_hello] = babelHelpers.applyDecs2305(_Inner, [[_dec, 0, "hello"]], []).e;
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
   return babelHelpers.createClass(Outer);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/class-shadow-builtins/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/class-shadow-builtins/output.mjs
@@ -1,7 +1,7 @@
 function _classPrivateFieldInitSpec(obj, privateMap, value) { _checkPrivateRedeclaration(obj, privateMap); privateMap.set(obj, value); }
 function _checkPrivateRedeclaration(obj, privateCollection) { if (privateCollection.has(obj)) { throw new TypeError("Cannot initialize the same private elements twice on an object"); } }
 var _message = /*#__PURE__*/new WeakMap();
-class _TypeError {
+class _TypeError2 {
   constructor() {
     _classPrivateFieldInitSpec(this, _message, {
       writable: true,
@@ -9,4 +9,4 @@ class _TypeError {
     });
   }
 }
-export { _TypeError as TypeError };
+export { _TypeError2 as TypeError };

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/derived/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/derived/output.js
@@ -9,10 +9,10 @@ var Foo = /*#__PURE__*/babelHelpers.createClass(function Foo() {
   });
 });
 var _prop2 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("prop");
-var Bar = /*#__PURE__*/function (_Foo) {
+var Bar = /*#__PURE__*/function (_Foo2) {
   "use strict";
 
-  babelHelpers.inherits(Bar, _Foo);
+  babelHelpers.inherits(Bar, _Foo2);
   function Bar(...args) {
     var _this;
     babelHelpers.classCallCheck(this, Bar);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
@@ -29,15 +29,15 @@ var Foo = /*#__PURE__*/function () {
         }
         return babelHelpers.createClass(Nested);
       }((_foo3 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), _babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo3)[_foo3], /*#__PURE__*/function () {
-        function _class4() {
-          babelHelpers.classCallCheck(this, _class4);
+        function _class() {
+          babelHelpers.classCallCheck(this, _class);
           Object.defineProperty(this, _foo3, {
             writable: true,
             value: 2
           });
           this[_babelHelpers$classPr] = 2;
         }
-        return babelHelpers.createClass(_class4);
+        return babelHelpers.createClass(_class);
       }()));
     }
   }]);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
@@ -28,11 +28,11 @@ var Foo = /*#__PURE__*/function () {
         }
         return babelHelpers.createClass(Nested);
       }((_babelHelpers$classPr = babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo], /*#__PURE__*/function () {
-        function _class4() {
-          babelHelpers.classCallCheck(this, _class4);
+        function _class() {
+          babelHelpers.classCallCheck(this, _class);
           this[_babelHelpers$classPr] = 2;
         }
-        return babelHelpers.createClass(_class4);
+        return babelHelpers.createClass(_class);
       }()));
     }
   }]);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/non-block-arrow-func/output.mjs
@@ -1,14 +1,14 @@
 export default (param => {
-  var _class, _props;
-  return _props = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("props"), (_class = class App {
+  var _App, _props;
+  return _props = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("props"), (_App = class App {
     getParam() {
       return param;
     }
-  }, Object.defineProperty(_class, _props, {
+  }, Object.defineProperty(_App, _props, {
     writable: true,
     value: {
       prop1: 'prop1',
       prop2: 'prop2'
     }
-  }), _class);
+  }), _App);
 });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-before-member-call-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-before-member-call-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
@@ -62,7 +62,7 @@ class Foo {
     (_getSelf6 = (_ref22 = fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self]) == null || _ref22.getSelf == null ? void 0 : _ref22.getSelf()) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf6.self, _m)[_m]();
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
@@ -75,7 +75,7 @@ Object.defineProperty(Foo, _m, {
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-before-member-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-before-member-call/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
@@ -62,7 +62,7 @@ class Foo {
     (_getSelf6 = (fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self])?.getSelf?.()) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf6.self, _m)[_m]();
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
@@ -75,7 +75,7 @@ Object.defineProperty(Foo, _m, {
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-before-property-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-before-property-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 class Foo {
@@ -61,14 +61,14 @@ class Foo {
     (_getSelf6 = (_ref22 = fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self]) == null || _ref22.getSelf == null ? void 0 : _ref22.getSelf()) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf6.self, _x)[_x];
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-before-property/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-before-property/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 class Foo {
@@ -61,14 +61,14 @@ class Foo {
     (_getSelf6 = (fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self])?.getSelf?.()) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf6.self, _x)[_x];
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-delete-property-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-delete-property-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 class Foo {
@@ -53,14 +53,14 @@ class Foo {
     (_ref20 = fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self]) == null || _ref20.getSelf == null || (_ref20 = _ref20.getSelf()) == null || delete _ref20.self.unicorn;
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-delete-property/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-delete-property/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 class Foo {
@@ -53,14 +53,14 @@ class Foo {
     delete (fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self])?.getSelf?.()?.self.unicorn;
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-in-function-param-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-in-function-param-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
@@ -43,7 +43,7 @@ class Foo {
     j(fn);
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
@@ -56,7 +56,7 @@ Object.defineProperty(Foo, _m, {
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-in-function-param/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-in-function-param/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
@@ -43,7 +43,7 @@ class Foo {
     j(fn);
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
@@ -56,7 +56,7 @@ Object.defineProperty(Foo, _m, {
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
@@ -65,7 +65,7 @@ class Foo {
     (_getSelf6 = (_ref28 = fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self]) == null || _ref28.getSelf == null ? void 0 : _ref28.getSelf()) === null || _getSelf6 === void 0 ? void 0 : (_babelHelpers$classPr79 = (_babelHelpers$classPr80 = babelHelpers.classPrivateFieldLooseBase(_getSelf6.self, _m))[_m]) == null ? void 0 : _babelHelpers$classPr79.call(_babelHelpers$classPr80);
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
@@ -78,7 +78,7 @@ Object.defineProperty(Foo, _m, {
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-member-optional-call/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
@@ -65,7 +65,7 @@ class Foo {
     (_getSelf6 = (fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self])?.getSelf?.()) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf6.self, _m)[_m]?.();
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
@@ -78,7 +78,7 @@ Object.defineProperty(Foo, _m, {
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-optional-member-call-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-optional-member-call-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
@@ -65,7 +65,7 @@ class Foo {
     (_getSelf$self4 = (_ref26 = fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self]) == null || _ref26.getSelf == null || (_ref26 = _ref26.getSelf()) == null ? void 0 : _ref26.self) === null || _getSelf$self4 === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf$self4, _m)[_m]();
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
@@ -78,7 +78,7 @@ Object.defineProperty(Foo, _m, {
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-optional-member-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-optional-member-call/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
@@ -65,7 +65,7 @@ class Foo {
     (_getSelf6 = (fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self])?.getSelf?.()) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf6.self, _m)[_m]();
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
@@ -78,7 +78,7 @@ Object.defineProperty(Foo, _m, {
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-optional-property-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-optional-property-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 class Foo {
@@ -64,14 +64,14 @@ class Foo {
     (_getSelf$self4 = (_ref26 = fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self]) == null || _ref26.getSelf == null || (_ref26 = _ref26.getSelf()) == null ? void 0 : _ref26.self) === null || _getSelf$self4 === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf$self4, _x)[_x];
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-optional-property/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/optional-chain-optional-property/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 class Foo {
@@ -64,14 +64,14 @@ class Foo {
     (_getSelf$self4 = (fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self])?.getSelf?.()?.self) === null || _getSelf$self4 === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_getSelf$self4, _x)[_x];
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/parenthesized-optional-member-call-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/parenthesized-optional-member-call-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _m = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("m");
 class Foo {
@@ -25,12 +25,12 @@ class Foo {
     ((_fn$Foo$self$getSelf2 = (fn == null || (_fn$Foo$self = fn().Foo.self) == null ? void 0 : _fn$Foo$self.getSelf.bind(_fn$Foo$self))()) === null || _fn$Foo$self$getSelf2 === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(_fn$Foo$self$getSelf2, _m)[_m].bind(_fn$Foo$self$getSelf2))();
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Object.defineProperty(Foo, _m, {
   writable: true,
   value: function () {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/parenthesized-optional-member-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/parenthesized-optional-member-call/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return Foo;
@@ -23,16 +23,16 @@ class Foo {
     ((_fn$Foo$self$getSelf2 = (fn?.().Foo.self?.getSelf)()) === null || _fn$Foo$self$getSelf2 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_fn$Foo$self$getSelf2, Foo, _m).bind(_fn$Foo$self$getSelf2))();
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 new Foo().test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/reevaluated/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/reevaluated/output.js
@@ -1,6 +1,6 @@
 function classFactory() {
-  var _class, _foo, _bar;
-  return _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar"), (_class = class Foo {
+  var _Foo, _foo, _bar;
+  return _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar"), (_Foo = class Foo {
     constructor() {
       Object.defineProperty(this, _foo, {
         writable: true,
@@ -19,10 +19,10 @@ function classFactory() {
     static static() {
       return babelHelpers.classPrivateFieldLooseBase(Foo, _bar)[_bar];
     }
-  }, Object.defineProperty(_class, _bar, {
+  }, Object.defineProperty(_Foo, _bar, {
     writable: true,
     value: "bar"
-  }), _class);
+  }), _Foo);
 }
 var Foo1 = classFactory();
 var Foo2 = classFactory();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/static-class-binding/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/static-class-binding/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _A;
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 var _getA = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getA");
 var A = /*#__PURE__*/babelHelpers.createClass(function A() {
@@ -6,12 +6,12 @@ var A = /*#__PURE__*/babelHelpers.createClass(function A() {
 
   babelHelpers.classCallCheck(this, A);
 });
-_class = A;
+_A = A;
 Object.defineProperty(A, _self, {
   writable: true,
-  value: _class
+  value: _A
 });
 Object.defineProperty(A, _getA, {
   writable: true,
-  value: () => _class
+  value: () => _A
 });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/static-infer-name/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/static-infer-name/output.js
@@ -1,5 +1,5 @@
-var _class, _num;
-var Foo = (_num = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("num"), (_class = class Foo {}, Object.defineProperty(_class, _num, {
+var _Class, _num;
+var Foo = (_num = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("num"), (_Class = class Foo {}, Object.defineProperty(_Class, _num, {
   writable: true,
   value: 0
-}), _class));
+}), _Class));

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/static-this/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/static-this/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _A;
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 var _getA = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getA");
 var A = /*#__PURE__*/babelHelpers.createClass(function A() {
@@ -6,12 +6,12 @@ var A = /*#__PURE__*/babelHelpers.createClass(function A() {
 
   babelHelpers.classCallCheck(this, A);
 });
-_class = A;
+_A = A;
 Object.defineProperty(A, _self, {
   writable: true,
-  value: _class
+  value: _A
 });
 Object.defineProperty(A, _getA, {
   writable: true,
-  value: () => _class
+  value: () => _A
 });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/class-shadow-builtins/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/class-shadow-builtins/output.mjs
@@ -1,7 +1,7 @@
 function _classPrivateFieldInitSpec(obj, privateMap, value) { _checkPrivateRedeclaration(obj, privateMap); privateMap.set(obj, value); }
 function _checkPrivateRedeclaration(obj, privateCollection) { if (privateCollection.has(obj)) { throw new TypeError("Cannot initialize the same private elements twice on an object"); } }
 var _message = /*#__PURE__*/new WeakMap();
-class _TypeError {
+class _TypeError2 {
   constructor() {
     _classPrivateFieldInitSpec(this, _message, {
       writable: true,
@@ -9,4 +9,4 @@ class _TypeError {
     });
   }
 }
-export { _TypeError as TypeError };
+export { _TypeError2 as TypeError };

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/derived/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/derived/output.js
@@ -9,10 +9,10 @@ var Foo = /*#__PURE__*/babelHelpers.createClass(function Foo() {
   });
 });
 var _prop2 = /*#__PURE__*/new WeakMap();
-var Bar = /*#__PURE__*/function (_Foo) {
+var Bar = /*#__PURE__*/function (_Foo2) {
   "use strict";
 
-  babelHelpers.inherits(Bar, _Foo);
+  babelHelpers.inherits(Bar, _Foo2);
   function Bar(...args) {
     var _this;
     babelHelpers.classCallCheck(this, Bar);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
@@ -29,15 +29,15 @@ var Foo = /*#__PURE__*/function () {
         }
         return babelHelpers.createClass(Nested);
       }((_foo3 = /*#__PURE__*/new WeakMap(), _babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo3), /*#__PURE__*/function () {
-        function _class4() {
-          babelHelpers.classCallCheck(this, _class4);
+        function _class() {
+          babelHelpers.classCallCheck(this, _class);
           babelHelpers.classPrivateFieldInitSpec(this, _foo3, {
             writable: true,
             value: 2
           });
           babelHelpers.defineProperty(this, _babelHelpers$classPr, 2);
         }
-        return babelHelpers.createClass(_class4);
+        return babelHelpers.createClass(_class);
       }()));
     }
   }]);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
@@ -28,11 +28,11 @@ var Foo = /*#__PURE__*/function () {
         }
         return babelHelpers.createClass(Nested);
       }((_babelHelpers$classPr = babelHelpers.classPrivateFieldGet(this, _foo), /*#__PURE__*/function () {
-        function _class4() {
-          babelHelpers.classCallCheck(this, _class4);
+        function _class() {
+          babelHelpers.classCallCheck(this, _class);
           babelHelpers.defineProperty(this, _babelHelpers$classPr, 2);
         }
-        return babelHelpers.createClass(_class4);
+        return babelHelpers.createClass(_class);
       }()));
     }
   }]);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/non-block-arrow-func/output.mjs
@@ -1,6 +1,6 @@
 export default (param => {
-  var _class, _props;
-  return _class = class App {
+  var _App, _props;
+  return _App = class App {
     getParam() {
       return param;
     }
@@ -10,5 +10,5 @@ export default (param => {
       prop1: 'prop1',
       prop2: 'prop2'
     }
-  }, _class;
+  }, _App;
 });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-member-call-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-member-call-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -59,7 +59,7 @@ class Foo {
     (_getSelf6 = (_ref22 = fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self)) === null || _ref22 === void 0 || (_ref22$getSelf = _ref22.getSelf) === null || _ref22$getSelf === void 0 ? void 0 : _ref22$getSelf.call(_ref22)) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf6$self = _getSelf6.self, Foo, _m).call(_getSelf6$self);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
@@ -67,12 +67,12 @@ var _x = {
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-member-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-member-call/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -59,7 +59,7 @@ class Foo {
     (_getSelf6 = (fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self))?.getSelf?.()) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf6$self = _getSelf6.self, Foo, _m).call(_getSelf6$self);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
@@ -67,12 +67,12 @@ var _x = {
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-property-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-property-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -59,14 +59,14 @@ class Foo {
     (_getSelf6 = (_ref22 = fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self)) === null || _ref22 === void 0 || (_ref22$getSelf = _ref22.getSelf) === null || _ref22$getSelf === void 0 ? void 0 : _ref22$getSelf.call(_ref22)) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf6.self, Foo, _x);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-property/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-before-property/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -59,14 +59,14 @@ class Foo {
     (_getSelf6 = (fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self))?.getSelf?.()) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf6.self, Foo, _x);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-delete-property-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-delete-property-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 var _x = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("x");
 var _self = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("self");
 class Foo {
@@ -53,14 +53,14 @@ class Foo {
     (_ref20 = fn === null || fn === void 0 ? void 0 : babelHelpers.classPrivateFieldLooseBase(fn().Foo, _self)[_self]) == null || _ref20.getSelf == null || (_ref20 = _ref20.getSelf()) == null || delete _ref20.self.unicorn;
   }
 }
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _x, {
   writable: true,
   value: 1
 });
 Object.defineProperty(Foo, _self, {
   writable: true,
-  value: _class
+  value: _Foo
 });
-Foo.self = _class;
+Foo.self = _Foo;
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-delete-property/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-delete-property/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -51,14 +51,14 @@ class Foo {
     delete (fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self))?.getSelf?.()?.self.unicorn;
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-in-function-param-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-in-function-param-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -40,7 +40,7 @@ class Foo {
     j(fn);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
@@ -48,12 +48,12 @@ var _x = {
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-in-function-param/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-in-function-param/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -40,7 +40,7 @@ class Foo {
     j(fn);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
@@ -48,12 +48,12 @@ var _x = {
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-member-optional-call-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-member-optional-call-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -62,7 +62,7 @@ class Foo {
     (_getSelf6 = (_ref28 = fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self)) === null || _ref28 === void 0 || (_ref28$getSelf = _ref28.getSelf) === null || _ref28$getSelf === void 0 ? void 0 : _ref28$getSelf.call(_ref28)) === null || _getSelf6 === void 0 ? void 0 : (_babelHelpers$classSt45 = babelHelpers.classStaticPrivateFieldSpecGet(_getSelf6$self = _getSelf6.self, Foo, _m)) === null || _babelHelpers$classSt45 === void 0 ? void 0 : _babelHelpers$classSt45.call(_getSelf6$self);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
@@ -70,12 +70,12 @@ var _x = {
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-member-optional-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-member-optional-call/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -62,7 +62,7 @@ class Foo {
     (_getSelf6 = (fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self))?.getSelf?.()) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf6$self = _getSelf6.self, Foo, _m)?.call(_getSelf6$self);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
@@ -70,12 +70,12 @@ var _x = {
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-member-call-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-member-call-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -62,7 +62,7 @@ class Foo {
     (_getSelf$self4 = (_ref26 = fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self)) === null || _ref26 === void 0 || (_ref26$getSelf = _ref26.getSelf) === null || _ref26$getSelf === void 0 || (_ref26$getSelf = _ref26$getSelf.call(_ref26)) === null || _ref26$getSelf === void 0 ? void 0 : _ref26$getSelf.self) === null || _getSelf$self4 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf$self4, Foo, _m).call(_getSelf$self4);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
@@ -70,12 +70,12 @@ var _x = {
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-member-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-member-call/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -62,7 +62,7 @@ class Foo {
     (_getSelf6 = (fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self))?.getSelf?.()) === null || _getSelf6 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf6$self = _getSelf6.self, Foo, _m).call(_getSelf6$self);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
@@ -70,12 +70,12 @@ var _x = {
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-property-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-property-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -62,14 +62,14 @@ class Foo {
     (_getSelf$self4 = (_ref26 = fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self)) === null || _ref26 === void 0 || (_ref26$getSelf = _ref26.getSelf) === null || _ref26$getSelf === void 0 || (_ref26$getSelf = _ref26$getSelf.call(_ref26)) === null || _ref26$getSelf === void 0 ? void 0 : _ref26$getSelf.self) === null || _getSelf$self4 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf$self4, Foo, _x);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-property/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/optional-chain-optional-property/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return this;
@@ -62,14 +62,14 @@ class Foo {
     (_getSelf$self4 = (fn === null || fn === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(fn().Foo, Foo, _self))?.getSelf?.()?.self) === null || _getSelf$self4 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_getSelf$self4, Foo, _x);
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
 };
 var _self = {
   writable: true,
-  value: _class
+  value: _Foo
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 Foo.test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/parenthesized-optional-member-call-with-transform/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/parenthesized-optional-member-call-with-transform/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return Foo;
@@ -23,16 +23,16 @@ class Foo {
     ((_fn$Foo$self$getSelf2 = (fn === null || fn === void 0 || (_fn$Foo$self = fn().Foo.self) === null || _fn$Foo$self === void 0 ? void 0 : _fn$Foo$self.getSelf.bind(_fn$Foo$self))()) === null || _fn$Foo$self$getSelf2 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_fn$Foo$self$getSelf2, Foo, _m).bind(_fn$Foo$self$getSelf2))();
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 new Foo().test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/parenthesized-optional-member-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/parenthesized-optional-member-call/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Foo;
 class Foo {
   static getSelf() {
     return Foo;
@@ -23,16 +23,16 @@ class Foo {
     ((_fn$Foo$self$getSelf2 = (fn?.().Foo.self?.getSelf)()) === null || _fn$Foo$self$getSelf2 === void 0 ? void 0 : babelHelpers.classStaticPrivateFieldSpecGet(_fn$Foo$self$getSelf2, Foo, _m).bind(_fn$Foo$self$getSelf2))();
   }
 }
-_class = Foo;
+_Foo = Foo;
 var _x = {
   writable: true,
   value: 1
 };
-babelHelpers.defineProperty(Foo, "self", _class);
+babelHelpers.defineProperty(Foo, "self", _Foo);
 var _m = {
   writable: true,
   value: function () {
-    return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _x);
+    return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _x);
   }
 };
 new Foo().test();

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/reevaluated/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/reevaluated/output.js
@@ -1,6 +1,6 @@
 function classFactory() {
-  var _class, _foo, _bar;
-  return _foo = /*#__PURE__*/new WeakMap(), (_class = class Foo {
+  var _Foo, _foo, _bar;
+  return _foo = /*#__PURE__*/new WeakMap(), (_Foo = class Foo {
     constructor() {
       babelHelpers.classPrivateFieldInitSpec(this, _foo, {
         writable: true,
@@ -11,16 +11,16 @@ function classFactory() {
       return babelHelpers.classPrivateFieldGet(this, _foo);
     }
     static() {
-      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, _class, _bar);
+      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, _Foo, _bar);
     }
     static instance(inst) {
       return babelHelpers.classPrivateFieldGet(inst, _foo);
     }
     static static() {
-      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, _class, _bar);
+      return babelHelpers.classStaticPrivateFieldSpecGet(Foo, _Foo, _bar);
     }
   }, _bar = {
     writable: true,
     value: "bar"
-  }, _class);
+  }, _Foo);
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/regression-T2983/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/regression-T2983/output.mjs
@@ -1,9 +1,9 @@
-var _class, _test;
-call((_class = class {}, _test = {
+var _Class, _test;
+call((_Class = class {}, _test = {
   writable: true,
   value: true
-}, _class));
-export default class _class2 {}
+}, _Class));
+export default class _Class2 {}
 var _test2 = {
   writable: true,
   value: true

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/regression-T6719/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/regression-T6719/output.js
@@ -1,6 +1,6 @@
 function withContext(ComposedComponent) {
-  var _class, _propTypes;
-  return _class = class WithContext extends Component {}, _propTypes = {
+  var _WithContext, _propTypes;
+  return _WithContext = class WithContext extends Component {}, _propTypes = {
     writable: true,
     value: {
       context: PropTypes.shape({
@@ -9,5 +9,5 @@ function withContext(ComposedComponent) {
         setMeta: PropTypes.func
       })
     }
-  }, _class;
+  }, _WithContext;
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-class-binding/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-class-binding/output.js
@@ -1,15 +1,15 @@
-var _class;
+var _A;
 var A = /*#__PURE__*/babelHelpers.createClass(function A() {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
 });
-_class = A;
+_A = A;
 var _self = {
   writable: true,
-  value: _class
+  value: _A
 };
 var _getA = {
   writable: true,
-  value: () => _class
+  value: () => _A
 };

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-infer-name/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-infer-name/output.js
@@ -1,5 +1,5 @@
-var _class, _num;
-var Foo = (_class = class Foo {}, _num = {
+var _Class, _num;
+var Foo = (_Class = class Foo {}, _num = {
   writable: true,
   value: 0
-}, _class);
+}, _Class);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-self-field/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-self-field/output.js
@@ -1,5 +1,5 @@
-var _class, _x;
-var f = (_class = class Foo {}, _x = {
+var _Foo, _x;
+var f = (_Foo = class Foo {}, _x = {
   writable: true,
-  value: _class
-}, babelHelpers.defineProperty(_class, "y", _class), _class);
+  value: _Foo
+}, babelHelpers.defineProperty(_Foo, "y", _Foo), _Foo);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-self-method/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-self-method/output.js
@@ -1,15 +1,15 @@
-var _class;
-var f = _class = class Foo {};
+var _Foo;
+var f = _Foo = class Foo {};
 function _bar() {
-  return _class;
+  return _Foo;
 }
 function _method() {
   return function inner() {
-    return _class;
+    return _Foo;
   };
 }
 function _method_shadowed() {
-  new _class();
+  new _Foo();
   return function inner() {
     var Foo = 3;
     return Foo;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-this/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-this/output.js
@@ -1,15 +1,15 @@
-var _class;
+var _A;
 var A = /*#__PURE__*/babelHelpers.createClass(function A() {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
 });
-_class = A;
+_A = A;
 var _self = {
   writable: true,
-  value: _class
+  value: _A
 };
 var _getA = {
   writable: true,
-  value: () => _class
+  value: () => _A
 };

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/class-shadow-builtins/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/class-shadow-builtins/output.mjs
@@ -1,9 +1,9 @@
 function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == typeof i ? i : String(i); }
 function _toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
-class _TypeError {
+class _TypeError2 {
   constructor() {
     _defineProperty(this, "message", void 0);
   }
 }
-export { _TypeError as TypeError };
+export { _TypeError2 as TypeError };

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/non-block-arrow-func/output.mjs
@@ -1,6 +1,6 @@
 export default (param => {
-  var _class;
-  return _class = /*#__PURE__*/function () {
+  var _App;
+  return _App = /*#__PURE__*/function () {
     function App() {
       babelHelpers.classCallCheck(this, App);
     }
@@ -11,8 +11,8 @@ export default (param => {
       }
     }]);
     return App;
-  }(), _class.props = {
+  }(), _App.props = {
     prop1: 'prop1',
     prop2: 'prop2'
-  }, _class;
+  }, _App;
 });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/regression-T2983/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/regression-T2983/output.mjs
@@ -1,7 +1,7 @@
-var _class;
-call((_class = /*#__PURE__*/babelHelpers.createClass(function _class() {
-  babelHelpers.classCallCheck(this, _class);
-}), _class.test = true, _class));
+var _Class;
+call((_Class = /*#__PURE__*/babelHelpers.createClass(function _Class() {
+  babelHelpers.classCallCheck(this, _Class);
+}), _Class.test = true, _Class));
 var _default = /*#__PURE__*/babelHelpers.createClass(function _default() {
   babelHelpers.classCallCheck(this, _default);
 });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/regression-T6719/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/regression-T6719/output.js
@@ -1,6 +1,6 @@
 function withContext(ComposedComponent) {
-  var _class;
-  return _class = /*#__PURE__*/function (_Component) {
+  var _WithContext;
+  return _WithContext = /*#__PURE__*/function (_Component) {
     "use strict";
 
     babelHelpers.inherits(WithContext, _Component);
@@ -9,11 +9,11 @@ function withContext(ComposedComponent) {
       return babelHelpers.callSuper(this, WithContext, arguments);
     }
     return babelHelpers.createClass(WithContext);
-  }(Component), _class.propTypes = {
+  }(Component), _WithContext.propTypes = {
     context: PropTypes.shape({
       addCss: PropTypes.func,
       setTitle: PropTypes.func,
       setMeta: PropTypes.func
     })
-  }, _class;
+  }, _WithContext;
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-class-binding/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-class-binding/output.js
@@ -1,9 +1,9 @@
-var _class;
+var _A;
 var A = /*#__PURE__*/babelHelpers.createClass(function A() {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
 });
-_class = A;
-A.self = _class;
-A.getA = () => _class;
+_A = A;
+A.self = _A;
+A.getA = () => _A;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-infer-name/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-infer-name/output.js
@@ -1,6 +1,6 @@
-var _class;
-var Foo = (_class = /*#__PURE__*/babelHelpers.createClass(function Foo() {
+var _Class;
+var Foo = (_Class = /*#__PURE__*/babelHelpers.createClass(function Foo() {
   "use strict";
 
   babelHelpers.classCallCheck(this, Foo);
-}), _class.num = 0, _class);
+}), _Class.num = 0, _Class);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-super/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-super/output.js
@@ -4,10 +4,10 @@ var A = /*#__PURE__*/babelHelpers.createClass(function A() {
   babelHelpers.classCallCheck(this, A);
 });
 A.prop = 1;
-var B = /*#__PURE__*/function (_A) {
+var B = /*#__PURE__*/function (_A2) {
   "use strict";
 
-  babelHelpers.inherits(B, _A);
+  babelHelpers.inherits(B, _A2);
   function B() {
     babelHelpers.classCallCheck(this, B);
     return babelHelpers.callSuper(this, B, arguments);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-this/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-this/output.js
@@ -1,9 +1,9 @@
-var _class;
+var _A;
 var A = /*#__PURE__*/babelHelpers.createClass(function A() {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
 });
-_class = A;
-A.self = _class;
-A.getA = () => _class;
+_A = A;
+A.self = _A;
+A.getA = () => _A;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/class-shadow-builtins/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/class-shadow-builtins/output.mjs
@@ -1,9 +1,9 @@
 function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == typeof i ? i : String(i); }
 function _toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
-class _TypeError {
+class _TypeError2 {
   constructor() {
     _defineProperty(this, "message", void 0);
   }
 }
-export { _TypeError as TypeError };
+export { _TypeError2 as TypeError };

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/computed-toPrimitive/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/computed-toPrimitive/output.js
@@ -1,12 +1,26 @@
-var _class;
+var _Class;
 var foo = {
   [Symbol.toPrimitive]: () => "foo"
 };
-expect((_class = /*#__PURE__*/babelHelpers.createClass(function _class() {
+expect((_Class = /*#__PURE__*/babelHelpers.createClass(function _Class() {
   "use strict";
 
-  babelHelpers.classCallCheck(this, _class);
-}), babelHelpers.defineProperty(_class, foo, 0), _class).foo).toBe(0);
+  babelHelpers.classCallCheck(this, _Class);
+}), babelHelpers.defineProperty(_Class, foo, 0), _Class).foo).toBe(0);
+expect( /*#__PURE__*/function () {
+  "use strict";
+
+  function _class() {
+    babelHelpers.classCallCheck(this, _class);
+  }
+  babelHelpers.createClass(_class, null, [{
+    key: foo,
+    value: function () {
+      return 0;
+    }
+  }]);
+  return _class;
+}().foo()).toBe(0);
 expect( /*#__PURE__*/function () {
   "use strict";
 
@@ -15,12 +29,12 @@ expect( /*#__PURE__*/function () {
   }
   babelHelpers.createClass(_class2, null, [{
     key: foo,
-    value: function () {
+    get: function () {
       return 0;
     }
   }]);
   return _class2;
-}().foo()).toBe(0);
+}().foo).toBe(0);
 expect( /*#__PURE__*/function () {
   "use strict";
 
@@ -29,94 +43,80 @@ expect( /*#__PURE__*/function () {
   }
   babelHelpers.createClass(_class3, null, [{
     key: foo,
-    get: function () {
-      return 0;
-    }
-  }]);
-  return _class3;
-}().foo).toBe(0);
-expect( /*#__PURE__*/function () {
-  "use strict";
-
-  function _class4() {
-    babelHelpers.classCallCheck(this, _class4);
-  }
-  babelHelpers.createClass(_class4, null, [{
-    key: foo,
     set: function (v) {
       return v;
     }
   }]);
-  return _class4;
+  return _class3;
 }().foo = 0).toBe(0);
 expect(new ( /*#__PURE__*/function () {
   "use strict";
 
-  function _class6() {
-    babelHelpers.classCallCheck(this, _class6);
+  function _class4() {
+    babelHelpers.classCallCheck(this, _class4);
     babelHelpers.defineProperty(this, foo, 0);
   }
-  return babelHelpers.createClass(_class6);
+  return babelHelpers.createClass(_class4);
 }())().foo).toBe(0);
 var arrayLike = {
   [Symbol.toPrimitive]: () => []
 };
 expect(() => {
-  var _class7;
-  return _class7 = /*#__PURE__*/babelHelpers.createClass(function _class7() {
+  var _Class3;
+  return _Class3 = /*#__PURE__*/babelHelpers.createClass(function _Class3() {
     "use strict";
 
-    babelHelpers.classCallCheck(this, _class7);
-  }), babelHelpers.defineProperty(_class7, arrayLike, 0), _class7;
+    babelHelpers.classCallCheck(this, _Class3);
+  }), babelHelpers.defineProperty(_Class3, arrayLike, 0), _Class3;
 }).toThrow("@@toPrimitive must return a primitive value.");
 expect(() => /*#__PURE__*/function () {
   "use strict";
 
-  function _class8() {
-    babelHelpers.classCallCheck(this, _class8);
+  function _class5() {
+    babelHelpers.classCallCheck(this, _class5);
   }
-  babelHelpers.createClass(_class8, null, [{
+  babelHelpers.createClass(_class5, null, [{
     key: arrayLike,
     value: function () {
       return 0;
     }
   }]);
-  return _class8;
+  return _class5;
 }()).toThrow("@@toPrimitive must return a primitive value.");
 expect(() => /*#__PURE__*/function () {
   "use strict";
 
-  function _class9() {
-    babelHelpers.classCallCheck(this, _class9);
+  function _class6() {
+    babelHelpers.classCallCheck(this, _class6);
   }
-  babelHelpers.createClass(_class9, null, [{
+  babelHelpers.createClass(_class6, null, [{
     key: arrayLike,
     get: function () {
       return 0;
     }
   }]);
-  return _class9;
+  return _class6;
 }()).toThrow("@@toPrimitive must return a primitive value.");
 expect(() => /*#__PURE__*/function () {
   "use strict";
 
-  function _class10() {
-    babelHelpers.classCallCheck(this, _class10);
+  function _class7() {
+    babelHelpers.classCallCheck(this, _class7);
   }
-  babelHelpers.createClass(_class10, null, [{
+  babelHelpers.createClass(_class7, null, [{
     key: arrayLike,
     set: function (v) {
       return v;
     }
   }]);
-  return _class10;
+  return _class7;
 }()).toThrow("@@toPrimitive must return a primitive value.");
 expect(() => new ( /*#__PURE__*/function () {
   "use strict";
 
-  function _class12() {
-    babelHelpers.classCallCheck(this, _class12);
+  function _class8() {
+    babelHelpers.classCallCheck(this, _class8);
     babelHelpers.defineProperty(this, arrayLike, 0);
   }
-  return babelHelpers.createClass(_class12);
+  return babelHelpers.createClass(_class8);
 }())()).toThrow("@@toPrimitive must return a primitive value.");

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/computed-without-block/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/computed-without-block/output.js
@@ -3,10 +3,10 @@ var createClass = k => {
   return _k = k(), /*#__PURE__*/function () {
     "use strict";
 
-    function _class2() {
-      babelHelpers.classCallCheck(this, _class2);
+    function _class() {
+      babelHelpers.classCallCheck(this, _class);
       babelHelpers.defineProperty(this, _k, 2);
     }
-    return babelHelpers.createClass(_class2);
+    return babelHelpers.createClass(_class);
   }();
 };

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/delete-super-property/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/delete-super-property/output.js
@@ -1,24 +1,24 @@
 new ( /*#__PURE__*/function () {
   "use strict";
 
-  function _class2() {
-    babelHelpers.classCallCheck(this, _class2);
+  function _class() {
+    babelHelpers.classCallCheck(this, _class);
     babelHelpers.defineProperty(this, "y", function () {
       throw new ReferenceError("'delete super.prop' is invalid");
     }());
   }
-  return babelHelpers.createClass(_class2);
+  return babelHelpers.createClass(_class);
 }())();
 new ( /*#__PURE__*/function () {
   "use strict";
 
-  function _class4() {
-    babelHelpers.classCallCheck(this, _class4);
+  function _class2() {
+    babelHelpers.classCallCheck(this, _class2);
     babelHelpers.defineProperty(this, "y", (babelHelpers.toPropertyKey(0), function () {
       throw new ReferenceError("'delete super[expr]' is invalid");
     }()));
   }
-  return babelHelpers.createClass(_class4);
+  return babelHelpers.createClass(_class2);
 }())();
 var X1 = /*#__PURE__*/babelHelpers.createClass(function X1() {
   "use strict";

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/non-block-arrow-func/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/non-block-arrow-func/output.mjs
@@ -1,6 +1,6 @@
 export default (param => {
-  var _class;
-  return _class = /*#__PURE__*/function () {
+  var _App;
+  return _App = /*#__PURE__*/function () {
     function App() {
       babelHelpers.classCallCheck(this, App);
     }
@@ -11,8 +11,8 @@ export default (param => {
       }
     }]);
     return App;
-  }(), babelHelpers.defineProperty(_class, "props", {
+  }(), babelHelpers.defineProperty(_App, "props", {
     prop1: 'prop1',
     prop2: 'prop2'
-  }), _class;
+  }), _App;
 });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/regression-T2983/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/regression-T2983/output.mjs
@@ -1,7 +1,7 @@
-var _class;
-call((_class = /*#__PURE__*/babelHelpers.createClass(function _class() {
-  babelHelpers.classCallCheck(this, _class);
-}), babelHelpers.defineProperty(_class, "test", true), _class));
+var _Class;
+call((_Class = /*#__PURE__*/babelHelpers.createClass(function _Class() {
+  babelHelpers.classCallCheck(this, _Class);
+}), babelHelpers.defineProperty(_Class, "test", true), _Class));
 var _default = /*#__PURE__*/babelHelpers.createClass(function _default() {
   babelHelpers.classCallCheck(this, _default);
 });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/regression-T6719/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/regression-T6719/output.js
@@ -1,6 +1,6 @@
 function withContext(ComposedComponent) {
-  var _class;
-  return _class = /*#__PURE__*/function (_Component) {
+  var _WithContext;
+  return _WithContext = /*#__PURE__*/function (_Component) {
     "use strict";
 
     babelHelpers.inherits(WithContext, _Component);
@@ -9,11 +9,11 @@ function withContext(ComposedComponent) {
       return babelHelpers.callSuper(this, WithContext, arguments);
     }
     return babelHelpers.createClass(WithContext);
-  }(Component), babelHelpers.defineProperty(_class, "propTypes", {
+  }(Component), babelHelpers.defineProperty(_WithContext, "propTypes", {
     context: PropTypes.shape({
       addCss: PropTypes.func,
       setTitle: PropTypes.func,
       setMeta: PropTypes.func
     })
-  }), _class;
+  }), _WithContext;
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/static-class-binding/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/static-class-binding/output.js
@@ -1,9 +1,9 @@
-var _class;
+var _A;
 var A = /*#__PURE__*/babelHelpers.createClass(function A() {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
 });
-_class = A;
-babelHelpers.defineProperty(A, "self", _class);
-babelHelpers.defineProperty(A, "getA", () => _class);
+_A = A;
+babelHelpers.defineProperty(A, "self", _A);
+babelHelpers.defineProperty(A, "getA", () => _A);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/static-infer-name/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/static-infer-name/output.js
@@ -1,6 +1,6 @@
-var _class;
-var Foo = (_class = /*#__PURE__*/babelHelpers.createClass(function Foo() {
+var _Class;
+var Foo = (_Class = /*#__PURE__*/babelHelpers.createClass(function Foo() {
   "use strict";
 
   babelHelpers.classCallCheck(this, Foo);
-}), babelHelpers.defineProperty(_class, "num", 0), _class);
+}), babelHelpers.defineProperty(_Class, "num", 0), _Class);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/static-super/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/static-super/output.js
@@ -1,21 +1,21 @@
-var _class2;
+var _B;
 var A = /*#__PURE__*/babelHelpers.createClass(function A() {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
 });
 babelHelpers.defineProperty(A, "prop", 1);
-var B = /*#__PURE__*/function (_A) {
+var B = /*#__PURE__*/function (_A2) {
   "use strict";
 
-  babelHelpers.inherits(B, _A);
+  babelHelpers.inherits(B, _A2);
   function B() {
     babelHelpers.classCallCheck(this, B);
     return babelHelpers.callSuper(this, B, arguments);
   }
   return babelHelpers.createClass(B);
 }(A);
-_class2 = B;
+_B = B;
 babelHelpers.defineProperty(B, "prop", 2);
-babelHelpers.defineProperty(B, "propA", babelHelpers.get(babelHelpers.getPrototypeOf(_class2), "prop", _class2));
-babelHelpers.defineProperty(B, "getPropA", () => babelHelpers.get(babelHelpers.getPrototypeOf(_class2), "prop", _class2));
+babelHelpers.defineProperty(B, "propA", babelHelpers.get(babelHelpers.getPrototypeOf(_B), "prop", _B));
+babelHelpers.defineProperty(B, "getPropA", () => babelHelpers.get(babelHelpers.getPrototypeOf(_B), "prop", _B));

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/static-this/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/static-this/output.js
@@ -1,9 +1,9 @@
-var _class;
+var _A;
 var A = /*#__PURE__*/babelHelpers.createClass(function A() {
   "use strict";
 
   babelHelpers.classCallCheck(this, A);
 });
-_class = A;
-babelHelpers.defineProperty(A, "self", _class);
-babelHelpers.defineProperty(A, "getA", () => _class);
+_A = A;
+babelHelpers.defineProperty(A, "self", _A);
+babelHelpers.defineProperty(A, "getA", () => _A);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/6153/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/6153/output.js
@@ -1,5 +1,5 @@
 (function () {
-  var _class;
+  var _Foo;
   class Foo {
     constructor() {
       var _this = this;
@@ -8,26 +8,26 @@
       });
     }
   }
-  _class = Foo;
+  _Foo = Foo;
   babelHelpers.defineProperty(Foo, "fn", function () {
-    return console.log(_class);
+    return console.log(_Foo);
   });
 });
 (function () {
-  var _class2;
-  return _class2 = class Bar {
+  var _Bar;
+  return _Bar = class Bar {
     constructor() {
       var _this2 = this;
       babelHelpers.defineProperty(this, "fn", function () {
         return console.log(_this2);
       });
     }
-  }, babelHelpers.defineProperty(_class2, "fn", function () {
-    return console.log(_class2);
-  }), _class2;
+  }, babelHelpers.defineProperty(_Bar, "fn", function () {
+    return console.log(_Bar);
+  }), _Bar;
 });
 (function () {
-  var _class3;
+  var _Baz;
   class Baz {
     constructor(_force) {
       var _this3 = this;
@@ -37,13 +37,13 @@
       babelHelpers.defineProperty(this, "force", force);
     }
   }
-  _class3 = Baz;
+  _Baz = Baz;
   babelHelpers.defineProperty(Baz, "fn", function () {
-    return console.log(_class3);
+    return console.log(_Baz);
   });
 });
 var qux = function () {
-  var _class4;
+  var _Qux;
   class Qux {
     constructor() {
       var _this4 = this;
@@ -52,8 +52,8 @@ var qux = function () {
       });
     }
   }
-  _class4 = Qux;
+  _Qux = Qux;
   babelHelpers.defineProperty(Qux, "fn", function () {
-    return console.log(_class4);
+    return console.log(_Qux);
   });
 }.bind(this);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/6154/output.js
@@ -1,7 +1,7 @@
 var Test = /*#__PURE__*/babelHelpers.createClass(function Test() {
   "use strict";
 
-  var _class;
+  var _Other;
   babelHelpers.classCallCheck(this, Test);
   var Other = /*#__PURE__*/function (_Test) {
     babelHelpers.inherits(Other, _Test);
@@ -19,8 +19,8 @@ var Test = /*#__PURE__*/babelHelpers.createClass(function Test() {
     }
     return babelHelpers.createClass(Other);
   }(Test);
-  _class = Other;
+  _Other = Other;
   babelHelpers.defineProperty(Other, "a", function () {
-    return babelHelpers.get(babelHelpers.getPrototypeOf(_class), "test", _class);
+    return babelHelpers.get(babelHelpers.getPrototypeOf(_Other), "test", _Other);
   });
 });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/8882/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/8882/output.js
@@ -1,8 +1,8 @@
 const classes = [];
 for (let i = 0; i <= 10; ++i) {
-  var _class, _bar;
+  var _A, _bar;
   let _i;
-  classes.push((_bar = /*#__PURE__*/new WeakMap(), _i = i, (_class = class A {
+  classes.push((_bar = /*#__PURE__*/new WeakMap(), _i = i, (_A = class A {
     constructor() {
       babelHelpers.defineProperty(this, _i, `computed field ${i}`);
       babelHelpers.classPrivateFieldInitSpec(this, _bar, {
@@ -13,5 +13,5 @@ for (let i = 0; i <= 10; ++i) {
     getBar() {
       return babelHelpers.classPrivateFieldGet(this, _bar);
     }
-  }, babelHelpers.defineProperty(_class, "foo", `static field ${i}`), _class)));
+  }, babelHelpers.defineProperty(_A, "foo", `static field ${i}`), _A)));
 }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T2983/output.mjs
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T2983/output.mjs
@@ -1,7 +1,7 @@
-var _class;
-call((_class = /*#__PURE__*/babelHelpers.createClass(function _class() {
-  babelHelpers.classCallCheck(this, _class);
-}), _class.test = true, _class));
+var _Class;
+call((_Class = /*#__PURE__*/babelHelpers.createClass(function _Class() {
+  babelHelpers.classCallCheck(this, _Class);
+}), _Class.test = true, _Class));
 var _default = /*#__PURE__*/babelHelpers.createClass(function _default() {
   babelHelpers.classCallCheck(this, _default);
 });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T6719/output.js
@@ -1,6 +1,6 @@
 function withContext(ComposedComponent) {
-  var _class;
-  return _class = /*#__PURE__*/function (_Component) {
+  var _WithContext;
+  return _WithContext = /*#__PURE__*/function (_Component) {
     "use strict";
 
     babelHelpers.inherits(WithContext, _Component);
@@ -9,11 +9,11 @@ function withContext(ComposedComponent) {
       return babelHelpers.callSuper(this, WithContext, arguments);
     }
     return babelHelpers.createClass(WithContext);
-  }(Component), _class.propTypes = {
+  }(Component), _WithContext.propTypes = {
     context: PropTypes.shape({
       addCss: PropTypes.func,
       setTitle: PropTypes.func,
       setMeta: PropTypes.func
     })
-  }, _class;
+  }, _WithContext;
 }

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/class-binding/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/class-binding/output.js
@@ -1,6 +1,6 @@
-var _class;
+var _Foo;
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 Foo.bar = 42;
-_class.foo = _class.bar;
+_Foo.foo = _Foo.bar;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/class-declaration/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/class-declaration/output.js
@@ -1,6 +1,6 @@
-var _class;
+var _Foo;
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 Foo.bar = 42;
-_class.foo = _class.bar;
+_Foo.foo = _Foo.bar;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/in-class-heritage/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/in-class-heritage/output.js
@@ -1,5 +1,5 @@
-var _class, _class2, _class3;
-class Foo extends (_class2 = class extends (_class3 = class Base {}, _class3.qux = 21, _class3) {}, _class2.bar = 21, _class2) {}
-_class = Foo;
-_class.foo = _class.bar + _class.qux;
+var _Foo, _Class, _Base;
+class Foo extends (_Class = class extends (_Base = class Base {}, _Base.qux = 21, _Base) {}, _Class.bar = 21, _Class) {}
+_Foo = Foo;
+_Foo.foo = _Foo.bar + _Foo.qux;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/multiple-static-initializers/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/multiple-static-initializers/output.js
@@ -1,14 +1,14 @@
-var _class;
+var _Foo;
 var _bar = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("bar");
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _bar, {
   writable: true,
   value: 21
 });
 (() => {
-  _class.foo = babelHelpers.classPrivateFieldLooseBase(_class, _bar)[_bar];
-  _class.qux1 = _class.qux;
+  _Foo.foo = babelHelpers.classPrivateFieldLooseBase(_Foo, _bar)[_bar];
+  _Foo.qux1 = _Foo.qux;
 })();
 Foo.qux = 21;
-_class.qux2 = _class.qux;
+_Foo.qux2 = _Foo.qux;

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/name-conflict/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/name-conflict/output.js
@@ -1,12 +1,12 @@
-var _class;
+var _Foo;
 var _ = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("_");
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 Object.defineProperty(Foo, _, {
   writable: true,
   value: 42
 });
 // static block can not be transformed as `#_` here
 
-_class.foo = babelHelpers.classPrivateFieldLooseBase(_class, _)[_];
+_Foo.foo = babelHelpers.classPrivateFieldLooseBase(_Foo, _)[_];
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/preserve-comments/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/preserve-comments/output.js
@@ -1,18 +1,18 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 /* before 1 */
 (() => {})();
 /* after 1 */
 /* before 2 */
-/* before this.foo */_class.foo = 42;
+/* before this.foo */_C.foo = 42;
 /* after this.foo */
 /* after 2 */
 /* before 3 */
 (() => {
   /* before this.bar */
-  _class.bar = 42;
-  _class.bar = 42;
+  _C.bar = 42;
+  _C.bar = 42;
   /* after this.bar */
 })();
 /* after 3 */

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/super-static-block/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration-loose/super-static-block/output.js
@@ -1,6 +1,6 @@
-var _ref, _class, _class2;
-class Foo extends (_ref = (_class2 = class _ref {}, _class2.bar = 42, _class2)) {}
-_class = Foo;
+var _ref, _Foo, _Class;
+class Foo extends (_ref = (_Class = class _ref {}, _Class.bar = 42, _Class)) {}
+_Foo = Foo;
 Foo.bar = 21;
-_class.foo = _ref.bar;
+_Foo.foo = _ref.bar;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/class-binding/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/class-binding/output.js
@@ -1,6 +1,6 @@
-var _class;
+var _Foo;
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 babelHelpers.defineProperty(Foo, "bar", 42);
-_class.foo = _class.bar;
+_Foo.foo = _Foo.bar;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/class-declaration/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/class-declaration/output.js
@@ -1,6 +1,6 @@
-var _class;
+var _Foo;
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 babelHelpers.defineProperty(Foo, "bar", 42);
-_class.foo = _class.bar;
+_Foo.foo = _Foo.bar;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/in-class-heritage/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/in-class-heritage/output.js
@@ -1,5 +1,5 @@
-var _class, _class2, _class3;
-class Foo extends (_class2 = class extends (_class3 = class Base {}, _class3.qux = 21, _class3) {}, _class2.bar = 21, _class2) {}
-_class = Foo;
-_class.foo = _class.bar + _class.qux;
+var _Foo, _Class, _Base;
+class Foo extends (_Class = class extends (_Base = class Base {}, _Base.qux = 21, _Base) {}, _Class.bar = 21, _Class) {}
+_Foo = Foo;
+_Foo.foo = _Foo.bar + _Foo.qux;
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/multiple-static-initializers/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/multiple-static-initializers/output.js
@@ -1,13 +1,13 @@
-var _class;
+var _Foo;
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 var _bar = {
   writable: true,
   value: 21
 };
 (() => {
-  _class.foo = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _bar);
-  _class.qux1 = _class.qux;
+  _Foo.foo = babelHelpers.classStaticPrivateFieldSpecGet(_Foo, _Foo, _bar);
+  _Foo.qux1 = _Foo.qux;
 })();
 babelHelpers.defineProperty(Foo, "qux", 21);
-_class.qux2 = _class.qux;
+_Foo.qux2 = _Foo.qux;

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/name-conflict/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/name-conflict/output.js
@@ -1,11 +1,11 @@
-var _class;
+var _Foo;
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 var _ = {
   writable: true,
   value: 42
 };
 // static block can not be transformed as `#_` here
 
-_class.foo = babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _);
+_Foo.foo = babelHelpers.classStaticPrivateFieldSpecGet(_Foo, _Foo, _);
 expect(Foo.foo).toBe(42);

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/new-target/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/new-target/output.js
@@ -1,7 +1,7 @@
 class Base {
   constructor() {
-    var _class;
-    this.Foo = (_class = class {}, _class.foo = void 0, _class);
+    var _Class;
+    this.Foo = (_Class = class {}, _Class.foo = void 0, _Class);
   }
 }
 expect(new Base().Foo.foo).toBe(undefined);

--- a/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/preserve-comments/output.js
+++ b/packages/babel-plugin-transform-class-static-block/test/fixtures/integration/preserve-comments/output.js
@@ -1,18 +1,18 @@
-var _class;
+var _C;
 class C {}
-_class = C;
+_C = C;
 /* before 1 */
 (() => {})();
 /* after 1 */
 /* before 2 */
-/* before this.foo */_class.foo = 42;
+/* before this.foo */_C.foo = 42;
 /* after this.foo */
 /* after 2 */
 /* before 3 */
 (() => {
   /* before this.bar */
-  _class.bar = 42;
-  _class.bar = 42;
+  _C.bar = 42;
+  _C.bar = 42;
   /* after this.bar */
 })();
 /* after 3 */

--- a/packages/babel-plugin-transform-class-static-block/test/plugin-ordering.test.js
+++ b/packages/babel-plugin-transform-class-static-block/test/plugin-ordering.test.js
@@ -20,13 +20,13 @@ describe("plugin ordering", () => {
         plugins: [proposalClassProperties, proposalClassStaticBlock],
       }).code,
     ).toMatchInlineSnapshot(`
-      "var _class;
+      "var _Foo;
       function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
       function _toPropertyKey(t) { var i = _toPrimitive(t, \\"string\\"); return \\"symbol\\" == typeof i ? i : String(i); }
       function _toPrimitive(t, r) { if (\\"object\\" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || \\"default\\"); if (\\"object\\" != typeof i) return i; throw new TypeError(\\"@@toPrimitive must return a primitive value.\\"); } return (\\"string\\" === r ? String : Number)(t); }
       class Foo {}
-      _class = Foo;
-      _class.foo = _class.bar;
+      _Foo = Foo;
+      _Foo.foo = _Foo.bar;
       _defineProperty(Foo, \\"bar\\", 42);"
     `);
   });

--- a/packages/babel-plugin-transform-new-target/test/fixtures/general/class-properties-loose/output.js
+++ b/packages/babel-plugin-transform-new-target/test/fixtures/general/class-properties-loose/output.js
@@ -1,28 +1,28 @@
 class Foo {
   constructor() {
     var _newtarget = this.constructor,
-      _class2;
+      _Class;
     this.test = function _target() {
       this instanceof _target ? this.constructor : void 0;
     };
     this.test2 = function () {
       _newtarget;
     };
-    this.Bar = (_class2 = class {
+    this.Bar = (_Class = class {
       constructor() {
         // should not replace
         this.q = this.constructor;
       } // should not replace
-    }, _class2.p = void 0, _class2.p1 = class {
+    }, _Class.p = void 0, _Class.p1 = class {
       constructor() {
         this.constructor;
       }
-    }, _class2.p2 = new function _target2() {
+    }, _Class.p2 = new function _target2() {
       this instanceof _target2 ? this.constructor : void 0;
-    }(), _class2.p3 = function () {
+    }(), _Class.p3 = function () {
       void 0;
-    }, _class2.p4 = function _target3() {
+    }, _Class.p4 = function _target3() {
       this instanceof _target3 ? this.constructor : void 0;
-    }, _class2);
+    }, _Class);
   }
 }

--- a/packages/babel-plugin-transform-new-target/test/fixtures/general/class-properties/output.js
+++ b/packages/babel-plugin-transform-new-target/test/fixtures/general/class-properties/output.js
@@ -1,28 +1,28 @@
 class Foo {
   constructor() {
     var _newtarget = this.constructor,
-      _class2;
+      _Class;
     babelHelpers.defineProperty(this, "test", function _target() {
       this instanceof _target ? this.constructor : void 0;
     });
     babelHelpers.defineProperty(this, "test2", function () {
       _newtarget;
     });
-    this.Bar = (_class2 = class {
+    this.Bar = (_Class = class {
       constructor() {
         // should not replace
         babelHelpers.defineProperty(this, "q", this.constructor);
       } // should not replace
-    }, babelHelpers.defineProperty(_class2, "p", void 0), babelHelpers.defineProperty(_class2, "p1", class {
+    }, babelHelpers.defineProperty(_Class, "p", void 0), babelHelpers.defineProperty(_Class, "p1", class {
       constructor() {
         this.constructor;
       }
-    }), babelHelpers.defineProperty(_class2, "p2", new function _target2() {
+    }), babelHelpers.defineProperty(_Class, "p2", new function _target2() {
       this instanceof _target2 ? this.constructor : void 0;
-    }()), babelHelpers.defineProperty(_class2, "p3", function () {
+    }()), babelHelpers.defineProperty(_Class, "p3", function () {
       void 0;
-    }), babelHelpers.defineProperty(_class2, "p4", function _target3() {
+    }), babelHelpers.defineProperty(_Class, "p4", function _target3() {
       this instanceof _target3 ? this.constructor : void 0;
-    }), _class2);
+    }), _Class);
   }
 }

--- a/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-arrow-functions/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/parameters/rest-arrow-functions/output.js
@@ -33,14 +33,14 @@ var x = function () {
   return rest;
 };
 var innerclassproperties = function () {
-  var _class;
+  var _Class;
   for (var _len3 = arguments.length, args = new Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
     args[_key3] = arguments[_key3];
   }
-  return _class = /*#__PURE__*/babelHelpers.createClass(function _class() {
+  return _Class = /*#__PURE__*/babelHelpers.createClass(function _Class() {
     "use strict";
 
-    babelHelpers.classCallCheck(this, _class);
+    babelHelpers.classCallCheck(this, _Class);
     this.args = args;
-  }), _class.args = args, _class;
+  }), _Class.args = args, _Class;
 };

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-loose/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-loose/class-binding/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _A;
 var _getA = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getA");
 class A {
   constructor() {
@@ -8,7 +8,7 @@ class A {
     });
   }
 }
-_class = A;
+_A = A;
 function _get_getA() {
-  return _class;
+  return _A;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsProperties/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsProperties/class-binding/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _A;
 var _getA = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getA");
 class A {
   constructor() {
@@ -8,7 +8,7 @@ class A {
     });
   }
 }
-_class = A;
+_A = A;
 function _get_getA() {
-  return _class;
+  return _A;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/class-binding/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _A;
 var _getA = /*#__PURE__*/Symbol("getA");
 class A {
   constructor() {
@@ -8,7 +8,7 @@ class A {
     });
   }
 }
-_class = A;
+_A = A;
 function _get_getA() {
-  return _class;
+  return _A;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors/class-binding/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _A;
 var _getA = /*#__PURE__*/new WeakMap();
 class A {
   constructor() {
@@ -8,7 +8,7 @@ class A {
     });
   }
 }
-_class = A;
+_A = A;
 function _get_getA() {
-  return _class;
+  return _A;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-loose/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-loose/class-binding/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _A;
 var _getA = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getA");
 class A {
   constructor() {
@@ -7,7 +7,7 @@ class A {
     });
   }
 }
-_class = A;
+_A = A;
 function _getA2() {
-  return _class;
+  return _A;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsProperties/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsProperties/class-binding/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _A;
 var _getA = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("getA");
 class A {
   constructor() {
@@ -7,7 +7,7 @@ class A {
     });
   }
 }
-_class = A;
+_A = A;
 function _getA2() {
-  return _class;
+  return _A;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsProperties/super/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Sub;
 class Base {
   superMethod() {
     return 'good';
@@ -19,7 +19,7 @@ class Sub extends Base {
     return babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod]();
   }
 }
-_class = Sub;
+_Sub = Sub;
 function _privateMethod2() {
-  return babelHelpers.get(babelHelpers.getPrototypeOf(_class.prototype), "superMethod", this).call(this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(_Sub.prototype), "superMethod", this).call(this);
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/class-binding/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _A;
 var _getA = /*#__PURE__*/Symbol("getA");
 class A {
   constructor() {
@@ -7,7 +7,7 @@ class A {
     });
   }
 }
-_class = A;
+_A = A;
 function _getA2() {
-  return _class;
+  return _A;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/super/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/super/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Sub;
 class Base {
   superMethod() {
     return 'good';
@@ -19,7 +19,7 @@ class Sub extends Base {
     return babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod]();
   }
 }
-_class = Sub;
+_Sub = Sub;
 function _privateMethod2() {
-  return babelHelpers.get(babelHelpers.getPrototypeOf(_class.prototype), "superMethod", this).call(this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(_Sub.prototype), "superMethod", this).call(this);
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method/class-binding/output.js
@@ -1,11 +1,11 @@
-var _class;
+var _A;
 var _getA = /*#__PURE__*/new WeakSet();
 class A {
   constructor() {
     babelHelpers.classPrivateMethodInitSpec(this, _getA);
   }
 }
-_class = A;
+_A = A;
 function _getA2() {
-  return _class;
+  return _A;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method/super/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method/super/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Sub;
 class Base {
   superMethod() {
     return 'good';
@@ -17,7 +17,7 @@ class Sub extends Base {
     return babelHelpers.classPrivateMethodGet(this, _privateMethod, _privateMethod2).call(this);
   }
 }
-_class = Sub;
+_Sub = Sub;
 function _privateMethod2() {
-  return babelHelpers.get(babelHelpers.getPrototypeOf(_class.prototype), "superMethod", this).call(this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(_Sub.prototype), "superMethod", this).call(this);
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-loose/class-expression/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-loose/class-expression/output.js
@@ -1,9 +1,9 @@
-var _class, _foo;
-console.log((_foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), (_class = class A {
+var _A, _foo;
+console.log((_foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), (_A = class A {
   method() {
     babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
   }
-}, Object.defineProperty(_class, _foo, {
+}, Object.defineProperty(_A, _foo, {
   value: _foo2
-}), _class)));
+}), _A)));
 function _foo2() {}

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-expression/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/class-expression/output.js
@@ -1,9 +1,9 @@
-var _class, _foo;
-console.log((_foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), (_class = class A {
+var _A, _foo;
+console.log((_foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo"), (_A = class A {
   method() {
     babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
   }
-}, Object.defineProperty(_class, _foo, {
+}, Object.defineProperty(_A, _foo, {
   value: _foo2
-}), _class)));
+}), _A)));
 function _foo2() {}

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/super/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Sub;
 class Base {
   static basePublicStaticMethod() {
     return 'good';
@@ -13,9 +13,9 @@ class Sub extends Base {
     babelHelpers.classPrivateFieldLooseBase(Sub, _subStaticPrivateMethod)[_subStaticPrivateMethod]();
   }
 }
-_class = Sub;
+_Sub = Sub;
 function _subStaticPrivateMethod2() {
-  return babelHelpers.get(babelHelpers.getPrototypeOf(_class), "basePublicStaticMethod", this).call(this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(_Sub), "basePublicStaticMethod", this).call(this);
 }
 Object.defineProperty(Sub, _subStaticPrivateMethod, {
   value: _subStaticPrivateMethod2

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsProperties/this/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _B;
 class A {
   static get a() {
     return 1;
@@ -14,9 +14,9 @@ class B extends A {
     return [babelHelpers.classPrivateFieldLooseBase(this, _getA)[_getA], babelHelpers.classPrivateFieldLooseBase(this, _getB)[_getB]];
   }
 }
-_class = B;
+_B = B;
 function _getA2() {
-  return babelHelpers.get(babelHelpers.getPrototypeOf(_class), "a", this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(_B), "a", this);
 }
 function _getB2() {
   return this.b;

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/class-expression/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/class-expression/output.js
@@ -1,9 +1,9 @@
-var _class, _foo;
-console.log((_foo = /*#__PURE__*/Symbol("foo"), (_class = class A {
+var _A, _foo;
+console.log((_foo = /*#__PURE__*/Symbol("foo"), (_A = class A {
   method() {
     babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
   }
-}, Object.defineProperty(_class, _foo, {
+}, Object.defineProperty(_A, _foo, {
   value: _foo2
-}), _class)));
+}), _A)));
 function _foo2() {}

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/super/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/super/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Sub;
 class Base {
   static basePublicStaticMethod() {
     return 'good';
@@ -13,9 +13,9 @@ class Sub extends Base {
     babelHelpers.classPrivateFieldLooseBase(Sub, _subStaticPrivateMethod)[_subStaticPrivateMethod]();
   }
 }
-_class = Sub;
+_Sub = Sub;
 function _subStaticPrivateMethod2() {
-  return babelHelpers.get(babelHelpers.getPrototypeOf(_class), "basePublicStaticMethod", this).call(this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(_Sub), "basePublicStaticMethod", this).call(this);
 }
 Object.defineProperty(Sub, _subStaticPrivateMethod, {
   value: _subStaticPrivateMethod2

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/this/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/this/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _B;
 class A {
   static get a() {
     return 1;
@@ -14,9 +14,9 @@ class B extends A {
     return [babelHelpers.classPrivateFieldLooseBase(this, _getA)[_getA], babelHelpers.classPrivateFieldLooseBase(this, _getB)[_getB]];
   }
 }
-_class = B;
+_B = B;
 function _getA2() {
-  return babelHelpers.get(babelHelpers.getPrototypeOf(_class), "a", this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(_B), "a", this);
 }
 function _getB2() {
   return this.b;

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method/class-expression/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method/class-expression/output.js
@@ -1,7 +1,7 @@
-var _class;
-console.log(_class = class A {
+var _A;
+console.log(_A = class A {
   method() {
-    babelHelpers.classStaticPrivateMethodGet(this, _class, _foo).call(this);
+    babelHelpers.classStaticPrivateMethodGet(this, _A, _foo).call(this);
   }
 });
 function _foo() {}

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method/super/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method/super/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Sub;
 class Base {
   static basePublicStaticMethod() {
     return 'good';
@@ -12,7 +12,7 @@ class Sub extends Base {
     babelHelpers.classStaticPrivateMethodGet(Sub, Sub, _subStaticPrivateMethod).call(Sub);
   }
 }
-_class = Sub;
+_Sub = Sub;
 function _subStaticPrivateMethod() {
-  return babelHelpers.get(babelHelpers.getPrototypeOf(_class), "basePublicStaticMethod", this).call(this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(_Sub), "basePublicStaticMethod", this).call(this);
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method/tagged-template/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method/tagged-template/output.js
@@ -1,7 +1,7 @@
-var _class;
+var _Foo;
 class Foo {}
-_class = Foo;
+_Foo = Foo;
 function _tag() {
-  babelHelpers.classStaticPrivateMethodGet(this, _class, _tag).bind(this)``;
+  babelHelpers.classStaticPrivateMethodGet(this, _Foo, _tag).bind(this)``;
 }
 new Foo();

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method/this/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method/this/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _B;
 class A {
   static get a() {
     return 1;
@@ -12,9 +12,9 @@ class B extends A {
     return [babelHelpers.classStaticPrivateMethodGet(this, B, _getA), babelHelpers.classStaticPrivateMethodGet(this, B, _getB)];
   }
 }
-_class = B;
+_B = B;
 function _getA() {
-  return babelHelpers.get(babelHelpers.getPrototypeOf(_class), "a", this);
+  return babelHelpers.get(babelHelpers.getPrototypeOf(_B), "a", this);
 }
 function _getB() {
   return this.b;

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-loose/basic/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-loose/basic/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Cl;
 var _PRIVATE_STATIC_FIELD = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
 var _privateStaticFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
 class Cl {
@@ -9,12 +9,12 @@ class Cl {
     babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue] = "dank";
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _get_privateStaticFieldValue() {
-  return babelHelpers.classPrivateFieldLooseBase(_class, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
+  return babelHelpers.classPrivateFieldLooseBase(_Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
 }
 function _set_privateStaticFieldValue(newValue) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = `Updated: ${newValue}`;
+  babelHelpers.classPrivateFieldLooseBase(_Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = `Updated: ${newValue}`;
 }
 Object.defineProperty(Cl, _privateStaticFieldValue, {
   get: _get_privateStaticFieldValue,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-loose/destructure-set/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-loose/destructure-set/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _C;
 var _p = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("p");
 var _q = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("q");
 class C {
@@ -6,9 +6,9 @@ class C {
     [babelHelpers.classPrivateFieldLooseBase(C, _p)[_p]] = [0];
   }
 }
-_class = C;
+_C = C;
 function _set_p(v) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _q)[_q] = v;
+  babelHelpers.classPrivateFieldLooseBase(_C, _q)[_q] = v;
 }
 Object.defineProperty(C, _p, {
   get: void 0,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-loose/get-only-setter/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-loose/get-only-setter/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Cl;
 var _PRIVATE_STATIC_FIELD = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
 var _privateStaticFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
 class Cl {
@@ -6,9 +6,9 @@ class Cl {
     return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue];
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _set_privateStaticFieldValue(newValue) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = newValue;
+  babelHelpers.classPrivateFieldLooseBase(_Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = newValue;
 }
 Object.defineProperty(Cl, _privateStaticFieldValue, {
   get: void 0,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-loose/updates/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-loose/updates/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Cl;
 var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 class Cl {
@@ -27,12 +27,12 @@ class Cl {
     Cl.publicFieldValue = -(Cl.publicFieldValue ** Cl.publicFieldValue);
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _get_privateFieldValue() {
-  return babelHelpers.classPrivateFieldLooseBase(_class, _privateField)[_privateField];
+  return babelHelpers.classPrivateFieldLooseBase(_Cl, _privateField)[_privateField];
 }
 function _set_privateFieldValue(newValue) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _privateField)[_privateField] = newValue;
+  babelHelpers.classPrivateFieldLooseBase(_Cl, _privateField)[_privateField] = newValue;
 }
 Object.defineProperty(Cl, _privateFieldValue, {
   get: _get_privateFieldValue,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/basic/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Cl;
 var _PRIVATE_STATIC_FIELD = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
 var _privateStaticFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
 class Cl {
@@ -9,12 +9,12 @@ class Cl {
     babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue] = "dank";
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _get_privateStaticFieldValue() {
-  return babelHelpers.classPrivateFieldLooseBase(_class, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
+  return babelHelpers.classPrivateFieldLooseBase(_Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
 }
 function _set_privateStaticFieldValue(newValue) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = `Updated: ${newValue}`;
+  babelHelpers.classPrivateFieldLooseBase(_Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = `Updated: ${newValue}`;
 }
 Object.defineProperty(Cl, _privateStaticFieldValue, {
   get: _get_privateStaticFieldValue,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/destructure-set/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _C;
 var _p = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("p");
 var _q = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("q");
 class C {
@@ -6,9 +6,9 @@ class C {
     [babelHelpers.classPrivateFieldLooseBase(C, _p)[_p]] = [0];
   }
 }
-_class = C;
+_C = C;
 function _set_p(v) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _q)[_q] = v;
+  babelHelpers.classPrivateFieldLooseBase(_C, _q)[_q] = v;
 }
 Object.defineProperty(C, _p, {
   get: void 0,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/get-only-setter/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Cl;
 var _PRIVATE_STATIC_FIELD = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("PRIVATE_STATIC_FIELD");
 var _privateStaticFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateStaticFieldValue");
 class Cl {
@@ -6,9 +6,9 @@ class Cl {
     return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue];
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _set_privateStaticFieldValue(newValue) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = newValue;
+  babelHelpers.classPrivateFieldLooseBase(_Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = newValue;
 }
 Object.defineProperty(Cl, _privateStaticFieldValue, {
   get: void 0,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsProperties/updates/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Cl;
 var _privateField = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateField");
 var _privateFieldValue = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("privateFieldValue");
 class Cl {
@@ -27,12 +27,12 @@ class Cl {
     Cl.publicFieldValue = -(Cl.publicFieldValue ** Cl.publicFieldValue);
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _get_privateFieldValue() {
-  return babelHelpers.classPrivateFieldLooseBase(_class, _privateField)[_privateField];
+  return babelHelpers.classPrivateFieldLooseBase(_Cl, _privateField)[_privateField];
 }
 function _set_privateFieldValue(newValue) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _privateField)[_privateField] = newValue;
+  babelHelpers.classPrivateFieldLooseBase(_Cl, _privateField)[_privateField] = newValue;
 }
 Object.defineProperty(Cl, _privateFieldValue, {
   get: _get_privateFieldValue,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/basic/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/basic/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Cl;
 var _PRIVATE_STATIC_FIELD = /*#__PURE__*/Symbol("PRIVATE_STATIC_FIELD");
 var _privateStaticFieldValue = /*#__PURE__*/Symbol("privateStaticFieldValue");
 class Cl {
@@ -9,12 +9,12 @@ class Cl {
     babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue] = "dank";
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _get_privateStaticFieldValue() {
-  return babelHelpers.classPrivateFieldLooseBase(_class, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
+  return babelHelpers.classPrivateFieldLooseBase(_Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD];
 }
 function _set_privateStaticFieldValue(newValue) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = `Updated: ${newValue}`;
+  babelHelpers.classPrivateFieldLooseBase(_Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = `Updated: ${newValue}`;
 }
 Object.defineProperty(Cl, _privateStaticFieldValue, {
   get: _get_privateStaticFieldValue,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/destructure-set/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/destructure-set/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _C;
 var _p = /*#__PURE__*/Symbol("p");
 var _q = /*#__PURE__*/Symbol("q");
 class C {
@@ -6,9 +6,9 @@ class C {
     [babelHelpers.classPrivateFieldLooseBase(C, _p)[_p]] = [0];
   }
 }
-_class = C;
+_C = C;
 function _set_p(v) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _q)[_q] = v;
+  babelHelpers.classPrivateFieldLooseBase(_C, _q)[_q] = v;
 }
 Object.defineProperty(C, _p, {
   get: void 0,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/get-only-setter/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/get-only-setter/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Cl;
 var _PRIVATE_STATIC_FIELD = /*#__PURE__*/Symbol("PRIVATE_STATIC_FIELD");
 var _privateStaticFieldValue = /*#__PURE__*/Symbol("privateStaticFieldValue");
 class Cl {
@@ -6,9 +6,9 @@ class Cl {
     return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue];
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _set_privateStaticFieldValue(newValue) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = newValue;
+  babelHelpers.classPrivateFieldLooseBase(_Cl, _PRIVATE_STATIC_FIELD)[_PRIVATE_STATIC_FIELD] = newValue;
 }
 Object.defineProperty(Cl, _privateStaticFieldValue, {
   get: void 0,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/updates/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/updates/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Cl;
 var _privateField = /*#__PURE__*/Symbol("privateField");
 var _privateFieldValue = /*#__PURE__*/Symbol("privateFieldValue");
 class Cl {
@@ -27,12 +27,12 @@ class Cl {
     Cl.publicFieldValue = -(Cl.publicFieldValue ** Cl.publicFieldValue);
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _get_privateFieldValue() {
-  return babelHelpers.classPrivateFieldLooseBase(_class, _privateField)[_privateField];
+  return babelHelpers.classPrivateFieldLooseBase(_Cl, _privateField)[_privateField];
 }
 function _set_privateFieldValue(newValue) {
-  babelHelpers.classPrivateFieldLooseBase(_class, _privateField)[_privateField] = newValue;
+  babelHelpers.classPrivateFieldLooseBase(_Cl, _privateField)[_privateField] = newValue;
 }
 Object.defineProperty(Cl, _privateFieldValue, {
   get: _get_privateFieldValue,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors/basic/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors/basic/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Cl;
 class Cl {
   static getValue() {
     return babelHelpers.classStaticPrivateFieldSpecGet(Cl, Cl, _privateStaticFieldValue);
@@ -7,12 +7,12 @@ class Cl {
     babelHelpers.classStaticPrivateFieldSpecSet(Cl, Cl, _privateStaticFieldValue, "dank");
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _get_privateStaticFieldValue() {
-  return babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _PRIVATE_STATIC_FIELD);
+  return babelHelpers.classStaticPrivateFieldSpecGet(_Cl, _Cl, _PRIVATE_STATIC_FIELD);
 }
 function _set_privateStaticFieldValue(newValue) {
-  babelHelpers.classStaticPrivateFieldSpecSet(_class, _class, _PRIVATE_STATIC_FIELD, `Updated: ${newValue}`);
+  babelHelpers.classStaticPrivateFieldSpecSet(_Cl, _Cl, _PRIVATE_STATIC_FIELD, `Updated: ${newValue}`);
 }
 var _privateStaticFieldValue = {
   get: _get_privateStaticFieldValue,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors/destructure-set/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors/destructure-set/output.js
@@ -1,12 +1,12 @@
-var _class;
+var _C;
 class C {
   constructor() {
     [babelHelpers.classStaticPrivateFieldDestructureSet(C, C, _p).value] = [0];
   }
 }
-_class = C;
+_C = C;
 function _set_p(v) {
-  babelHelpers.classStaticPrivateFieldSpecSet(_class, _class, _q, v);
+  babelHelpers.classStaticPrivateFieldSpecSet(_C, _C, _q, v);
 }
 var _p = {
   get: void 0,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors/get-only-setter/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors/get-only-setter/output.js
@@ -1,12 +1,12 @@
-var _class;
+var _Cl;
 class Cl {
   static getPrivateStaticFieldValue() {
     return babelHelpers.classStaticPrivateFieldSpecGet(Cl, Cl, _privateStaticFieldValue);
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _set_privateStaticFieldValue(newValue) {
-  babelHelpers.classStaticPrivateFieldSpecSet(_class, _class, _PRIVATE_STATIC_FIELD, newValue);
+  babelHelpers.classStaticPrivateFieldSpecSet(_Cl, _Cl, _PRIVATE_STATIC_FIELD, newValue);
 }
 var _privateStaticFieldValue = {
   get: void 0,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors/set-only-getter/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors/set-only-getter/output.js
@@ -1,13 +1,13 @@
-var _class;
+var _Cl;
 class Cl {
   constructor() {
     babelHelpers.classStaticPrivateFieldSpecSet(Cl, Cl, _privateFieldValue, 1);
     [babelHelpers.classStaticPrivateFieldDestructureSet(Cl, Cl, _privateFieldValue).value] = [1];
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _get_privateFieldValue() {
-  return babelHelpers.classStaticPrivateFieldSpecGet(this, _class, _privateField);
+  return babelHelpers.classStaticPrivateFieldSpecGet(this, _Cl, _privateField);
 }
 var _privateFieldValue = {
   get: _get_privateFieldValue,

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors/updates/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors/updates/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _Cl;
 class Cl {
   static publicGetPrivateField() {
     return babelHelpers.classStaticPrivateFieldSpecGet(Cl, Cl, _privateFieldValue);
@@ -26,12 +26,12 @@ class Cl {
     Cl.publicFieldValue = -(Cl.publicFieldValue ** Cl.publicFieldValue);
   }
 }
-_class = Cl;
+_Cl = Cl;
 function _get_privateFieldValue() {
-  return babelHelpers.classStaticPrivateFieldSpecGet(_class, _class, _privateField);
+  return babelHelpers.classStaticPrivateFieldSpecGet(_Cl, _Cl, _privateField);
 }
 function _set_privateFieldValue(newValue) {
-  babelHelpers.classStaticPrivateFieldSpecSet(_class, _class, _privateField, newValue);
+  babelHelpers.classStaticPrivateFieldSpecSet(_Cl, _Cl, _privateField, newValue);
 }
 var _privateFieldValue = {
   get: _get_privateFieldValue,

--- a/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-firefox-70/output.js
+++ b/packages/babel-preset-env/test/fixtures/shipped-proposals/new-class-features-firefox-70/output.js
@@ -1,4 +1,4 @@
-var _class;
+var _A;
 var _foo = /*#__PURE__*/new WeakMap();
 class A {
   constructor() {
@@ -8,5 +8,5 @@ class A {
     });
   }
 }
-_class = A;
-register(_class, _foo.has(babelHelpers.checkInRHS(_class)));
+_A = A;
+register(_A, _foo.has(babelHelpers.checkInRHS(_A)));


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
before
```ts
var _initClass, _dec, _dec2, _dec3, _dec4, _dec5, _dec6, _dec7, _dec8, _initProto;
const dec = () => {};
_dec = call();
_dec2 = chain.expr();
_dec3 = arbitrary + expr;
_dec4 = array[expr];
_dec5 = call();
_dec6 = chain.expr();
_dec7 = arbitrary + expr;
_dec8 = array[expr];
let _Foo;
class Foo {
  static {
    [_initProto, _Foo, _initClass] = babelHelpers.applyDecs(this, [[[dec, _dec5, _dec6, _dec7, _dec8], 2, "method"]], [dec, _dec, _dec2, _dec3, _dec4]);
  }
  constructor(...args) {
    _initProto(this);
  }
  #a;
  method() {}
  makeClass() {
    var _dec9, _init_bar;
    return _dec9 = this.#a, class Nested {
      static {
        [_init_bar] = babelHelpers.applyDecs(this, [[_dec9, 0, "bar"]], []);
      }
      bar = _init_bar(this);
    };  
}
  static {
    _initClass();
  }
}
```
after:
```ts
var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto;
const dec = () => {};
_classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
_dec = call();
_dec2 = chain.expr();
_dec3 = arbitrary + expr;
_dec4 = array[expr];
let _Foo;
class Foo {
  static {
    [_initProto, _Foo, _initClass] = babelHelpers.applyDecs(this, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs);
  }
  constructor() {
    _initProto(this);
  }
  #a;
  method() {}
  makeClass() {
    var _dec5, _init_bar;
    return _dec5 = this.#a, class Nested {
      static {
        [_init_bar] = babelHelpers.applyDecs(this, [[_dec5, 0, "bar"]], []);
      }
      bar = _init_bar(this);
    };
  }
  static {
    _initClass();
  }
}
```

In addition, some class reference variable naming logic has been improved.