### PR TITLE
Use `Object.hasOwn` when available

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -392,7 +392,6 @@ function bool(value) {
 // copy and paste it.
 // `((v,w)=>(v=v.split("."),w=w.split("."),+v[0]>+w[0]||v[0]==w[0]&&+v[1]>=+w[1]))`;
 
-// TODO(Babel 8) This polyfills are only needed for Node.js 6 and 8
 /** @param {import("@babel/core")} api */
 function pluginPolyfillsOldNode({ template, types: t }) {
   const polyfills = [
@@ -474,6 +473,8 @@ function pluginPolyfillsOldNode({ template, types: t }) {
       necessary: () => true,
       supported: path =>
         path.parentPath.isCallExpression({ callee: path.node }),
+      // Object.hasOwn has been introduced in Node.js 16.9.0
+      // https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V16.md#v8-93
       replacement: template`hasOwnProperty.call`,
     },
   ];

--- a/babel.config.js
+++ b/babel.config.js
@@ -114,6 +114,7 @@ module.exports = function (api) {
         "packages/babel-runtime/regenerator"
       );
       targets = { ie: 7 };
+      needsPolyfillsForOldNode = true;
       break;
     case "rollup":
       convertESM = false;
@@ -183,10 +184,6 @@ module.exports = function (api) {
       ["@babel/transform-object-rest-spread", { useBuiltIns: true }],
 
       convertESM ? "@babel/transform-export-namespace-from" : null,
-
-      pluginPackageJsonMacro,
-
-      needsPolyfillsForOldNode && pluginPolyfillsOldNode,
     ].filter(Boolean),
     overrides: [
       {
@@ -250,6 +247,10 @@ module.exports = function (api) {
             },
             "flag-BABEL_8_BREAKING",
           ],
+
+          pluginPackageJsonMacro,
+
+          needsPolyfillsForOldNode && pluginPolyfillsOldNode,
         ].filter(Boolean),
       },
       convertESM && {

--- a/babel.config.js
+++ b/babel.config.js
@@ -468,6 +468,13 @@ function pluginPolyfillsOldNode({ template, types: t }) {
         process.allowedNodeEnvironmentFlags || require("node-environment-flags")
       `,
     },
+    {
+      name: "Object.hasOwn",
+      necessary: () => true,
+      supported: path =>
+        path.parentPath.isCallExpression({ callee: path.node }),
+      replacement: template`hasOwnProperty.call`,
+    },
   ];
 
   return {

--- a/packages/babel-core/src/config/config-chain.ts
+++ b/packages/babel-core/src/config/config-chain.ts
@@ -754,7 +754,7 @@ function normalizeOptions(opts: ValidatedOptions): ValidatedOptions {
 
   // "sourceMap" is just aliased to sourceMap, so copy it over as
   // we merge the options together.
-  if (Object.prototype.hasOwnProperty.call(options, "sourceMap")) {
+  if (Object.hasOwn(options, "sourceMap")) {
     options.sourceMaps = options.sourceMap;
     delete options.sourceMap;
   }

--- a/packages/babel-core/src/config/validation/option-assertions.ts
+++ b/packages/babel-core/src/config/validation/option-assertions.ts
@@ -427,7 +427,7 @@ export function assertTargets(
 
     if (key === "esmodules") assertBoolean(subLoc, val);
     else if (key === "browsers") assertBrowsersList(subLoc, val);
-    else if (!Object.hasOwnProperty.call(TargetNames, key)) {
+    else if (!Object.hasOwn(TargetNames, key)) {
       const validTargets = Object.keys(TargetNames).join(", ");
       throw new Error(
         `${msg(

--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -396,12 +396,8 @@ function throwUnknownError(loc: OptionPath) {
   }
 }
 
-function has(obj: {}, key: string) {
-  return Object.prototype.hasOwnProperty.call(obj, key);
-}
-
 function assertNoDuplicateSourcemap(opts: {}): void {
-  if (has(opts, "sourceMap") && has(opts, "sourceMaps")) {
+  if (Object.hasOwn(opts, "sourceMap") && Object.hasOwn(opts, "sourceMaps")) {
     throw new Error(".sourceMap is an alias for .sourceMaps, cannot use both");
   }
 }

--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -399,7 +399,7 @@ export function resolveOptionPluginOrPreset(
   }
   if (options.env) {
     for (const envName in options.env) {
-      if (!{}.hasOwnProperty.call(options.env, envName)) continue;
+      if (!Object.hasOwn(options.env, envName)) continue;
       resolveOptionPluginOrPreset(options.env[envName], optionsDir);
     }
   }

--- a/packages/babel-helper-plugin-utils/src/index.ts
+++ b/packages/babel-helper-plugin-utils/src/index.ts
@@ -78,10 +78,10 @@ function copyApiObject(api: PluginAPI): PluginAPI {
     proto = Object.getPrototypeOf(api);
     if (
       proto &&
-      (!has(proto, "version") ||
-        !has(proto, "transform") ||
-        !has(proto, "template") ||
-        !has(proto, "types"))
+      (!Object.hasOwn(proto, "version") ||
+        !Object.hasOwn(proto, "transform") ||
+        !Object.hasOwn(proto, "template") ||
+        !Object.hasOwn(proto, "types"))
     ) {
       proto = null;
     }
@@ -91,10 +91,6 @@ function copyApiObject(api: PluginAPI): PluginAPI {
     ...proto,
     ...api,
   };
-}
-
-function has(obj: {}, key: string) {
-  return Object.prototype.hasOwnProperty.call(obj, key);
 }
 
 function throwVersionError(range: string | number, version: string) {

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -733,7 +733,7 @@ const assertTest = function (
           // saveInFiles always creates an empty .babelrc, so lets exclude for now
           filename !== ".babelrc" &&
           filename !== ".babelignore" &&
-          !Object.prototype.hasOwnProperty.call(opts.inFiles, filename)
+          !Object.hasOwn(opts.inFiles, filename)
         ) {
           const expected = opts.outFiles[filename];
           const actual = actualFiles[filename];

--- a/packages/babel-parser/src/parser/lval.ts
+++ b/packages/babel-parser/src/parser/lval.ts
@@ -32,7 +32,7 @@ import { Errors, type LValAncestor } from "../parse-error.ts";
 import type Parser from "./index.ts";
 
 const getOwn = <T extends {}>(object: T, key: keyof T) =>
-  Object.hasOwnProperty.call(object, key) && object[key];
+  Object.hasOwn(object, key) && object[key];
 
 const unwrapParenthesizedExpression = (node: Node): Node => {
   return node.type === "ParenthesizedExpression"

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -31,7 +31,7 @@ import type { IJSXParserMixin } from "../jsx/index.ts";
 import { ParseBindingListFlags } from "../../parser/lval.ts";
 
 const getOwn = <T extends {}>(object: T, key: keyof T) =>
-  Object.hasOwnProperty.call(object, key) && object[key];
+  Object.hasOwn(object, key) && object[key];
 
 type TsModifier =
   | "readonly"
@@ -409,7 +409,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
           enforceOrder(startLoc, modifier, "in", "out");
         } else {
-          if (Object.hasOwnProperty.call(modified, modifier)) {
+          if (Object.hasOwn(modified, modifier)) {
             this.raise(TSErrors.DuplicateModifier, startLoc, { modifier });
           } else {
             enforceOrder(startLoc, modifier, "static", "readonly");

--- a/packages/babel-plugin-transform-runtime/src/index.ts
+++ b/packages/babel-plugin-transform-runtime/src/index.ts
@@ -55,11 +55,7 @@ export default declare((api, options: Options, dirname) => {
     var supportsCJSDefault = hasMinVersion(DUAL_MODE_RUNTIME, runtimeVersion);
   }
 
-  function has(obj: {}, key: string) {
-    return Object.prototype.hasOwnProperty.call(obj, key);
-  }
-
-  if (has(options, "useBuiltIns")) {
+  if (Object.hasOwn(options, "useBuiltIns")) {
     // @ts-expect-error deprecated options
     if (options["useBuiltIns"]) {
       throw new Error(
@@ -74,7 +70,7 @@ export default declare((api, options: Options, dirname) => {
     }
   }
 
-  if (has(options, "polyfill")) {
+  if (Object.hasOwn(options, "polyfill")) {
     // @ts-expect-error deprecated options
     if (options["polyfill"] === false) {
       throw new Error(
@@ -89,7 +85,7 @@ export default declare((api, options: Options, dirname) => {
     }
   }
 
-  if (has(options, "moduleName")) {
+  if (Object.hasOwn(options, "moduleName")) {
     throw new Error(
       "The 'moduleName' option has been removed. @babel/transform-runtime " +
         "no longer supports arbitrary runtimes. If you were using this to " +
@@ -99,7 +95,7 @@ export default declare((api, options: Options, dirname) => {
   }
 
   if (process.env.BABEL_8_BREAKING) {
-    if (has(options, "regenerator")) {
+    if (Object.hasOwn(options, "regenerator")) {
       throw new Error(
         "The 'regenerator' option has been removed. The generators transform " +
           "no longers relies on a 'regeneratorRuntime' global. " +
@@ -110,7 +106,7 @@ export default declare((api, options: Options, dirname) => {
   }
 
   if (process.env.BABEL_8_BREAKING) {
-    if (has(options, "useESModules")) {
+    if (Object.hasOwn(options, "useESModules")) {
       throw new Error(
         "The 'useESModules' option has been removed. @babel/runtime now uses " +
           "package.json#exports to support both CommonJS and ESM helpers.",

--- a/packages/babel-preset-env/src/debug.ts
+++ b/packages/babel-preset-env/src/debug.ts
@@ -22,7 +22,7 @@ export const logPlugin = (
       const proposalName = `proposal-${item.slice(10)}`;
       if (
         proposalName === "proposal-dynamic-import" ||
-        Object.prototype.hasOwnProperty.call(compatData, proposalName)
+        Object.hasOwn(compatData, proposalName)
       ) {
         item = proposalName;
       }

--- a/packages/babel-preset-env/src/filter-items.ts
+++ b/packages/babel-preset-env/src/filter-items.ts
@@ -1,8 +1,6 @@
 import semver from "semver";
 import { minVersions } from "./available-plugins.ts";
 
-const has = Function.call.bind(Object.hasOwnProperty);
-
 export function addProposalSyntaxPlugins(
   items: Set<string>,
   proposalSyntaxPlugins: readonly string[],
@@ -25,7 +23,7 @@ export function removeUnsupportedItems(
 ) {
   items.forEach(item => {
     if (
-      has(minVersions, item) &&
+      Object.hasOwn(minVersions, item) &&
       semver.lt(
         babelVersion,
         // @ts-expect-error we have checked minVersions[item] in has call

--- a/packages/babel-preset-env/src/plugins-compat-data.ts
+++ b/packages/babel-preset-env/src/plugins-compat-data.ts
@@ -18,7 +18,7 @@ function filterAvailable<Data extends { [name: string]: unknown }>(
 ): { [Name in keyof Data & keyof typeof availablePlugins]: Data[Name] } {
   const result = {} as any;
   for (const plugin of keys(data)) {
-    if (Object.hasOwnProperty.call(availablePlugins, plugin)) {
+    if (Object.hasOwn(availablePlugins, plugin)) {
       result[plugin] = data[plugin];
     }
   }

--- a/packages/babel-standalone/src/index.ts
+++ b/packages/babel-standalone/src/index.ts
@@ -94,7 +94,7 @@ const isArray =
  */
 function loadBuiltin(builtinTable: Record<string, unknown>, name: any) {
   if (isArray(name) && typeof name[0] === "string") {
-    if (Object.prototype.hasOwnProperty.call(builtinTable, name[0])) {
+    if (Object.hasOwn(builtinTable, name[0])) {
       return [builtinTable[name[0]]].concat(name.slice(1));
     }
     return;
@@ -120,7 +120,7 @@ function processOptions(options: InputOptions) {
       if (
         isArray(preset) &&
         typeof preset[0] === "object" &&
-        Object.prototype.hasOwnProperty.call(preset[0], "buildPreset")
+        Object.hasOwn(preset[0], "buildPreset")
       ) {
         preset[0] = { ...preset[0], buildPreset: preset[0].buildPreset };
       }
@@ -169,7 +169,7 @@ export const buildExternalHelpers = babelBuildExternalHelpers;
  * Registers a named plugin for use with Babel.
  */
 export function registerPlugin(name: string, plugin: () => PluginObject): void {
-  if (Object.prototype.hasOwnProperty.call(availablePlugins, name)) {
+  if (Object.hasOwn(availablePlugins, name)) {
     console.warn(
       `A plugin named "${name}" is already registered, it will be overridden`,
     );
@@ -192,7 +192,7 @@ export function registerPlugins(newPlugins: {
  * Registers a named preset for use with Babel.
  */
 export function registerPreset(name: string, preset: () => PresetObject): void {
-  if (Object.prototype.hasOwnProperty.call(availablePresets, name)) {
+  if (Object.hasOwn(availablePresets, name)) {
     if (name === "env") {
       console.warn(
         "@babel/preset-env is now included in @babel/standalone, please remove @babel/preset-env-standalone",

--- a/packages/babel-template/src/literal.ts
+++ b/packages/babel-template/src/literal.ts
@@ -22,7 +22,7 @@ export default function literalTemplate<T>(
 
       if (replacements) {
         Object.keys(replacements).forEach(key => {
-          if (Object.prototype.hasOwnProperty.call(defaultReplacements, key)) {
+          if (Object.hasOwn(defaultReplacements, key)) {
             throw new Error("Unexpected replacement overlap.");
           }
         });

--- a/packages/babel-template/src/populate.ts
+++ b/packages/babel-template/src/populate.ts
@@ -22,9 +22,7 @@ export default function populatePlaceholders(
 
   if (replacements) {
     metadata.placeholders.forEach(placeholder => {
-      if (
-        !Object.prototype.hasOwnProperty.call(replacements, placeholder.name)
-      ) {
+      if (!Object.hasOwn(replacements, placeholder.name)) {
         const placeholderName = placeholder.name;
 
         throw new Error(

--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -445,8 +445,7 @@ function _evaluate(path: NodePath, state: State): any {
       ) {
         context = global[object.node.name];
         const key = property.node.name;
-        // TODO(Babel 8): Use Object.hasOwn
-        if (Object.hasOwnProperty.call(context, key)) {
+        if (Object.hasOwn(context, key)) {
           func = context[key as keyof typeof context];
         }
       }

--- a/packages/babel-types/src/clone/cloneNode.ts
+++ b/packages/babel-types/src/clone/cloneNode.ts
@@ -2,7 +2,9 @@ import { NODE_FIELDS } from "../definitions/index.ts";
 import type * as t from "../index.ts";
 import { isFile, isIdentifier } from "../validators/generated/index.ts";
 
-const has = Function.call.bind(Object.prototype.hasOwnProperty);
+const { hasOwn } = process.env.BABEL_8_BREAKING
+  ? Object
+  : { hasOwn: Function.call.bind(Object.prototype.hasOwnProperty) };
 
 type CommentCache = Map<t.Comment, t.Comment>;
 
@@ -60,11 +62,11 @@ function cloneNodeInternal<T extends t.Node>(
   if (isIdentifier(node)) {
     newNode.name = node.name;
 
-    if (has(node, "optional") && typeof node.optional === "boolean") {
+    if (hasOwn(node, "optional") && typeof node.optional === "boolean") {
       newNode.optional = node.optional;
     }
 
-    if (has(node, "typeAnnotation")) {
+    if (hasOwn(node, "typeAnnotation")) {
       newNode.typeAnnotation = deep
         ? cloneIfNodeOrArray(
             node.typeAnnotation,
@@ -74,11 +76,11 @@ function cloneNodeInternal<T extends t.Node>(
           )
         : node.typeAnnotation;
     }
-  } else if (!has(NODE_FIELDS, type)) {
+  } else if (!hasOwn(NODE_FIELDS, type)) {
     throw new Error(`Unknown node type: "${type}"`);
   } else {
     for (const field of Object.keys(NODE_FIELDS[type])) {
-      if (has(node, field)) {
+      if (hasOwn(node, field)) {
         if (deep) {
           newNode[field] =
             isFile(node) && field === "comments"
@@ -104,14 +106,14 @@ function cloneNodeInternal<T extends t.Node>(
     }
   }
 
-  if (has(node, "loc")) {
+  if (hasOwn(node, "loc")) {
     if (withoutLoc) {
       newNode.loc = null;
     } else {
       newNode.loc = node.loc;
     }
   }
-  if (has(node, "leadingComments")) {
+  if (hasOwn(node, "leadingComments")) {
     newNode.leadingComments = maybeCloneComments(
       node.leadingComments,
       deep,
@@ -119,7 +121,7 @@ function cloneNodeInternal<T extends t.Node>(
       commentsCache,
     );
   }
-  if (has(node, "innerComments")) {
+  if (hasOwn(node, "innerComments")) {
     newNode.innerComments = maybeCloneComments(
       node.innerComments,
       deep,
@@ -127,7 +129,7 @@ function cloneNodeInternal<T extends t.Node>(
       commentsCache,
     );
   }
-  if (has(node, "trailingComments")) {
+  if (hasOwn(node, "trailingComments")) {
     newNode.trailingComments = maybeCloneComments(
       node.trailingComments,
       deep,
@@ -135,7 +137,7 @@ function cloneNodeInternal<T extends t.Node>(
       commentsCache,
     );
   }
-  if (has(node, "extra")) {
+  if (hasOwn(node, "extra")) {
     newNode.extra = {
       ...node.extra,
     };

--- a/packages/babel-types/src/definitions/placeholders.ts
+++ b/packages/babel-types/src/definitions/placeholders.ts
@@ -25,7 +25,7 @@ export const PLACEHOLDERS_FLIPPED_ALIAS: Record<string, string[]> = {};
 
 Object.keys(PLACEHOLDERS_ALIAS).forEach(type => {
   PLACEHOLDERS_ALIAS[type].forEach(alias => {
-    if (!Object.hasOwnProperty.call(PLACEHOLDERS_FLIPPED_ALIAS, alias)) {
+    if (!Object.hasOwn(PLACEHOLDERS_FLIPPED_ALIAS, alias)) {
       PLACEHOLDERS_FLIPPED_ALIAS[alias] = [];
     }
     PLACEHOLDERS_FLIPPED_ALIAS[alias].push(type);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In Babel 8 we can use `Object.hasOwn`, and it's very easy with our build infra to polyfill it for Babel 7 :)