### PR TITLE
Use updated native GitHub markdown `Note` admonition

### DIFF
--- a/doc/design/monorepo.md
+++ b/doc/design/monorepo.md
@@ -1,6 +1,7 @@
 # Why is Babel a monorepo?
 
-> **Note** We don't use `lerna` to manage packages inside the monorepo, but yarn workspaces with an additional [custom plugin](https://github.com/nicolo-ribaudo/yarn-plugin-babel-release-tool).
+> [!NOTE]
+> We don't use `lerna` to manage packages inside the monorepo, but yarn workspaces with an additional [custom plugin](https://github.com/nicolo-ribaudo/yarn-plugin-babel-release-tool).
 
 Juggling a multimodule project over multiple repos is like trying to teach a newborn baby how to
 ride a bike.

--- a/eslint/babel-eslint-plugin-development/README.md
+++ b/eslint/babel-eslint-plugin-development/README.md
@@ -26,7 +26,8 @@ Then, load the plugin in your `.eslintrc` configuration file. You can omit the `
 
 ## Supported Rules
 
-> **Note** Rules marked with :wrench: are autofixable.
+> [!NOTE]
+> Rules marked with :wrench: are autofixable.
 
 * `@babel/development/no-deprecated-clone` (:wrench:): Disallows using the deprecated
   `t.clone(node)` and `t.cloneDeep(node)` methods from `@babel/types`. Those


### PR DESCRIPTION
- Follows https://github.com/babel/babel/pull/15443

GitHub will render it with an icon and color the blockquote. The docs: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | None
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
GitHub changed the way they render alerts.

# Before 
## `doc/design/monorepo.md`
![image](https://github.com/babel/babel/assets/20454870/0a564811-1c9c-4224-aa66-7c284e44b6bc)

## `eslint/babel-eslint-plugin-development/README.md`
![image](https://github.com/babel/babel/assets/20454870/16ea40ac-ef7f-44d8-adb4-8824bc1561e8)

# After
## `doc/design/monorepo.md`
![image](https://github.com/babel/babel/assets/20454870/8dde81fc-1516-4d53-acbf-b2172cea7b5d)

## `eslint/babel-eslint-plugin-development/README.md`
![image](https://github.com/babel/babel/assets/20454870/71f56f68-2ab9-4bd8-bff8-b8f788961aff)

