### PR TITLE
test: add replacement-static-decorator-initializer-this test

### DIFF
--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-decorator-initializer-this/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-decorator-initializer-this/exec.js
@@ -1,0 +1,39 @@
+
+let original, replaced, accessorThis, getterThis, setterThis, methodThis, propertyThis;
+
+function dec(Klass) {
+  original = Klass;
+  replaced = class extends Klass {};
+
+  return replaced;
+}
+
+function captureInitializerThis(callback) {
+  return function (_, context) {
+    context.addInitializer(function () {
+      callback(this);
+    })
+  }
+}
+
+@dec
+class Foo {
+  @(captureInitializerThis(v => accessorThis = v))
+  static accessor;
+  @(captureInitializerThis(v => getterThis = v))
+  static get getter() {};
+  @(captureInitializerThis(v => setterThis = v))
+  static set setter(_) {};
+  @(captureInitializerThis(v => methodThis = v))
+  static method() {}
+  @(captureInitializerThis(v => propertyThis = v))
+  static property;
+}
+
+expect(getterThis).toBe(original);
+expect(setterThis).toBe(original);
+expect(methodThis).toBe(original);
+
+expect(accessorThis).toBe(replaced);
+expect(propertyThis).toBe(replaced);
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-decorator-initializer-this/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-decorator-initializer-this/input.js
@@ -1,0 +1,31 @@
+
+let original, replaced, accessorThis, getterThis, setterThis, methodThis, propertyThis;
+
+function dec(Klass) {
+  original = Klass;
+  replaced = class extends Klass {};
+
+  return replaced;
+}
+
+function captureInitializerThis(callback) {
+  return function (_, context) {
+    context.addInitializer(function () {
+      callback(this);
+    })
+  }
+}
+
+@dec
+class Foo {
+  @(captureInitializerThis(v => accessorThis = v))
+  static accessor;
+  @(captureInitializerThis(v => getterThis = v))
+  static get getter() {};
+  @(captureInitializerThis(v => setterThis = v))
+  static set setter(_) {};
+  @(captureInitializerThis(v => methodThis = v))
+  static method() {}
+  @(captureInitializerThis(v => propertyThis = v))
+  static property;
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-decorator-initializer-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-decorator-initializer-this/output.js
@@ -1,0 +1,41 @@
+var _initStatic, _initClass, _accessorDecs, _init_accessor, _init_extra_accessor, _getterDecs, _setterDecs, _methodDecs, _propertyDecs, _init_property, _init_extra_property, _temp;
+let original, replaced, accessorThis, getterThis, setterThis, methodThis, propertyThis;
+function dec(Klass) {
+  original = Klass;
+  replaced = class extends Klass {};
+  return replaced;
+}
+function captureInitializerThis(callback) {
+  return function (_, context) {
+    context.addInitializer(function () {
+      callback(this);
+    });
+  };
+}
+_accessorDecs = captureInitializerThis(v => accessorThis = v);
+_getterDecs = captureInitializerThis(v => getterThis = v);
+_setterDecs = captureInitializerThis(v => setterThis = v);
+_methodDecs = captureInitializerThis(v => methodThis = v);
+_propertyDecs = captureInitializerThis(v => propertyThis = v);
+let _Foo;
+new (_temp = class extends babelHelpers.identity {
+  constructor() {
+    (super(_Foo), babelHelpers.defineProperty(this, "accessor", _init_accessor(this)), babelHelpers.defineProperty(this, "property", (_init_extra_accessor(this), _init_property(this)))), (() => {
+      _init_extra_property(this);
+    })(), _initClass();
+  }
+}, (_Foo2 => {
+  class Foo {
+    static get getter() {}
+    static set setter(_) {}
+    static method() {}
+  }
+  _Foo2 = Foo;
+  (() => {
+    ({
+      e: [_init_accessor, _init_extra_accessor, _init_property, _init_extra_property, _initStatic],
+      c: [_Foo, _initClass]
+    } = babelHelpers.applyDecs2311(_Foo2, [[_getterDecs, 11, "getter"], [_setterDecs, 12, "setter"], [_methodDecs, 10, "method"], [_accessorDecs, 8, "accessor"], [_propertyDecs, 8, "property"]], [dec]));
+    _initStatic(_Foo2);
+  })();
+})(), _temp)();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-decorator-initializer-this/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-decorator-initializer-this/input.js
@@ -1,0 +1,31 @@
+
+let original, replaced, accessorThis, getterThis, setterThis, methodThis, propertyThis;
+
+function dec(Klass) {
+  original = Klass;
+  replaced = class extends Klass {};
+
+  return replaced;
+}
+
+function captureInitializerThis(callback) {
+  return function (_, context) {
+    context.addInitializer(function () {
+      callback(this);
+    })
+  }
+}
+
+@dec
+class Foo {
+  @(captureInitializerThis(v => accessorThis = v))
+  static accessor;
+  @(captureInitializerThis(v => getterThis = v))
+  static get getter() {};
+  @(captureInitializerThis(v => setterThis = v))
+  static set setter(_) {};
+  @(captureInitializerThis(v => methodThis = v))
+  static method() {}
+  @(captureInitializerThis(v => propertyThis = v))
+  static property;
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-decorator-initializer-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-decorator-initializer-this/output.js
@@ -1,0 +1,43 @@
+var _initStatic, _initClass, _accessorDecs, _init_accessor, _init_extra_accessor, _getterDecs, _setterDecs, _methodDecs, _propertyDecs, _init_property, _init_extra_property;
+let original, replaced, accessorThis, getterThis, setterThis, methodThis, propertyThis;
+function dec(Klass) {
+  original = Klass;
+  replaced = class extends Klass {};
+  return replaced;
+}
+function captureInitializerThis(callback) {
+  return function (_, context) {
+    context.addInitializer(function () {
+      callback(this);
+    });
+  };
+}
+_accessorDecs = captureInitializerThis(v => accessorThis = v);
+_getterDecs = captureInitializerThis(v => getterThis = v);
+_setterDecs = captureInitializerThis(v => setterThis = v);
+_methodDecs = captureInitializerThis(v => methodThis = v);
+_propertyDecs = captureInitializerThis(v => propertyThis = v);
+let _Foo;
+new class extends babelHelpers.identity {
+  static {
+    class Foo {
+      static {
+        ({
+          e: [_init_accessor, _init_extra_accessor, _init_property, _init_extra_property, _initStatic],
+          c: [_Foo, _initClass]
+        } = babelHelpers.applyDecs2311(this, [[_getterDecs, 11, "getter"], [_setterDecs, 12, "setter"], [_methodDecs, 10, "method"], [_accessorDecs, 8, "accessor"], [_propertyDecs, 8, "property"]], [dec]));
+        _initStatic(this);
+      }
+      static get getter() {}
+      static set setter(_) {}
+      static method() {}
+    }
+  }
+  accessor = _init_accessor(this);
+  property = (_init_extra_accessor(this), _init_property(this));
+  constructor() {
+    super(_Foo), (() => {
+      _init_extra_property(this);
+    })(), _initClass();
+  }
+}();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we add a new class replacement test. It seems that the `this` value of initializers in a decorated class are not covered in other tests.