### PR TITLE
Remove logic for deprecated decorator versions from Babel 8

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1441,7 +1441,7 @@ function createLocalsAssignment(
   elementDecorations: t.ArrayExpression | t.Identifier,
   classDecorations: t.ArrayExpression | t.Identifier,
   classDecorationsFlag: t.NumericLiteral,
-  maybePrivateBranName: t.PrivateName | null,
+  maybePrivateBrandName: t.PrivateName | null,
   setClassName: t.Identifier | t.StringLiteral | undefined,
   superClass: null | t.Expression,
   state: PluginPass,
@@ -1476,16 +1476,16 @@ function createLocalsAssignment(
     version === "2023-05"
   ) {
     if (
-      maybePrivateBranName ||
+      maybePrivateBrandName ||
       superClass ||
       classDecorationsFlag.value !== 0
     ) {
       args.push(classDecorationsFlag);
     }
-    if (maybePrivateBranName) {
+    if (maybePrivateBrandName) {
       args.push(
         template.expression.ast`
-            _ => ${t.cloneNode(maybePrivateBranName)} in _
+            _ => ${t.cloneNode(maybePrivateBrandName)} in _
           ` as t.ArrowFunctionExpression,
       );
     } else if (superClass) {
@@ -1498,10 +1498,10 @@ function createLocalsAssignment(
       rhs = t.callExpression(state.addHelper("applyDecs2305"), args);
     }
   } else if (version === "2023-01") {
-    if (maybePrivateBranName) {
+    if (maybePrivateBrandName) {
       args.push(
         template.expression.ast`
-            _ => ${t.cloneNode(maybePrivateBranName)} in _
+            _ => ${t.cloneNode(maybePrivateBrandName)} in _
           ` as t.ArrowFunctionExpression,
       );
     }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/exec.js
@@ -1,4 +1,4 @@
-let hasX, hasM, OriginalFoo;
+let hasX, hasA, hasM, OriginalFoo;
 
 class Bar {}
 
@@ -10,24 +10,32 @@ function dec(Foo) {
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }
 
 expect(hasX(Bar)).toBe(true);
+expect(hasA(Bar)).toBe(true);
 expect(hasM(Bar)).toBe(true);
 expect(hasX(OriginalFoo)).toBe(false);
+expect(hasA(OriginalFoo)).toBe(false);
 expect(hasM(OriginalFoo)).toBe(false);
 
 expect(Bar.hasOwnProperty("x")).toBe(true);
 expect(OriginalFoo.hasOwnProperty("x")).toBe(false);
+
+expect(Bar.hasOwnProperty("a")).toBe(false);
+expect(OriginalFoo.hasOwnProperty("a")).toBe(true);
 
 expect(Bar.hasOwnProperty("m")).toBe(false);
 expect(OriginalFoo.hasOwnProperty("m")).toBe(true);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/input.js
@@ -1,16 +1,19 @@
-const dec = () => {}; 
-let hasX, hasM;
+const dec = () => {};
+let hasX, hasA, hasM;
 
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -1,22 +1,44 @@
-var _initClass, _x, _m, _temp;
+var _initClass, _x, _A, _a, _m, _B, _temp;
 const dec = () => {};
-let hasX, hasM;
+let hasX, hasA, hasM;
 let _Foo;
-new (_x = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), (_temp = class extends babelHelpers.identity {
+new (_x = /*#__PURE__*/new WeakMap(), _A = /*#__PURE__*/new WeakMap(), _a = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), _B = /*#__PURE__*/new WeakMap(), (_temp = class extends babelHelpers.identity {
   constructor() {
-    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _m), babelHelpers.classPrivateFieldInitSpec(this, _x, {
+    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _m), babelHelpers.classPrivateFieldInitSpec(this, _a, {
+      get: _get_a,
+      set: _set_a
+    }), babelHelpers.classPrivateFieldInitSpec(this, _x, {
       writable: true,
       value: void 0
-    }), babelHelpers.defineProperty(this, "x", void 0)), (() => {
+    }), babelHelpers.classPrivateFieldInitSpec(this, _A, {
+      writable: true,
+      value: void 0
+    }), babelHelpers.defineProperty(this, "x", void 0), babelHelpers.classPrivateFieldInitSpec(this, _B, {
+      writable: true,
+      value: void 0
+    }), this), (() => {
       hasX = o => _x.has(babelHelpers.checkInRHS(o));
+      hasA = o => _a.has(babelHelpers.checkInRHS(o));
       hasM = o => _m.has(babelHelpers.checkInRHS(o));
     })(), _initClass();
   }
 }, (_Foo2 => {
   class Foo {
+    static get a() {
+      return babelHelpers.classPrivateFieldGet(this, _B);
+    }
+    static set a(v) {
+      babelHelpers.classPrivateFieldSet(this, _B, v);
+    }
     static m() {}
   }
   _Foo2 = Foo;
   [_Foo, _initClass] = babelHelpers.applyDecs(_Foo2, [], [dec]);
 })(), _temp))();
+function _get_a() {
+  return babelHelpers.classPrivateFieldGet(this, _A);
+}
+function _set_a(v) {
+  babelHelpers.classPrivateFieldSet(this, _A, v);
+}
 function _m2() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement-static-installed-on-correct-class/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement-static-installed-on-correct-class/input.js
@@ -1,16 +1,19 @@
-const dec = () => {}; 
-let hasX, hasM;
+const dec = () => {};
+let hasX, hasA, hasM;
 
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement-static-installed-on-correct-class/output.js
@@ -1,6 +1,6 @@
 var _initClass;
 const dec = () => {};
-let hasX, hasM;
+let hasX, hasA, hasM;
 let _Foo;
 new class extends babelHelpers.identity {
   static {
@@ -8,15 +8,30 @@ new class extends babelHelpers.identity {
       static {
         [_Foo, _initClass] = babelHelpers.applyDecs(this, [], [dec]);
       }
+      static get a() {
+        return this.#B;
+      }
+      static set a(v) {
+        this.#B = v;
+      }
       static m() {}
     }
   }
   #x;
+  #A;
+  get #a() {
+    return this.#A;
+  }
+  set #a(v) {
+    this.#A = v;
+  }
   #m() {}
   x;
+  #B;
   constructor() {
     super(_Foo), (() => {
       hasX = o => #x in o;
+      hasA = o => #a in o;
       hasM = o => #m in o;
     })(), _initClass();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-installed-on-correct-class/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-installed-on-correct-class/exec.js
@@ -1,4 +1,4 @@
-let hasX, hasM, OriginalFoo;
+let hasX, hasA, hasM, OriginalFoo;
 
 class Bar {}
 
@@ -10,24 +10,32 @@ function dec(Foo) {
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }
 
 expect(hasX(Bar)).toBe(true);
+expect(hasA(Bar)).toBe(true);
 expect(hasM(Bar)).toBe(true);
 expect(hasX(OriginalFoo)).toBe(false);
+expect(hasA(OriginalFoo)).toBe(false);
 expect(hasM(OriginalFoo)).toBe(false);
 
 expect(Bar.hasOwnProperty("x")).toBe(true);
 expect(OriginalFoo.hasOwnProperty("x")).toBe(false);
+
+expect(Bar.hasOwnProperty("a")).toBe(false);
+expect(OriginalFoo.hasOwnProperty("a")).toBe(true);
 
 expect(Bar.hasOwnProperty("m")).toBe(false);
 expect(OriginalFoo.hasOwnProperty("m")).toBe(true);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-installed-on-correct-class/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-installed-on-correct-class/input.js
@@ -1,16 +1,19 @@
-const dec = () => {}; 
-let hasX, hasM;
+const dec = () => {};
+let hasX, hasA, hasM;
 
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -1,22 +1,44 @@
-var _initClass, _x, _m, _temp;
+var _initClass, _x, _A, _a, _m, _B, _temp;
 const dec = () => {};
-let hasX, hasM;
+let hasX, hasA, hasM;
 let _Foo;
-new (_x = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), (_temp = class extends babelHelpers.identity {
+new (_x = /*#__PURE__*/new WeakMap(), _A = /*#__PURE__*/new WeakMap(), _a = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), _B = /*#__PURE__*/new WeakMap(), (_temp = class extends babelHelpers.identity {
   constructor() {
-    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _m), babelHelpers.classPrivateFieldInitSpec(this, _x, {
+    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _m), babelHelpers.classPrivateFieldInitSpec(this, _a, {
+      get: _get_a,
+      set: _set_a
+    }), babelHelpers.classPrivateFieldInitSpec(this, _x, {
       writable: true,
       value: void 0
-    }), babelHelpers.defineProperty(this, "x", void 0)), (() => {
+    }), babelHelpers.classPrivateFieldInitSpec(this, _A, {
+      writable: true,
+      value: void 0
+    }), babelHelpers.defineProperty(this, "x", void 0), babelHelpers.classPrivateFieldInitSpec(this, _B, {
+      writable: true,
+      value: void 0
+    }), this), (() => {
       hasX = o => _x.has(babelHelpers.checkInRHS(o));
+      hasA = o => _a.has(babelHelpers.checkInRHS(o));
       hasM = o => _m.has(babelHelpers.checkInRHS(o));
     })(), _initClass();
   }
 }, (_Foo2 => {
   class Foo {
+    static get a() {
+      return babelHelpers.classPrivateFieldGet(this, _B);
+    }
+    static set a(v) {
+      babelHelpers.classPrivateFieldSet(this, _B, v);
+    }
     static m() {}
   }
   _Foo2 = Foo;
   [_Foo, _initClass] = babelHelpers.applyDecs2203R(_Foo2, [], [dec]).c;
 })(), _temp))();
+function _get_a() {
+  return babelHelpers.classPrivateFieldGet(this, _A);
+}
+function _set_a(v) {
+  babelHelpers.classPrivateFieldSet(this, _A, v);
+}
 function _m2() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement-static-installed-on-correct-class/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement-static-installed-on-correct-class/input.js
@@ -1,16 +1,19 @@
-const dec = () => {}; 
-let hasX, hasM;
+const dec = () => {};
+let hasX, hasA, hasM;
 
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement-static-installed-on-correct-class/output.js
@@ -1,6 +1,6 @@
 var _initClass;
 const dec = () => {};
-let hasX, hasM;
+let hasX, hasA, hasM;
 let _Foo;
 new class extends babelHelpers.identity {
   static {
@@ -8,15 +8,30 @@ new class extends babelHelpers.identity {
       static {
         [_Foo, _initClass] = babelHelpers.applyDecs2203R(this, [], [dec]).c;
       }
+      static get a() {
+        return this.#B;
+      }
+      static set a(v) {
+        this.#B = v;
+      }
       static m() {}
     }
   }
   #x;
+  #A;
+  get #a() {
+    return this.#A;
+  }
+  set #a(v) {
+    this.#A = v;
+  }
   #m() {}
   x;
+  #B;
   constructor() {
     super(_Foo), (() => {
       hasX = o => #x in o;
+      hasA = o => #a in o;
       hasM = o => #m in o;
     })(), _initClass();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-installed-on-correct-class/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-installed-on-correct-class/exec.js
@@ -1,4 +1,4 @@
-let hasX, hasM, OriginalFoo;
+let hasX, hasA, hasM, OriginalFoo;
 
 class Bar {}
 
@@ -10,24 +10,32 @@ function dec(Foo) {
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }
 
 expect(hasX(Bar)).toBe(true);
+expect(hasA(Bar)).toBe(true);
 expect(hasM(Bar)).toBe(true);
 expect(hasX(OriginalFoo)).toBe(false);
+expect(hasA(OriginalFoo)).toBe(false);
 expect(hasM(OriginalFoo)).toBe(false);
 
 expect(Bar.hasOwnProperty("x")).toBe(true);
 expect(OriginalFoo.hasOwnProperty("x")).toBe(false);
+
+expect(Bar.hasOwnProperty("a")).toBe(false);
+expect(OriginalFoo.hasOwnProperty("a")).toBe(true);
 
 expect(Bar.hasOwnProperty("m")).toBe(false);
 expect(OriginalFoo.hasOwnProperty("m")).toBe(true);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-installed-on-correct-class/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-installed-on-correct-class/input.js
@@ -1,16 +1,19 @@
-const dec = () => {}; 
-let hasX, hasM;
+const dec = () => {};
+let hasX, hasA, hasM;
 
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -1,22 +1,44 @@
-var _initClass, _x, _m, _temp;
+var _initClass, _x, _A, _a, _m, _B, _temp;
 const dec = () => {};
-let hasX, hasM;
+let hasX, hasA, hasM;
 let _Foo;
-new (_x = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), (_temp = class extends babelHelpers.identity {
+new (_x = /*#__PURE__*/new WeakMap(), _A = /*#__PURE__*/new WeakMap(), _a = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), _B = /*#__PURE__*/new WeakMap(), (_temp = class extends babelHelpers.identity {
   constructor() {
-    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _m), babelHelpers.classPrivateFieldInitSpec(this, _x, {
+    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _m), babelHelpers.classPrivateFieldInitSpec(this, _a, {
+      get: _get_a,
+      set: _set_a
+    }), babelHelpers.classPrivateFieldInitSpec(this, _x, {
       writable: true,
       value: void 0
-    }), babelHelpers.defineProperty(this, "x", void 0)), (() => {
+    }), babelHelpers.classPrivateFieldInitSpec(this, _A, {
+      writable: true,
+      value: void 0
+    }), babelHelpers.defineProperty(this, "x", void 0), babelHelpers.classPrivateFieldInitSpec(this, _B, {
+      writable: true,
+      value: void 0
+    }), this), (() => {
       hasX = o => _x.has(babelHelpers.checkInRHS(o));
+      hasA = o => _a.has(babelHelpers.checkInRHS(o));
       hasM = o => _m.has(babelHelpers.checkInRHS(o));
     })(), _initClass();
   }
 }, (_Foo2 => {
   class Foo {
+    static get a() {
+      return babelHelpers.classPrivateFieldGet(this, _B);
+    }
+    static set a(v) {
+      babelHelpers.classPrivateFieldSet(this, _B, v);
+    }
     static m() {}
   }
   _Foo2 = Foo;
   [_Foo, _initClass] = babelHelpers.applyDecs2301(_Foo2, [], [dec]).c;
 })(), _temp))();
+function _get_a() {
+  return babelHelpers.classPrivateFieldGet(this, _A);
+}
+function _set_a(v) {
+  babelHelpers.classPrivateFieldSet(this, _A, v);
+}
 function _m2() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement-static-installed-on-correct-class/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement-static-installed-on-correct-class/input.js
@@ -1,16 +1,19 @@
-const dec = () => {}; 
-let hasX, hasM;
+const dec = () => {};
+let hasX, hasA, hasM;
 
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement-static-installed-on-correct-class/output.js
@@ -1,6 +1,6 @@
 var _initClass;
 const dec = () => {};
-let hasX, hasM;
+let hasX, hasA, hasM;
 let _Foo;
 new class extends babelHelpers.identity {
   static {
@@ -8,15 +8,30 @@ new class extends babelHelpers.identity {
       static {
         [_Foo, _initClass] = babelHelpers.applyDecs2301(this, [], [dec]).c;
       }
+      static get a() {
+        return this.#B;
+      }
+      static set a(v) {
+        this.#B = v;
+      }
       static m() {}
     }
   }
   #x;
+  #A;
+  get #a() {
+    return this.#A;
+  }
+  set #a(v) {
+    this.#A = v;
+  }
   #m() {}
   x;
+  #B;
   constructor() {
     super(_Foo), (() => {
       hasX = o => #x in o;
+      hasA = o => #a in o;
       hasM = o => #m in o;
     })(), _initClass();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-installed-on-correct-class/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-installed-on-correct-class/exec.js
@@ -1,4 +1,4 @@
-let hasX, hasM, OriginalFoo;
+let hasX, hasA, hasM, OriginalFoo;
 
 class Bar {}
 
@@ -10,24 +10,32 @@ function dec(Foo) {
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }
 
 expect(hasX(Bar)).toBe(true);
+expect(hasA(Bar)).toBe(true);
 expect(hasM(Bar)).toBe(true);
 expect(hasX(OriginalFoo)).toBe(false);
+expect(hasA(OriginalFoo)).toBe(false);
 expect(hasM(OriginalFoo)).toBe(false);
 
 expect(Bar.hasOwnProperty("x")).toBe(true);
 expect(OriginalFoo.hasOwnProperty("x")).toBe(false);
+
+expect(Bar.hasOwnProperty("a")).toBe(false);
+expect(OriginalFoo.hasOwnProperty("a")).toBe(true);
 
 expect(Bar.hasOwnProperty("m")).toBe(false);
 expect(OriginalFoo.hasOwnProperty("m")).toBe(true);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-installed-on-correct-class/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-installed-on-correct-class/input.js
@@ -1,16 +1,19 @@
-const dec = () => {}; 
-let hasX, hasM;
+const dec = () => {};
+let hasX, hasA, hasM;
 
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -1,22 +1,44 @@
-var _initClass, _x, _m, _temp;
+var _initClass, _x, _A, _a, _m, _B, _temp;
 const dec = () => {};
-let hasX, hasM;
+let hasX, hasA, hasM;
 let _Foo;
-new (_x = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), (_temp = class extends babelHelpers.identity {
+new (_x = /*#__PURE__*/new WeakMap(), _A = /*#__PURE__*/new WeakMap(), _a = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), _B = /*#__PURE__*/new WeakMap(), (_temp = class extends babelHelpers.identity {
   constructor() {
-    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _m), babelHelpers.classPrivateFieldInitSpec(this, _x, {
+    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _m), babelHelpers.classPrivateFieldInitSpec(this, _a, {
+      get: _get_a,
+      set: _set_a
+    }), babelHelpers.classPrivateFieldInitSpec(this, _x, {
       writable: true,
       value: void 0
-    }), babelHelpers.defineProperty(this, "x", void 0)), (() => {
+    }), babelHelpers.classPrivateFieldInitSpec(this, _A, {
+      writable: true,
+      value: void 0
+    }), babelHelpers.defineProperty(this, "x", void 0), babelHelpers.classPrivateFieldInitSpec(this, _B, {
+      writable: true,
+      value: void 0
+    }), this), (() => {
       hasX = o => _x.has(babelHelpers.checkInRHS(o));
+      hasA = o => _a.has(babelHelpers.checkInRHS(o));
       hasM = o => _m.has(babelHelpers.checkInRHS(o));
     })(), _initClass();
   }
 }, (_Foo2 => {
   class Foo {
+    static get a() {
+      return babelHelpers.classPrivateFieldGet(_Foo, _B);
+    }
+    static set a(v) {
+      babelHelpers.classPrivateFieldSet(_Foo, _B, v);
+    }
     static m() {}
   }
   _Foo2 = Foo;
   [_Foo, _initClass] = babelHelpers.applyDecs2305(_Foo2, [], [dec]).c;
 })(), _temp))();
+function _get_a() {
+  return babelHelpers.classPrivateFieldGet(_Foo, _A);
+}
+function _set_a(v) {
+  babelHelpers.classPrivateFieldSet(_Foo, _A, v);
+}
 function _m2() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement-static-installed-on-correct-class/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement-static-installed-on-correct-class/input.js
@@ -1,16 +1,19 @@
-const dec = () => {}; 
-let hasX, hasM;
+const dec = () => {};
+let hasX, hasA, hasM;
 
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement-static-installed-on-correct-class/output.js
@@ -1,6 +1,6 @@
 var _initClass;
 const dec = () => {};
-let hasX, hasM;
+let hasX, hasA, hasM;
 let _Foo;
 new class extends babelHelpers.identity {
   static {
@@ -8,15 +8,30 @@ new class extends babelHelpers.identity {
       static {
         [_Foo, _initClass] = babelHelpers.applyDecs2305(this, [], [dec]).c;
       }
+      static get a() {
+        return _Foo.#B;
+      }
+      static set a(v) {
+        _Foo.#B = v;
+      }
       static m() {}
     }
   }
   #x;
+  #A;
+  get #a() {
+    return _Foo.#A;
+  }
+  set #a(v) {
+    _Foo.#A = v;
+  }
   #m() {}
   x;
