### PR TITLE
Fix evaluation order of decorators with cached receiver

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -909,6 +909,7 @@ function transformClass(
   const decoratedPrivateMethods = new Set<string>();
 
   let classInitLocal: t.Identifier, classIdLocal: t.Identifier;
+  let decoratorReceiverId: t.Identifier | null = null;
 
   // Memoise the this value `a.b` of decorator member expressions `@a.b.dec`,
   type HandleDecoratorExpressionsResult = {
@@ -922,7 +923,6 @@ function transformClass(
   ): HandleDecoratorExpressionsResult {
     let needMemoise = false;
     const decoratorsThis: (t.Expression | null)[] = [];
-    let receiverId: t.Identifier | null = null;
     for (const expression of expressions) {
       let object;
       if (
@@ -935,13 +935,14 @@ function transformClass(
         } else if (scopeParent.isStatic(expression.object)) {
           object = t.cloneNode(expression.object);
         } else {
-          receiverId ??= scopeParent.generateDeclaredUidIdentifier("obj");
+          decoratorReceiverId ??=
+            scopeParent.generateDeclaredUidIdentifier("obj");
           object = t.assignmentExpression(
             "=",
-            t.cloneNode(receiverId),
+            t.cloneNode(decoratorReceiverId),
             expression.object,
           );
-          expression.object = t.cloneNode(receiverId);
+          expression.object = t.cloneNode(decoratorReceiverId);
         }
       }
       decoratorsThis.push(object);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
@@ -1,10 +1,8 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _obj, _classDecs, _obj2, _m2Decs, _C2;
-    _obj = this;
-    _classDecs = [_obj, super.dec1];
-    _obj2 = this;
-    _m2Decs = [_obj2, super.dec2];
+    var _initProto, _initClass, _classDecs, _m2Decs, _C2;
+    _classDecs = [this, super.dec1];
+    _m2Decs = [this, super.dec2];
     let _C;
     class C {
       constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
@@ -1,12 +1,7 @@
 var _initClass, _obj, _obj2, _classDecs, _obj3, _obj4, _xDecs, _init_x, _obj5, _yDecs, _init_y, _A2;
-_obj = o1;
-_obj2 = o2;
-_classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec];
-_obj3 = o2;
-_obj4 = o3.o;
-_xDecs = [_obj3, _obj3.dec, _obj4, _obj4.dec];
-_obj5 = o2;
-_yDecs = [_obj5, _obj5.dec, void 0, dec];
+_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj2 = o2, _obj2.dec];
+_xDecs = [_obj3 = o2, _obj3.dec, _obj4 = o3.o, _obj4.dec];
+_yDecs = [_obj5 = o2, _obj5.dec, void 0, dec];
 let _A;
 class A {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
@@ -1,7 +1,7 @@
-var _initClass, _obj, _obj2, _classDecs, _obj3, _obj4, _xDecs, _init_x, _obj5, _yDecs, _init_y, _A2;
-_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj2 = o2, _obj2.dec];
-_xDecs = [_obj3 = o2, _obj3.dec, _obj4 = o3.o, _obj4.dec];
-_yDecs = [_obj5 = o2, _obj5.dec, void 0, dec];
+var _initClass, _obj, _classDecs, _obj2, _xDecs, _init_x, _obj3, _yDecs, _init_y, _A2;
+_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj = o2, _obj.dec];
+_xDecs = [_obj2 = o2, _obj2.dec, _obj2 = o3.o, _obj2.dec];
+_yDecs = [_obj3 = o2, _obj3.dec, void 0, dec];
 let _A;
 class A {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
@@ -1,7 +1,7 @@
-var _initClass, _obj, _classDecs, _obj2, _xDecs, _init_x, _obj3, _yDecs, _init_y, _A2;
+var _initClass, _obj, _classDecs, _xDecs, _init_x, _yDecs, _init_y, _A2;
 _classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj = o2, _obj.dec];
-_xDecs = [_obj2 = o2, _obj2.dec, _obj2 = o3.o, _obj2.dec];
-_yDecs = [_obj3 = o2, _obj3.dec, void 0, dec];
+_xDecs = [_obj = o2, _obj.dec, _obj = o3.o, _obj.dec];
+_yDecs = [_obj = o2, _obj.dec, void 0, dec];
 let _A;
 class A {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
@@ -1,7 +1,7 @@
-var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs, _Foo2;
+var _initProto, _initClass, _obj, _classDecs, _methodDecs, _Foo2;
 const dec = () => {};
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
-_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2 = array, _obj2[expr]];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
@@ -1,9 +1,7 @@
 var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs, _Foo2;
 const dec = () => {};
-_obj = array;
-_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
-_obj2 = array;
-_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2, _obj2[expr]];
+_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2 = array, _obj2[expr]];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
@@ -1,10 +1,8 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _obj, _classDecs, _obj2, _m2Decs;
-    _obj = this;
-    _classDecs = [_obj, super.dec1];
-    _obj2 = this;
-    _m2Decs = [_obj2, super.dec2];
+    var _initProto, _initClass, _classDecs, _m2Decs;
+    _classDecs = [this, super.dec1];
+    _m2Decs = [this, super.dec2];
     let _C;
     class C {
       static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
@@ -1,7 +1,7 @@
-var _initClass, _obj, _obj2, _classDecs, _obj3, _obj4, _xDecs, _init_x, _obj5, _yDecs, _init_y;
-_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj2 = o2, _obj2.dec];
-_xDecs = [_obj3 = o2, _obj3.dec, _obj4 = o3.o, _obj4.dec];
-_yDecs = [_obj5 = o2, _obj5.dec, void 0, dec];
+var _initClass, _obj, _classDecs, _obj2, _xDecs, _init_x, _obj3, _yDecs, _init_y;
+_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj = o2, _obj.dec];
+_xDecs = [_obj2 = o2, _obj2.dec, _obj2 = o3.o, _obj2.dec];
+_yDecs = [_obj3 = o2, _obj3.dec, void 0, dec];
 let _A;
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
@@ -1,12 +1,7 @@
 var _initClass, _obj, _obj2, _classDecs, _obj3, _obj4, _xDecs, _init_x, _obj5, _yDecs, _init_y;
