### PR TITLE
fix: handle decorated async private method and generator

### DIFF
--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/exec.js
@@ -1,0 +1,23 @@
+let counter = 0;
+
+class Foo {
+  @(function (fn) {
+    counter++;
+    expect(fn.constructor.name).toBe("AsyncFunction");
+  })
+  async #a() {}
+
+  @(function (fn) {
+    counter++;
+    expect(fn.constructor.name).toBe("GeneratorFunction");
+  })
+  *#g() {}
+
+  @(function (fn) {
+    counter++;
+    expect(fn.constructor.name).toBe("AsyncGeneratorFunction");
+  })
+  async *#ag() {}
+}
+
+expect(counter).toBe(3);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/input.js
@@ -1,0 +1,10 @@
+class Foo {
+  @dec
+  async #a() {}
+
+  @dec
+  *#g() {}
+
+  @dec
+  async *#ag() {}
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/options.json
@@ -1,0 +1,3 @@
+{
+  "minNodeVersion": "10.0.0"
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/output.js
@@ -1,0 +1,26 @@
+var _initProto, _dec, _call_a, _dec2, _call_g, _dec3, _call_ag, _Foo;
+_dec = dec;
+_dec2 = dec;
+_dec3 = dec;
+var _ag = /*#__PURE__*/new WeakMap();
+var _g = /*#__PURE__*/new WeakMap();
+var _a = /*#__PURE__*/new WeakMap();
+class Foo {
+  constructor() {
+    babelHelpers.classPrivateFieldInitSpec(this, _ag, {
+      writable: true,
+      value: _call_ag
+    });
+    babelHelpers.classPrivateFieldInitSpec(this, _g, {
+      writable: true,
+      value: _call_g
+    });
+    babelHelpers.classPrivateFieldInitSpec(this, _a, {
+      writable: true,
+      value: _call_a
+    });
+    _initProto(this);
+  }
+}
+_Foo = Foo;
+[_call_a, _call_g, _call_ag, _initProto] = babelHelpers.applyDecs2311(_Foo, [[_dec, 2, "a", async function () {}], [_dec2, 2, "g", function* () {}], [_dec3, 2, "ag", async function* () {}]], [], 0, _ => _a.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/exec.js
@@ -1,0 +1,23 @@
+let counter = 0;
+
+class Foo {
+  @(function (fn) {
+    counter++;
+    expect(fn.constructor.name).toBe("AsyncFunction");
+  })
+  async #a() {}
+
+  @(function (fn) {
+    counter++;
+    expect(fn.constructor.name).toBe("GeneratorFunction");
+  })
+  *#g() {}
+
+  @(function (fn) {
+    counter++;
+    expect(fn.constructor.name).toBe("AsyncGeneratorFunction");
+  })
+  async *#ag() {}
+}
+
+expect(counter).toBe(3);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/input.js
@@ -1,0 +1,10 @@
+class Foo {
+  @dec
+  async #a() {}
+
+  @dec
+  *#g() {}
+
+  @dec
+  async *#ag() {}
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/options.json
@@ -1,0 +1,3 @@
+{
+  "minNodeVersion": "16.11.0"
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/output.js
@@ -1,0 +1,15 @@
+var _initProto, _dec, _call_a, _dec2, _call_g, _dec3, _call_ag;
+_dec = dec;
+_dec2 = dec;
+_dec3 = dec;
+class Foo {
+  static {
+    [_call_a, _call_g, _call_ag, _initProto] = babelHelpers.applyDecs2311(this, [[_dec, 2, "a", async function () {}], [_dec2, 2, "g", function* () {}], [_dec3, 2, "ag", async function* () {}]], [], 0, _ => #a in _).e;
+  }
+  constructor() {
+    _initProto(this);
+  }
+  #ag = _call_ag;
+  #g = _call_g;
+  #a = _call_a;
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/16257
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we fix incorrect argument order when creating a function expression from the decorated private method. The test cases are only added to the `2023-11` decorator version since the other versions will be removed in Babel 8. The fix should apply for other decorator versions as well.