### PR TITLE
Continue writing `output.js` when `exec.js` throws

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -301,6 +301,8 @@ async function run(task: Test) {
   let result: FileResult;
   let resultExec;
 
+  let execErr: Error;
+
   if (execCode) {
     const context = createContext();
     const execOpts = getOpts(exec);
@@ -318,9 +320,13 @@ async function run(task: Test) {
       resultExec = runCodeInTestContext(execCode, execOpts, context);
     } catch (err) {
       // Pass empty location to include the whole file in the output.
-      err.message =
-        `${exec.loc}: ${err.message}\n` + codeFrameColumns(execCode, {} as any);
-      throw err;
+      if (typeof err === "object" && err.message) {
+        err.message =
+          `${exec.loc}: ${err.message}\n` +
+          codeFrameColumns(execCode, {} as any);
+      }
+
+      execErr = err;
     }
   }
 
@@ -393,6 +399,10 @@ async function run(task: Test) {
         stderr.code,
       );
     }
+  }
+
+  if (execErr) {
+    throw execErr;
   }
 
   if (task.validateSourceMapVisual === true) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
We might want to see what happens to `output.js` when `exec.js` throws.