### PR TITLE
Refactor `protoInit` call injection

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -270,7 +270,7 @@ function extractProxyAccessorsFor(
 
 /**
  * Prepend expressions to the field initializer. If the initializer is not defined,
- * this function will add a trailing `void 0` expression
+ * this function will wrap the last expression within a `void` unary expression.
  *
  * @param {t.Expression[]} expressions
  * @param {(NodePath<
@@ -286,8 +286,11 @@ function prependExpressionsToFieldInitializer(
   const initializer = fieldPath.get("value");
   if (initializer.node) {
     expressions.push(initializer.node);
-  } else {
-    expressions.push(t.unaryExpression("void", t.numericLiteral(0)));
+  } else if (expressions.length > 0) {
+    expressions[expressions.length - 1] = t.unaryExpression(
+      "void",
+      expressions[expressions.length - 1],
+    );
   }
   initializer.replaceWith(maybeSequenceExpression(expressions));
 }

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -371,7 +371,7 @@ function insertExpressionsAfterSuperCallAndOptimize(
           path.node,
           ...expressions.map(expr => t.cloneNode(expr)),
         ];
-        // preserve completion result if super() is in the return
+        // preserve completion result if super() is in an RHS or a return statement
         if (path.isCompletionRecord()) {
           newNodes.push(t.thisExpression());
         }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _Foo;
+var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _Foo;
+var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _a = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto, _Foo;
+var _initProto, _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _Foo;
+var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic, _Foo;
+var _initStatic, _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic;
+var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto;
+var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto;
+var _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic;
+var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic;
+var _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto, _Foo;
+var _initProto, _computedKey, _computedKey2, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto, _Foo;
+var _initProto, _computedKey, _computedKey2, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto, _Foo;
+var _initProto, _init_a, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-value/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto;
+var _initProto, _init_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initProto, _Foo;
+var _initProto, _call_a, _call_a2, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic, _Foo;
+var _initStatic, _call_a, _call_a2, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initProto;
+var _initProto, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic;
+var _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static callA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -1,4 +1,4 @@
-var _dec, _initProto, _A;
+var _initProto, _dec, _A;
 const dec = () => {};
 _dec = deco;
 class A extends B {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto, _Foo2;
+var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _Foo2;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/all-decorators/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r, _initProto, _initStatic;
+var _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
 const dec = () => {};
 let _Class;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,4 +1,4 @@
-var _dec, _initProto, _dec2, _initProto2;
+var _initProto, _dec, _initProto2, _dec2;
 const dec = () => {};
 _dec = deco;
 class A extends B {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor/output.js
@@ -68,7 +68,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        var _computedKey, _initProto3;
+        var _initProto3, _computedKey;
         let key;
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
@@ -94,7 +94,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _dec, _initProto4;
+        var _initProto4, _dec;
         _dec = noop(log.push(super(7).method()));
         class A extends B {
           static {
@@ -147,7 +147,7 @@
         [_initProto6] = babelHelpers.applyDecs(this, [[dec, 2, "method"]], []);
       }
       constructor() {
-        var _dec2, _initProto7;
+        var _initProto7, _dec2;
         new (_dec2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
           static {
             [_initProto7] = babelHelpers.applyDecs(this, [[_dec2, 2, "noop"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto;
+var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _Foo;
+var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _Foo;
+var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _a = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto, _Foo;
+var _initProto, _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _Foo;
+var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic, _Foo;
+var _initStatic, _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic;
+var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto;
+var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto;
+var _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic;
+var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic;
+var _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initProto, _C2;
+var _initProto, _initClass, _C2;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initProto;
+var _initProto, _initClass;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto, _Foo;
+var _initProto, _computedKey, _computedKey2, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto, _Foo;
+var _initProto, _computedKey, _computedKey2, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto, _Foo;
+var _initProto, _init_a, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-value/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto;
+var _initProto, _init_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initProto, _Foo;
+var _initProto, _call_a, _call_a2, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic, _Foo;
+var _initStatic, _call_a, _call_a2, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initProto;
+var _initProto, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic;
+var _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static callA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -66,7 +66,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        var _computedKey, _initProto3, _A3;
+        var _initProto3, _computedKey, _A3;
         let key;
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
@@ -90,7 +90,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _dec, _initProto4, _A4;
+        var _initProto4, _dec, _A4;
         _dec = noop(log.push(super(7).method()));
         class A extends B {
           constructor() {
@@ -138,7 +138,7 @@
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        var _dec2, _initProto7, _Dummy2;
+        var _initProto7, _dec2, _Dummy2;
         new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto, _Foo2;
+var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _Foo2;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/all-decorators/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r, _initProto, _initStatic;
+var _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
 const dec = () => {};
 let _Class;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,4 +1,4 @@
-var _dec, _initProto, _dec2, _initProto2;
+var _initProto, _dec, _initProto2, _dec2;
 const dec = () => {};
 _dec = deco;
 class A extends B {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor/output.js
@@ -68,7 +68,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        var _computedKey, _initProto3;
+        var _initProto3, _computedKey;
         let key;
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
@@ -94,7 +94,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _dec, _initProto4;
+        var _initProto4, _dec;
         _dec = noop(log.push(super(7).method()));
         class A extends B {
           static {
@@ -147,7 +147,7 @@
         [_initProto6] = babelHelpers.applyDecs2203R(this, [[dec, 2, "method"]], []).e;
       }
       constructor() {
-        var _dec2, _initProto7;
+        var _initProto7, _dec2;
         new (_dec2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
           static {
             [_initProto7] = babelHelpers.applyDecs2203R(this, [[_dec2, 2, "noop"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto;
+var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _Foo;
+var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _Foo;
+var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _a = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto, _Foo;
+var _initProto, _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _Foo;
+var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic, _Foo;
+var _initStatic, _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic;
+var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto;
+var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto;
+var _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic;
+var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic;
+var _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initProto, _C2;
+var _initProto, _initClass, _C2;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initProto;
+var _initProto, _initClass;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto, _Foo;
+var _initProto, _computedKey, _computedKey2, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto, _Foo;
+var _initProto, _computedKey, _computedKey2, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto, _Foo;
+var _initProto, _init_a, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-value/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto;
+var _initProto, _init_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initProto, _Foo;
+var _initProto, _call_a, _call_a2, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic, _Foo;
+var _initStatic, _call_a, _call_a2, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initProto;
+var _initProto, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic;
+var _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static callA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -66,7 +66,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        var _computedKey, _initProto3, _A3;
+        var _initProto3, _computedKey, _A3;
         let key;
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
@@ -90,7 +90,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _dec, _initProto4, _A4;
+        var _initProto4, _dec, _A4;
         _dec = noop(log.push(super(7).method()));
         class A extends B {
           constructor() {
@@ -138,7 +138,7 @@
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        var _dec2, _initProto7, _Dummy2;
+        var _initProto7, _dec2, _Dummy2;
         new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto, _Foo2;
+var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _Foo2;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/all-decorators/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r, _initProto, _initStatic;
+var _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
 const dec = () => {};
 let _Class;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,4 +1,4 @@
-var _dec, _initProto, _dec2, _initProto2;
+var _initProto, _dec, _initProto2, _dec2;
 const dec = () => {};
 _dec = deco;
 class A extends B {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor/output.js
@@ -68,7 +68,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        var _computedKey, _initProto3;
+        var _initProto3, _computedKey;
         let key;
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
@@ -94,7 +94,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _dec, _initProto4;
+        var _initProto4, _dec;
         _dec = noop(log.push(super(7).method()));
         class A extends B {
           static {
@@ -147,7 +147,7 @@
         [_initProto6] = babelHelpers.applyDecs2301(this, [[dec, 2, "method"]], []).e;
       }
       constructor() {
-        var _dec2, _initProto7;
+        var _initProto7, _dec2;
         new (_dec2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
           static {
             [_initProto7] = babelHelpers.applyDecs2301(this, [[_dec2, 2, "noop"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _initProto;
+var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 _dec = call();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic, _Foo;
+var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto, _Foo;
+var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _a = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto, _Foo;
+var _initProto, _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic, _Foo;
+var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic, _Foo;
+var _initStatic, _init_a, _init_b, _init_computedKey, _Foo;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7, _initStatic;
+var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto;
+var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initProto;
+var _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic;
+var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey, _initStatic;
+var _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-assumption-constantSuper/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-assumption-constantSuper/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto, _Bar;
+var _initProto, _call_x, _Bar;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-assumption-constantSuper/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-assumption-constantSuper/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto, _Bar;
+var _initProto, _call_x, _Bar;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initProto, _C2;
+var _initProto, _initClass, _C2;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initProto;
+var _initProto, _initClass;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto, _Foo;
+var _initProto, _computedKey, _computedKey2, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto, _Foo;
+var _initProto, _computedKey, _computedKey2, _Foo;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto, _Foo;
+var _initProto, _init_a, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-value/output.js
@@ -1,4 +1,4 @@
-var _computedKey, _computedKey2, _initProto;
+var _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _init_a, _initProto;
+var _initProto, _init_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initProto, _Foo;
+var _initProto, _call_a, _call_a2, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic, _Foo;
+var _initStatic, _call_a, _call_a2, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initProto;
+var _initProto, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _call_a2, _initStatic;
+var _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static callA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -66,7 +66,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        var _computedKey, _initProto3, _A3;
+        var _initProto3, _computedKey, _A3;
         let key;
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
@@ -90,7 +90,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _dec, _initProto4, _A4;
+        var _initProto4, _dec, _A4;
         _dec = noop(log.push(super(7).method()));
         class A extends B {
           constructor() {
@@ -138,7 +138,7 @@
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        var _dec2, _initProto7, _Dummy2;
+        var _initProto7, _dec2, _Dummy2;
         new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
@@ -1,6 +1,6 @@
 class A extends B {
   m() {
-    var _initClass, _classDecs, _obj, _dec, _initProto, _C2;
+    var _initProto, _initClass, _classDecs, _obj, _dec, _C2;
     _classDecs = [this, super.dec1];
     _obj = this;
     _dec = super.dec2;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initClass, _classDecs, _dec, _dec2, _dec3, _obj, _dec4, _initProto, _Foo2;
+var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _obj, _dec4, _Foo2;
 const dec = () => {};
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, array, array[expr]];
 _dec = call();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/all-decorators/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r, _initProto, _initStatic;
+var _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
 const dec = () => {};
 let _Class;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,4 +1,4 @@
-var _dec, _initProto, _B, _dec2, _initProto2, _B2;
+var _initProto, _dec, _B, _initProto2, _dec2, _B2;
 const dec = () => {};
 _dec = deco;
 class A extends (_B = B) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor/output.js
@@ -68,7 +68,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        var _computedKey, _initProto3;
+        var _initProto3, _computedKey;
         let key;
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
@@ -94,7 +94,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _dec, _initProto4;
+        var _initProto4, _dec;
         _dec = noop(log.push(super(7).method()));
         class A extends B {
           static {
@@ -147,7 +147,7 @@
         [_initProto6] = babelHelpers.applyDecs2305(this, [[dec, 2, "method"]], [], 0, void 0, B).e;
       }
       constructor() {
-        var _dec2, _initProto7;
+        var _initProto7, _dec2;
         new (_dec2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
           static {
             [_initProto7] = babelHelpers.applyDecs2305(this, [[_dec2, 2, "noop"]], [], 0, void 0, B).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-shadowed-private-method-valid/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-shadowed-private-method-valid/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto;
+var _initProto, _call_x;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
@@ -1,6 +1,6 @@
 class A extends B {
   m() {
-    var _initClass, _classDecs, _obj, _dec, _initProto;
+    var _initProto, _initClass, _classDecs, _obj, _dec;
     _classDecs = [this, super.dec1];
     _obj = this;
     _dec = super.dec2;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto, _Bar;
+var _initProto, _call_x, _Bar;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _call_x, _initProto, _Bar;
+var _initProto, _call_x, _Bar;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initClass, _classDecs, _dec, _dec2, _dec3, _obj, _dec4, _initProto;
+var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _obj, _dec4;
 const dec = () => {};
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, array, array[expr]];
 _dec = call();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering--to-es2015/initializers-and-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering--to-es2015/initializers-and-static-blocks/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_field, _init_field2, _init_accessor, _init_accessor2, _initProto, _initStatic, _ref, _B, _temp;
+var _initProto, _initStatic, _initClass, _init_field, _init_field2, _init_accessor, _init_accessor2, _ref, _B, _temp;
 const log = [];
 const classDec1 = (cls, ctxClass) => {
   log.push("c2");

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering/initializers-and-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering/initializers-and-static-blocks/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_field, _init_field2, _init_accessor, _init_accessor2, _initProto, _initStatic, _ref;
+var _initProto, _initStatic, _initClass, _init_field, _init_field2, _init_accessor, _init_accessor2, _ref;
 const log = [];
 const classDec1 = (cls, ctxClass) => {
   log.push("c2");

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic, _Foo;
+var _initStatic, _call_a, _computedKey, _Foo;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto, _Foo;
+var _initProto, _call_a, _Foo;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic, _Foo;
+var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/output.js
@@ -1,4 +1,4 @@
-var _call_a, _computedKey, _initStatic;
+var _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initProto;
+var _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _call_a, _initStatic;
+var _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This is a refactoring PR that paves the road to implement https://github.com/pzuraq/ecma262/pull/12.

Previously we are searching the first field to inject `initProto`. In this PR we create a `fieldInitializerAssignments` queue, which will be prepended to the next available non-static field initializers, falling back to the class constructor. Though in this PR the `fieldInitializerAssignments` contains only the `initProto` call, it is designed to work with other assignments as well, such as the extra initializers introduced in https://github.com/pzuraq/ecma262/pull/12.

For example, according to the updated spec, the input
```js
class C {
  @dec #p = 1;
  #q = 2;
}
```
should be transformed to

```js
class C {
  static {
    [_init_p, _extra_init_p] = _applyDecs(this, [[dec, 0, "p", o => o.#p, (o, v) => o.#p = v]], [], 0, _ => #q in _).e;
  }
  #p = _init_p(this, 1);
  #q = (_extra_init_p(this), 2);
}
```
as the extra initializers added by `context.addInitializers()` are now run _after_ the field is created in the receiver class.

The test fixtures are updated because `protoInit` and the `staticInit` id are now declared before other generated identifiers. There are no behaviour changes introduced in this PR.