### PR TITLE
Improve decorated private method check

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -569,7 +569,7 @@ function checkPrivateMethodUpdateError(
           parentParentPath.node.left === parentPath.node)
       ) {
         throw path.buildCodeFrameError(
-          `Decorated private methods are not updatable, but "#${path.node.id.name}" is updated via this expression.`,
+          `Decorated private methods are read-only, but "#${path.node.id.name}" is updated via this expression.`,
         );
       }
     },

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1061,10 +1061,6 @@ function transformClass(
     elementLocals.push(staticInitLocal);
   }
 
-  if (decoratedPrivateMethods.size > 0) {
-    checkPrivateMethodUpdateError(path, decoratedPrivateMethods);
-  }
-
   const classLocals: t.Identifier[] = [];
   let classInitInjected = false;
   const classInitCall =
@@ -1209,6 +1205,10 @@ function transformClass(
         t.variableDeclarator(t.cloneNode(classIdLocal)),
       ]),
     );
+  }
+
+  if (decoratedPrivateMethods.size > 0) {
+    checkPrivateMethodUpdateError(path, decoratedPrivateMethods);
   }
 
   // Recrawl the scope to make sure new identifiers are properly synced

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -574,7 +574,7 @@ function checkPrivateMethodUpdateError(
       }
     },
   });
-  const privateNamesMap = new Map();
+  const privateNamesMap = new Map<string, null>();
   for (const name of decoratedPrivateMethods) {
     privateNamesMap.set(name, null);
   }

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -26,7 +26,7 @@ interface PrivateNameMetadata {
   setterDeclared?: boolean;
 }
 
-export type PrivateNamesMapGeneric<V> = Map<string, V>;
+type PrivateNamesMapGeneric<V> = Map<string, V>;
 
 type PrivateNamesMap = PrivateNamesMapGeneric<PrivateNameMetadata>;
 

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -26,7 +26,9 @@ interface PrivateNameMetadata {
   setterDeclared?: boolean;
 }
 