+  #B;
   constructor() {
     super(_Foo), (() => {
       hasX = o => #x in o;
+      hasA = o => #a in o;
       hasM = o => #m in o;
     })(), _initClass();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-installed-on-correct-class/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-installed-on-correct-class/exec.js
@@ -1,4 +1,4 @@
-let hasX, hasM, OriginalFoo;
+let hasX, hasA, hasM, OriginalFoo;
 
 class Bar {}
 
@@ -10,24 +10,32 @@ function dec(Foo) {
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }
 
 expect(hasX(Bar)).toBe(true);
+expect(hasA(Bar)).toBe(true);
 expect(hasM(Bar)).toBe(true);
 expect(hasX(OriginalFoo)).toBe(false);
+expect(hasA(OriginalFoo)).toBe(false);
 expect(hasM(OriginalFoo)).toBe(false);
 
 expect(Bar.hasOwnProperty("x")).toBe(true);
 expect(OriginalFoo.hasOwnProperty("x")).toBe(false);
+
+expect(Bar.hasOwnProperty("a")).toBe(false);
+expect(OriginalFoo.hasOwnProperty("a")).toBe(true);
 
 expect(Bar.hasOwnProperty("m")).toBe(false);
 expect(OriginalFoo.hasOwnProperty("m")).toBe(true);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-installed-on-correct-class/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-installed-on-correct-class/input.js
@@ -1,16 +1,19 @@
-const dec = () => {}; 
-let hasX, hasM;
+const dec = () => {};
+let hasX, hasA, hasM;
 
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -1,22 +1,44 @@
-var _initClass, _x, _m, _temp;
+var _initClass, _x, _A, _a, _m, _B, _temp;
 const dec = () => {};
-let hasX, hasM;
+let hasX, hasA, hasM;
 let _Foo;
-new (_x = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), (_temp = class extends babelHelpers.identity {
+new (_x = /*#__PURE__*/new WeakMap(), _A = /*#__PURE__*/new WeakMap(), _a = /*#__PURE__*/new WeakMap(), _m = /*#__PURE__*/new WeakSet(), _B = /*#__PURE__*/new WeakMap(), (_temp = class extends babelHelpers.identity {
   constructor() {
-    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _m), babelHelpers.classPrivateFieldInitSpec(this, _x, {
+    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _m), babelHelpers.classPrivateFieldInitSpec(this, _a, {
+      get: _get_a,
+      set: _set_a
+    }), babelHelpers.classPrivateFieldInitSpec(this, _x, {
       writable: true,
       value: void 0
-    }), babelHelpers.defineProperty(this, "x", void 0)), (() => {
+    }), babelHelpers.classPrivateFieldInitSpec(this, _A, {
+      writable: true,
+      value: void 0
+    }), babelHelpers.defineProperty(this, "x", void 0), babelHelpers.classPrivateFieldInitSpec(this, _B, {
+      writable: true,
+      value: void 0
+    }), this), (() => {
       hasX = o => _x.has(babelHelpers.checkInRHS(o));
+      hasA = o => _a.has(babelHelpers.checkInRHS(o));
       hasM = o => _m.has(babelHelpers.checkInRHS(o));
     })(), _initClass();
   }
 }, (_Foo2 => {
   class Foo {
+    static get a() {
+      return babelHelpers.classPrivateFieldGet(_Foo, _B);
+    }
+    static set a(v) {
+      babelHelpers.classPrivateFieldSet(_Foo, _B, v);
+    }
     static m() {}
   }
   _Foo2 = Foo;
   [_Foo, _initClass] = babelHelpers.applyDecs2311(_Foo2, [], [dec]).c;
 })(), _temp))();
+function _get_a() {
+  return babelHelpers.classPrivateFieldGet(_Foo, _A);
+}
+function _set_a(v) {
+  babelHelpers.classPrivateFieldSet(_Foo, _A, v);
+}
 function _m2() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-installed-on-correct-class/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-installed-on-correct-class/input.js
@@ -1,16 +1,19 @@
-const dec = () => {}; 
-let hasX, hasM;
+const dec = () => {};
+let hasX, hasA, hasM;
 
 @dec
 class Foo {
   static #x;
+  static accessor #a;
   static #m() {}
 
   static x;
+  static accessor a;
   static m() {}
 
   static {
     hasX = o => #x in o;
+    hasA = o => #a in o;
     hasM = o => #m in o;
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-installed-on-correct-class/output.js
@@ -1,6 +1,6 @@
 var _initClass;
 const dec = () => {};
-let hasX, hasM;
+let hasX, hasA, hasM;
 let _Foo;
 new class extends babelHelpers.identity {
   static {
@@ -8,15 +8,30 @@ new class extends babelHelpers.identity {
       static {
         [_Foo, _initClass] = babelHelpers.applyDecs2311(this, [], [dec]).c;
       }
+      static get a() {
+        return _Foo.#B;
+      }
+      static set a(v) {
+        _Foo.#B = v;
+      }
       static m() {}
     }
   }
   #x;
+  #A;
+  get #a() {
+    return _Foo.#A;
+  }
+  set #a(v) {
+    _Foo.#A = v;
+  }
   #m() {}
   x;
+  #B;
   constructor() {
     super(_Foo), (() => {
       hasX = o => #x in o;
+      hasA = o => #a in o;
       hasM = o => #m in o;
     })(), _initClass();
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/pull/16242#discussion_r1472695124
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As a follow-up to https://github.com/babel/babel/pull/16242, in this PR we wrap the versions check within Babel 7 check for those deprecated decorator versions. This PR also fixes some typo and expands current test cases.