-_obj = o1;
-_obj2 = o2;
-_classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec];
-_obj3 = o2;
-_obj4 = o3.o;
-_xDecs = [_obj3, _obj3.dec, _obj4, _obj4.dec];
-_obj5 = o2;
-_yDecs = [_obj5, _obj5.dec, void 0, dec];
+_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj2 = o2, _obj2.dec];
+_xDecs = [_obj3 = o2, _obj3.dec, _obj4 = o3.o, _obj4.dec];
+_yDecs = [_obj5 = o2, _obj5.dec, void 0, dec];
 let _A;
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
@@ -1,7 +1,7 @@
-var _initClass, _obj, _classDecs, _obj2, _xDecs, _init_x, _obj3, _yDecs, _init_y;
+var _initClass, _obj, _classDecs, _xDecs, _init_x, _yDecs, _init_y;
 _classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj = o2, _obj.dec];
-_xDecs = [_obj2 = o2, _obj2.dec, _obj2 = o3.o, _obj2.dec];
-_yDecs = [_obj3 = o2, _obj3.dec, void 0, dec];
+_xDecs = [_obj = o2, _obj.dec, _obj = o3.o, _obj.dec];
+_yDecs = [_obj = o2, _obj.dec, void 0, dec];
 let _A;
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
@@ -13,8 +13,8 @@ class Foo {
   #a = void _initProto(this);
   method() {}
   makeClass() {
-    var _obj3, _barDecs, _init_bar;
-    return _obj3 = this, _barDecs = [_obj3, this.#a], class Nested {
+    var _barDecs, _init_bar;
+    return _barDecs = [this, this.#a], class Nested {
       static {
         [_init_bar] = babelHelpers.applyDecs2305(this, [[_barDecs, 16, "bar"]], []).e;
       }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
@@ -1,7 +1,7 @@
-var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs;
+var _initProto, _initClass, _obj, _classDecs, _methodDecs;
 const dec = () => {};
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
-_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2 = array, _obj2[expr]];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
 let _Foo;
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
@@ -1,9 +1,7 @@
 var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs;
 const dec = () => {};
-_obj = array;
-_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
-_obj2 = array;
-_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2, _obj2[expr]];
+_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2 = array, _obj2[expr]];
 let _Foo;
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/super-in-decorator/output.js
@@ -1,10 +1,8 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _obj, _classDecs, _obj2, _m2Decs, _C2;
-    _obj = this;
-    _classDecs = [_obj, super.dec1];
-    _obj2 = this;
-    _m2Decs = [_obj2, super.dec2];
+    var _initProto, _initClass, _classDecs, _m2Decs, _C2;
+    _classDecs = [this, super.dec1];
+    _m2Decs = [this, super.dec2];
     let _C;
     class C {
       constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
@@ -1,7 +1,7 @@
-var _initClass, _obj, _obj2, _classDecs, _obj3, _obj4, _xDecs, _init_x, _init_extra_x, _obj5, _yDecs, _init_y, _init_extra_y, _A2;
-_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj2 = o2, _obj2.dec];
-_xDecs = [_obj3 = o2, _obj3.dec, _obj4 = o3.o, _obj4.dec];
-_yDecs = [_obj5 = o2, _obj5.dec, void 0, dec];
+var _initClass, _obj, _classDecs, _obj2, _xDecs, _init_x, _init_extra_x, _obj3, _yDecs, _init_y, _init_extra_y, _A2;
+_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj = o2, _obj.dec];
+_xDecs = [_obj2 = o2, _obj2.dec, _obj2 = o3.o, _obj2.dec];
+_yDecs = [_obj3 = o2, _obj3.dec, void 0, dec];
 let _A;
 class A {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
@@ -1,12 +1,7 @@
 var _initClass, _obj, _obj2, _classDecs, _obj3, _obj4, _xDecs, _init_x, _init_extra_x, _obj5, _yDecs, _init_y, _init_extra_y, _A2;
-_obj = o1;
-_obj2 = o2;
-_classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec];
-_obj3 = o2;
-_obj4 = o3.o;
-_xDecs = [_obj3, _obj3.dec, _obj4, _obj4.dec];
-_obj5 = o2;
-_yDecs = [_obj5, _obj5.dec, void 0, dec];
+_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj2 = o2, _obj2.dec];
+_xDecs = [_obj3 = o2, _obj3.dec, _obj4 = o3.o, _obj4.dec];
+_yDecs = [_obj5 = o2, _obj5.dec, void 0, dec];
 let _A;
 class A {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
@@ -1,7 +1,7 @@
-var _initClass, _obj, _classDecs, _obj2, _xDecs, _init_x, _init_extra_x, _obj3, _yDecs, _init_y, _init_extra_y, _A2;
+var _initClass, _obj, _classDecs, _xDecs, _init_x, _init_extra_x, _yDecs, _init_y, _init_extra_y, _A2;
 _classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj = o2, _obj.dec];