-type PrivateNamesMap = Map<string, PrivateNameMetadata>;
+export type PrivateNamesMapGeneric<V> = Map<string, V>;
+
+type PrivateNamesMap = PrivateNamesMapGeneric<PrivateNameMetadata>;
 
 export function buildPrivateNamesMap(props: PropPath[]) {
   const privateNamesMap: PrivateNamesMap = new Map();
@@ -102,17 +104,16 @@ export function buildPrivateNamesNodes(
   return initNodes;
 }
 
-interface PrivateNameVisitorState {
-  privateNamesMap: PrivateNamesMap;
-  privateFieldsAsProperties: boolean;
+export interface PrivateNameVisitorState<V> {
+  privateNamesMap: PrivateNamesMapGeneric<V>;
   redeclared?: string[];
 }
 
 // Traverses the class scope, handling private name references. If an inner
 // class redeclares the same private name, it will hand off traversal to the
 // restricted visitor (which doesn't traverse the inner class's inner scope).
-function privateNameVisitorFactory<S>(
-  visitor: Visitor<PrivateNameVisitorState & S>,
+export function privateNameVisitorFactory<S, V>(
+  visitor: Visitor<PrivateNameVisitorState<V> & S>,
 ) {
   // Traverses the outer portion of a class, without touching the class's inner
   // scope, for private names.
@@ -123,7 +124,10 @@ function privateNameVisitorFactory<S>(
     environmentVisitor,
   ]);
 
-  const privateNameVisitor: Visitor<PrivateNameVisitorState & S> = {
+  // @ts-expect-error: TS2590: Expression produces a union type that is too complex to represent.
+  const privateNameVisitor: Visitor<
+    PrivateNameVisitorState<PrivateNameMetadata> & S
+  > = {
     ...visitor,
 
     Class(path) {
@@ -175,7 +179,8 @@ interface PrivateNameState {
 }
 
 const privateNameVisitor = privateNameVisitorFactory<
-  HandlerState<PrivateNameState> & PrivateNameState
+  HandlerState<PrivateNameState> & PrivateNameState,
+  PrivateNameMetadata
 >({
   PrivateName(path, { noDocumentAll }) {
     const { privateNamesMap, redeclared } = this;
@@ -222,11 +227,15 @@ export function buildCheckInRHS(
   return t.callExpression(file.addHelper("checkInRHS"), [rhs]);
 }
 
-const privateInVisitor = privateNameVisitorFactory<{
-  classRef: t.Identifier;
-  file: File;
-  innerBinding?: t.Identifier;
-}>({
+const privateInVisitor = privateNameVisitorFactory<
+  {
+    classRef: t.Identifier;
+    file: File;
+    innerBinding?: t.Identifier;
+    privateFieldsAsProperties: boolean;
+  },
+  PrivateNameMetadata
+>({
   BinaryExpression(path, { file }) {
     const { operator, left, right } = path.node;
     if (operator !== "in") return;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method-via-array-pattern/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method-via-array-pattern/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method-via-for-of/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method-via-for-of/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method-via-object-pattern/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method-via-object-pattern/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method-via-rest/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method-via-rest/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method-via-update/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method-via-update/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/setting-private-method/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method-via-array-pattern/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method-via-array-pattern/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method-via-for-of/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method-via-for-of/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method-via-object-pattern/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method-via-object-pattern/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method-via-rest/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method-via-rest/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method-via-update/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method-via-update/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/setting-private-method/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method-via-array-pattern/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method-via-array-pattern/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method-via-for-of/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method-via-for-of/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method-via-object-pattern/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method-via-object-pattern/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method-via-rest/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method-via-rest/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method-via-update/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method-via-update/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/setting-private-method/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-in-body/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-in-body/input.js
@@ -1,0 +1,6 @@
+const dec = () => {};
+class Foo {
+  @dec #x() {
+    this.#x = 123;
+  }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-in-body/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-in-body/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-in-body/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-in-body/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-via-array-pattern/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-via-array-pattern/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-via-for-of/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-via-for-of/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-via-object-pattern/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-via-object-pattern/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-via-rest/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-via-rest/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-via-update/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method-via-update/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-private-method/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Decorated private methods are not updatable, but \"#x\" is updated via this expression."
+  "throws": "Decorated private methods are read-only, but \"#x\" is updated via this expression."
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-shadowed-private-method-valid/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-shadowed-private-method-valid/input.js
@@ -1,0 +1,11 @@
+const dec = () => {};
+class Foo {
+  @dec #x() {
+    class Nested {
+      static #x;
+      static set x(v) {
+        this.#x = v;
+      }
+    }
+  }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-shadowed-private-method-valid/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-shadowed-private-method-valid/output.js
@@ -1,0 +1,18 @@
+var _call_x, _initProto;
+const dec = () => {};
+class Foo {
+  static {
+    [_call_x, _initProto] = babelHelpers.applyDecs2305(this, [[dec, 2, "x", function () {
+      class Nested {
+        static #x;
+        static set x(v) {
+          this.#x = v;
+        }
+      }
+    }]], [], 0, _ => #x in _).e;
+  }
+  constructor() {
+    _initProto(this);
+  }
+  #x = _call_x;
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Babel throws when a private name shadowing decorated private method gets updated. ([REPL](https://babel.dev/repl#?browsers=chrome%2094&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=MYewdgzgLgBAJgU2DAvDAFASlQPhgbwF8BuAKGABsBDCCGAMRBANJhgAFFkBiADywKFWMALYIoACxBwB-YW0o06AOQTQEcFm20xoVKAEsevMjrZ7DyCOJj8AbtjlntkgxAB0fVDDumzQnQCYIUIgA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=true&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact&prettier=false&targets=&version=7.23.8&externalPlugins=%40babel%2Fplugin-proposal-decorators%407.23.3&assumptions=%7B%7D))
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we improve the decorated private method check in decorator transform. It now reuses the private name visitor factory from the class features plugin, which can handle the shadowed private name usage.

We also move the check after the decorator transform so that if the decorated method gets updated in its own function body, we can still detect such error.

This PR can be reviewed by commits.