### PR TITLE
Preserve `static` on decorated private `accessor`

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -182,10 +182,9 @@ function addProxyAccessorsFor(
   originalKey: t.PrivateName | t.Expression,
   targetKey: t.PrivateName,
   version: DecoratorVersionKind,
-  isComputed = false,
+  isComputed: boolean,
+  isStatic: boolean,
 ): void {
-  const { static: isStatic } = element.node;
-
   const thisArg =
     (version === "2023-11" ||
       (!process.env.BABEL_8_BREAKING && version === "2023-05")) &&
@@ -610,6 +609,7 @@ function addCallAccessorsFor(
   key: t.PrivateName,
   getId: t.Identifier,
   setId: t.Identifier,
+  isStatic: boolean,
 ) {
   element.insertAfter(
     t.classPrivateMethod(
@@ -621,6 +621,7 @@ function addCallAccessorsFor(
           t.callExpression(t.cloneNode(getId), [t.thisExpression()]),
         ),
       ]),
+      isStatic,
     ),
   );
 
@@ -637,6 +638,7 @@ function addCallAccessorsFor(
           ]),
         ),
       ]),
+      isStatic,
     ),
   );
 }
@@ -885,6 +887,7 @@ function transformClass(
         newId,
         version,
         computed,
+        isStatic,
       );
     }
   }
@@ -1099,7 +1102,7 @@ function transformClass(
               `set_${name}`,
             );
 
-            addCallAccessorsFor(newPath, key, getId, setId);
+            addCallAccessorsFor(newPath, key, getId, setId, isStatic);
 
             locals = [newFieldInitId, getId, setId];
           } else {
@@ -1110,6 +1113,7 @@ function transformClass(
               newId,
               version,
               isComputed,
+              isStatic,
             );
             locals = [newFieldInitId];
           }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
@@ -10,14 +10,7 @@ const f = () => {
   };
 };
 _computedKey = babelHelpers.toPropertyKey(f());
-var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor() {
-    babelHelpers.classPrivateFieldInitSpec(this, _a, {
-      get: _get_a2,
-      set: _set_a2
-    });
-  }
   static get a() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _A);
   }
@@ -74,6 +67,10 @@ function _set_a2(v) {
 function _get_a2() {
   return _get_a(this);
 }
+var _a = {
+  get: _get_a2,
+  set: _set_a2
+};
 (() => {
   [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 6, "a"], [dec, 6, "a", function () {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _B);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-private/output.js
@@ -1,19 +1,6 @@
 var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
-var _a = /*#__PURE__*/new WeakMap();
-var _b = /*#__PURE__*/new WeakMap();
-class Foo {
-  constructor() {
-    babelHelpers.classPrivateFieldInitSpec(this, _b, {
-      get: _get_b2,
-      set: _set_b2
-    });
-    babelHelpers.classPrivateFieldInitSpec(this, _a, {
-      get: _get_a2,
-      set: _set_a2
-    });
-  }
-}
+class Foo {}
 _Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
@@ -27,6 +14,14 @@ function _set_b2(v) {
 function _get_b2() {
   return _get_b(this);
 }
+var _b = {
+  get: _get_b2,
+  set: _set_b2
+};
+var _a = {
+  get: _get_a2,
+  set: _set_a2
+};
 (() => {
   [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 6, "a", function () {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _A);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/output.js
@@ -27,10 +27,10 @@ class Foo {
     this.#A = v;
   }
   static #B = _init_a2(this);
-  set #a(v) {
+  static set #a(v) {
     _set_a(this, v);
   }
-  get #a() {
+  static get #a() {
     return _get_a(this);
   }
   static #C = _init_computedKey(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-private/output.js
@@ -14,17 +14,17 @@ class Foo {
     _initStatic(this);
   }
   static #A = _init_a(this);
-  set #a(v) {
+  static set #a(v) {
     _set_a(this, v);
   }
-  get #a() {
+  static get #a() {
     return _get_a(this);
   }
   static #B = _init_b(this, 123);
-  set #b(v) {
+  static set #b(v) {
     _set_b(this, v);
   }
-  get #b() {
+  static get #b() {
     return _get_b(this);
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/all-decorators/output.js
@@ -59,12 +59,6 @@ new class extends babelHelpers.identity {
       static set m(v) {
         this.#C = v;
       }
-      set #r(v) {
-        _set_r(this, v);
-      }
-      get #r() {
-        return _get_r(this);
-      }
     }
   }
   #o = _call_o;
@@ -78,6 +72,12 @@ new class extends babelHelpers.identity {
     _call_q(this, v);
   }
   #D = _init_r(this);
