### PR TITLE
fix: avoid `popContext` on unvisited node paths

### DIFF
--- a/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/regression-16293/input.js
+++ b/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/regression-16293/input.js
@@ -1,0 +1,5 @@
+async () => do {
+  await 0
+  while (0) {}
+  0
+}

--- a/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/regression-16293/output.js
+++ b/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/regression-16293/output.js
@@ -1,0 +1,5 @@
+async () => await async function () {
+  await 0;
+  while (0) {}
+  return 0;
+}();

--- a/packages/babel-traverse/src/context.ts
+++ b/packages/babel-traverse/src/context.ts
@@ -118,9 +118,12 @@ export default class TraversalContext<S = unknown> {
 
     const visited = new WeakSet();
     let stop = false;
+    let visitIndex = 0;
 
     // visit the queue
-    for (const path of queue) {
+    for (; visitIndex < queue.length; ) {
+      const path = queue[visitIndex];
+      visitIndex++;
       path.resync();
 
       if (
@@ -154,9 +157,9 @@ export default class TraversalContext<S = unknown> {
       }
     }
 
-    // clear queue
-    for (const path of queue) {
-      path.popContext();
+    // pop contexts
+    for (let i = 0; i < visitIndex; i++) {
+      queue[i].popContext();
     }
 
     // clear queue


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16293 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When Babel invokes `traverse.hasType` to check whether there is an await expression in the do expression body:

https://github.com/babel/babel/blob/8c3f035a572cdbff5c52e2cb5611940996831301/packages/babel-traverse/src/path/replacement.ts#L309-L316

it throws when it is trying to initialize a `Scope` during `path.popContext()` when the `path` is supposed to work only within the `{ noScope: true }` traversal context.

This issue is likely directly caused by the breaking change https://github.com/babel/babel/pull/15759, as reverting these change will also fix this issue.

However it reveals a bug in the traverser: currently Babel is popping the context even if the visit queue exits early, rendering some unvisited node paths trying to initialize the `Scope` without the top traversal context.