-_xDecs = [_obj2 = o2, _obj2.dec, _obj2 = o3.o, _obj2.dec];
-_yDecs = [_obj3 = o2, _obj3.dec, void 0, dec];
+_xDecs = [_obj = o2, _obj.dec, _obj = o3.o, _obj.dec];
+_yDecs = [_obj = o2, _obj.dec, void 0, dec];
 let _A;
 class A {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/valid-expression-formats/output.js
@@ -1,7 +1,7 @@
-var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs, _Foo2;
+var _initProto, _initClass, _obj, _classDecs, _methodDecs, _Foo2;
 const dec = () => {};
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
-_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2 = array, _obj2[expr]];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/valid-expression-formats/output.js
@@ -1,9 +1,7 @@
 var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs, _Foo2;
 const dec = () => {};
-_obj = array;
-_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
-_obj2 = array;
-_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2, _obj2[expr]];
+_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2 = array, _obj2[expr]];
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-decorator/output.js
@@ -1,10 +1,8 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _obj, _classDecs, _obj2, _m2Decs;
-    _obj = this;
-    _classDecs = [_obj, super.dec1];
-    _obj2 = this;
-    _m2Decs = [_obj2, super.dec2];
+    var _initProto, _initClass, _classDecs, _m2Decs;
+    _classDecs = [this, super.dec1];
+    _m2Decs = [this, super.dec2];
     let _C;
     class C {
       static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
@@ -1,7 +1,7 @@
-var _initClass, _obj, _classDecs, _obj2, _xDecs, _init_x, _init_extra_x, _obj3, _yDecs, _init_y, _init_extra_y;
+var _initClass, _obj, _classDecs, _xDecs, _init_x, _init_extra_x, _yDecs, _init_y, _init_extra_y;
 _classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj = o2, _obj.dec, _obj = o4.o(), _obj.dec];