+  set #r(v) {
+    _set_r(this, v);
+  }
+  get #r() {
+    return _get_r(this);
+  }
   constructor() {
     super(_Class), _initClass();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
@@ -10,14 +10,7 @@ const f = () => {
   };
 };
 _computedKey = babelHelpers.toPropertyKey(f());
-var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor() {
-    babelHelpers.classPrivateFieldInitSpec(this, _a, {
-      get: _get_a2,
-      set: _set_a2
-    });
-  }
   static get a() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _A);
   }
@@ -74,6 +67,10 @@ function _set_a2(v) {
 function _get_a2() {
   return _get_a(this);
 }
+var _a = {
+  get: _get_a2,
+  set: _set_a2
+};
 (() => {
   [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 6, "a"], [dec, 6, "a", function () {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _B);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-private/output.js
@@ -1,19 +1,6 @@
 var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
-var _a = /*#__PURE__*/new WeakMap();
-var _b = /*#__PURE__*/new WeakMap();
-class Foo {
-  constructor() {
-    babelHelpers.classPrivateFieldInitSpec(this, _b, {
-      get: _get_b2,
-      set: _set_b2
-    });
-    babelHelpers.classPrivateFieldInitSpec(this, _a, {
-      get: _get_a2,
-      set: _set_a2
-    });
-  }
-}
+class Foo {}
 _Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
@@ -27,6 +14,14 @@ function _set_b2(v) {
 function _get_b2() {
   return _get_b(this);
 }
+var _b = {
+  get: _get_b2,
+  set: _set_b2
+};
+var _a = {
+  get: _get_a2,
+  set: _set_a2
+};
 (() => {
   [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 6, "a", function () {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, _Foo, _A);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/output.js
@@ -27,10 +27,10 @@ class Foo {
     this.#A = v;
   }
   static #B = _init_a2(this);
-  set #a(v) {
+  static set #a(v) {
     _set_a(this, v);
   }
-  get #a() {
+  static get #a() {
     return _get_a(this);
   }
   static #C = _init_computedKey(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-private/output.js
@@ -14,17 +14,17 @@ class Foo {
     _initStatic(this);
   }
   static #A = _init_a(this);
-  set #a(v) {
+  static set #a(v) {
     _set_a(this, v);
   }
-  get #a() {
+  static get #a() {
     return _get_a(this);
   }
   static #B = _init_b(this, 123);
-  set #b(v) {
+  static set #b(v) {
     _set_b(this, v);
   }
-  get #b() {
+  static get #b() {
     return _get_b(this);
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/all-decorators/output.js
@@ -62,12 +62,6 @@ new class extends babelHelpers.identity {
       static set m(v) {
         this.#C = v;
       }
-      set #r(v) {
-        _set_r(this, v);
-      }
-      get #r() {
-        return _get_r(this);
-      }
     }
   }
   #o = _call_o;
@@ -81,6 +75,12 @@ new class extends babelHelpers.identity {
     _call_q(this, v);
   }
   #D = _init_r(this);
+  set #r(v) {
+    _set_r(this, v);
+  }
+  get #r() {
+    return _get_r(this);
+  }
   constructor() {
     super(_Class), _initClass();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
@@ -10,14 +10,7 @@ const f = () => {
   };
 };
 _computedKey = babelHelpers.toPropertyKey(f());
-var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor() {
-    babelHelpers.classPrivateFieldInitSpec(this, _a, {
-      get: _get_a2,
-      set: _set_a2
-    });
-  }
   static get a() {
     return babelHelpers.classStaticPrivateFieldSpecGet(this, Foo, _A);
   }
@@ -74,6 +67,10 @@ function _set_a2(v) {
 function _get_a2() {
   return _get_a(this);
 }
+var _a = {
+  get: _get_a2,
+  set: _set_a2
+};
 (() => {
   [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 6, "a"], [dec, 6, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _B, v)], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-private/output.js
@@ -1,19 +1,6 @@
 var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
-var _a = /*#__PURE__*/new WeakMap();
-var _b = /*#__PURE__*/new WeakMap();
-class Foo {
-  constructor() {
-    babelHelpers.classPrivateFieldInitSpec(this, _b, {
-      get: _get_b2,
-      set: _set_b2
-    });
-    babelHelpers.classPrivateFieldInitSpec(this, _a, {
-      get: _get_a2,
-      set: _set_a2
-    });
-  }
-}
+class Foo {}
 _Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
@@ -27,6 +14,14 @@ function _set_b2(v) {
 function _get_b2() {
   return _get_b(this);
 }
+var _b = {
+  get: _get_b2,
+  set: _set_b2
+};
+var _a = {
+  get: _get_a2,
+  set: _set_a2
+};
 (() => {
   [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 6, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _A), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _A, v)], [dec, 6, "b", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _B, v)]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/output.js
@@ -23,10 +23,10 @@ class Foo {
     this.#A = v;
   }
   static #B = _init_a2(this);
-  set #a(v) {
+  static set #a(v) {
     _set_a(this, v);
   }
-  get #a() {
+  static get #a() {
     return _get_a(this);
   }
   static #C = _init_computedKey(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-private/output.js
