### PR TITLE
Do not consider `arguments` in a helper as a global reference

### DIFF
--- a/packages/babel-helpers/src/index.ts
+++ b/packages/babel-helpers/src/index.ts
@@ -110,7 +110,9 @@ function getHelperMetadata(file: File): HelperMetadata {
       const name = child.node.name;
       const binding = child.scope.getBinding(name);
       if (!binding) {
-        globals.add(name);
+        if (name !== "arguments" || child.scope.path.isProgram()) {
+          globals.add(name);
+        }
       } else if (dependencies.has(binding.identifier)) {
         importBindingsReferences.push(makePath(child));
       }

--- a/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/input.js
+++ b/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/input.js
@@ -1,0 +1,1 @@
+var arguments;

--- a/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/options.json
+++ b/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin"]
+}

--- a/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/options.json
+++ b/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/options.json
@@ -1,3 +1,4 @@
 {
-  "plugins": ["./plugin"]
+  "plugins": ["./plugin"],
+  "minNodeVersion": "12.0.0"
 }

--- a/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/output.js
+++ b/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/output.js
@@ -1,0 +1,2 @@
+function _assertClassBrand(e, t, n) { if ("function" == typeof t ? t === e : t.has(e)) return arguments.length < 3 ? e : n; throw new TypeError("Private element is not present on this object"); }
+var arguments;

--- a/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/plugin.js
+++ b/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/plugin.js
@@ -1,0 +1,9 @@
+export default function () {
+  return {
+    visitor: {
+      Program(path, file) {
+        file.addHelper("assertClassBrand");
+      },
+    },
+  };
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I figured out the test262 failure. We were considering `arguments` in the helper as a global reference and thus renaming the global `var arguments`.

This is not a bug, since we don't guarantee that we won't rename vars, but it's nice to get the test to pass again.