### PR TITLE
Reduce element decorator temp variables

### DIFF
--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/member-decorator/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/member-decorator/output.mjs
@@ -1,8 +1,8 @@
-var _dec, _init_x;
-_dec = dec;
+var _xDecs, _init_x;
+_xDecs = dec;
 export class A {
   static {
-    [_init_x] = babelHelpers.applyDecs(this, [[_dec, 0, "x"]], []);
+    [_init_x] = babelHelpers.applyDecs(this, [[_xDecs, 0, "x"]], []);
   }
   x = _init_x(this);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -1,6 +1,6 @@
-var _initProto, _dec, _A;
+var _initProto, _methodDecs, _A;
 const dec = () => {};
-_dec = deco;
+_methodDecs = deco;
 class A extends B {
   constructor() {
     let a = 2;
@@ -10,4 +10,4 @@ class A extends B {
   method() {}
 }
 _A = A;
-[_initProto] = babelHelpers.applyDecs(_A, [[_dec, 2, "method"]], []);
+[_initProto] = babelHelpers.applyDecs(_A, [[_methodDecs, 2, "method"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
@@ -1,10 +1,7 @@
-var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _Foo2;
+var _initProto, _initClass, _classDecs, _methodDecs, _Foo2;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
-_dec = call();
-_dec2 = chain.expr();
-_dec3 = arbitrary + expr;
-_dec4 = array[expr];
+_methodDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
@@ -13,14 +10,14 @@ class Foo {
   }
   method() {}
   makeClass() {
-    var _dec5, _init_bar, _Nested;
-    return _dec5 = babelHelpers.classPrivateFieldGet2(this, _a), (_Nested = class Nested {
+    var _barDecs, _init_bar, _Nested;
+    return _barDecs = babelHelpers.classPrivateFieldGet2(this, _a), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, "bar", _init_bar(this));
       }
-    }, [_init_bar] = babelHelpers.applyDecs(_Nested, [[_dec5, 0, "bar"]], []), _Nested);
+    }, [_init_bar] = babelHelpers.applyDecs(_Nested, [[_barDecs, 0, "bar"]], []), _Nested);
   }
 }
 _Foo2 = Foo;
-[_initProto, _Foo, _initClass] = babelHelpers.applyDecs(_Foo2, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs);
+[_initProto, _Foo, _initClass] = babelHelpers.applyDecs(_Foo2, [[_methodDecs, 2, "method"]], _classDecs);
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,9 +1,9 @@
-var _initProto, _dec, _initProto2, _dec2;
+var _initProto, _methodDecs, _initProto2, _methodDecs2;
 const dec = () => {};
-_dec = deco;
+_methodDecs = deco;
 class A extends B {
   static {
-    [_initProto] = babelHelpers.applyDecs(this, [[_dec, 2, "method"]], []);
+    [_initProto] = babelHelpers.applyDecs(this, [[_methodDecs, 2, "method"]], []);
   }
   constructor() {
     if (Math.random() > 0.5) {
@@ -14,10 +14,10 @@ class A extends B {
   }
   method() {}
 }
-_dec2 = deco;
+_methodDecs2 = deco;
 class C extends B {
   static {
-    [_initProto2] = babelHelpers.applyDecs(this, [[_dec2, 2, "method"]], []);
+    [_initProto2] = babelHelpers.applyDecs(this, [[_methodDecs2, 2, "method"]], []);
   }
   constructor() {
     try {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor/output.js
@@ -94,11 +94,11 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _dec;
-        _dec = noop(log.push(super(7).method()));
+        var _initProto4, _noopDecs;
+        _noopDecs = noop(log.push(super(7).method()));
         class A extends B {
           static {
-            [_initProto4] = babelHelpers.applyDecs(this, [[dec, 2, "method"], [_dec, 2, "noop"]], []);
+            [_initProto4] = babelHelpers.applyDecs(this, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], []);
           }
           constructor() {
             log.push(_initProto4(super(8)).method());
@@ -147,10 +147,10 @@
         [_initProto6] = babelHelpers.applyDecs(this, [[dec, 2, "method"]], []);
       }
       constructor() {
-        var _initProto7, _dec2;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
+        var _initProto7, _noopDecs2;
+        new (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
           static {
-            [_initProto7] = babelHelpers.applyDecs(this, [[_dec2, 2, "noop"]], []);
+            [_initProto7] = babelHelpers.applyDecs(this, [[_noopDecs2, 2, "noop"]], []);
           }
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
@@ -1,22 +1,19 @@
-var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4;
+var _initProto, _initClass, _classDecs, _methodDecs;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
-_dec = call();
-_dec2 = chain.expr();
-_dec3 = arbitrary + expr;
-_dec4 = array[expr];
+_methodDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
 class Foo {
   static {
-    [_initProto, _Foo, _initClass] = babelHelpers.applyDecs(this, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs);
+    [_initProto, _Foo, _initClass] = babelHelpers.applyDecs(this, [[_methodDecs, 2, "method"]], _classDecs);
   }
   #a = void _initProto(this);
   method() {}
   makeClass() {
-    var _dec5, _init_bar;
-    return _dec5 = this.#a, class Nested {
+    var _barDecs, _init_bar;
+    return _barDecs = this.#a, class Nested {
       static {
-        [_init_bar] = babelHelpers.applyDecs(this, [[_dec5, 0, "bar"]], []);
+        [_init_bar] = babelHelpers.applyDecs(this, [[_barDecs, 0, "bar"]], []);
       }
       bar = _init_bar(this);
     };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/member-decorator/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/member-decorator/output.mjs
@@ -1,8 +1,8 @@
-var _dec, _init_x;
-_dec = dec;
+var _xDecs, _init_x;
+_xDecs = dec;
 export class A {
   static {
-    [_init_x] = babelHelpers.applyDecs2203R(this, [[_dec, 0, "x"]], []).e;
+    [_init_x] = babelHelpers.applyDecs2203R(this, [[_xDecs, 0, "x"]], []).e;
   }
   x = _init_x(this);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -90,8 +90,8 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _dec, _A4;
-        _dec = noop(log.push(super(7).method()));
+        var _initProto4, _noopDecs, _A4;
+        _noopDecs = noop(log.push(super(7).method()));
         class A extends B {
           constructor() {
             log.push(_initProto4(super(8)).method());
@@ -102,7 +102,7 @@
           noop() {}
         }
         _A4 = A;
-        [_initProto4] = babelHelpers.applyDecs2203R(_A4, [[dec, 2, "method"], [_dec, 2, "noop"]], []).e;
+        [_initProto4] = babelHelpers.applyDecs2203R(_A4, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], []).e;
         new A();
       }
     }();
@@ -138,13 +138,13 @@
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        var _initProto7, _dec2, _Dummy2;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
+        var _initProto7, _noopDecs2, _Dummy2;
+        new (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());
           }
           noop() {}
-        }, [_initProto7] = babelHelpers.applyDecs2203R(_Dummy2, [[_dec2, 2, "noop"]], []).e, _Dummy2))();
+        }, [_initProto7] = babelHelpers.applyDecs2203R(_Dummy2, [[_noopDecs2, 2, "noop"]], []).e, _Dummy2))();
       }
       method() {
         return this.a;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/valid-expression-formats/output.js
@@ -1,10 +1,7 @@
-var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _Foo2;
+var _initProto, _initClass, _classDecs, _methodDecs, _Foo2;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
-_dec = call();
-_dec2 = chain.expr();
-_dec3 = arbitrary + expr;
-_dec4 = array[expr];
+_methodDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
@@ -13,17 +10,17 @@ class Foo {
   }
   method() {}
   makeClass() {
-    var _dec5, _init_bar, _Nested;
-    return _dec5 = babelHelpers.classPrivateFieldGet2(this, _a), (_Nested = class Nested {
+    var _barDecs, _init_bar, _Nested;
+    return _barDecs = babelHelpers.classPrivateFieldGet2(this, _a), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, "bar", _init_bar(this));
       }
-    }, [_init_bar] = babelHelpers.applyDecs2203R(_Nested, [[_dec5, 0, "bar"]], []).e, _Nested);
+    }, [_init_bar] = babelHelpers.applyDecs2203R(_Nested, [[_barDecs, 0, "bar"]], []).e, _Nested);
   }
 }
 _Foo2 = Foo;
 ({
   e: [_initProto],
   c: [_Foo, _initClass]
-} = babelHelpers.applyDecs2203R(_Foo2, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs));
+} = babelHelpers.applyDecs2203R(_Foo2, [[_methodDecs, 2, "method"]], _classDecs));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,9 +1,9 @@
-var _initProto, _dec, _initProto2, _dec2;
+var _initProto, _methodDecs, _initProto2, _methodDecs2;
 const dec = () => {};
