### PR TITLE
Fix class private properties when `privateFieldsAsSymbols`

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -183,7 +183,9 @@ export function buildPrivateNamesNodes(
     }
 
     if (init) {
-      annotateAsPure(init);
+      if (!privateFieldsAsSymbols) {
+        annotateAsPure(init);
+      }
       initNodes.push(template.statement.ast`var ${id} = ${init}`);
     }
   }
@@ -1283,7 +1285,7 @@ function buildPrivateMethodDeclaration(
   file: File,
   prop: NodePath<t.ClassPrivateMethod>,
   privateNamesMap: PrivateNamesMap,
-  privateFieldsAsProperties = false,
+  privateFieldsAsSymbolsOrProperties = false,
 ) {
   const privateName = privateNamesMap.get(prop.node.key.id.name);
   const {
@@ -1310,7 +1312,7 @@ function buildPrivateMethodDeclaration(
   if (
     (process.env.BABEL_8_BREAKING || newHelpers(file)) &&
     (isGetter || isSetter) &&
-    !privateFieldsAsProperties
+    !privateFieldsAsSymbolsOrProperties
   ) {
     const scope = prop.get("body").scope;
     const thisArg = scope.generateUidIdentifier("this");
@@ -1350,7 +1352,7 @@ function buildPrivateMethodDeclaration(
       initAdded: true,
     });
     declId = setId;
-  } else if (isStatic && !privateFieldsAsProperties) {
+  } else if (isStatic && !privateFieldsAsSymbolsOrProperties) {
     declId = id;
   }
 
@@ -1511,7 +1513,7 @@ export function buildFieldsInitNodes(
   privateNamesMap: PrivateNamesMap,
   file: File,
   setPublicClassFields: boolean,
-  privateFieldsAsProperties: boolean,
+  privateFieldsAsSymbolsOrProperties: boolean,
   noUninitializedPrivateFieldAccess: boolean,
   constantSuper: boolean,
   innerBindingRef: t.Identifier | null,
@@ -1606,12 +1608,18 @@ export function buildFieldsInitNodes(
         }
         break;
       }
-      case isStatic && isPrivate && isField && privateFieldsAsProperties:
+      case isStatic &&
+        isPrivate &&
+        isField &&
+        privateFieldsAsSymbolsOrProperties:
         staticNodes.push(
           buildPrivateFieldInitLoose(t.cloneNode(ref), prop, privateNamesMap),
         );
         break;
-      case isStatic && isPrivate && isField && !privateFieldsAsProperties:
+      case isStatic &&
+        isPrivate &&
+        isField &&
+        !privateFieldsAsSymbolsOrProperties:
         if (!process.env.BABEL_8_BREAKING && !newHelpers(file)) {
           staticNodes.push(
             buildPrivateStaticFieldInitSpecOld(prop, privateNamesMap),
@@ -1645,12 +1653,18 @@ export function buildFieldsInitNodes(
           buildPublicFieldInitSpec(t.cloneNode(ref), prop, file),
         );
         break;
-      case isInstance && isPrivate && isField && privateFieldsAsProperties:
+      case isInstance &&
+        isPrivate &&
+        isField &&
+        privateFieldsAsSymbolsOrProperties:
         instanceNodes.push(
           buildPrivateFieldInitLoose(t.thisExpression(), prop, privateNamesMap),
         );
         break;
-      case isInstance && isPrivate && isField && !privateFieldsAsProperties:
+      case isInstance &&
+        isPrivate &&
+        isField &&
+        !privateFieldsAsSymbolsOrProperties:
         instanceNodes.push(
           buildPrivateInstanceFieldInitSpec(
             t.thisExpression(),
@@ -1660,7 +1674,10 @@ export function buildFieldsInitNodes(
           ),
         );
         break;
-      case isInstance && isPrivate && isMethod && privateFieldsAsProperties:
+      case isInstance &&
+        isPrivate &&
+        isMethod &&
+        privateFieldsAsSymbolsOrProperties:
         instanceNodes.unshift(
           buildPrivateMethodInitLoose(
             t.thisExpression(),
@@ -1675,11 +1692,14 @@ export function buildFieldsInitNodes(
             // @ts-expect-error checked in switch
             prop,
             privateNamesMap,
-            privateFieldsAsProperties,
+            privateFieldsAsSymbolsOrProperties,
           ),
         );
         break;
-      case isInstance && isPrivate && isMethod && !privateFieldsAsProperties:
+      case isInstance &&
+        isPrivate &&
+        isMethod &&
+        !privateFieldsAsSymbolsOrProperties:
         instanceNodes.unshift(
           buildPrivateInstanceMethodInitSpec(
             t.thisExpression(),
@@ -1695,11 +1715,14 @@ export function buildFieldsInitNodes(
             // @ts-expect-error checked in switch
             prop,
             privateNamesMap,
-            privateFieldsAsProperties,
+            privateFieldsAsSymbolsOrProperties,
           ),
         );
         break;
-      case isStatic && isPrivate && isMethod && !privateFieldsAsProperties:
+      case isStatic &&
+        isPrivate &&
+        isMethod &&
+        !privateFieldsAsSymbolsOrProperties:
         if (!process.env.BABEL_8_BREAKING && !newHelpers(file)) {
           staticNodes.unshift(
             // @ts-expect-error checked in switch
@@ -1712,11 +1735,14 @@ export function buildFieldsInitNodes(
             // @ts-expect-error checked in switch
             prop,
             privateNamesMap,
-            privateFieldsAsProperties,
+            privateFieldsAsSymbolsOrProperties,
           ),
         );
         break;
-      case isStatic && isPrivate && isMethod && privateFieldsAsProperties:
+      case isStatic &&
+        isPrivate &&
+        isMethod &&
+        privateFieldsAsSymbolsOrProperties:
         staticNodes.unshift(
           buildPrivateStaticMethodInitLoose(
             t.cloneNode(ref),
@@ -1732,7 +1758,7 @@ export function buildFieldsInitNodes(
             // @ts-expect-error checked in switch
             prop,
             privateNamesMap,
-            privateFieldsAsProperties,
+            privateFieldsAsSymbolsOrProperties,
           ),
         );
         break;

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -47,7 +47,7 @@ if (!process.env.BABEL_8_BREAKING) {
 
 export function buildPrivateNamesMap(
   className: string,
-  privateFieldsAsProperties: boolean,
+  privateFieldsAsSymbolsOrProperties: boolean,
   props: PropPath[],
   file: File,
 ) {
@@ -63,7 +63,7 @@ export function buildPrivateNamesMap(
         let initAdded = false;
         let id: t.Identifier;
         if (
-          !privateFieldsAsProperties &&
+          !privateFieldsAsSymbolsOrProperties &&
           (process.env.BABEL_8_BREAKING || newHelpers(file)) &&
           isMethod &&
           !isStatic

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -240,7 +240,7 @@ export function createClassFeaturePlugin({
 
         const privateNamesMap = buildPrivateNamesMap(
           classRefForDefine.name,
-          privateFieldsAsProperties ?? loose,
+          privateFieldsAsSymbolsOrProperties ?? loose,
           props,
           file,
         );

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/basic/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/basic/output.js
@@ -1,8 +1,8 @@
 var _privateField = /*#__PURE__*/Symbol("privateField");
-var _Cl_brand = /*#__PURE__*/Symbol("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/Symbol("privateFieldValue");
 class Cl {
   constructor() {
-    Object.defineProperty(this, _Cl_brand, {
+    Object.defineProperty(this, _privateFieldValue, {
       get: _get_privateFieldValue,
       set: _set_privateFieldValue
     });
@@ -13,10 +13,10 @@ class Cl {
     this.publicField = "not secret string";
   }
   publicGetPrivateField() {
-    return babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand];
+    return babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
   }
   publicSetPrivateField(newValue) {
-    babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand] = newValue;
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = newValue;
   }
 }
 function _get_privateFieldValue() {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/basic/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/basic/output.js
@@ -1,5 +1,5 @@
-var _privateField = /*#__PURE__*/Symbol("privateField");
-var _privateFieldValue = /*#__PURE__*/Symbol("privateFieldValue");
+var _privateField = Symbol("privateField");
+var _privateFieldValue = Symbol("privateFieldValue");
 class Cl {
   constructor() {
     Object.defineProperty(this, _privateFieldValue, {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/class-binding/output.js
@@ -1,5 +1,5 @@
 var _A;
-var _getA = /*#__PURE__*/Symbol("getA");
+var _getA = Symbol("getA");
 class A {
   constructor() {
     Object.defineProperty(this, _getA, {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/class-binding/output.js
@@ -1,8 +1,8 @@
 var _A;
-var _A_brand = /*#__PURE__*/Symbol("getA");
+var _getA = /*#__PURE__*/Symbol("getA");
 class A {
   constructor() {
-    Object.defineProperty(this, _A_brand, {
+    Object.defineProperty(this, _getA, {
       get: _get_getA,
       set: void 0
     });

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/get-only-setter/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/get-only-setter/output.js
@@ -1,8 +1,8 @@
 var _privateField = /*#__PURE__*/Symbol("privateField");
-var _Cl_brand = /*#__PURE__*/Symbol("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/Symbol("privateFieldValue");
 class Cl {
   constructor() {
-    Object.defineProperty(this, _Cl_brand, {
+    Object.defineProperty(this, _privateFieldValue, {
       get: void 0,
       set: _set_privateFieldValue
     });
@@ -10,7 +10,7 @@ class Cl {
       writable: true,
       value: 0
     });
-    this.publicField = babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand];
+    this.publicField = babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
   }
 }
 function _set_privateFieldValue(newValue) {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/get-only-setter/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/get-only-setter/output.js
@@ -1,5 +1,5 @@
-var _privateField = /*#__PURE__*/Symbol("privateField");
-var _privateFieldValue = /*#__PURE__*/Symbol("privateFieldValue");
+var _privateField = Symbol("privateField");
+var _privateFieldValue = Symbol("privateFieldValue");
 class Cl {
   constructor() {
     Object.defineProperty(this, _privateFieldValue, {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/preserve-comments/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/preserve-comments/output.js
@@ -1,8 +1,8 @@
-var _C_brand = /*#__PURE__*/Symbol("a");
+var _a = /*#__PURE__*/Symbol("a");
 class C {
   constructor() {
     /* before get a */
-    Object.defineProperty(this, _C_brand, {
+    Object.defineProperty(this, _a, {
       get: _get_a,
       set: _set_a
     });

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/preserve-comments/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/preserve-comments/output.js
@@ -1,4 +1,4 @@
-var _a = /*#__PURE__*/Symbol("a");
+var _a = Symbol("a");
 class C {
   constructor() {
     /* before get a */

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/set-only-getter/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/set-only-getter/output.js
@@ -1,8 +1,8 @@
 var _privateField = /*#__PURE__*/Symbol("privateField");
-var _Cl_brand = /*#__PURE__*/Symbol("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/Symbol("privateFieldValue");
 class Cl {
   constructor() {
-    Object.defineProperty(this, _Cl_brand, {
+    Object.defineProperty(this, _privateFieldValue, {
       get: _get_privateFieldValue,
       set: void 0
     });
@@ -10,8 +10,8 @@ class Cl {
       writable: true,
       value: 0
     });
-    babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand] = 1;
-    [babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand]] = [1];
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = 1;
+    [babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue]] = [1];
   }
 }
 function _get_privateFieldValue() {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/set-only-getter/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/set-only-getter/output.js
@@ -1,5 +1,5 @@
-var _privateField = /*#__PURE__*/Symbol("privateField");
-var _privateFieldValue = /*#__PURE__*/Symbol("privateFieldValue");
+var _privateField = Symbol("privateField");
+var _privateFieldValue = Symbol("privateFieldValue");
 class Cl {
   constructor() {
     Object.defineProperty(this, _privateFieldValue, {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/updates/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/updates/output.js
@@ -1,5 +1,5 @@
-var _privateField = /*#__PURE__*/Symbol("privateField");
-var _privateFieldValue = /*#__PURE__*/Symbol("privateFieldValue");
+var _privateField = Symbol("privateField");
+var _privateFieldValue = Symbol("privateFieldValue");
 class Cl {
   constructor() {
     Object.defineProperty(this, _privateFieldValue, {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/updates/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/accessors-privateFieldsAsSymbols/updates/output.js
@@ -1,8 +1,8 @@
 var _privateField = /*#__PURE__*/Symbol("privateField");
-var _Cl_brand = /*#__PURE__*/Symbol("privateFieldValue");
+var _privateFieldValue = /*#__PURE__*/Symbol("privateFieldValue");
 class Cl {
   constructor() {
-    Object.defineProperty(this, _Cl_brand, {
+    Object.defineProperty(this, _privateFieldValue, {
       get: _get_privateFieldValue,
       set: _set_privateFieldValue
     });
@@ -13,10 +13,10 @@ class Cl {
     this.publicField = "not secret string";
   }
   publicGetPrivateField() {
-    return babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand];
+    return babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
   }
   publicSetPrivateField(newValue) {
-    babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand] = newValue;
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = newValue;
   }
   get publicFieldValue() {
     return this.publicField;
@@ -27,13 +27,13 @@ class Cl {
   testUpdates() {
     babelHelpers.classPrivateFieldLooseBase(this, _privateField)[_privateField] = 0;
     this.publicField = 0;
-    babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand] = babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand]++;
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue]++;
     this.publicFieldValue = this.publicFieldValue++;
-    ++babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand];
+    ++babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue];
     ++this.publicFieldValue;
-    babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand] += 1;
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] += 1;
     this.publicFieldValue += 1;
-    babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand] = -(babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand] ** babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand]);
+    babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] = -(babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue] ** babelHelpers.classPrivateFieldLooseBase(this, _privateFieldValue)[_privateFieldValue]);
     this.publicFieldValue = -(this.publicFieldValue ** this.publicFieldValue);
   }
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/assignment/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/assignment/output.js
@@ -1,4 +1,4 @@
-var _privateMethod = /*#__PURE__*/Symbol("privateMethod");
+var _privateMethod = Symbol("privateMethod");
 class Foo {
   constructor() {
     Object.defineProperty(this, _privateMethod, {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/assignment/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/assignment/output.js
@@ -1,12 +1,12 @@
-var _Foo_brand = /*#__PURE__*/Symbol("privateMethod");
+var _privateMethod = /*#__PURE__*/Symbol("privateMethod");
 class Foo {
   constructor() {
-    Object.defineProperty(this, _Foo_brand, {
-      value: _privateMethod
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
     });
-    this.publicField = babelHelpers.classPrivateFieldLooseBase(this, _Foo_brand)[_Foo_brand]();
+    this.publicField = babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod]();
   }
 }
-function _privateMethod() {
+function _privateMethod2() {
   return 42;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/before-fields/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/before-fields/output.js
@@ -1,20 +1,20 @@
 var _priv = /*#__PURE__*/Symbol("priv");
-var _Cl_brand = /*#__PURE__*/Symbol("method");
+var _method = /*#__PURE__*/Symbol("method");
 class Cl {
   constructor() {
-    Object.defineProperty(this, _Cl_brand, {
-      value: _method
+    Object.defineProperty(this, _method, {
+      value: _method2
     });
-    babelHelpers.defineProperty(this, "prop", babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand](1));
+    babelHelpers.defineProperty(this, "prop", babelHelpers.classPrivateFieldLooseBase(this, _method)[_method](1));
     Object.defineProperty(this, _priv, {
       writable: true,
-      value: babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand](2)
+      value: babelHelpers.classPrivateFieldLooseBase(this, _method)[_method](2)
     });
   }
   getPriv() {
     return babelHelpers.classPrivateFieldLooseBase(this, _priv)[_priv];
   }
 }
-function _method(x) {
+function _method2(x) {
   return x;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/before-fields/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/before-fields/output.js
@@ -1,5 +1,5 @@
-var _priv = /*#__PURE__*/Symbol("priv");
-var _method = /*#__PURE__*/Symbol("method");
+var _priv = Symbol("priv");
+var _method = Symbol("method");
 class Cl {
   constructor() {
     Object.defineProperty(this, _method, {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/class-binding/output.js
@@ -1,13 +1,13 @@
 var _A;
-var _A_brand = /*#__PURE__*/Symbol("getA");
+var _getA = /*#__PURE__*/Symbol("getA");
 class A {
   constructor() {
-    Object.defineProperty(this, _A_brand, {
-      value: _getA
+    Object.defineProperty(this, _getA, {
+      value: _getA2
     });
   }
 }
 _A = A;
-function _getA() {
+function _getA2() {
   return _A;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/class-binding/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/class-binding/output.js
@@ -1,5 +1,5 @@
 var _A;
-var _getA = /*#__PURE__*/Symbol("getA");
+var _getA = Symbol("getA");
 class A {
   constructor() {
     Object.defineProperty(this, _getA, {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/class-expression/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/class-expression/output.js
@@ -1,5 +1,5 @@
 var _foo;
-console.log((_foo = /*#__PURE__*/Symbol("foo"), class A {
+console.log((_foo = Symbol("foo"), class A {
   constructor() {
     Object.defineProperty(this, _foo, {
       value: _foo2

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/class-expression/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/class-expression/output.js
@@ -1,12 +1,12 @@
-var _A_brand;
-console.log((_A_brand = /*#__PURE__*/Symbol("foo"), class A {
+var _foo;
+console.log((_foo = /*#__PURE__*/Symbol("foo"), class A {
   constructor() {
-    Object.defineProperty(this, _A_brand, {
-      value: _foo
+    Object.defineProperty(this, _foo, {
+      value: _foo2
     });
   }
   method() {
-    babelHelpers.classPrivateFieldLooseBase(this, _A_brand)[_A_brand]();
+    babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
   }
 }));
-function _foo() {}
+function _foo2() {}

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/context/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/context/output.js
@@ -1,4 +1,4 @@
-var _getStatus = /*#__PURE__*/Symbol("getStatus");
+var _getStatus = Symbol("getStatus");
 class Foo {
   constructor(status) {
     Object.defineProperty(this, _getStatus, {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/context/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/context/output.js
@@ -1,19 +1,19 @@
-var _Foo_brand = /*#__PURE__*/Symbol("getStatus");
+var _getStatus = /*#__PURE__*/Symbol("getStatus");
 class Foo {
   constructor(status) {
-    Object.defineProperty(this, _Foo_brand, {
-      value: _getStatus
+    Object.defineProperty(this, _getStatus, {
+      value: _getStatus2
     });
     this.status = status;
   }
   getCurrentStatus() {
-    return babelHelpers.classPrivateFieldLooseBase(this, _Foo_brand)[_Foo_brand]();
+    return babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus]();
   }
   setCurrentStatus(newStatus) {
     this.status = newStatus;
   }
   getFakeStatus(fakeStatus) {
-    const fakeGetStatus = babelHelpers.classPrivateFieldLooseBase(this, _Foo_brand)[_Foo_brand];
+    const fakeGetStatus = babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus];
     return function () {
       return fakeGetStatus.call({
         status: fakeStatus
@@ -23,10 +23,10 @@ class Foo {
   getFakeStatusFunc() {
     return {
       status: 'fake-status',
-      getFakeStatus: babelHelpers.classPrivateFieldLooseBase(this, _Foo_brand)[_Foo_brand]
+      getFakeStatus: babelHelpers.classPrivateFieldLooseBase(this, _getStatus)[_getStatus]
     };
   }
 }
-function _getStatus() {
+function _getStatus2() {
   return this.status;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/exfiltrated/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/exfiltrated/output.js
@@ -1,13 +1,13 @@
 let exfiltrated;
-var _Foo_brand = /*#__PURE__*/Symbol("privateMethod");
+var _privateMethod = /*#__PURE__*/Symbol("privateMethod");
 class Foo {
   constructor() {
-    Object.defineProperty(this, _Foo_brand, {
-      value: _privateMethod
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
     });
     if (exfiltrated === undefined) {
-      exfiltrated = babelHelpers.classPrivateFieldLooseBase(this, _Foo_brand)[_Foo_brand];
+      exfiltrated = babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod];
     }
   }
 }
-function _privateMethod() {}
+function _privateMethod2() {}

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/exfiltrated/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/exfiltrated/output.js
@@ -1,5 +1,5 @@
 let exfiltrated;
-var _privateMethod = /*#__PURE__*/Symbol("privateMethod");
+var _privateMethod = Symbol("privateMethod");
 class Foo {
   constructor() {
     Object.defineProperty(this, _privateMethod, {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/generator/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/generator/output.js
@@ -1,4 +1,4 @@
-var _foo = /*#__PURE__*/Symbol("foo");
+var _foo = Symbol("foo");
 class Cl {
   constructor() {
     Object.defineProperty(this, _foo, {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/generator/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/generator/output.js
@@ -1,15 +1,15 @@
-var _Cl_brand = /*#__PURE__*/Symbol("foo");
+var _foo = /*#__PURE__*/Symbol("foo");
 class Cl {
   constructor() {
-    Object.defineProperty(this, _Cl_brand, {
-      value: _foo
+    Object.defineProperty(this, _foo, {
+      value: _foo2
     });
   }
   test() {
-    return babelHelpers.classPrivateFieldLooseBase(this, _Cl_brand)[_Cl_brand]();
+    return babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
   }
 }
-function* _foo() {
+function* _foo2() {
   yield 2;
   return 3;
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/super/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/super/output.js
@@ -4,22 +4,22 @@ class Base {
     return 'good';
   }
 }
-var _Sub_brand = /*#__PURE__*/Symbol("privateMethod");
+var _privateMethod = /*#__PURE__*/Symbol("privateMethod");
 class Sub extends Base {
   constructor(...args) {
     super(...args);
-    Object.defineProperty(this, _Sub_brand, {
-      value: _privateMethod
+    Object.defineProperty(this, _privateMethod, {
+      value: _privateMethod2
     });
   }
   superMethod() {
     return 'bad';
   }
   publicMethod() {
-    return babelHelpers.classPrivateFieldLooseBase(this, _Sub_brand)[_Sub_brand]();
+    return babelHelpers.classPrivateFieldLooseBase(this, _privateMethod)[_privateMethod]();
   }
 }
 _Sub = Sub;
-function _privateMethod() {
+function _privateMethod2() {
   return babelHelpers.get(babelHelpers.getPrototypeOf(_Sub.prototype), "superMethod", this).call(this);
 }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/super/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-privateFieldsAsSymbols/super/output.js
@@ -4,7 +4,7 @@ class Base {
     return 'good';
   }
 }
-var _privateMethod = /*#__PURE__*/Symbol("privateMethod");
+var _privateMethod = Symbol("privateMethod");
 class Sub extends Base {
   constructor(...args) {
     super(...args);

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/basic/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/basic/output.js
@@ -1,4 +1,4 @@
-var _privateStaticMethod = /*#__PURE__*/Symbol("privateStaticMethod");
+var _privateStaticMethod = Symbol("privateStaticMethod");
 class Cl {
   static staticMethod2() {
     return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticMethod)[_privateStaticMethod]();

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/class-check/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/class-check/output.js
@@ -1,4 +1,4 @@
-var _privateStaticMethod = /*#__PURE__*/Symbol("privateStaticMethod");
+var _privateStaticMethod = Symbol("privateStaticMethod");
 class Cl {
   publicMethod(checked) {
     return babelHelpers.classPrivateFieldLooseBase(checked, _privateStaticMethod)[_privateStaticMethod]();

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/class-expression/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/class-expression/output.js
@@ -1,5 +1,5 @@
 var _A, _foo;
-console.log((_foo = /*#__PURE__*/Symbol("foo"), (_A = class A {
+console.log((_foo = Symbol("foo"), (_A = class A {
   method() {
     babelHelpers.classPrivateFieldLooseBase(this, _foo)[_foo]();
   }

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/exfiltrated/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/exfiltrated/output.js
@@ -1,5 +1,5 @@
 let exfiltrated;
-var _privateStaticMethod = /*#__PURE__*/Symbol("privateStaticMethod");
+var _privateStaticMethod = Symbol("privateStaticMethod");
 class Cl {
   constructor() {
     if (exfiltrated === undefined) {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/generator/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/generator/output.js
@@ -1,4 +1,4 @@
-var _foo = /*#__PURE__*/Symbol("foo");
+var _foo = Symbol("foo");
 class Cl {
   test() {
     return babelHelpers.classPrivateFieldLooseBase(Cl, _foo)[_foo]();

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/reassignment/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/reassignment/output.js
@@ -1,4 +1,4 @@
-var _privateStaticMethod = /*#__PURE__*/Symbol("privateStaticMethod");
+var _privateStaticMethod = Symbol("privateStaticMethod");
 class Cl {
   constructor() {
     babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticMethod)[_privateStaticMethod] = null;

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/super/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/super/output.js
@@ -4,7 +4,7 @@ class Base {
     return 'good';
   }
 }
-var _subStaticPrivateMethod = /*#__PURE__*/Symbol("subStaticPrivateMethod");
+var _subStaticPrivateMethod = Symbol("subStaticPrivateMethod");
 class Sub extends Base {
   static basePublicStaticMethod() {
     return 'bad';

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/this/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/private-static-method-privateFieldsAsSymbols/this/output.js
@@ -4,8 +4,8 @@ class A {
     return 1;
   }
 }
-var _getA = /*#__PURE__*/Symbol("getA");
-var _getB = /*#__PURE__*/Symbol("getB");
+var _getA = Symbol("getA");
+var _getB = Symbol("getB");
 class B extends A {
   static get b() {
     return 2;

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/basic/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/basic/output.js
@@ -1,6 +1,6 @@
 var _Cl;
-var _PRIVATE_STATIC_FIELD = /*#__PURE__*/Symbol("PRIVATE_STATIC_FIELD");
-var _privateStaticFieldValue = /*#__PURE__*/Symbol("privateStaticFieldValue");
+var _PRIVATE_STATIC_FIELD = Symbol("PRIVATE_STATIC_FIELD");
+var _privateStaticFieldValue = Symbol("privateStaticFieldValue");
 class Cl {
   static getValue() {
     return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue];

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/destructure-set/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/destructure-set/output.js
@@ -1,6 +1,6 @@
 var _C;
-var _p = /*#__PURE__*/Symbol("p");
-var _q = /*#__PURE__*/Symbol("q");
+var _p = Symbol("p");
+var _q = Symbol("q");
 class C {
   constructor() {
     [babelHelpers.classPrivateFieldLooseBase(C, _p)[_p]] = [0];

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/get-only-setter/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/get-only-setter/output.js
@@ -1,6 +1,6 @@
 var _Cl;
-var _PRIVATE_STATIC_FIELD = /*#__PURE__*/Symbol("PRIVATE_STATIC_FIELD");
-var _privateStaticFieldValue = /*#__PURE__*/Symbol("privateStaticFieldValue");
+var _PRIVATE_STATIC_FIELD = Symbol("PRIVATE_STATIC_FIELD");
+var _privateStaticFieldValue = Symbol("privateStaticFieldValue");
 class Cl {
   static getPrivateStaticFieldValue() {
     return babelHelpers.classPrivateFieldLooseBase(Cl, _privateStaticFieldValue)[_privateStaticFieldValue];

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/preserve-comments/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/preserve-comments/output.js
@@ -1,4 +1,4 @@
-var _a = /*#__PURE__*/Symbol("a");
+var _a = Symbol("a");
 class C {}
 /* before get a */
 function _get_a() {

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/set-only-getter/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/set-only-getter/output.js
@@ -1,5 +1,5 @@
-var _privateField = /*#__PURE__*/Symbol("privateField");
-var _privateFieldValue = /*#__PURE__*/Symbol("privateFieldValue");
+var _privateField = Symbol("privateField");
+var _privateFieldValue = Symbol("privateFieldValue");
 class Cl {
   constructor() {
     babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue] = 1;

--- a/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/updates/output.js
+++ b/packages/babel-plugin-transform-private-methods/test/fixtures/static-accessors-privateFieldsAsSymbols/updates/output.js
@@ -1,6 +1,6 @@
 var _Cl;
-var _privateField = /*#__PURE__*/Symbol("privateField");
-var _privateFieldValue = /*#__PURE__*/Symbol("privateFieldValue");
+var _privateField = Symbol("privateField");
+var _privateFieldValue = Symbol("privateFieldValue");
 class Cl {
   static publicGetPrivateField() {
     return babelHelpers.classPrivateFieldLooseBase(Cl, _privateFieldValue)[_privateFieldValue];

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/exec.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/exec.js
@@ -1,0 +1,18 @@
+class Foo {
+  #foo() { }
+  #foo2() { }
+
+  test(other) {
+    return #foo in other;
+  }
+  test2(other) {
+    return #foo2 in other;
+  }
+}
+
+const cl = new Foo();
+
+expect(cl.test({})).toBe(false);
+expect(cl.test(cl)).toBe(true);
+expect(cl.test2({})).toBe(false);
+expect(cl.test2(cl)).toBe(true);

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/input.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/input.js
@@ -1,7 +1,11 @@
 class Foo {
-  #foo() {}
+  #foo() { }
+  #foo2() { }
 
   test(other) {
     return #foo in other;
+  }
+  test2(other) {
+    return #foo2 in other;
   }
 }

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsProperties/method/output.js
@@ -1,6 +1,10 @@
 var _foo = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo");
+var _foo3 = /*#__PURE__*/babelHelpers.classPrivateFieldLooseKey("foo2");
 class Foo {
   constructor() {
+    Object.defineProperty(this, _foo3, {
+      value: _foo4
+    });
     Object.defineProperty(this, _foo, {
       value: _foo2
     });
@@ -8,5 +12,9 @@ class Foo {
   test(other) {
     return Object.prototype.hasOwnProperty.call(babelHelpers.checkInRHS(other), _foo);
   }
+  test2(other) {
+    return Object.prototype.hasOwnProperty.call(babelHelpers.checkInRHS(other), _foo3);
+  }
 }
 function _foo2() {}
+function _foo4() {}

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/accessor/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/accessor/output.js
@@ -1,13 +1,13 @@
-var _Foo_brand = /*#__PURE__*/Symbol("foo");
+var _foo = /*#__PURE__*/Symbol("foo");
 class Foo {
   constructor() {
-    Object.defineProperty(this, _Foo_brand, {
+    Object.defineProperty(this, _foo, {
       get: _get_foo,
       set: void 0
     });
   }
   test(other) {
-    return Object.prototype.hasOwnProperty.call(babelHelpers.checkInRHS(other), _Foo_brand);
+    return Object.prototype.hasOwnProperty.call(babelHelpers.checkInRHS(other), _foo);
   }
 }
 function _get_foo() {}

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/accessor/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/accessor/output.js
@@ -1,4 +1,4 @@
-var _foo = /*#__PURE__*/Symbol("foo");
+var _foo = Symbol("foo");
 class Foo {
   constructor() {
     Object.defineProperty(this, _foo, {

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/compiled-classes/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/compiled-classes/output.js
@@ -1,5 +1,5 @@
-var _foo = /*#__PURE__*/Symbol("foo");
-var _bar = /*#__PURE__*/Symbol("bar");
+var _foo = Symbol("foo");
+var _bar = Symbol("bar");
 let Foo = /*#__PURE__*/function () {
   "use strict";
 

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/field/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/field/output.js
@@ -1,4 +1,4 @@
-var _foo = /*#__PURE__*/Symbol("foo");
+var _foo = Symbol("foo");
 class Foo {
   constructor() {
     Object.defineProperty(this, _foo, {

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/method/exec.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/method/exec.js
@@ -1,0 +1,18 @@
+class Foo {
+  #foo() { }
+  #foo2() { }
+
+  test(other) {
+    return #foo in other;
+  }
+  test2(other) {
+    return #foo2 in other;
+  }
+}
+
+const cl = new Foo();
+
+expect(cl.test({})).toBe(false);
+expect(cl.test(cl)).toBe(true);
+expect(cl.test2({})).toBe(false);
+expect(cl.test2(cl)).toBe(true);

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/method/input.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/method/input.js
@@ -1,7 +1,11 @@
 class Foo {
-  #foo() {}
+  #foo() { }
+  #foo2() { }
 
   test(other) {
+    return #foo in other;
+  }
+  test2(other) {
     return #foo in other;
   }
 }

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/method/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/method/output.js
@@ -1,5 +1,5 @@
-var _foo = /*#__PURE__*/Symbol("foo");
-var _foo3 = /*#__PURE__*/Symbol("foo2");
+var _foo = Symbol("foo");
+var _foo3 = Symbol("foo2");
 class Foo {
   constructor() {
     Object.defineProperty(this, _foo3, {

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/method/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/method/output.js
@@ -1,12 +1,20 @@
-var _Foo_brand = /*#__PURE__*/Symbol("foo");
+var _foo = /*#__PURE__*/Symbol("foo");
+var _foo3 = /*#__PURE__*/Symbol("foo2");
 class Foo {
   constructor() {
-    Object.defineProperty(this, _Foo_brand, {
-      value: _foo
+    Object.defineProperty(this, _foo3, {
+      value: _foo4
+    });
+    Object.defineProperty(this, _foo, {
+      value: _foo2
     });
   }
   test(other) {
-    return Object.prototype.hasOwnProperty.call(babelHelpers.checkInRHS(other), _Foo_brand);
+    return Object.prototype.hasOwnProperty.call(babelHelpers.checkInRHS(other), _foo);
+  }
+  test2(other) {
+    return Object.prototype.hasOwnProperty.call(babelHelpers.checkInRHS(other), _foo);
   }
 }
-function _foo() {}
+function _foo2() {}
+function _foo4() {}

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/nested-class-other-redeclared/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/nested-class-other-redeclared/output.js
@@ -1,5 +1,5 @@
-var _foo = /*#__PURE__*/Symbol("foo");
-var _bar = /*#__PURE__*/Symbol("bar");
+var _foo = Symbol("foo");
+var _bar = Symbol("bar");
 class Foo {
   constructor() {
     Object.defineProperty(this, _foo, {
@@ -12,7 +12,7 @@ class Foo {
     });
   }
   test() {
-    var _bar2 = /*#__PURE__*/Symbol("bar");
+    var _bar2 = Symbol("bar");
     class Nested {
       constructor() {
         Object.defineProperty(this, _bar2, {

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/nested-class-redeclared/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/nested-class-redeclared/output.js
@@ -1,4 +1,4 @@
-var _foo = /*#__PURE__*/Symbol("foo");
+var _foo = Symbol("foo");
 class Foo {
   constructor() {
     Object.defineProperty(this, _foo, {
@@ -7,7 +7,7 @@ class Foo {
     });
   }
   test() {
-    var _foo2 = /*#__PURE__*/Symbol("foo");
+    var _foo2 = Symbol("foo");
     class Nested {
       constructor() {
         Object.defineProperty(this, _foo2, {

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/nested-class/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/nested-class/output.js
@@ -1,4 +1,4 @@
-var _foo = /*#__PURE__*/Symbol("foo");
+var _foo = Symbol("foo");
 class Foo {
   constructor() {
     Object.defineProperty(this, _foo, {

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/static-accessor/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/static-accessor/output.js
@@ -1,4 +1,4 @@
-var _foo = /*#__PURE__*/Symbol("foo");
+var _foo = Symbol("foo");
 class Foo {
   test(other) {
     return Object.prototype.hasOwnProperty.call(babelHelpers.checkInRHS(other), _foo);

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/static-field/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/static-field/output.js
@@ -1,4 +1,4 @@
-var _foo = /*#__PURE__*/Symbol("foo");
+var _foo = Symbol("foo");
 class Foo {
   test(other) {
     return Object.prototype.hasOwnProperty.call(babelHelpers.checkInRHS(other), _foo);

--- a/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/static-method/output.js
+++ b/packages/babel-plugin-transform-private-property-in-object/test/fixtures/assumption-privateFieldsAsSymbols/static-method/output.js
@@ -1,4 +1,4 @@
-var _foo = /*#__PURE__*/Symbol("foo");
+var _foo = Symbol("foo");
 class Foo {
   test(other) {
     return Object.prototype.hasOwnProperty.call(babelHelpers.checkInRHS(other), _foo);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Ref: https://github.com/babel/babel/pull/16261

I found it while looking to see if there was still anything that could be optimized, it wasn't published and wouldn't affect anyone. :)
`Symbol` should be treated as pure by modern minimizers.