### PR TITLE
Implement `noUninitializedPrivateFieldAccess` assumption

### DIFF
--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -281,6 +281,7 @@ const knownAssumptions = [
   "noDocumentAll",
   "noIncompleteNsImportDetection",
   "noNewArrows",
+  "noUninitializedPrivateFieldAccess",
   "objectRestNoSymbols",
   "privateFieldsAsSymbols",
   "privateFieldsAsProperties",

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -75,6 +75,8 @@ export function createClassFeaturePlugin({
   const setPublicClassFields = api.assumption("setPublicClassFields");
   const privateFieldsAsSymbols = api.assumption("privateFieldsAsSymbols");
   const privateFieldsAsProperties = api.assumption("privateFieldsAsProperties");
+  const noUninitializedPrivateFieldAccess =
+    api.assumption("noUninitializedPrivateFieldAccess") ?? false;
   const constantSuper = api.assumption("constantSuper");
   const noDocumentAll = api.assumption("noDocumentAll");
 
@@ -256,6 +258,7 @@ export function createClassFeaturePlugin({
           {
             privateFieldsAsProperties:
               privateFieldsAsSymbolsOrProperties ?? loose,
+            noUninitializedPrivateFieldAccess,
             noDocumentAll,
             innerBinding,
           },
@@ -296,6 +299,7 @@ export function createClassFeaturePlugin({
               file,
               setPublicClassFields ?? loose,
               privateFieldsAsSymbolsOrProperties ?? loose,
+              noUninitializedPrivateFieldAccess,
               constantSuper ?? loose,
               innerBinding,
             ));
@@ -317,6 +321,7 @@ export function createClassFeaturePlugin({
             file,
             setPublicClassFields ?? loose,
             privateFieldsAsSymbolsOrProperties ?? loose,
+            noUninitializedPrivateFieldAccess,
             constantSuper ?? loose,
             innerBinding,
           ));

--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -173,10 +173,10 @@ export default Object.freeze({
     "7.1.5",
     'import toPrimitive from"toPrimitive";export default function toPropertyKey(t){var i=toPrimitive(t,"string");return"symbol"==typeof i?i:String(i)}',
   ),
-  // size: 134, gzip size: 134
+  // size: 144, gzip size: 141
   toSetter: helper(
     "7.22.0",
-    'export default function _toSetter(t,e,n){var r=e.length++;return Object.defineProperty({},"_",{set:function(o){e[r]=o,t.apply(n,e)}})}',
+    'export default function _toSetter(t,e,n){e||(e=[]);var r=e.length++;return Object.defineProperty({},"_",{set:function(o){e[r]=o,t.apply(n,e)}})}',
   ),
   // size: 289, gzip size: 165
   typeof: helper(

--- a/packages/babel-helpers/src/helpers/toSetter.ts
+++ b/packages/babel-helpers/src/helpers/toSetter.ts
@@ -1,6 +1,7 @@
 /* @minVersion 7.22.0 */
 
 export default function _toSetter(fn: Function, args: any[], thisArg: any) {
+  if (!args) args = [];
   var l = args.length++;
   return Object.defineProperty({}, "_", {
     set: function (v) {

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-noUninitializedPrivateFieldAccess/options.json
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-noUninitializedPrivateFieldAccess/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["transform-class-properties"],
+  "assumptions": {
+    "noUninitializedPrivateFieldAccess": true
+  }
+}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-noUninitializedPrivateFieldAccess/static-private/exec.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-noUninitializedPrivateFieldAccess/static-private/exec.js
@@ -1,0 +1,23 @@
+class A {
+  static #x = 0;
+
+  static dynamicCheck() {
+    expect(this.#x).toBe(0);
+    expect(this.#x = 1).toBe(1);
+    expect(this.#x).toBe(1);
+    [this.#x] = [2];
+    expect(this.#x).toBe(2);
+  }
+
+  static noCheck() {
+    expect(A.#x).toBe(2);
+    expect(A.#x = 3).toBe(3);
+    [A.#x] = [4];
+    expect(A.#x).toBe(4);
+  }
+}
+
+A.dynamicCheck();
+A.noCheck();
+
+

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-noUninitializedPrivateFieldAccess/static-private/input.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-noUninitializedPrivateFieldAccess/static-private/input.js
@@ -1,0 +1,15 @@
+class A {
+  static #x = 2;
+
+  static dynamicCheck() {
+    this.#x;
+    this.#x = 2;
+    [this.#x] = [];
+  }
+
+  static noCheck() {
+    A.#x;
+    A.#x = 2;
+    [A.#x] = [];
+  }
+}

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-noUninitializedPrivateFieldAccess/static-private/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-noUninitializedPrivateFieldAccess/static-private/output.js
@@ -1,0 +1,13 @@
+class A {
+  static dynamicCheck() {
+    babelHelpers.assertClassBrand(this, A, _x);
+    _x = babelHelpers.assertClassBrand(this, A, 2);
+    [babelHelpers.toSetter(babelHelpers.assertClassBrand(this, A, _ => _x = _))._] = [];
+  }
+  static noCheck() {
+    _x;
+    _x = 2;
+    [_x] = [];
+  }
+}
+var _x = 2;


### PR DESCRIPTION
* copy test cases from 2023-05

* update 2023-11 test options

* copy applyDecs2305 to applyDecs2311

* allow 2023-11 decorator version

* feat: support per-field intitializers

* update test fixtures

OVERWRITE=1 yarn jest decorators -t "2023 11"

* update generated helpers

* update other class tests

* expand field-initializers-after-methods case

* Add failing private flavour test

* update pipeline operator tests

* Don't run Babel 8 test with 2023-05 decorator

* add release todo item<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Following up to the recent changes, this PR makes it possible to also avoid the extra object for static private fields. The drawback is that at runtime an uninitialized static private field on the correct receiver looks just like if it was already initialized but to `undefined`.