### PR TITLE
Fix `protoInit` call injection timing

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1138,20 +1138,20 @@ function transformClass(
         if (element.node) {
           element.node.decorators = null;
         }
+      }
 
-        if (
-          fieldInitializerAssignments.length > 0 &&
-          !isStatic &&
-          (kind === FIELD || kind === ACCESSOR)
-        ) {
-          prependExpressionsToFieldInitializer(
-            fieldInitializerAssignments,
-            element as NodePath<
-              t.ClassProperty | t.ClassPrivateProperty | t.ClassAccessorProperty
-            >,
-          );
-          fieldInitializerAssignments = [];
-        }
+      if (
+        fieldInitializerAssignments.length > 0 &&
+        !isStatic &&
+        (kind === FIELD || kind === ACCESSOR)
+      ) {
+        prependExpressionsToFieldInitializer(
+          fieldInitializerAssignments,
+          element as NodePath<
+            t.ClassProperty | t.ClassPrivateProperty | t.ClassAccessorProperty
+          >,
+        );
+        fieldInitializerAssignments = [];
       }
     }
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: _get_a,
       set: void 0
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
     return babelHelpers.classPrivateFieldGet(this, _a);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   get a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: _get_a,
       set: _set_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
     return babelHelpers.classPrivateFieldGet(this, _a);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   get a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/private/output.js
@@ -8,10 +8,7 @@ class Foo {
       this.value = v;
     }]], []);
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get #a() {
     return _call_a(this);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []);
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/private/output.js
@@ -6,10 +6,7 @@ class Foo {
       return this.value;
     }]], []);
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get #a() {
     return _call_a(this);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 3, "a"], [dec, 3, 'b']], []);
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       writable: true,
       value: _call_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   callA() {
     return babelHelpers.classPrivateFieldGet(this, _a).call(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/private/output.js
@@ -6,11 +6,8 @@ class Foo {
       return this.value;
     }]], []);
   }
-  constructor() {
-    _initProto(this);
-  }
   #a = _call_a;
-  value = 1;
+  value = (_initProto(this), 1);
   callA() {
     return this.#a();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 2, "a"], [dec, 2, 'b']], []);
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
@@ -11,9 +11,8 @@ class Foo {
   constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
-      value: void 0
+      value: void _initProto(this)
     });
-    _initProto(this);
   }
   method() {}
   makeClass() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor/output.js
@@ -76,12 +76,12 @@
             [_initProto3] = babelHelpers.applyDecs(this, [[dec, 2, "method"]], []);
           }
           constructor() {
-            log.push(_initProto3(super(6)).method());
+            log.push(super(6).method());
           }
           method() {
             return this.a;
           }
-          [_computedKey];
+          [_computedKey] = void _initProto3(this);
         }
         new A();
       }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
@@ -10,10 +10,7 @@ class Foo {
   static {
     [_initProto, _Foo, _initClass] = babelHelpers.applyDecs(this, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs);
   }
-  constructor() {
-    _initProto(this);
-  }
-  #a;
+  #a = void _initProto(this);
   method() {}
   makeClass() {
     var _dec5, _init_bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: void 0,
       set: _set_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   setA(v) {
     babelHelpers.classPrivateFieldSet(this, _a, v);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   set a(v) {
     return this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/private/output.js
@@ -6,10 +6,7 @@ class Foo {
       return this.value = v;
     }]], []);
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   set #a(v) {
     _call_a(this, v);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs(this, [[dec, 4, "a"], [dec, 4, 'b']], []);
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   set a(v) {
     return this.value = v;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: _get_a,
       set: void 0
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
     return babelHelpers.classPrivateFieldGet(this, _a);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   get a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: _get_a,
       set: _set_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
     return babelHelpers.classPrivateFieldGet(this, _a);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   get a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/private/output.js
@@ -8,10 +8,7 @@ class Foo {
       this.value = v;
     }]], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get #a() {
     return _call_a(this);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/private/output.js