-_xDecs = [_obj2 = o2, _obj2.dec, _obj2 = o3.o, _obj2.dec, _obj2 = o4.o(), _obj2.dec];
-_yDecs = [_obj3 = o2, _obj3.dec, void 0, dec];
+_xDecs = [_obj = o2, _obj.dec, _obj = o3.o, _obj.dec, _obj = o4.o(), _obj.dec];
+_yDecs = [_obj = o2, _obj.dec, void 0, dec];
 let _A;
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
@@ -1,7 +1,7 @@
-var _initClass, _obj, _obj2, _obj3, _classDecs, _obj4, _obj5, _obj6, _xDecs, _init_x, _init_extra_x, _obj7, _yDecs, _init_y, _init_extra_y;
-_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj2 = o2, _obj2.dec, _obj3 = o4.o(), _obj3.dec];
-_xDecs = [_obj4 = o2, _obj4.dec, _obj5 = o3.o, _obj5.dec, _obj6 = o4.o(), _obj6.dec];
-_yDecs = [_obj7 = o2, _obj7.dec, void 0, dec];
+var _initClass, _obj, _classDecs, _obj2, _xDecs, _init_x, _init_extra_x, _obj3, _yDecs, _init_y, _init_extra_y;
+_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj = o2, _obj.dec, _obj = o4.o(), _obj.dec];
+_xDecs = [_obj2 = o2, _obj2.dec, _obj2 = o3.o, _obj2.dec, _obj2 = o4.o(), _obj2.dec];
+_yDecs = [_obj3 = o2, _obj3.dec, void 0, dec];
 let _A;
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
@@ -1,14 +1,7 @@
 var _initClass, _obj, _obj2, _obj3, _classDecs, _obj4, _obj5, _obj6, _xDecs, _init_x, _init_extra_x, _obj7, _yDecs, _init_y, _init_extra_y;
