### PR TITLE
Avoid intermediate functions for private accessors with decs

### DIFF
--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
@@ -61,12 +61,6 @@ class Foo {
   }
 }
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
 (() => {
   [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 6, "a"], [dec, 6, "a", function () {
     return babelHelpers.assertClassBrand(_Foo, this, _B)._;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/private/output.js
@@ -11,18 +11,6 @@ class Foo {
   }
 }
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
-function _set_b2(_this3, v) {
-  _set_b(_this3, v);
-}
-function _get_b2(_this4) {
-  return _get_b(_this4);
-}
 [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs(_Foo, [[dec, 1, "a", function () {
   return babelHelpers.classPrivateFieldGet2(_A, this);
 }, function (value) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-private/output.js
@@ -2,18 +2,6 @@ var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
-function _set_b2(_this3, v) {
-  _set_b(_this3, v);
-}
-function _get_b2(_this4) {
-  return _get_b(_this4);
-}
 (() => {
   [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 6, "a", function () {
     return babelHelpers.assertClassBrand(_Foo, this, _A)._;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
@@ -21,9 +21,6 @@ class Foo {
   static get [_computedKey]() {}
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []);
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
@@ -7,13 +7,10 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
-    return babelHelpers.classPrivateGetter(_Foo_brand, this, _get_a);
+    return babelHelpers.classPrivateGetter(_Foo_brand, this, _call_a);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 [_call_a, _initProto] = babelHelpers.applyDecs(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-private/output.js
@@ -2,13 +2,10 @@ var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
-    return babelHelpers.classPrivateGetter(Foo, this, _get_a);
+    return babelHelpers.classPrivateGetter(Foo, this, _call_a);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 8, "a", function () {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
@@ -7,19 +7,13 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
-    return babelHelpers.classPrivateGetter(_Foo_brand, this, _get_a);
+    return babelHelpers.classPrivateGetter(_Foo_brand, this, _call_a);
   }
   setA(v) {
-    babelHelpers.classPrivateSetter(_Foo_brand, _set_a, this, v);
+    babelHelpers.classPrivateSetter(_Foo_brand, _call_a2, this, v);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
-function _set_a(_this2, v) {
-  _call_a2(_this2, v);
-}
 [_call_a, _call_a2, _initProto] = babelHelpers.applyDecs(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }], [dec, 4, "a", function (v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-private/output.js
@@ -2,19 +2,13 @@ var _initStatic, _call_a, _call_a2, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
-    return babelHelpers.classPrivateGetter(Foo, this, _get_a);
+    return babelHelpers.classPrivateGetter(Foo, this, _call_a);
   }
   static setA(v) {
-    babelHelpers.classPrivateSetter(Foo, _set_a, this, v);
+    babelHelpers.classPrivateSetter(Foo, _call_a2, this, v);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
-function _set_a(_this2, v) {
-  _call_a2(_this2, v);
-}
 (() => {
   [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 8, "a", function () {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
@@ -21,9 +21,6 @@ class Foo {
   static set [_computedKey](v) {}
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []);
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
@@ -7,13 +7,10 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   setA(v) {
-    babelHelpers.classPrivateSetter(_Foo_brand, _set_a, this, v);
+    babelHelpers.classPrivateSetter(_Foo_brand, _call_a, this, v);
   }
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 [_call_a, _initProto] = babelHelpers.applyDecs(_Foo, [[dec, 4, "a", function (v) {
   return this.value = v;
 }]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-private/output.js
@@ -2,13 +2,10 @@ var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {
-    babelHelpers.classPrivateSetter(Foo, _set_a, this, v);
+    babelHelpers.classPrivateSetter(Foo, _call_a, this, v);
   }
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs(_Foo, [[dec, 9, "a", function (v) {
     return this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
@@ -61,12 +61,6 @@ class Foo {
   }
 }
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
 (() => {
   [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 6, "a"], [dec, 6, "a", function () {
     return babelHelpers.assertClassBrand(_Foo, this, _B)._;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/private/output.js
@@ -11,18 +11,6 @@ class Foo {
   }
 }
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
-function _set_b2(_this3, v) {
-  _set_b(_this3, v);
-}
-function _get_b2(_this4) {
-  return _get_b(_this4);
-}
 [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 1, "a", function () {
   return babelHelpers.classPrivateFieldGet2(_A, this);
 }, function (value) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-private/output.js
@@ -2,18 +2,6 @@ var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
-function _set_b2(_this3, v) {
-  _set_b(_this3, v);
-}
-function _get_b2(_this4) {
-  return _get_b(_this4);
-}
 (() => {
   [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 6, "a", function () {
     return babelHelpers.assertClassBrand(_Foo, this, _A)._;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
@@ -21,9 +21,6 @@ class Foo {
   static get [_computedKey]() {}
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/private/output.js
@@ -7,13 +7,10 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
-    return babelHelpers.classPrivateGetter(_Foo_brand, this, _get_a);
+    return babelHelpers.classPrivateGetter(_Foo_brand, this, _call_a);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 [_call_a, _initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-private/output.js
@@ -2,13 +2,10 @@ var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
-    return babelHelpers.classPrivateGetter(Foo, this, _get_a);
+    return babelHelpers.classPrivateGetter(Foo, this, _call_a);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 8, "a", function () {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/private/output.js
@@ -7,19 +7,13 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
-    return babelHelpers.classPrivateGetter(_Foo_brand, this, _get_a);
+    return babelHelpers.classPrivateGetter(_Foo_brand, this, _call_a);
   }
   setA(v) {
-    babelHelpers.classPrivateSetter(_Foo_brand, _set_a, this, v);
+    babelHelpers.classPrivateSetter(_Foo_brand, _call_a2, this, v);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
-function _set_a(_this2, v) {
-  _call_a2(_this2, v);
-}
 [_call_a, _call_a2, _initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }], [dec, 4, "a", function (v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-private/output.js
@@ -2,19 +2,13 @@ var _initStatic, _call_a, _call_a2, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
-    return babelHelpers.classPrivateGetter(Foo, this, _get_a);
+    return babelHelpers.classPrivateGetter(Foo, this, _call_a);
   }
   static setA(v) {
-    babelHelpers.classPrivateSetter(Foo, _set_a, this, v);
+    babelHelpers.classPrivateSetter(Foo, _call_a2, this, v);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
-function _set_a(_this2, v) {
-  _call_a2(_this2, v);
-}
 (() => {
   [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 8, "a", function () {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
@@ -21,9 +21,6 @@ class Foo {
   static set [_computedKey](v) {}
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/private/output.js
@@ -7,13 +7,10 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   setA(v) {
-    babelHelpers.classPrivateSetter(_Foo_brand, _set_a, this, v);
+    babelHelpers.classPrivateSetter(_Foo_brand, _call_a, this, v);
   }
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 [_call_a, _initProto] = babelHelpers.applyDecs2203R(_Foo, [[dec, 4, "a", function (v) {
   return this.value = v;
 }]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-private/output.js
@@ -2,13 +2,10 @@ var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {
-    babelHelpers.classPrivateSetter(Foo, _set_a, this, v);
+    babelHelpers.classPrivateSetter(Foo, _call_a, this, v);
   }
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2203R(_Foo, [[dec, 9, "a", function (v) {
     return this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
@@ -61,12 +61,6 @@ class Foo {
   }
 }
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
 (() => {
   [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 6, "a"], [dec, 6, "a", o => babelHelpers.assertClassBrand(_Foo, o, _B)._, (o, v) => _B._ = babelHelpers.assertClassBrand(_Foo, o, v)], [dec, 6, "b"], [dec, 6, "c"], [dec, 6, 0], [dec, 6, 1], [dec, 6, 2n], [dec, 6, 3n], [dec, 6, _computedKey]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/private/output.js
@@ -11,16 +11,4 @@ class Foo {
   }
 }
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
-function _set_b2(_this3, v) {
-  _set_b(_this3, v);
-}
-function _get_b2(_this4) {
-  return _get_b(_this4);
-}
 [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 1, "a", o => babelHelpers.classPrivateFieldGet2(_A, o), (o, v) => babelHelpers.classPrivateFieldSet2(_A, o, v)], [dec, 1, "b", o => babelHelpers.classPrivateFieldGet2(_B, o), (o, v) => babelHelpers.classPrivateFieldSet2(_B, o, v)]], [], _ => _Foo_brand.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-private/output.js
@@ -2,18 +2,6 @@ var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
-function _set_b2(_this3, v) {
-  _set_b(_this3, v);
-}
-function _get_b2(_this4) {
-  return _get_b(_this4);
-}
 (() => {
   [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 6, "a", o => babelHelpers.assertClassBrand(_Foo, o, _A)._, (o, v) => _A._ = babelHelpers.assertClassBrand(_Foo, o, v)], [dec, 6, "b", o => babelHelpers.assertClassBrand(_Foo, o, _B)._, (o, v) => _B._ = babelHelpers.assertClassBrand(_Foo, o, v)]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
@@ -21,9 +21,6 @@ class Foo {
   static get [_computedKey]() {}
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 8, "a"], [dec, 8, "a", function () {}], [dec, 8, "b"], [dec, 8, "c"], [dec, 8, 0], [dec, 8, 1], [dec, 8, 2n], [dec, 8, 3n], [dec, 8, _computedKey]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/private/output.js
@@ -7,13 +7,10 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
-    return babelHelpers.classPrivateGetter(_Foo_brand, this, _get_a);
+    return babelHelpers.classPrivateGetter(_Foo_brand, this, _call_a);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 [_call_a, _initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }]], [], _ => _Foo_brand.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-private/output.js
@@ -2,13 +2,10 @@ var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
-    return babelHelpers.classPrivateGetter(Foo, this, _get_a);
+    return babelHelpers.classPrivateGetter(Foo, this, _call_a);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 8, "a", function () {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/private/output.js
@@ -7,19 +7,13 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
-    return babelHelpers.classPrivateGetter(_Foo_brand, this, _get_a);
+    return babelHelpers.classPrivateGetter(_Foo_brand, this, _call_a);
   }
   setA(v) {
-    babelHelpers.classPrivateSetter(_Foo_brand, _set_a, this, v);
+    babelHelpers.classPrivateSetter(_Foo_brand, _call_a2, this, v);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
-function _set_a(_this2, v) {
-  _call_a2(_this2, v);
-}
 [_call_a, _call_a2, _initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }], [dec, 4, "a", function (v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-private/output.js
@@ -2,19 +2,13 @@ var _initStatic, _call_a, _call_a2, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
-    return babelHelpers.classPrivateGetter(Foo, this, _get_a);
+    return babelHelpers.classPrivateGetter(Foo, this, _call_a);
   }
   static setA(v) {
-    babelHelpers.classPrivateSetter(Foo, _set_a, this, v);
+    babelHelpers.classPrivateSetter(Foo, _call_a2, this, v);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
-function _set_a(_this2, v) {
-  _call_a2(_this2, v);
-}
 (() => {
   [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 8, "a", function () {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
@@ -21,9 +21,6 @@ class Foo {
   static set [_computedKey](v) {}
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 9, "a"], [dec, 9, "a", function (v) {}], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/private/output.js
@@ -7,13 +7,10 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   setA(v) {
-    babelHelpers.classPrivateSetter(_Foo_brand, _set_a, this, v);
+    babelHelpers.classPrivateSetter(_Foo_brand, _call_a, this, v);
   }
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 [_call_a, _initProto] = babelHelpers.applyDecs2301(_Foo, [[dec, 4, "a", function (v) {
   return this.value = v;
 }]], [], _ => _Foo_brand.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-private/output.js
@@ -2,13 +2,10 @@ var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {
-    babelHelpers.classPrivateSetter(Foo, _set_a, this, v);
+    babelHelpers.classPrivateSetter(Foo, _call_a, this, v);
   }
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2301(_Foo, [[dec, 9, "a", function (v) {
     return this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
@@ -61,12 +61,6 @@ class Foo {
   }
 }
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
 (() => {
   [_init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 9, "a"], [dec, 9, "a", o => babelHelpers.assertClassBrand(_Foo, o, _B)._, (o, v) => _B._ = babelHelpers.assertClassBrand(_Foo, o, v)], [dec, 9, "b"], [dec, 9, "c"], [dec, 9, 0], [dec, 9, 1], [dec, 9, 2n], [dec, 9, 3n], [dec, 9, _computedKey]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/private/output.js
@@ -11,16 +11,4 @@ class Foo {
   }
 }
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
-function _set_b2(_this3, v) {
-  _set_b(_this3, v);
-}
-function _get_b2(_this4) {
-  return _get_b(_this4);
-}
 [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 1, "a", o => babelHelpers.classPrivateFieldGet2(_A, o), (o, v) => babelHelpers.classPrivateFieldSet2(_A, o, v)], [dec, 1, "b", o => babelHelpers.classPrivateFieldGet2(_B, o), (o, v) => babelHelpers.classPrivateFieldSet2(_B, o, v)]], [], 0, _ => _Foo_brand.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-private/output.js
@@ -2,18 +2,6 @@ var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
-function _set_b2(_this3, v) {
-  _set_b(_this3, v);
-}
-function _get_b2(_this4) {
-  return _get_b(_this4);
-}
 (() => {
   [_init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 9, "a", o => babelHelpers.assertClassBrand(_Foo, o, _A)._, (o, v) => _A._ = babelHelpers.assertClassBrand(_Foo, o, v)], [dec, 9, "b", o => babelHelpers.assertClassBrand(_Foo, o, _B)._, (o, v) => _B._ = babelHelpers.assertClassBrand(_Foo, o, v)]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
@@ -21,9 +21,6 @@ class Foo {
   static get [_computedKey]() {}
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 11, "a"], [dec, 11, "a", function () {}], [dec, 11, "b"], [dec, 11, "c"], [dec, 11, 0], [dec, 11, 1], [dec, 11, 2n], [dec, 11, 3n], [dec, 11, _computedKey]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/private/output.js
@@ -7,13 +7,10 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
-    return babelHelpers.classPrivateGetter(_Foo_brand, this, _get_a);
+    return babelHelpers.classPrivateGetter(_Foo_brand, this, _call_a);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 [_call_a, _initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }]], [], 0, _ => _Foo_brand.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-private/output.js
@@ -2,13 +2,10 @@ var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
-    return babelHelpers.classPrivateGetter(Foo, this, _get_a);
+    return babelHelpers.classPrivateGetter(Foo, this, _call_a);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 11, "a", function () {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/private/output.js
@@ -7,19 +7,13 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
-    return babelHelpers.classPrivateGetter(_Foo_brand, this, _get_a);
+    return babelHelpers.classPrivateGetter(_Foo_brand, this, _call_a);
   }
   setA(v) {
-    babelHelpers.classPrivateSetter(_Foo_brand, _set_a, this, v);
+    babelHelpers.classPrivateSetter(_Foo_brand, _call_a2, this, v);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
-function _set_a(_this2, v) {
-  _call_a2(_this2, v);
-}
 [_call_a, _call_a2, _initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 3, "a", function () {
   return this.value;
 }], [dec, 4, "a", function (v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-private/output.js
@@ -2,19 +2,13 @@ var _initStatic, _call_a, _call_a2, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
-    return babelHelpers.classPrivateGetter(Foo, this, _get_a);
+    return babelHelpers.classPrivateGetter(Foo, this, _call_a);
   }
   static setA(v) {
-    babelHelpers.classPrivateSetter(Foo, _set_a, this, v);
+    babelHelpers.classPrivateSetter(Foo, _call_a2, this, v);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
-function _set_a(_this2, v) {
-  _call_a2(_this2, v);
-}
 (() => {
   [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 11, "a", function () {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
@@ -21,9 +21,6 @@ class Foo {
   static set [_computedKey](v) {}
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 12, "a"], [dec, 12, "a", function (v) {}], [dec, 12, "b"], [dec, 12, "c"], [dec, 12, 0], [dec, 12, 1], [dec, 12, 2n], [dec, 12, 3n], [dec, 12, _computedKey]], []).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/private/output.js
@@ -7,13 +7,10 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   setA(v) {
-    babelHelpers.classPrivateSetter(_Foo_brand, _set_a, this, v);
+    babelHelpers.classPrivateSetter(_Foo_brand, _call_a, this, v);
   }
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 [_call_a, _initProto] = babelHelpers.applyDecs2305(_Foo, [[dec, 4, "a", function (v) {
   return this.value = v;
 }]], [], 0, _ => _Foo_brand.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-private/output.js
@@ -2,13 +2,10 @@ var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {
-    babelHelpers.classPrivateSetter(Foo, _set_a, this, v);
+    babelHelpers.classPrivateSetter(Foo, _call_a, this, v);
   }
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2305(_Foo, [[dec, 12, "a", function (v) {
     return this.value = v;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/private/output.js
@@ -12,16 +12,4 @@ class Foo {
   }
 }
 _Foo = Foo;
-function _set_a2(_this, v) {
-  _set_a(_this, v);
-}
-function _get_a2(_this2) {
-  return _get_a(_this2);
-}
-function _set_b2(_this3, v) {
-  _set_b(_this3, v);
-}
-function _get_b2(_this4) {
-  return _get_b(_this4);
-}
 [_init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b] = babelHelpers.applyDecs2311(_Foo, [], [[dec, 1, "a", o => babelHelpers.classPrivateFieldGet2(_A, o), (o, v) => babelHelpers.classPrivateFieldSet2(_A, o, v)], [dec, 1, "b", o => babelHelpers.classPrivateFieldGet2(_B, o), (o, v) => babelHelpers.classPrivateFieldSet2(_B, o, v)]], 0, _ => _Foo_brand.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/context-name/output.js
@@ -21,9 +21,6 @@ class Foo {
   static get [_computedKey]() {}
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2311(_Foo, [], [[dec, 11, "a"], [dec, 11, "a", function () {}], [dec, 11, "b"], [dec, 11, "c"], [dec, 11, 0], [dec, 11, 1], [dec, 11, 2n], [dec, 11, 3n], [dec, 11, _computedKey]]).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/private/output.js
@@ -7,13 +7,10 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
-    return babelHelpers.classPrivateGetter(_Foo_brand, this, _get_a);
+    return babelHelpers.classPrivateGetter(_Foo_brand, this, _call_a);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 [_call_a, _initProto] = babelHelpers.applyDecs2311(_Foo, [], [[dec, 3, "a", function () {
   return this.value;
 }]], 0, _ => _Foo_brand.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/static-private/output.js
@@ -2,13 +2,10 @@ var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
-    return babelHelpers.classPrivateGetter(Foo, this, _get_a);
+    return babelHelpers.classPrivateGetter(Foo, this, _call_a);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2311(_Foo, [], [[dec, 11, "a", function () {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/private/output.js
@@ -7,19 +7,13 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   getA() {
-    return babelHelpers.classPrivateGetter(_Foo_brand, this, _get_a);
+    return babelHelpers.classPrivateGetter(_Foo_brand, this, _call_a);
   }
   setA(v) {
-    babelHelpers.classPrivateSetter(_Foo_brand, _set_a, this, v);
+    babelHelpers.classPrivateSetter(_Foo_brand, _call_a2, this, v);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
-function _set_a(_this2, v) {
-  _call_a2(_this2, v);
-}
 [_call_a, _call_a2, _initProto] = babelHelpers.applyDecs2311(_Foo, [], [[dec, 3, "a", function () {
   return this.value;
 }], [dec, 4, "a", function (v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/static-private/output.js
@@ -2,19 +2,13 @@ var _initStatic, _call_a, _call_a2, _Foo;
 const dec = () => {};
 class Foo {
   static getA() {
-    return babelHelpers.classPrivateGetter(Foo, this, _get_a);
+    return babelHelpers.classPrivateGetter(Foo, this, _call_a);
   }
   static setA(v) {
-    babelHelpers.classPrivateSetter(Foo, _set_a, this, v);
+    babelHelpers.classPrivateSetter(Foo, _call_a2, this, v);
   }
 }
 _Foo = Foo;
-function _get_a(_this) {
-  return _call_a(_this);
-}
-function _set_a(_this2, v) {
-  _call_a2(_this2, v);
-}
 (() => {
   [_call_a, _call_a2, _initStatic] = babelHelpers.applyDecs2311(_Foo, [], [[dec, 11, "a", function () {
     return this.value;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/context-name/output.js
@@ -21,9 +21,6 @@ class Foo {
   static set [_computedKey](v) {}
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2311(_Foo, [], [[dec, 12, "a"], [dec, 12, "a", function (v) {}], [dec, 12, "b"], [dec, 12, "c"], [dec, 12, 0], [dec, 12, 1], [dec, 12, 2n], [dec, 12, 3n], [dec, 12, _computedKey]]).e;
   _initStatic(_Foo);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/private/output.js
@@ -7,13 +7,10 @@ class Foo {
     babelHelpers.defineProperty(this, "value", (_initProto(this), 1));
   }
   setA(v) {
-    babelHelpers.classPrivateSetter(_Foo_brand, _set_a, this, v);
+    babelHelpers.classPrivateSetter(_Foo_brand, _call_a, this, v);
   }
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 [_call_a, _initProto] = babelHelpers.applyDecs2311(_Foo, [], [[dec, 4, "a", function (v) {
   return this.value = v;
 }]], 0, _ => _Foo_brand.has(babelHelpers.checkInRHS(_))).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/static-private/output.js
@@ -2,13 +2,10 @@ var _initStatic, _call_a, _Foo;
 const dec = () => {};
 class Foo {
   static setA(v) {
-    babelHelpers.classPrivateSetter(Foo, _set_a, this, v);
+    babelHelpers.classPrivateSetter(Foo, _call_a, this, v);
   }
 }
 _Foo = Foo;
-function _set_a(_this, v) {
-  _call_a(_this, v);
-}
 (() => {
   [_call_a, _initStatic] = babelHelpers.applyDecs2311(_Foo, [], [[dec, 12, "a", function (v) {
     return this.value = v;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR improves how we compile very simple getters/setters, so that we can avoid an intermediate function when compiling the getter/setter generated for `accessor` properties.

This PR does not need to block the next release.