@@ -6,17 +6,17 @@ class Foo {
     _initStatic(this);
   }
   static #A = _init_a(this);
-  set #a(v) {
+  static set #a(v) {
     _set_a(this, v);
   }
-  get #a() {
+  static get #a() {
     return _get_a(this);
   }
   static #B = _init_b(this, 123);
-  set #b(v) {
+  static set #b(v) {
     _set_b(this, v);
   }
-  get #b() {
+  static get #b() {
     return _get_b(this);
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/all-decorators/output.js
@@ -46,12 +46,6 @@ new class extends babelHelpers.identity {
       static set m(v) {
         this.#C = v;
       }
-      set #r(v) {
-        _set_r(this, v);
-      }
-      get #r() {
-        return _get_r(this);
-      }
     }
   }
   #o = _call_o;
@@ -65,6 +59,12 @@ new class extends babelHelpers.identity {
     _call_q(this, v);
   }
   #D = _init_r(this);
+  set #r(v) {
+    _set_r(this, v);
+  }
+  get #r() {
+    return _get_r(this);
+  }
   constructor() {
     super(_Class), _initClass();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
@@ -10,14 +10,7 @@ const f = () => {
   };
 };
 _computedKey = babelHelpers.toPropertyKey(f());
-var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor() {
-    babelHelpers.classPrivateFieldInitSpec(this, _a, {
-      get: _get_a2,
-      set: _set_a2
-    });
-  }
   static get a() {
     return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _A);
   }
@@ -74,6 +67,10 @@ function _set_a2(v) {
 function _get_a2() {
   return _get_a(this);
 }
+var _a = {
+  get: _get_a2,
+  set: _set_a2
+};
 (() => {
   [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 9, "a"], [dec, 9, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _B, v)], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-private/output.js
@@ -1,19 +1,6 @@
 var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
-var _a = /*#__PURE__*/new WeakMap();
-var _b = /*#__PURE__*/new WeakMap();
-class Foo {
-  constructor() {
-    babelHelpers.classPrivateFieldInitSpec(this, _b, {
-      get: _get_b2,
-      set: _set_b2
-    });
-    babelHelpers.classPrivateFieldInitSpec(this, _a, {
-      get: _get_a2,
-      set: _set_a2
-    });
-  }
-}
+class Foo {}
 _Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
@@ -27,6 +14,14 @@ function _set_b2(v) {
 function _get_b2() {
   return _get_b(this);
 }
+var _b = {
+  get: _get_b2,
+  set: _set_b2
+};
+var _a = {
+  get: _get_a2,
+  set: _set_a2
+};
 (() => {
   [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 9, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _A), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _A, v)], [dec, 9, "b", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _B, v)]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/output.js
@@ -23,10 +23,10 @@ class Foo {
     Foo.#A = v;
   }
   static #B = _init_a2(this);
-  set #a(v) {
+  static set #a(v) {
     _set_a(this, v);
   }
-  get #a() {
+  static get #a() {
     return _get_a(this);
   }
   static #C = _init_computedKey(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-private/output.js
@@ -6,17 +6,17 @@ class Foo {
     _initStatic(this);
   }
   static #A = _init_a(this);
-  set #a(v) {
+  static set #a(v) {
     _set_a(this, v);
   }
-  get #a() {
+  static get #a() {
     return _get_a(this);
   }
   static #B = _init_b(this, 123);
-  set #b(v) {
+  static set #b(v) {
     _set_b(this, v);
   }
-  get #b() {
+  static get #b() {
     return _get_b(this);
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/all-decorators/output.js
@@ -46,12 +46,6 @@ new class extends babelHelpers.identity {
       static set m(v) {
         Class.#C = v;
       }
-      set #r(v) {
-        _set_r(this, v);
-      }
-      get #r() {
-        return _get_r(this);
-      }
     }
   }
   #o = _call_o;
@@ -65,6 +59,12 @@ new class extends babelHelpers.identity {
     _call_q(this, v);
   }
   #D = _init_r(this);
+  set #r(v) {
+    _set_r(this, v);
+  }
+  get #r() {
+    return _get_r(this);
+  }
   constructor() {
     super(_Class), _initClass();
   }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/context-name/output.js