-_obj = o1;
-_obj2 = o2;
-_obj3 = o4.o();
-_classDecs = [_obj, _obj.dec, void 0, dec, _obj2, _obj2.dec, _obj3, _obj3.dec];
-_obj4 = o2;
-_obj5 = o3.o;
-_obj6 = o4.o();
-_xDecs = [_obj4, _obj4.dec, _obj5, _obj5.dec, _obj6, _obj6.dec];
-_obj7 = o2;
-_yDecs = [_obj7, _obj7.dec, void 0, dec];
+_classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj2 = o2, _obj2.dec, _obj3 = o4.o(), _obj3.dec];
+_xDecs = [_obj4 = o2, _obj4.dec, _obj5 = o3.o, _obj5.dec, _obj6 = o4.o(), _obj6.dec];
+_yDecs = [_obj7 = o2, _obj7.dec, void 0, dec];
 let _A;
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
@@ -13,8 +13,8 @@ class Foo {
   #a = void _initProto(this);
   method() {}
   makeClass() {
-    var _obj3, _barDecs, _init_bar, _init_extra_bar;
-    return _obj3 = this, _barDecs = [_obj3, this.#a], class Nested {
+    var _barDecs, _init_bar, _init_extra_bar;
+    return _barDecs = [this, this.#a], class Nested {
       static {
         [_init_bar, _init_extra_bar] = babelHelpers.applyDecs2311(this, [[_barDecs, 16, "bar"]], []).e;
       }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
@@ -1,7 +1,7 @@
-var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs;
+var _initProto, _initClass, _obj, _classDecs, _methodDecs;
 const dec = () => {};
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
-_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2 = array, _obj2[expr]];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
 let _Foo;
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
@@ -1,9 +1,7 @@
 var _initProto, _initClass, _obj, _classDecs, _obj2, _methodDecs;
 const dec = () => {};
-_obj = array;
-_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj, _obj[expr]];
-_obj2 = array;
-_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2, _obj2[expr]];
+_classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
+_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj2 = array, _obj2[expr]];
 let _Foo;
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering--to-es2015/decorators-evaluation-with-this-caching/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering--to-es2015/decorators-evaluation-with-this-caching/exec.js
@@ -1,0 +1,17 @@
+let result = [];
+const fn = () => { result.push(1); return () => {} }
+const obj = {
+  get prop() {
+    result.push(2);
+    return {
+      get foo() { result.push(3); return () => {} }
+    }
+  }
+};
+class A {
+  @fn()
+  @obj.prop.foo
+  method() {}
+}
+
+expect(result).toEqual([1, 2, 3]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering--to-es2015/decorators-evaluation-with-this-caching/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering--to-es2015/decorators-evaluation-with-this-caching/input.js
@@ -1,0 +1,7 @@
+let fn, obj;
+class A {
+  @fn()
+  @obj.prop.foo
+  method() {}
+}
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering--to-es2015/decorators-evaluation-with-this-caching/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering--to-es2015/decorators-evaluation-with-this-caching/output.js
@@ -1,7 +1,6 @@
 var _initProto, _obj, _methodDecs, _A;
 let fn, obj;
-_obj = obj.prop;
-_methodDecs = [void 0, fn(), _obj, _obj.foo];
+_methodDecs = [void 0, fn(), _obj = obj.prop, _obj.foo];
 class A {
   constructor() {
     _initProto(this);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering--to-es2015/decorators-evaluation-with-this-caching/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering--to-es2015/decorators-evaluation-with-this-caching/output.js
@@ -1,0 +1,12 @@
+var _initProto, _obj, _methodDecs, _A;
+let fn, obj;
+_obj = obj.prop;
+_methodDecs = [void 0, fn(), _obj, _obj.foo];
+class A {
+  constructor() {
+    _initProto(this);
+  }
+  method() {}
+}
+_A = A;
+[_initProto] = babelHelpers.applyDecs2311(_A, [[_methodDecs, 18, "method"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering/decorators-evaluation-with-this-caching/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering/decorators-evaluation-with-this-caching/input.js
@@ -1,0 +1,7 @@
+let fn, obj;
+class A {
+  @fn()
+  @obj.prop.foo
+  method() {}
+}
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering/decorators-evaluation-with-this-caching/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering/decorators-evaluation-with-this-caching/output.js
@@ -1,7 +1,6 @@
 var _initProto, _obj, _methodDecs;
 let fn, obj;
-_obj = obj.prop;
-_methodDecs = [void 0, fn(), _obj, _obj.foo];
+_methodDecs = [void 0, fn(), _obj = obj.prop, _obj.foo];
 class A {
   static {
     [_initProto] = babelHelpers.applyDecs2311(this, [[_methodDecs, 18, "method"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering/decorators-evaluation-with-this-caching/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering/decorators-evaluation-with-this-caching/output.js
@@ -1,0 +1,13 @@
+var _initProto, _obj, _methodDecs;
+let fn, obj;
+_obj = obj.prop;
+_methodDecs = [void 0, fn(), _obj, _obj.foo];
+class A {
+  static {
+    [_initProto] = babelHelpers.applyDecs2311(this, [[_methodDecs, 18, "method"]], []).e;
+  }
+  constructor() {
+    _initProto(this);
+  }
+  method() {}
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

- The first commit shows the bug (the new exec test fails with `[2, 1, 3]` ordering)
- The second commit fixes it
- The other commits reduce the number of temp variables used for this case

I recommend _not_ reviewing this commit-by-commit, since I did some renames in the second one that then I undid.