### PR TITLE
Use `.toHaveProperty` to check for property

### DIFF
--- a/packages/babel-plugin-transform-classes/test/fixtures/exec/class-prototype-chain.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/exec/class-prototype-chain.js
@@ -20,4 +20,4 @@ class E {}
 
 expect(Object.getPrototypeOf(E)).toBe(Function.prototype);
 expect(Object.getPrototypeOf(E.prototype)).toBe(Object.prototype);
-expect(E).not.toContain('keys');
+expect(E).not.toHaveProperty('keys');


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Fixes the CI failure in https://github.com/babel/babel/pull/16294 (that is actually also failing on main, we just didn't trigger CI yet)

`expect@30.0.0-alpha.3` was recently released, with a change that causes `expect(notAnIterable).not.toContain(foo)` to throw rather than passing because `notAnIterable` does not contain anything so it doesn't contain `foo` (https://github.com/jestjs/jest/commit/bd3a7e9fd7ba7d4eafa1f0ceb1e3a4186e7b3abd).

Our CI somehow pulls in not only the latest stable version of packages, but the latest version _in general_ and so it uncovered this bug in our tests.

@SimenB I don't think this change was intentional, but maybe it would be great to have it documented in the 30.0.0 release notes :)