-_dec = deco;
+_methodDecs = deco;
 class A extends B {
   static {
-    [_initProto] = babelHelpers.applyDecs2203R(this, [[_dec, 2, "method"]], []).e;
+    [_initProto] = babelHelpers.applyDecs2203R(this, [[_methodDecs, 2, "method"]], []).e;
   }
   constructor() {
     if (Math.random() > 0.5) {
@@ -14,10 +14,10 @@ class A extends B {
   }
   method() {}
 }
-_dec2 = deco;
+_methodDecs2 = deco;
 class C extends B {
   static {
-    [_initProto2] = babelHelpers.applyDecs2203R(this, [[_dec2, 2, "method"]], []).e;
+    [_initProto2] = babelHelpers.applyDecs2203R(this, [[_methodDecs2, 2, "method"]], []).e;
   }
   constructor() {
     try {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor/output.js
@@ -94,11 +94,11 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _dec;
-        _dec = noop(log.push(super(7).method()));
+        var _initProto4, _noopDecs;
+        _noopDecs = noop(log.push(super(7).method()));
         class A extends B {
           static {
-            [_initProto4] = babelHelpers.applyDecs2203R(this, [[dec, 2, "method"], [_dec, 2, "noop"]], []).e;
+            [_initProto4] = babelHelpers.applyDecs2203R(this, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], []).e;
           }
           constructor() {
             log.push(_initProto4(super(8)).method());
@@ -147,10 +147,10 @@
         [_initProto6] = babelHelpers.applyDecs2203R(this, [[dec, 2, "method"]], []).e;
       }
       constructor() {
-        var _initProto7, _dec2;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
+        var _initProto7, _noopDecs2;
+        new (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
           static {
-            [_initProto7] = babelHelpers.applyDecs2203R(this, [[_dec2, 2, "noop"]], []).e;
+            [_initProto7] = babelHelpers.applyDecs2203R(this, [[_noopDecs2, 2, "noop"]], []).e;
           }
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/valid-expression-formats/output.js
@@ -1,25 +1,22 @@
-var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4;
+var _initProto, _initClass, _classDecs, _methodDecs;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
-_dec = call();
-_dec2 = chain.expr();
-_dec3 = arbitrary + expr;
-_dec4 = array[expr];
+_methodDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
 class Foo {
   static {
     ({
       e: [_initProto],
       c: [_Foo, _initClass]
-    } = babelHelpers.applyDecs2203R(this, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs));
+    } = babelHelpers.applyDecs2203R(this, [[_methodDecs, 2, "method"]], _classDecs));
   }
   #a = void _initProto(this);
   method() {}
   makeClass() {
-    var _dec5, _init_bar;
-    return _dec5 = this.#a, class Nested {
+    var _barDecs, _init_bar;
+    return _barDecs = this.#a, class Nested {
       static {
-        [_init_bar] = babelHelpers.applyDecs2203R(this, [[_dec5, 0, "bar"]], []).e;
+        [_init_bar] = babelHelpers.applyDecs2203R(this, [[_barDecs, 0, "bar"]], []).e;
       }
       bar = _init_bar(this);
     };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/member-decorator/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/member-decorator/output.mjs
@@ -1,8 +1,8 @@
-var _dec, _init_x;
-_dec = dec;
+var _xDecs, _init_x;
+_xDecs = dec;
 export class A {
   static {
-    [_init_x] = babelHelpers.applyDecs2301(this, [[_dec, 0, "x"]], []).e;
+    [_init_x] = babelHelpers.applyDecs2301(this, [[_xDecs, 0, "x"]], []).e;
   }
   x = _init_x(this);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -90,8 +90,8 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _dec, _A4;
-        _dec = noop(log.push(super(7).method()));
+        var _initProto4, _noopDecs, _A4;
+        _noopDecs = noop(log.push(super(7).method()));
         class A extends B {
           constructor() {
             log.push(_initProto4(super(8)).method());
@@ -102,7 +102,7 @@
           noop() {}
         }
         _A4 = A;
-        [_initProto4] = babelHelpers.applyDecs2301(_A4, [[dec, 2, "method"], [_dec, 2, "noop"]], []).e;
+        [_initProto4] = babelHelpers.applyDecs2301(_A4, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], []).e;
         new A();
       }
     }();
@@ -138,13 +138,13 @@
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        var _initProto7, _dec2, _Dummy2;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
+        var _initProto7, _noopDecs2, _Dummy2;
+        new (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());
           }
           noop() {}
-        }, [_initProto7] = babelHelpers.applyDecs2301(_Dummy2, [[_dec2, 2, "noop"]], []).e, _Dummy2))();
+        }, [_initProto7] = babelHelpers.applyDecs2301(_Dummy2, [[_noopDecs2, 2, "noop"]], []).e, _Dummy2))();
       }
       method() {
         return this.a;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/valid-expression-formats/output.js
@@ -1,10 +1,7 @@
-var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4, _Foo2;
+var _initProto, _initClass, _classDecs, _methodDecs, _Foo2;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
-_dec = call();
-_dec2 = chain.expr();
-_dec3 = arbitrary + expr;
-_dec4 = array[expr];
+_methodDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
@@ -13,17 +10,17 @@ class Foo {
   }
   method() {}
   makeClass() {
-    var _dec5, _init_bar, _Nested;
-    return _dec5 = babelHelpers.classPrivateFieldGet2(this, _a), (_Nested = class Nested {
+    var _barDecs, _init_bar, _Nested;
+    return _barDecs = babelHelpers.classPrivateFieldGet2(this, _a), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, "bar", _init_bar(this));
       }
-    }, [_init_bar] = babelHelpers.applyDecs2301(_Nested, [[_dec5, 0, "bar"]], []).e, _Nested);
+    }, [_init_bar] = babelHelpers.applyDecs2301(_Nested, [[_barDecs, 0, "bar"]], []).e, _Nested);
   }
 }
 _Foo2 = Foo;
 ({
   e: [_initProto],
   c: [_Foo, _initClass]
-} = babelHelpers.applyDecs2301(_Foo2, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs));
+} = babelHelpers.applyDecs2301(_Foo2, [[_methodDecs, 2, "method"]], _classDecs));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,9 +1,9 @@
-var _initProto, _dec, _initProto2, _dec2;
+var _initProto, _methodDecs, _initProto2, _methodDecs2;
 const dec = () => {};