@@ -6,10 +6,7 @@ class Foo {
       return this.value;
     }]], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get #a() {
     return _call_a(this);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       writable: true,
       value: _call_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   callA() {
     return babelHelpers.classPrivateFieldGet(this, _a).call(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/private/output.js
@@ -6,11 +6,8 @@ class Foo {
       return this.value;
     }]], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
   #a = _call_a;
-  value = 1;
+  value = (_initProto(this), 1);
   callA() {
     return this.#a();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -71,7 +71,7 @@
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
           constructor() {
-            log.push(_initProto3((super(6), babelHelpers.defineProperty(this, _computedKey, void 0))).method());
+            log.push((super(6), babelHelpers.defineProperty(this, _computedKey, void _initProto3(this))).method());
           }
           method() {
             return this.a;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/valid-expression-formats/output.js
@@ -11,9 +11,8 @@ class Foo {
   constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
-      value: void 0
+      value: void _initProto(this)
     });
-    _initProto(this);
   }
   method() {}
   makeClass() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor/output.js
@@ -76,12 +76,12 @@
             [_initProto3] = babelHelpers.applyDecs2203R(this, [[dec, 2, "method"]], []).e;
           }
           constructor() {
-            log.push(_initProto3(super(6)).method());
+            log.push(super(6).method());
           }
           method() {
             return this.a;
           }
-          [_computedKey];
+          [_computedKey] = void _initProto3(this);
         }
         new A();
       }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/valid-expression-formats/output.js
@@ -13,10 +13,7 @@ class Foo {
       c: [_Foo, _initClass]
     } = babelHelpers.applyDecs2203R(this, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs));
   }
-  constructor() {
-    _initProto(this);
-  }
-  #a;
+  #a = void _initProto(this);
   method() {}
   makeClass() {
     var _dec5, _init_bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: void 0,
       set: _set_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   setA(v) {
     babelHelpers.classPrivateFieldSet(this, _a, v);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   set a(v) {
     return this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/private/output.js
@@ -6,10 +6,7 @@ class Foo {
       return this.value = v;
     }]], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   set #a(v) {
     _call_a(this, v);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2203R(this, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   set a(v) {
     return this.value = v;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: _get_a,
       set: void 0
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
     return babelHelpers.classPrivateFieldGet(this, _a);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   get a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: _get_a,
       set: _set_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
     return babelHelpers.classPrivateFieldGet(this, _a);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   get a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/private/output.js
@@ -8,10 +8,7 @@ class Foo {
       this.value = v;
     }]], [], _ => #a in _).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get #a() {
     return _call_a(this);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/private/output.js
@@ -6,10 +6,7 @@ class Foo {
       return this.value;
     }]], [], _ => #a in _).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get #a() {
     return _call_a(this);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       writable: true,
       value: _call_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   callA() {
     return babelHelpers.classPrivateFieldGet(this, _a).call(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/private/output.js
@@ -6,11 +6,8 @@ class Foo {
       return this.value;
     }]], [], _ => #a in _).e;
   }
-  constructor() {
-    _initProto(this);
-  }
   #a = _call_a;
-  value = 1;
+  value = (_initProto(this), 1);
   callA() {
     return this.#a();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -71,7 +71,7 @@
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
           constructor() {
-            log.push(_initProto3((super(6), babelHelpers.defineProperty(this, _computedKey, void 0))).method());
+            log.push((super(6), babelHelpers.defineProperty(this, _computedKey, void _initProto3(this))).method());
           }
           method() {
             return this.a;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/valid-expression-formats/output.js
@@ -11,9 +11,8 @@ class Foo {
   constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
-      value: void 0
+      value: void _initProto(this)
     });
-    _initProto(this);
   }
   method() {}
   makeClass() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor/output.js
@@ -76,12 +76,12 @@
             [_initProto3] = babelHelpers.applyDecs2301(this, [[dec, 2, "method"]], []).e;
           }
           constructor() {
-            log.push(_initProto3(super(6)).method());
+            log.push(super(6).method());
           }
           method() {
             return this.a;
           }
-          [_computedKey];
+          [_computedKey] = void _initProto3(this);
         }
         new A();
       }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/valid-expression-formats/output.js
@@ -13,10 +13,7 @@ class Foo {
       c: [_Foo, _initClass]
     } = babelHelpers.applyDecs2301(this, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs));
   }