@@ -10,14 +10,7 @@ const f = () => {
   };
 };
 _computedKey = babelHelpers.toPropertyKey(f());
-var _a = /*#__PURE__*/new WeakMap();
 class Foo {
-  constructor() {
-    babelHelpers.classPrivateFieldInitSpec(this, _a, {
-      get: _get_a2,
-      set: _set_a2
-    });
-  }
   static get a() {
     return babelHelpers.classStaticPrivateFieldSpecGet(Foo, Foo, _A);
   }
@@ -74,6 +67,10 @@ function _set_a2(v) {
 function _get_a2() {
   return _get_a(this);
 }
+var _a = {
+  get: _get_a2,
+  set: _set_a2
+};
 [_init_a, _init_extra_a, _init_a2, _get_a, _set_a, _init_extra_a2, _init_computedKey, _init_extra_computedKey, _init_computedKey2, _init_extra_computedKey2, _init_computedKey3, _init_extra_computedKey3, _init_computedKey4, _init_extra_computedKey4, _init_computedKey5, _init_extra_computedKey5, _init_computedKey6, _init_extra_computedKey6, _init_computedKey7, _init_extra_computedKey7] = babelHelpers.applyDecs2311(_Foo, [[dec, 9, "a"], [dec, 9, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _B, v)], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
 var _A = {
   writable: true,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/static-private/output.js
@@ -1,19 +1,6 @@
 var _init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b, _Foo;
 const dec = () => {};
-var _a = /*#__PURE__*/new WeakMap();
-var _b = /*#__PURE__*/new WeakMap();
-class Foo {
-  constructor() {
-    babelHelpers.classPrivateFieldInitSpec(this, _b, {
-      get: _get_b2,
-      set: _set_b2
-    });
-    babelHelpers.classPrivateFieldInitSpec(this, _a, {
-      get: _get_a2,
-      set: _set_a2
-    });
-  }
-}
+class Foo {}
 _Foo = Foo;
 function _set_a2(v) {
   _set_a(this, v);
@@ -27,6 +14,14 @@ function _set_b2(v) {
 function _get_b2() {
   return _get_b(this);
 }
+var _b = {
+  get: _get_b2,
+  set: _set_b2
+};
+var _a = {
+  get: _get_a2,
+  set: _set_a2
+};
 [_init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b] = babelHelpers.applyDecs2311(_Foo, [[dec, 9, "a", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _A), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _A, v)], [dec, 9, "b", o => babelHelpers.classStaticPrivateFieldSpecGet(o, _Foo, _B), (o, v) => babelHelpers.classStaticPrivateFieldSpecSet(o, _Foo, _B, v)]], []).e;
 var _A = {
   writable: true,

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/context-name/output.js
@@ -22,10 +22,10 @@ class Foo {
     Foo.#A = v;
   }
   static #B = (_init_extra_a(this), _init_a2(this));
-  set #a(v) {
+  static set #a(v) {
     _set_a(this, v);
   }
-  get #a() {
+  static get #a() {
     return _get_a(this);
   }
   static #C = (_init_extra_a2(this), _init_computedKey(this));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/static-private/output.js
@@ -5,17 +5,17 @@ class Foo {
     [_init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b] = babelHelpers.applyDecs2311(this, [[dec, 9, "a", o => o.#A, (o, v) => o.#A = v], [dec, 9, "b", o => o.#B, (o, v) => o.#B = v]], []).e;
   }
   static #A = _init_a(this);
-  set #a(v) {
+  static set #a(v) {
     _set_a(this, v);
   }
-  get #a() {
+  static get #a() {
     return _get_a(this);
   }
   static #B = (_init_extra_a(this), _init_b(this, 123));
-  set #b(v) {
+  static set #b(v) {
     _set_b(this, v);
   }
-  get #b() {
+  static get #b() {
     return _get_b(this);
   }
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/all-decorators/output.js
@@ -49,12 +49,6 @@ new class extends babelHelpers.identity {
       static set m(v) {
         Class.#C = v;
       }
-      set #r(v) {
-        _set_r(this, v);
-      }
-      get #r() {
-        return _get_r(this);
-      }
     }
   }
   #o = _call_o;
@@ -68,6 +62,12 @@ new class extends babelHelpers.identity {
     _call_q(this, v);
   }
   #D = (_init_extra_n(this), _init_r(this));
+  set #r(v) {
+    _set_r(this, v);
+  }
+  get #r() {
+    return _get_r(this);
+  }
   constructor() {
     super(_Class), (() => {
       _init_extra_r(this);


### PR DESCRIPTION


| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Not sure how we missed this, but we were rewriting decorated static private accessors to static _instance_ private getters/setters.