-_dec = deco;
+_methodDecs = deco;
 class A extends B {
   static {
-    [_initProto] = babelHelpers.applyDecs2301(this, [[_dec, 2, "method"]], []).e;
+    [_initProto] = babelHelpers.applyDecs2301(this, [[_methodDecs, 2, "method"]], []).e;
   }
   constructor() {
     if (Math.random() > 0.5) {
@@ -14,10 +14,10 @@ class A extends B {
   }
   method() {}
 }
-_dec2 = deco;
+_methodDecs2 = deco;
 class C extends B {
   static {
-    [_initProto2] = babelHelpers.applyDecs2301(this, [[_dec2, 2, "method"]], []).e;
+    [_initProto2] = babelHelpers.applyDecs2301(this, [[_methodDecs2, 2, "method"]], []).e;
   }
   constructor() {
     try {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor/output.js
@@ -94,11 +94,11 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _dec;
-        _dec = noop(log.push(super(7).method()));
+        var _initProto4, _noopDecs;
+        _noopDecs = noop(log.push(super(7).method()));
         class A extends B {
           static {
-            [_initProto4] = babelHelpers.applyDecs2301(this, [[dec, 2, "method"], [_dec, 2, "noop"]], []).e;
+            [_initProto4] = babelHelpers.applyDecs2301(this, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], []).e;
           }
           constructor() {
             log.push(_initProto4(super(8)).method());
@@ -147,10 +147,10 @@
         [_initProto6] = babelHelpers.applyDecs2301(this, [[dec, 2, "method"]], []).e;
       }
       constructor() {
-        var _initProto7, _dec2;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
+        var _initProto7, _noopDecs2;
+        new (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
           static {
-            [_initProto7] = babelHelpers.applyDecs2301(this, [[_dec2, 2, "noop"]], []).e;
+            [_initProto7] = babelHelpers.applyDecs2301(this, [[_noopDecs2, 2, "noop"]], []).e;
           }
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/valid-expression-formats/output.js
@@ -1,25 +1,22 @@
-var _initProto, _initClass, _classDecs, _dec, _dec2, _dec3, _dec4;
+var _initProto, _initClass, _classDecs, _methodDecs;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
-_dec = call();
-_dec2 = chain.expr();
-_dec3 = arbitrary + expr;
-_dec4 = array[expr];
+_methodDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
 class Foo {
   static {
     ({
       e: [_initProto],
       c: [_Foo, _initClass]
-    } = babelHelpers.applyDecs2301(this, [[[dec, _dec, _dec2, _dec3, _dec4], 2, "method"]], _classDecs));
+    } = babelHelpers.applyDecs2301(this, [[_methodDecs, 2, "method"]], _classDecs));
   }
   #a = void _initProto(this);
   method() {}
   makeClass() {
-    var _dec5, _init_bar;
-    return _dec5 = this.#a, class Nested {
+    var _barDecs, _init_bar;
+    return _barDecs = this.#a, class Nested {
       static {
-        [_init_bar] = babelHelpers.applyDecs2301(this, [[_dec5, 0, "bar"]], []).e;
+        [_init_bar] = babelHelpers.applyDecs2301(this, [[_barDecs, 0, "bar"]], []).e;
       }
       bar = _init_bar(this);
     };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/member-decorator/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/member-decorator/output.mjs
@@ -1,8 +1,8 @@
-var _dec, _init_x;
-_dec = dec;
+var _xDecs, _init_x;
+_xDecs = dec;
 export class A {
   static {
-    [_init_x] = babelHelpers.applyDecs2305(this, [[_dec, 0, "x"]], []).e;
+    [_init_x] = babelHelpers.applyDecs2305(this, [[_xDecs, 0, "x"]], []).e;
   }
   x = _init_x(this);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -90,8 +90,8 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _dec, _A4;
-        _dec = noop(log.push(super(7).method()));
+        var _initProto4, _noopDecs, _A4;
+        _noopDecs = noop(log.push(super(7).method()));
         class A extends B {
           constructor() {
             log.push(_initProto4(super(8)).method());
@@ -102,7 +102,7 @@
           noop() {}
         }
         _A4 = A;
-        [_initProto4] = babelHelpers.applyDecs2305(_A4, [[dec, 2, "method"], [_dec, 2, "noop"]], [], 0, void 0, B).e;
+        [_initProto4] = babelHelpers.applyDecs2305(_A4, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], [], 0, void 0, B).e;
         new A();
       }
     }();
@@ -138,13 +138,13 @@
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        var _initProto7, _dec2, _Dummy2;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
+        var _initProto7, _noopDecs2, _Dummy2;
+        new (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());
           }
           noop() {}
-        }, [_initProto7] = babelHelpers.applyDecs2305(_Dummy2, [[_dec2, 2, "noop"]], [], 0, void 0, B).e, _Dummy2))();
+        }, [_initProto7] = babelHelpers.applyDecs2305(_Dummy2, [[_noopDecs2, 2, "noop"]], [], 0, void 0, B).e, _Dummy2))();
       }
       method() {
         return this.a;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
@@ -1,10 +1,10 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _obj, _classDecs, _obj2, _dec, _C2;
+    var _initProto, _initClass, _obj, _classDecs, _obj2, _m2Decs, _C2;
     _obj = this;
     _classDecs = [_obj, super.dec1];
     _obj2 = this;
-    _dec = super.dec2;
+    _m2Decs = [_obj2, super.dec2];
     let _C;
     class C {
       constructor() {
@@ -16,7 +16,7 @@ class A extends B {
     ({
       e: [_initProto],
       c: [_C, _initClass]
-    } = babelHelpers.applyDecs2305(_C2, [[[_obj2, _dec], 18, "m2"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2305(_C2, [[_m2Decs, 18, "m2"]], _classDecs, 1));
     _initClass();
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
@@ -1,14 +1,12 @@
-var _initClass, _obj, _obj2, _classDecs, _obj3, _dec, _obj4, _dec2, _init_x, _obj5, _dec3, _dec4, _init_y, _A2;
+var _initClass, _obj, _obj2, _classDecs, _obj3, _obj4, _xDecs, _init_x, _obj5, _yDecs, _init_y, _A2;
 _obj = o1;
 _obj2 = o2;
 _classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec];
 _obj3 = o2;
-_dec = _obj3.dec;
 _obj4 = o3.o;
-_dec2 = _obj4.dec;
+_xDecs = [_obj3, _obj3.dec, _obj4, _obj4.dec];
 _obj5 = o2;
-_dec3 = _obj5.dec;
-_dec4 = dec;
+_yDecs = [_obj5, _obj5.dec, void 0, dec];
 let _A;
 class A {
   constructor() {
@@ -20,5 +18,5 @@ _A2 = A;
 ({
   e: [_init_x, _init_y],
   c: [_A, _initClass]
-} = babelHelpers.applyDecs2305(_A2, [[[_obj3, _dec, _obj4, _dec2], 16, "x"], [[_obj5, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
+} = babelHelpers.applyDecs2305(_A2, [[_xDecs, 16, "x"], [_yDecs, 16, "y"]], _classDecs, 1));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
@@ -1,12 +1,9 @@
-var _initProto, _initClass, _obj, _classDecs, _dec, _dec2, _dec3, _obj2, _dec4, _Foo2;
+var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs, _Foo2;
 const dec = () => {};
 _obj = array;
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
-_dec = call();
-_dec2 = chain.expr();
-_dec3 = arbitrary + expr;
 _obj2 = array;
-_dec4 = _obj2[expr];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2, _obj2[expr]];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
@@ -15,17 +12,17 @@ class Foo {
   }
   method() {}
   makeClass() {
-    var _dec5, _init_bar, _Nested;
-    return _dec5 = babelHelpers.classPrivateFieldGet2(this, _a), (_Nested = class Nested {
+    var _barDecs, _init_bar, _Nested;
+    return _barDecs = babelHelpers.classPrivateFieldGet2(this, _a), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, "bar", _init_bar(this));
       }
-    }, [_init_bar] = babelHelpers.applyDecs2305(_Nested, [[_dec5, 0, "bar"]], []).e, _Nested);
+    }, [_init_bar] = babelHelpers.applyDecs2305(_Nested, [[_barDecs, 0, "bar"]], []).e, _Nested);
   }
 }
 _Foo2 = Foo;
 ({
   e: [_initProto],
   c: [_Foo, _initClass]
-} = babelHelpers.applyDecs2305(_Foo2, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj2, _dec4], 18, "method"]], _classDecs, 1));
+} = babelHelpers.applyDecs2305(_Foo2, [[_methodDecs, 18, "method"]], _classDecs, 1));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,9 +1,9 @@
-var _initProto, _dec, _B, _initProto2, _dec2, _B2;
+var _initProto, _methodDecs, _B, _initProto2, _methodDecs2, _B2;
 const dec = () => {};