-  constructor() {
-    _initProto(this);
-  }
-  #a;
+  #a = void _initProto(this);
   method() {}
   makeClass() {
     var _dec5, _init_bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: void 0,
       set: _set_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   setA(v) {
     babelHelpers.classPrivateFieldSet(this, _a, v);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   set a(v) {
     return this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/private/output.js
@@ -6,10 +6,7 @@ class Foo {
       return this.value = v;
     }]], [], _ => #a in _).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   set #a(v) {
     _call_a(this, v);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2301(this, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   set a(v) {
     return this.value = v;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: _get_a,
       set: void 0
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
     return babelHelpers.classPrivateFieldGet(this, _a);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   get a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: _get_a,
       set: _set_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
     return babelHelpers.classPrivateFieldGet(this, _a);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   get a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/private/output.js
@@ -8,10 +8,7 @@ class Foo {
       this.value = v;
     }]], [], 0, _ => #a in _).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get #a() {
     return _call_a(this);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 3, "a"], [dec, 4, "a"], [dec, 3, 'b'], [dec, 4, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/private/output.js
@@ -6,10 +6,7 @@ class Foo {
       return this.value;
     }]], [], 0, _ => #a in _).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get #a() {
     return _call_a(this);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 3, "a"], [dec, 3, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   get a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       writable: true,
       value: _call_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   callA() {
     return babelHelpers.classPrivateFieldGet(this, _a).call(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   a() {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/private/output.js
@@ -6,11 +6,8 @@ class Foo {
       return this.value;
     }]], [], 0, _ => #a in _).e;
   }
-  constructor() {
-    _initProto(this);
-  }
   #a = _call_a;
-  value = 1;
+  value = (_initProto(this), 1);
   callA() {
     return this.#a();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 2, "a"], [dec, 2, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   a() {
     return this.value;
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -71,7 +71,7 @@
         _computedKey = babelHelpers.toPropertyKey((key = super(5).method(), log.push(key), key));
         class A extends B {
           constructor() {
-            log.push(_initProto3((super(6), babelHelpers.defineProperty(this, _computedKey, void 0))).method());
+            log.push((super(6), babelHelpers.defineProperty(this, _computedKey, void _initProto3(this))).method());
           }
           method() {
             return this.a;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
@@ -12,9 +12,8 @@ class Foo {
   constructor() {
     babelHelpers.classPrivateFieldInitSpec(this, _a, {
       writable: true,
-      value: void 0
+      value: void _initProto(this)
     });
-    _initProto(this);
   }
   method() {}
   makeClass() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor/output.js
@@ -76,12 +76,12 @@
             [_initProto3] = babelHelpers.applyDecs2305(this, [[dec, 2, "method"]], [], 0, void 0, B).e;
           }
           constructor() {
-            log.push(_initProto3(super(6)).method());
+            log.push(super(6).method());
           }
           method() {
             return this.a;
           }
-          [_computedKey];
+          [_computedKey] = void _initProto3(this);
         }
         new A();
       }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
@@ -14,10 +14,7 @@ class Foo {
       c: [_Foo, _initClass]
     } = babelHelpers.applyDecs2305(this, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj, _dec4], 18, "method"]], _classDecs, 1));
   }
