### PR TITLE
Fix decorator this memoization

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -930,18 +930,10 @@ function transformClass(
           t.isSuper(expression.object) ||
           t.isThisExpression(expression.object)
         ) {
-          needMemoise = true;
-          if (memoiseInPlace) {
-            object = memoiseExpression(t.thisExpression(), "obj");
-          } else {
-            object = t.thisExpression();
-          }
+          object = memoiseExpression(t.thisExpression(), "obj");
         } else {
           if (!scopeParent.isStatic(expression.object)) {
-            needMemoise = true;
-            if (memoiseInPlace) {
-              expression.object = memoiseExpression(expression.object, "obj");
-            }
+            expression.object = memoiseExpression(expression.object, "obj");
           }
           object = t.cloneNode(expression.object);
         }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
@@ -1,8 +1,9 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _classDecs, _obj, _dec, _C2;
-    _classDecs = [this, super.dec1];
+    var _initProto, _initClass, _obj, _classDecs, _obj2, _dec, _C2;
     _obj = this;
+    _classDecs = [_obj, super.dec1];
+    _obj2 = this;
     _dec = super.dec2;
     let _C;
     class C {
@@ -15,7 +16,7 @@ class A extends B {
     ({
       e: [_initProto],
       c: [_C, _initClass]
-    } = babelHelpers.applyDecs2305(_C2, [[[_obj, _dec], 18, "m2"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2305(_C2, [[[_obj2, _dec], 18, "m2"]], _classDecs, 1));
     _initClass();
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
@@ -1,11 +1,13 @@
-var _initClass, _classDecs, _obj, _dec, _obj2, _dec2, _init_x, _obj3, _dec3, _dec4, _init_y, _A2;
-_classDecs = [o1, o1.dec, void 0, dec, o2, o2.dec];
-_obj = o2;
-_dec = _obj.dec;
-_obj2 = o3.o;
-_dec2 = _obj2.dec;
+var _initClass, _obj, _obj2, _classDecs, _obj3, _dec, _obj4, _dec2, _init_x, _obj5, _dec3, _dec4, _init_y, _A2;
+_obj = o1;
+_obj2 = o2;
+_classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec];
 _obj3 = o2;
-_dec3 = _obj3.dec;
+_dec = _obj3.dec;
+_obj4 = o3.o;
+_dec2 = _obj4.dec;
+_obj5 = o2;
+_dec3 = _obj5.dec;
 _dec4 = dec;
 let _A;
 class A {
@@ -18,5 +20,5 @@ _A2 = A;
 ({
   e: [_init_x, _init_y],
   c: [_A, _initClass]
-} = babelHelpers.applyDecs2305(_A2, [[[_obj, _dec, _obj2, _dec2], 16, "x"], [[_obj3, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
+} = babelHelpers.applyDecs2305(_A2, [[[_obj3, _dec, _obj4, _dec2], 16, "x"], [[_obj5, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
@@ -1,11 +1,12 @@
-var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _obj, _dec4, _Foo2;
+var _initProto, _initClass, _obj, _classDecs, _dec, _dec2, _dec3, _obj2, _dec4, _Foo2;
 const dec = () => {};
-_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, array, array[expr]];
+_obj = array;
+_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
-_obj = array;
-_dec4 = _obj[expr];
+_obj2 = array;
+_dec4 = _obj2[expr];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
@@ -26,5 +27,5 @@ _Foo2 = Foo;
 ({
   e: [_initProto],
   c: [_Foo, _initClass]
-} = babelHelpers.applyDecs2305(_Foo2, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj, _dec4], 18, "method"]], _classDecs, 1));
+} = babelHelpers.applyDecs2305(_Foo2, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj2, _dec4], 18, "method"]], _classDecs, 1));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
@@ -1,8 +1,9 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _classDecs, _obj, _dec;
-    _classDecs = [this, super.dec1];
+    var _initProto, _initClass, _obj, _classDecs, _obj2, _dec;
     _obj = this;
+    _classDecs = [_obj, super.dec1];
+    _obj2 = this;
     _dec = super.dec2;
     let _C;
     class C {
@@ -10,7 +11,7 @@ class A extends B {
         ({
           e: [_initProto],
           c: [_C, _initClass]
-        } = babelHelpers.applyDecs2305(this, [[[_obj, _dec], 18, "m2"]], _classDecs, 1));
+        } = babelHelpers.applyDecs2305(this, [[[_obj2, _dec], 18, "m2"]], _classDecs, 1));
       }
       constructor() {
         _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
@@ -1,11 +1,13 @@
-var _initClass, _classDecs, _obj, _dec, _obj2, _dec2, _init_x, _obj3, _dec3, _dec4, _init_y;
-_classDecs = [o1, o1.dec, void 0, dec, o2, o2.dec];
-_obj = o2;
-_dec = _obj.dec;
-_obj2 = o3.o;
-_dec2 = _obj2.dec;
+var _initClass, _obj, _obj2, _classDecs, _obj3, _dec, _obj4, _dec2, _init_x, _obj5, _dec3, _dec4, _init_y;
+_obj = o1;
+_obj2 = o2;
+_classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec];
 _obj3 = o2;
-_dec3 = _obj3.dec;
+_dec = _obj3.dec;
+_obj4 = o3.o;
+_dec2 = _obj4.dec;
+_obj5 = o2;
+_dec3 = _obj5.dec;
 _dec4 = dec;
 let _A;
 class A {
@@ -13,7 +15,7 @@ class A {
     ({
       e: [_init_x, _init_y],
       c: [_A, _initClass]
-    } = babelHelpers.applyDecs2305(this, [[[_obj, _dec, _obj2, _dec2], 16, "x"], [[_obj3, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2305(this, [[[_obj3, _dec, _obj4, _dec2], 16, "x"], [[_obj5, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
   }
   x = _init_x(this);
   y = _init_y(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
@@ -1,26 +1,27 @@
-var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _obj, _dec4;
+var _initProto, _initClass, _obj, _classDecs, _dec, _dec2, _dec3, _obj2, _dec4;
 const dec = () => {};
-_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, array, array[expr]];
+_obj = array;
+_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
-_obj = array;
-_dec4 = _obj[expr];
+_obj2 = array;
+_dec4 = _obj2[expr];
 let _Foo;
 class Foo {
   static {
     ({
       e: [_initProto],
       c: [_Foo, _initClass]
-    } = babelHelpers.applyDecs2305(this, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj, _dec4], 18, "method"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2305(this, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj2, _dec4], 18, "method"]], _classDecs, 1));
   }
   #a = void _initProto(this);
   method() {}
   makeClass() {
-    var _obj2, _dec5, _init_bar;
-    return _obj2 = this, _dec5 = this.#a, class Nested {
+    var _obj3, _dec5, _init_bar;
+    return _obj3 = this, _dec5 = this.#a, class Nested {
       static {
-        [_init_bar] = babelHelpers.applyDecs2305(this, [[[_obj2, _dec5], 16, "bar"]], []).e;
+        [_init_bar] = babelHelpers.applyDecs2305(this, [[[_obj3, _dec5], 16, "bar"]], []).e;
       }
       bar = _init_bar(this);
     };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/super-in-decorator/output.js
@@ -1,8 +1,9 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _classDecs, _obj, _dec, _C2;
-    _classDecs = [this, super.dec1];
+    var _initProto, _initClass, _obj, _classDecs, _obj2, _dec, _C2;
     _obj = this;
+    _classDecs = [_obj, super.dec1];
+    _obj2 = this;
     _dec = super.dec2;
     let _C;
     class C {
@@ -15,7 +16,7 @@ class A extends B {
     ({
       e: [_initProto],
       c: [_C, _initClass]
-    } = babelHelpers.applyDecs2311(_C2, [[[_obj, _dec], 18, "m2"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2311(_C2, [[[_obj2, _dec], 18, "m2"]], _classDecs, 1));
     _initClass();
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
@@ -1,11 +1,13 @@
-var _initClass, _classDecs, _obj, _dec, _obj2, _dec2, _init_x, _init_extra_x, _obj3, _dec3, _dec4, _init_y, _init_extra_y, _A2;
-_classDecs = [o1, o1.dec, void 0, dec, o2, o2.dec];
-_obj = o2;
-_dec = _obj.dec;
-_obj2 = o3.o;
-_dec2 = _obj2.dec;
+var _initClass, _obj, _obj2, _classDecs, _obj3, _dec, _obj4, _dec2, _init_x, _init_extra_x, _obj5, _dec3, _dec4, _init_y, _init_extra_y, _A2;
+_obj = o1;
+_obj2 = o2;
+_classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec];
 _obj3 = o2;
-_dec3 = _obj3.dec;
+_dec = _obj3.dec;
+_obj4 = o3.o;
+_dec2 = _obj4.dec;
+_obj5 = o2;
+_dec3 = _obj5.dec;
 _dec4 = dec;
 let _A;
 class A {
@@ -19,5 +21,5 @@ _A2 = A;
 ({
   e: [_init_x, _init_extra_x, _init_y, _init_extra_y],
   c: [_A, _initClass]
-} = babelHelpers.applyDecs2311(_A2, [[[_obj, _dec, _obj2, _dec2], 16, "x"], [[_obj3, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
+} = babelHelpers.applyDecs2311(_A2, [[[_obj3, _dec, _obj4, _dec2], 16, "x"], [[_obj5, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/valid-expression-formats/output.js
@@ -1,11 +1,12 @@
-var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _obj, _dec4, _Foo2;
+var _initProto, _initClass, _obj, _classDecs, _dec, _dec2, _dec3, _obj2, _dec4, _Foo2;
 const dec = () => {};
-_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, array, array[expr]];
+_obj = array;
+_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
-_obj = array;
-_dec4 = _obj[expr];
+_obj2 = array;
+_dec4 = _obj2[expr];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
@@ -27,5 +28,5 @@ _Foo2 = Foo;
 ({
   e: [_initProto],
   c: [_Foo, _initClass]
-} = babelHelpers.applyDecs2311(_Foo2, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj, _dec4], 18, "method"]], _classDecs, 1));
+} = babelHelpers.applyDecs2311(_Foo2, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj2, _dec4], 18, "method"]], _classDecs, 1));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-decorator/output.js
@@ -1,8 +1,9 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _classDecs, _obj, _dec;
-    _classDecs = [this, super.dec1];
+    var _initProto, _initClass, _obj, _classDecs, _obj2, _dec;
     _obj = this;
+    _classDecs = [_obj, super.dec1];
+    _obj2 = this;
     _dec = super.dec2;
     let _C;
     class C {
@@ -10,7 +11,7 @@ class A extends B {
         ({
           e: [_initProto],
           c: [_C, _initClass]
-        } = babelHelpers.applyDecs2311(this, [[[_obj, _dec], 18, "m2"]], _classDecs, 1));
+        } = babelHelpers.applyDecs2311(this, [[[_obj2, _dec], 18, "m2"]], _classDecs, 1));
       }
       constructor() {
         _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/exec.js
@@ -9,13 +9,17 @@ function dec() {
 let o1 = { dec };
 let o2 = { dec };
 let o3 = { o: { dec } };
+let o4oCounter = 0;
+let o4 = { o() { o4oCounter++; return o1 } };
 
 @o1.dec
 @dec
 @o2.dec
+@(o4.o().dec)
 class A {
     @o2.dec
     @o3.o.dec
+    @(o4.o().dec)
     x;
 
     @o2.dec
@@ -23,4 +27,5 @@ class A {
     y;
 }
 
-expect(_this).toEqual([o3.o, o2, undefined, o2, o2, undefined, o1]);
+expect(_this).toEqual([o1, o3.o, o2, undefined, o2, o1, o2, undefined, o1]);
+expect(o4oCounter).toBe(2);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/input.js
@@ -1,9 +1,11 @@
 @o1.dec
 @dec
 @o2.dec
+@(o4.o().dec)
 class A {
     @o2.dec
     @o3.o.dec
+    @(o4.o().dec)
     x;
 
     @o2.dec

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
@@ -1,19 +1,24 @@
-var _initClass, _classDecs, _obj, _dec, _obj2, _dec2, _init_x, _init_extra_x, _obj3, _dec3, _dec4, _init_y, _init_extra_y;
-_classDecs = [o1, o1.dec, void 0, dec, o2, o2.dec];
-_obj = o2;
-_dec = _obj.dec;
-_obj2 = o3.o;
-_dec2 = _obj2.dec;
-_obj3 = o2;
-_dec3 = _obj3.dec;
-_dec4 = dec;
+var _initClass, _obj, _obj2, _obj3, _classDecs, _obj4, _dec, _obj5, _dec2, _obj6, _dec3, _init_x, _init_extra_x, _obj7, _dec4, _dec5, _init_y, _init_extra_y;
+_obj = o1;
+_obj2 = o2;
+_obj3 = o4.o();
+_classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec, _obj3, _obj3.dec];
+_obj4 = o2;
+_dec = _obj4.dec;
+_obj5 = o3.o;
+_dec2 = _obj5.dec;
+_obj6 = o4.o();
+_dec3 = _obj6.dec;
+_obj7 = o2;
+_dec4 = _obj7.dec;
+_dec5 = dec;
 let _A;
 class A {
   static {
     ({
       e: [_init_x, _init_extra_x, _init_y, _init_extra_y],
       c: [_A, _initClass]
-    } = babelHelpers.applyDecs2311(this, [[[_obj, _dec, _obj2, _dec2], 16, "x"], [[_obj3, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2311(this, [[[_obj4, _dec, _obj5, _dec2, _obj6, _dec3], 16, "x"], [[_obj7, _dec4, void 0, _dec5], 16, "y"]], _classDecs, 1));
   }
   constructor() {
     _init_extra_y(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
@@ -1,26 +1,27 @@
-var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _obj, _dec4;
+var _initProto, _initClass, _obj, _classDecs, _dec, _dec2, _dec3, _obj2, _dec4;
 const dec = () => {};
-_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, array, array[expr]];
+_obj = array;
+_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
 _dec = call();
 _dec2 = chain.expr();
 _dec3 = arbitrary + expr;
-_obj = array;
-_dec4 = _obj[expr];
+_obj2 = array;
+_dec4 = _obj2[expr];
 let _Foo;
 class Foo {
   static {
     ({
       e: [_initProto],
       c: [_Foo, _initClass]
-    } = babelHelpers.applyDecs2311(this, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj, _dec4], 18, "method"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2311(this, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj2, _dec4], 18, "method"]], _classDecs, 1));
   }
   #a = void _initProto(this);
   method() {}
   makeClass() {
-    var _obj2, _dec5, _init_bar, _init_extra_bar;
-    return _obj2 = this, _dec5 = this.#a, class Nested {
+    var _obj3, _dec5, _init_bar, _init_extra_bar;
+    return _obj3 = this, _dec5 = this.#a, class Nested {
       static {
-        [_init_bar, _init_extra_bar] = babelHelpers.applyDecs2311(this, [[[_obj2, _dec5], 16, "bar"]], []).e;
+        [_init_bar, _init_extra_bar] = babelHelpers.applyDecs2311(this, [[[_obj3, _dec5], 16, "bar"]], []).e;
       }
       constructor() {
         _init_extra_bar(this);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | When a class decorator is an member expression with non-static parent object, Babel fails to memoise the parent object when generating `this` value for the decoration helper. ([REPL](https://babel.dev/repl#?browsers=chrome%2094&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=EQVwzgpgBGAuBOBLAxrYBuAUJgZiAdqogPb5QAmEyAFAJRQDeAvtgDYSxTECMUAvIwpUoTLO07EALMQDCxArAjx-UAAxiOXSSoZc6gqbPn5F8ANRn0UeBxDwyPESKyYAAtSkA6YnU-VktJjIrACGYGBQAIKMLEGkYMTsnqzEAOYe0nIKSrToQA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=true&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact&prettier=false&targets=&version=7.23.10&externalPlugins=%40babel%2Fplugin-proposal-decorators%407.23.3&assumptions=%7B%7D))
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we fix a regression introduced in https://github.com/babel/babel/pull/16218. In the following example
```js
"use strict";

function dec() {}

let o1 = { dec };
let o4oCounter = 0;
let o4 = { o() { o4oCounter++; return o1 } };

@(o4.o().dec)
class A {}

console.log(o4oCounter);
```
The `o4oCounter` should be `1` because `o4.o` is only called once. However it currently logs `2` because Babel does not memoise `o4.o()` when generating class decorators:
```js
_classDecs = [o4.o(), o4.o().dec];
```