-_dec = deco;
+_methodDecs = deco;
 class A extends (_B = B) {
   static {
-    [_initProto] = babelHelpers.applyDecs2305(this, [[_dec, 2, "method"]], [], 0, void 0, _B).e;
+    [_initProto] = babelHelpers.applyDecs2305(this, [[_methodDecs, 2, "method"]], [], 0, void 0, _B).e;
   }
   constructor() {
     if (Math.random() > 0.5) {
@@ -14,10 +14,10 @@ class A extends (_B = B) {
   }
   method() {}
 }
-_dec2 = deco;
+_methodDecs2 = deco;
 class C extends (_B2 = B) {
   static {
-    [_initProto2] = babelHelpers.applyDecs2305(this, [[_dec2, 2, "method"]], [], 0, void 0, _B2).e;
+    [_initProto2] = babelHelpers.applyDecs2305(this, [[_methodDecs2, 2, "method"]], [], 0, void 0, _B2).e;
   }
   constructor() {
     try {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor/output.js
@@ -94,11 +94,11 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _dec;
-        _dec = noop(log.push(super(7).method()));
+        var _initProto4, _noopDecs;
+        _noopDecs = noop(log.push(super(7).method()));
         class A extends B {
           static {
-            [_initProto4] = babelHelpers.applyDecs2305(this, [[dec, 2, "method"], [_dec, 2, "noop"]], [], 0, void 0, B).e;
+            [_initProto4] = babelHelpers.applyDecs2305(this, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], [], 0, void 0, B).e;
           }
           constructor() {
             log.push(_initProto4(super(8)).method());
@@ -147,10 +147,10 @@
         [_initProto6] = babelHelpers.applyDecs2305(this, [[dec, 2, "method"]], [], 0, void 0, B).e;
       }
       constructor() {
-        var _initProto7, _dec2;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
+        var _initProto7, _noopDecs2;
+        new (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
           static {
-            [_initProto7] = babelHelpers.applyDecs2305(this, [[_dec2, 2, "noop"]], [], 0, void 0, B).e;
+            [_initProto7] = babelHelpers.applyDecs2305(this, [[_noopDecs2, 2, "noop"]], [], 0, void 0, B).e;
           }
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
@@ -1,17 +1,17 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _obj, _classDecs, _obj2, _dec;
+    var _initProto, _initClass, _obj, _classDecs, _obj2, _m2Decs;
     _obj = this;
     _classDecs = [_obj, super.dec1];
     _obj2 = this;
-    _dec = super.dec2;
+    _m2Decs = [_obj2, super.dec2];
     let _C;
     class C {
       static {
         ({
           e: [_initProto],
           c: [_C, _initClass]
-        } = babelHelpers.applyDecs2305(this, [[[_obj2, _dec], 18, "m2"]], _classDecs, 1));
+        } = babelHelpers.applyDecs2305(this, [[_m2Decs, 18, "m2"]], _classDecs, 1));
       }
       constructor() {
         _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
@@ -1,21 +1,19 @@
-var _initClass, _obj, _obj2, _classDecs, _obj3, _dec, _obj4, _dec2, _init_x, _obj5, _dec3, _dec4, _init_y;
+var _initClass, _obj, _obj2, _classDecs, _obj3, _obj4, _xDecs, _init_x, _obj5, _yDecs, _init_y;
 _obj = o1;
 _obj2 = o2;
 _classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec];
 _obj3 = o2;
-_dec = _obj3.dec;
 _obj4 = o3.o;
-_dec2 = _obj4.dec;
+_xDecs = [_obj3, _obj3.dec, _obj4, _obj4.dec];
 _obj5 = o2;
-_dec3 = _obj5.dec;
-_dec4 = dec;
+_yDecs = [_obj5, _obj5.dec, void 0, dec];
 let _A;
 class A {
   static {
     ({
       e: [_init_x, _init_y],
       c: [_A, _initClass]
-    } = babelHelpers.applyDecs2305(this, [[[_obj3, _dec, _obj4, _dec2], 16, "x"], [[_obj5, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2305(this, [[_xDecs, 16, "x"], [_yDecs, 16, "y"]], _classDecs, 1));
   }
   x = _init_x(this);
   y = _init_y(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
@@ -1,27 +1,24 @@
-var _initProto, _initClass, _obj, _classDecs, _dec, _dec2, _dec3, _obj2, _dec4;
+var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs;
 const dec = () => {};
 _obj = array;
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
-_dec = call();
-_dec2 = chain.expr();
-_dec3 = arbitrary + expr;
 _obj2 = array;
-_dec4 = _obj2[expr];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2, _obj2[expr]];
 let _Foo;
 class Foo {
   static {
     ({
       e: [_initProto],
       c: [_Foo, _initClass]
-    } = babelHelpers.applyDecs2305(this, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj2, _dec4], 18, "method"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2305(this, [[_methodDecs, 18, "method"]], _classDecs, 1));
   }
   #a = void _initProto(this);
   method() {}
   makeClass() {
-    var _obj3, _dec5, _init_bar;
-    return _obj3 = this, _dec5 = this.#a, class Nested {
+    var _obj3, _barDecs, _init_bar;
+    return _obj3 = this, _barDecs = [_obj3, this.#a], class Nested {
       static {
-        [_init_bar] = babelHelpers.applyDecs2305(this, [[[_obj3, _dec5], 16, "bar"]], []).e;
+        [_init_bar] = babelHelpers.applyDecs2305(this, [[_barDecs, 16, "bar"]], []).e;
       }
       bar = _init_bar(this);
     };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-exported/member-decorator/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-exported/member-decorator/output.mjs
@@ -1,8 +1,8 @@
-var _dec, _init_x, _init_extra_x;
-_dec = dec;
+var _xDecs, _init_x, _init_extra_x;
+_xDecs = dec;
 export class A {
   static {
-    [_init_x, _init_extra_x] = babelHelpers.applyDecs2311(this, [[_dec, 0, "x"]], []).e;
+    [_init_x, _init_extra_x] = babelHelpers.applyDecs2311(this, [[_xDecs, 0, "x"]], []).e;
   }
   constructor() {
     _init_extra_x(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/output.js
@@ -1,7 +1,7 @@
-var _initProto, _dec, _call_a, _dec2, _call_g, _dec3, _call_ag, _Foo;
-_dec = dec;
-_dec2 = dec;
-_dec3 = dec;
+var _initProto, _aDecs, _call_a, _gDecs, _call_g, _agDecs, _call_ag, _Foo;
+_aDecs = dec;
+_gDecs = dec;
+_agDecs = dec;
 var _ag = /*#__PURE__*/new WeakMap();
 var _g = /*#__PURE__*/new WeakMap();
 var _a = /*#__PURE__*/new WeakMap();
@@ -14,4 +14,4 @@ class Foo {
   }
 }
 _Foo = Foo;
-[_call_a, _call_g, _call_ag, _initProto] = babelHelpers.applyDecs2311(_Foo, [[_dec, 2, "a", async function () {}], [_dec2, 2, "g", function* () {}], [_dec3, 2, "ag", async function* () {}]], [], 0, _ => _a.has(babelHelpers.checkInRHS(_))).e;
+[_call_a, _call_g, _call_ag, _initProto] = babelHelpers.applyDecs2311(_Foo, [[_aDecs, 2, "a", async function () {}], [_gDecs, 2, "g", function* () {}], [_agDecs, 2, "ag", async function* () {}]], [], 0, _ => _a.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/output.js
@@ -1,10 +1,10 @@
-var _initProto, _dec, _call_a, _dec2, _call_g, _dec3, _call_ag;
-_dec = dec;
-_dec2 = dec;
-_dec3 = dec;
+var _initProto, _aDecs, _call_a, _gDecs, _call_g, _agDecs, _call_ag;
+_aDecs = dec;
+_gDecs = dec;
+_agDecs = dec;
 class Foo {
   static {
-    [_call_a, _call_g, _call_ag, _initProto] = babelHelpers.applyDecs2311(this, [[_dec, 2, "a", async function () {}], [_dec2, 2, "g", function* () {}], [_dec3, 2, "ag", async function* () {}]], [], 0, _ => #a in _).e;
+    [_call_a, _call_g, _call_ag, _initProto] = babelHelpers.applyDecs2311(this, [[_aDecs, 2, "a", async function () {}], [_gDecs, 2, "g", function* () {}], [_agDecs, 2, "ag", async function* () {}]], [], 0, _ => #a in _).e;
   }
   constructor() {
     _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -90,8 +90,8 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _dec, _A4;
-        _dec = noop(log.push(super(7).method()));
+        var _initProto4, _noopDecs, _A4;
+        _noopDecs = noop(log.push(super(7).method()));
         class A extends B {
           constructor() {
             log.push(_initProto4(super(8)).method());
@@ -102,7 +102,7 @@
           noop() {}
         }
         _A4 = A;
-        [_initProto4] = babelHelpers.applyDecs2311(_A4, [[dec, 2, "method"], [_dec, 2, "noop"]], [], 0, void 0, B).e;
+        [_initProto4] = babelHelpers.applyDecs2311(_A4, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], [], 0, void 0, B).e;
         new A();
       }
     }();
@@ -138,13 +138,13 @@
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        var _initProto7, _dec2, _Dummy2;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
+        var _initProto7, _noopDecs2, _Dummy2;
+        new (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());
           }
           noop() {}
-        }, [_initProto7] = babelHelpers.applyDecs2311(_Dummy2, [[_dec2, 2, "noop"]], [], 0, void 0, B).e, _Dummy2))();
+        }, [_initProto7] = babelHelpers.applyDecs2311(_Dummy2, [[_noopDecs2, 2, "noop"]], [], 0, void 0, B).e, _Dummy2))();
       }
       method() {
         return this.a;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/super-in-decorator/output.js
@@ -1,10 +1,10 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _obj, _classDecs, _obj2, _dec, _C2;
+    var _initProto, _initClass, _obj, _classDecs, _obj2, _m2Decs, _C2;
     _obj = this;
     _classDecs = [_obj, super.dec1];
     _obj2 = this;
-    _dec = super.dec2;
+    _m2Decs = [_obj2, super.dec2];
     let _C;
     class C {
       constructor() {
@@ -16,7 +16,7 @@ class A extends B {
     ({
       e: [_initProto],
       c: [_C, _initClass]
-    } = babelHelpers.applyDecs2311(_C2, [[[_obj2, _dec], 18, "m2"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2311(_C2, [[_m2Decs, 18, "m2"]], _classDecs, 1));
     _initClass();
   }
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
@@ -1,14 +1,12 @@
-var _initClass, _obj, _obj2, _classDecs, _obj3, _dec, _obj4, _dec2, _init_x, _init_extra_x, _obj5, _dec3, _dec4, _init_y, _init_extra_y, _A2;
+var _initClass, _obj, _obj2, _classDecs, _obj3, _obj4, _xDecs, _init_x, _init_extra_x, _obj5, _yDecs, _init_y, _init_extra_y, _A2;
 _obj = o1;
 _obj2 = o2;
 _classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec];
 _obj3 = o2;
-_dec = _obj3.dec;
 _obj4 = o3.o;
-_dec2 = _obj4.dec;
+_xDecs = [_obj3, _obj3.dec, _obj4, _obj4.dec];
 _obj5 = o2;
-_dec3 = _obj5.dec;
-_dec4 = dec;
+_yDecs = [_obj5, _obj5.dec, void 0, dec];
 let _A;
 class A {
   constructor() {
@@ -21,5 +19,5 @@ _A2 = A;
 ({
   e: [_init_x, _init_extra_x, _init_y, _init_extra_y],
   c: [_A, _initClass]
-} = babelHelpers.applyDecs2311(_A2, [[[_obj3, _dec, _obj4, _dec2], 16, "x"], [[_obj5, _dec3, void 0, _dec4], 16, "y"]], _classDecs, 1));
+} = babelHelpers.applyDecs2311(_A2, [[_xDecs, 16, "x"], [_yDecs, 16, "y"]], _classDecs, 1));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/valid-expression-formats/output.js
@@ -1,12 +1,9 @@
-var _initProto, _initClass, _obj, _classDecs, _dec, _dec2, _dec3, _obj2, _dec4, _Foo2;
+var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs, _Foo2;
 const dec = () => {};
 _obj = array;
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
-_dec = call();
-_dec2 = chain.expr();
-_dec3 = arbitrary + expr;
 _obj2 = array;
-_dec4 = _obj2[expr];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2, _obj2[expr]];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {
@@ -15,18 +12,18 @@ class Foo {
   }
   method() {}
   makeClass() {
-    var _dec5, _init_bar, _init_extra_bar, _Nested;
-    return _dec5 = babelHelpers.classPrivateFieldGet2(this, _a), (_Nested = class Nested {
+    var _barDecs, _init_bar, _init_extra_bar, _Nested;
+    return _barDecs = babelHelpers.classPrivateFieldGet2(this, _a), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, "bar", _init_bar(this));
         _init_extra_bar(this);
       }
-    }, [_init_bar, _init_extra_bar] = babelHelpers.applyDecs2311(_Nested, [[_dec5, 0, "bar"]], []).e, _Nested);
+    }, [_init_bar, _init_extra_bar] = babelHelpers.applyDecs2311(_Nested, [[_barDecs, 0, "bar"]], []).e, _Nested);
   }
 }
 _Foo2 = Foo;
 ({
   e: [_initProto],
   c: [_Foo, _initClass]
-} = babelHelpers.applyDecs2311(_Foo2, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj2, _dec4], 18, "method"]], _classDecs, 1));
+} = babelHelpers.applyDecs2311(_Foo2, [[_methodDecs, 18, "method"]], _classDecs, 1));
 _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,9 +1,9 @@
-var _initProto, _dec, _B, _initProto2, _dec2, _B2;
+var _initProto, _methodDecs, _B, _initProto2, _methodDecs2, _B2;
 const dec = () => {};
-_dec = deco;
+_methodDecs = deco;
 class A extends (_B = B) {
   static {
-    [_initProto] = babelHelpers.applyDecs2311(this, [[_dec, 2, "method"]], [], 0, void 0, _B).e;
+    [_initProto] = babelHelpers.applyDecs2311(this, [[_methodDecs, 2, "method"]], [], 0, void 0, _B).e;
   }
   constructor() {
     if (Math.random() > 0.5) {
@@ -14,10 +14,10 @@ class A extends (_B = B) {
   }
   method() {}
 }
-_dec2 = deco;
+_methodDecs2 = deco;
 class C extends (_B2 = B) {
   static {
-    [_initProto2] = babelHelpers.applyDecs2311(this, [[_dec2, 2, "method"]], [], 0, void 0, _B2).e;
+    [_initProto2] = babelHelpers.applyDecs2311(this, [[_methodDecs2, 2, "method"]], [], 0, void 0, _B2).e;
   }
   constructor() {
     try {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/initProto-existing-derived-constructor/output.js
@@ -94,11 +94,11 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _dec;
-        _dec = noop(log.push(super(7).method()));
+        var _initProto4, _noopDecs;
+        _noopDecs = noop(log.push(super(7).method()));
         class A extends B {
           static {
-            [_initProto4] = babelHelpers.applyDecs2311(this, [[dec, 2, "method"], [_dec, 2, "noop"]], [], 0, void 0, B).e;
+            [_initProto4] = babelHelpers.applyDecs2311(this, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], [], 0, void 0, B).e;
           }
           constructor() {
             log.push(_initProto4(super(8)).method());
@@ -147,10 +147,10 @@
         [_initProto6] = babelHelpers.applyDecs2311(this, [[dec, 2, "method"]], [], 0, void 0, B).e;
       }
       constructor() {
-        var _initProto7, _dec2;
-        new (_dec2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
+        var _initProto7, _noopDecs2;
+        new (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), class Dummy extends B {
           static {
-            [_initProto7] = babelHelpers.applyDecs2311(this, [[_dec2, 2, "noop"]], [], 0, void 0, B).e;
+            [_initProto7] = babelHelpers.applyDecs2311(this, [[_noopDecs2, 2, "noop"]], [], 0, void 0, B).e;
           }
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-decorator/output.js
@@ -1,17 +1,17 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _obj, _classDecs, _obj2, _dec;
+    var _initProto, _initClass, _obj, _classDecs, _obj2, _m2Decs;
     _obj = this;
     _classDecs = [_obj, super.dec1];
     _obj2 = this;
-    _dec = super.dec2;
+    _m2Decs = [_obj2, super.dec2];
     let _C;
     class C {
       static {
         ({
           e: [_initProto],
           c: [_C, _initClass]
-        } = babelHelpers.applyDecs2311(this, [[[_obj2, _dec], 18, "m2"]], _classDecs, 1));
+        } = babelHelpers.applyDecs2311(this, [[_m2Decs, 18, "m2"]], _classDecs, 1));
       }
       constructor() {
         _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
@@ -1,24 +1,21 @@
-var _initClass, _obj, _obj2, _obj3, _classDecs, _obj4, _dec, _obj5, _dec2, _obj6, _dec3, _init_x, _init_extra_x, _obj7, _dec4, _dec5, _init_y, _init_extra_y;
+var _initClass, _obj, _obj2, _obj3, _classDecs, _obj4, _obj5, _obj6, _xDecs, _init_x, _init_extra_x, _obj7, _yDecs, _init_y, _init_extra_y;
 _obj = o1;
 _obj2 = o2;
 _obj3 = o4.o();
 _classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec, _obj3, _obj3.dec];
 _obj4 = o2;
-_dec = _obj4.dec;
 _obj5 = o3.o;
-_dec2 = _obj5.dec;
 _obj6 = o4.o();
-_dec3 = _obj6.dec;
+_xDecs = [_obj4, _obj4.dec, _obj5, _obj5.dec, _obj6, _obj6.dec];
 _obj7 = o2;
-_dec4 = _obj7.dec;
-_dec5 = dec;
+_yDecs = [_obj7, _obj7.dec, void 0, dec];
 let _A;
 class A {
   static {
     ({
       e: [_init_x, _init_extra_x, _init_y, _init_extra_y],
       c: [_A, _initClass]
-    } = babelHelpers.applyDecs2311(this, [[[_obj4, _dec, _obj5, _dec2, _obj6, _dec3], 16, "x"], [[_obj7, _dec4, void 0, _dec5], 16, "y"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2311(this, [[_xDecs, 16, "x"], [_yDecs, 16, "y"]], _classDecs, 1));
   }
   constructor() {
     _init_extra_y(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
@@ -1,27 +1,24 @@
-var _initProto, _initClass, _obj, _classDecs, _dec, _dec2, _dec3, _obj2, _dec4;
+var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs;
 const dec = () => {};
 _obj = array;
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
-_dec = call();
-_dec2 = chain.expr();
-_dec3 = arbitrary + expr;
 _obj2 = array;
-_dec4 = _obj2[expr];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2, _obj2[expr]];
 let _Foo;
 class Foo {
   static {
     ({
       e: [_initProto],
       c: [_Foo, _initClass]
-    } = babelHelpers.applyDecs2311(this, [[[void 0, dec, void 0, _dec, void 0, _dec2, void 0, _dec3, _obj2, _dec4], 18, "method"]], _classDecs, 1));
+    } = babelHelpers.applyDecs2311(this, [[_methodDecs, 18, "method"]], _classDecs, 1));
   }
   #a = void _initProto(this);
   method() {}
   makeClass() {
-    var _obj3, _dec5, _init_bar, _init_extra_bar;
-    return _obj3 = this, _dec5 = this.#a, class Nested {
+    var _obj3, _barDecs, _init_bar, _init_extra_bar;
+    return _obj3 = this, _barDecs = [_obj3, this.#a], class Nested {
       static {
-        [_init_bar, _init_extra_bar] = babelHelpers.applyDecs2311(this, [[[_obj3, _dec5], 16, "bar"]], []).e;
+        [_init_bar, _init_extra_bar] = babelHelpers.applyDecs2311(this, [[_barDecs, 16, "bar"]], []).e;
       }
       constructor() {
         _init_extra_bar(this);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
@@ -7,17 +7,17 @@ let Hello = /*#__PURE__*/babelHelpers.createClass(function Hello() {
 let Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
   function Outer() {
-    var _dec, _init_hello, _init_extra_hello, _Inner;
+    var _helloDecs, _init_hello, _init_extra_hello, _Inner;
     var _this;
     babelHelpers.classCallCheck(this, Outer);
-    _dec = _this = babelHelpers.callSuper(this, Outer);
+    _helloDecs = _this = babelHelpers.callSuper(this, Outer);
     let Inner = /*#__PURE__*/babelHelpers.createClass(function Inner() {
       babelHelpers.classCallCheck(this, Inner);
       babelHelpers.defineProperty(this, "hello", _init_hello(this));
       _init_extra_hello(this);
     });
     _Inner = Inner;
-    [_init_hello, _init_extra_hello] = babelHelpers.applyDecs2311(_Inner, [[_dec, 0, "hello"]], []).e;
+    [_init_hello, _init_extra_hello] = babelHelpers.applyDecs2311(_Inner, [[_helloDecs, 0, "hello"]], []).e;
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
   return babelHelpers.createClass(Outer);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
@@ -15,18 +15,18 @@ let Hello = /*#__PURE__*/function () {
 let Outer = /*#__PURE__*/function (_Hello) {
   babelHelpers.inherits(Outer, _Hello);
   function Outer() {
-    var _dec, _init_hello, _init_extra_hello, _Inner;
+    var _helloDecs, _init_hello, _init_extra_hello, _Inner;
     var _thisSuper, _this;
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.callSuper(this, Outer);
-    _dec = babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "dec", _thisSuper);
+    _helloDecs = babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "dec", _thisSuper);
     let Inner = /*#__PURE__*/babelHelpers.createClass(function Inner() {
       babelHelpers.classCallCheck(this, Inner);
       babelHelpers.defineProperty(this, "hello", _init_hello(this));
       _init_extra_hello(this);
     });
     _Inner = Inner;
-    [_init_hello, _init_extra_hello] = babelHelpers.applyDecs2311(_Inner, [[_dec, 0, "hello"]], []).e;
+    [_init_hello, _init_extra_hello] = babelHelpers.applyDecs2311(_Inner, [[_helloDecs, 0, "hello"]], []).e;
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
   return babelHelpers.createClass(Outer);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Implements https://github.com/babel/babel/pull/16218#issuecomment-1894942802
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is inspired from https://github.com/babel/babel/pull/16218.

Previously Babel memoises each individual decorator expressions, combines them into an array and passes it to the `applyDecs` helper. In this PR we memoise the combined decorators + decoratorThis array, so we allocate atmost 1 temporary variable for _each decorated class fields_.

## Code Example
Input
```js
function decFactory() {
  return () => {}
}

class C {
  @decFactory(1)
  @decFactory(2)
  foo() {}
  
  @decFactory(3)
  @decFactory(4)
  bar() {}
}
```

Output on main
```js
var _initProto, _dec, _dec2, _dec3, _dec4
function decFactory() {
  return () => {};
}
_dec = decFactory(1);
_dec2 = decFactory(2);
_dec3 = decFactory(3);
_dec4 = decFactory(4);
class C {
  static {
    [_initProto] = _applyDecs(this, [[[_dec, _dec2], 2, "foo"], [[_dec3, _dec4], 2, "bar"]], []).e;
  }
  constructor() {
    _initProto(this);
  }
  foo() {}
  bar() {}
}
```

Output on this PR
```js
var _initProto, _fooDecs, _barDecs;
function decFactory() {
  return () => {};
}
_fooDecs = [decFactory(1), decFactory(2)];
_barDecs = [decFactory(3), decFactory(4)];
class C {
  static {
    [_initProto] = babelHelpers.applyDecs2311(this, [[_fooDecs, 2, "foo"], [_barDecs, 2, "bar"]], []).e;
  }
  constructor() {
    _initProto(this);
  }
  foo() {}
  bar() {}
}
```
While the example above shows the output of `2023-11` decorator versions, this optimization is available for other decorator versions later than `2021-12` as well.

Note that this PR does not seek to memoise _all_ element decorator expressions into one memoiser, since computed keys have to be interleaved with decorator evaluations.

This PR contains commits from https://github.com/babel/babel/pull/16279. It also contains small memory tweaks.