-  constructor() {
-    _initProto(this);
-  }
-  #a;
+  #a = void _initProto(this);
   method() {}
   makeClass() {
     var _obj2, _dec5, _init_bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering--to-es2015/method-initializers-field-value/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering--to-es2015/method-initializers-field-value/exec.js
@@ -1,0 +1,153 @@
+{
+  const log = [];
+  const methodDec1 = (fn, ctxMethod) => {
+    log.push("m2");
+    ctxMethod.addInitializer(() => log.push("m5"));
+    ctxMethod.addInitializer(() => log.push("m6"));
+  };
+  const methodDec2 = (fn, ctxMethod) => {
+    log.push("m1");
+    ctxMethod.addInitializer(() => log.push("m3"));
+    ctxMethod.addInitializer(() => log.push("m4"));
+  };
+  const getterDec1 = (fn, ctxGetter) => {
+    log.push("g2");
+    ctxGetter.addInitializer(() => log.push("g5"));
+    ctxGetter.addInitializer(() => log.push("g6"));
+  };
+  const getterDec2 = (fn, ctxGetter) => {
+    log.push("g1");
+    ctxGetter.addInitializer(() => log.push("g3"));
+    ctxGetter.addInitializer(() => log.push("g4"));
+  };
+  const setterDec1 = (fn, ctxSetter) => {
+    log.push("s2");
+    ctxSetter.addInitializer(() => log.push("s5"));
+    ctxSetter.addInitializer(() => log.push("s6"));
+  };
+  const setterDec2 = (fn, ctxSetter) => {
+    log.push("s1");
+    ctxSetter.addInitializer(() => log.push("s3"));
+    ctxSetter.addInitializer(() => log.push("s4"));
+  };
+  log.push("start");
+  class Foo extends (log.push("extends"), Object) {
+    static {
+      log.push("static:start");
+    }
+    constructor() {
+      log.push("ctor:start");
+      super();
+      log.push("ctor:end");
+    }
+    @methodDec1
+    @methodDec2
+    method() {}
+
+    field = log.push("f");
+
+    @getterDec1
+    @getterDec2
+    get getter() {
+      return;
+    }
+    @setterDec1
+    @setterDec2
+    set setter(x) {}
+    static {
+      log.push("static:end");
+    }
+  }
+  log.push("after");
+  new Foo();
+  log.push("end");
+  expect(log + "").toEqual(
+    "start,extends," +
+      "m1,m2,g1,g2,s1,s2," + // For each element e of instanceElements if e.[[Kind]] is not field
+      "static:start," + // staticElements
+      "static:end," + // staticElements
+      "after," +
+      "ctor:start," +
+      "m3,m4,m5,m6,g3,g4,g5,g6,s3,s4,s5,s6," + // instanceExtraInitializers
+      "f," + // InitializeFieldOrAccessor
+      "ctor:end," +
+      "end",
+  );
+}
+
+{
+  const log = [];
+  const methodDec1 = (fn, ctxMethod) => {
+    log.push("m2");
+    ctxMethod.addInitializer(() => log.push("m5"));
+    ctxMethod.addInitializer(() => log.push("m6"));
+  };
+  const methodDec2 = (fn, ctxMethod) => {
+    log.push("m1");
+    ctxMethod.addInitializer(() => log.push("m3"));
+    ctxMethod.addInitializer(() => log.push("m4"));
+  };
+  const getterDec1 = (fn, ctxGetter) => {
+    log.push("g2");
+    ctxGetter.addInitializer(() => log.push("g5"));
+    ctxGetter.addInitializer(() => log.push("g6"));
+  };
+  const getterDec2 = (fn, ctxGetter) => {
+    log.push("g1");
+    ctxGetter.addInitializer(() => log.push("g3"));
+    ctxGetter.addInitializer(() => log.push("g4"));
+  };
+  const setterDec1 = (fn, ctxSetter) => {
+    log.push("s2");
+    ctxSetter.addInitializer(() => log.push("s5"));
+    ctxSetter.addInitializer(() => log.push("s6"));
+  };
+  const setterDec2 = (fn, ctxSetter) => {
+    log.push("s1");
+    ctxSetter.addInitializer(() => log.push("s3"));
+    ctxSetter.addInitializer(() => log.push("s4"));
+  };
+  log.push("start");
+  class Foo extends (log.push("extends"), Object) {
+    static {
+      log.push("static:start");
+    }
+    constructor() {
+      log.push("ctor:start");
+      super();
+      log.push("ctor:end");
+    }
+    @methodDec1
+    @methodDec2
+    method() {}
+
+    accessor field = log.push("a");
+
+    @getterDec1
+    @getterDec2
+    get getter() {
+      return;
+    }
+    @setterDec1
+    @setterDec2
+    set setter(x) {}
+    static {
+      log.push("static:end");
+    }
+  }
+  log.push("after");
+  new Foo();
+  log.push("end");
+  expect(log + "").toEqual(
+    "start,extends," +
+      "m1,m2,g1,g2,s1,s2," + // For each element e of instanceElements if e.[[Kind]] is not field
+      "static:start," + // staticElements
+      "static:end," + // staticElements
+      "after," +
+      "ctor:start," +
+      "m3,m4,m5,m6,g3,g4,g5,g6,s3,s4,s5,s6," + // instanceExtraInitializers
+      "a," + // InitializeFieldOrAccessor
+      "ctor:end," +
+      "end",
+  );
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering/method-initializers-field-value/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering/method-initializers-field-value/exec.js
@@ -1,0 +1,153 @@
+{
+  const log = [];
+  const methodDec1 = (fn, ctxMethod) => {
+    log.push("m2");
+    ctxMethod.addInitializer(() => log.push("m5"));
+    ctxMethod.addInitializer(() => log.push("m6"));
+  };
+  const methodDec2 = (fn, ctxMethod) => {
+    log.push("m1");
+    ctxMethod.addInitializer(() => log.push("m3"));
+    ctxMethod.addInitializer(() => log.push("m4"));
+  };
+  const getterDec1 = (fn, ctxGetter) => {
+    log.push("g2");
+    ctxGetter.addInitializer(() => log.push("g5"));
+    ctxGetter.addInitializer(() => log.push("g6"));
+  };
+  const getterDec2 = (fn, ctxGetter) => {
+    log.push("g1");
+    ctxGetter.addInitializer(() => log.push("g3"));
+    ctxGetter.addInitializer(() => log.push("g4"));
+  };
+  const setterDec1 = (fn, ctxSetter) => {
+    log.push("s2");
+    ctxSetter.addInitializer(() => log.push("s5"));
+    ctxSetter.addInitializer(() => log.push("s6"));
+  };
+  const setterDec2 = (fn, ctxSetter) => {
+    log.push("s1");
+    ctxSetter.addInitializer(() => log.push("s3"));
+    ctxSetter.addInitializer(() => log.push("s4"));
+  };
+  log.push("start");
+  class Foo extends (log.push("extends"), Object) {
+    static {
+      log.push("static:start");
+    }
+    constructor() {
+      log.push("ctor:start");
+      super();
+      log.push("ctor:end");
+    }
+    @methodDec1
+    @methodDec2
+    method() {}
+
+    field = log.push("f");
+
+    @getterDec1
+    @getterDec2
+    get getter() {
+      return;
+    }
+    @setterDec1
+    @setterDec2
+    set setter(x) {}
+    static {
+      log.push("static:end");
+    }
+  }
+  log.push("after");
+  new Foo();
+  log.push("end");
+  expect(log + "").toEqual(
+    "start,extends," +
+      "m1,m2,g1,g2,s1,s2," + // For each element e of instanceElements if e.[[Kind]] is not field
+      "static:start," + // staticElements
+      "static:end," + // staticElements
+      "after," +
+      "ctor:start," +
+      "m3,m4,m5,m6,g3,g4,g5,g6,s3,s4,s5,s6," + // instanceExtraInitializers
+      "f," + // InitializeFieldOrAccessor
+      "ctor:end," +
+      "end",
+  );
+}
+
+{
+  const log = [];
+  const methodDec1 = (fn, ctxMethod) => {
+    log.push("m2");
+    ctxMethod.addInitializer(() => log.push("m5"));
+    ctxMethod.addInitializer(() => log.push("m6"));
+  };
+  const methodDec2 = (fn, ctxMethod) => {
+    log.push("m1");
+    ctxMethod.addInitializer(() => log.push("m3"));
+    ctxMethod.addInitializer(() => log.push("m4"));
+  };
+  const getterDec1 = (fn, ctxGetter) => {
+    log.push("g2");
+    ctxGetter.addInitializer(() => log.push("g5"));
+    ctxGetter.addInitializer(() => log.push("g6"));
+  };
+  const getterDec2 = (fn, ctxGetter) => {
+    log.push("g1");
+    ctxGetter.addInitializer(() => log.push("g3"));
+    ctxGetter.addInitializer(() => log.push("g4"));
+  };
+  const setterDec1 = (fn, ctxSetter) => {
+    log.push("s2");
+    ctxSetter.addInitializer(() => log.push("s5"));
+    ctxSetter.addInitializer(() => log.push("s6"));
+  };
+  const setterDec2 = (fn, ctxSetter) => {
+    log.push("s1");
+    ctxSetter.addInitializer(() => log.push("s3"));
+    ctxSetter.addInitializer(() => log.push("s4"));
+  };
+  log.push("start");
+  class Foo extends (log.push("extends"), Object) {
+    static {
+      log.push("static:start");
+    }
+    constructor() {
+      log.push("ctor:start");
+      super();
+      log.push("ctor:end");
+    }
+    @methodDec1
+    @methodDec2
+    method() {}
+
+    accessor field = log.push("a");
+
+    @getterDec1
+    @getterDec2
+    get getter() {
+      return;
+    }
+    @setterDec1
+    @setterDec2
+    set setter(x) {}
+    static {
+      log.push("static:end");
+    }
+  }
+  log.push("after");
+  new Foo();
+  log.push("end");
+  expect(log + "").toEqual(
+    "start,extends," +
+      "m1,m2,g1,g2,s1,s2," + // For each element e of instanceElements if e.[[Kind]] is not field
+      "static:start," + // staticElements
+      "static:end," + // staticElements
+      "after," +
+      "ctor:start," +
+      "m3,m4,m5,m6,g3,g4,g5,g6,s3,s4,s5,s6," + // instanceExtraInitializers
+      "a," + // InitializeFieldOrAccessor
+      "ctor:end," +
+      "end",
+  );
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/private/output.js
@@ -7,8 +7,7 @@ class Foo {
       get: void 0,
       set: _set_a
     });
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   setA(v) {
     babelHelpers.classPrivateFieldSet(this, _a, v);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/public/output.js
@@ -2,8 +2,7 @@ var _initProto, _Foo;
 const dec = () => {};
 class Foo {
   constructor() {
-    babelHelpers.defineProperty(this, "value", 1);
-    _initProto(this);
+    babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   set a(v) {
     return this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/private/output.js
@@ -6,10 +6,7 @@ class Foo {
       return this.value = v;
     }]], [], 0, _ => #a in _).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   set #a(v) {
     _call_a(this, v);
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/public/output.js
@@ -4,10 +4,7 @@ class Foo {
   static {
     [_initProto] = babelHelpers.applyDecs2305(this, [[dec, 4, "a"], [dec, 4, 'b']], []).e;
   }
-  constructor() {
-    _initProto(this);
-  }
-  value = 1;
+  value = (_initProto(this), 1);
   set a(v) {
     return this.value = v;
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Babel runs method initializers added by `context.addInitializers` after undecorated field initializer ([REPL](https://babel.dev/repl#?browsers=chrome%2094&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=DYUwLgBAlgdlYGECGxQBMDcAoLAzArjAMZhQD2MEaIRAFAG4r4gA0ERFYIAHmAJQQA3lgjtOPMADokaNAEk4pFFABeIAE61aAgLwA-aIuSoQaCDohh1zPtgC-OIsCQBnFxARCREAALUiEAC22kIOogAO5obwxuj2jhQuZKCSwGQA5lowIADuHnyS4XxAA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=true&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact&prettier=false&targets=&version=7.23.8&externalPlugins=%40babel%2Fplugin-proposal-decorators%407.23.3&assumptions=%7B%7D))
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT


<s>This PR includes commits from https://github.com/babel/babel/pull/16234, I will rebase once that PR gets merged.</s>

Per [spec: InitializeInstanceElements](https://arai-a.github.io/ecma262-compare/?pr=2417&id=sec-initializeinstanceelements)

The method initializers should run before any fields are defined. 

In the REPL example,
```js
let initCalled;

function dec(value, context) {
  context.addInitializer(() => initCalled = true);
}

class C {
  @dec m() {}
  p = initCalled;
}

console.log((new C).p)
```
When the property `p` is defined, the `initCalled` should be `true`. Previously we inject the `protoInit` calls in the first _decorated_ field, in this PR we move the field initializer injection out of the `hasDecorators` branch.