### PR TITLE
Fix decorator memoiser binding kind

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -129,13 +129,14 @@ function replaceClassWithVar(
   id: t.Identifier;
   path: NodePath<t.ClassDeclaration | t.ClassExpression>;
 } {
+  const id = path.node.id;
+  const scope = path.scope;
   if (path.type === "ClassDeclaration") {
-    const id = path.node.id;
     const className = id.name;
-    const varId = path.scope.generateUidIdentifierBasedOnNode(id);
+    const varId = scope.generateUidIdentifierBasedOnNode(id);
     const classId = t.identifier(className);
 
-    path.scope.rename(className, varId.name);
+    scope.rename(className, varId.name);
 
     path.get("id").replaceWith(classId);
 
@@ -143,12 +144,13 @@ function replaceClassWithVar(
   } else {
     let varId: t.Identifier;
 
-    if (path.node.id) {
-      className = path.node.id.name;
-      varId = path.scope.parent.generateDeclaredUidIdentifier(className);
-      path.scope.rename(className, varId.name);
+    if (id) {
+      className = id.name;
+      varId = generateLetUidIdentifier(scope.parent, className);
+      scope.rename(className, varId.name);
     } else {
-      varId = path.scope.parent.generateDeclaredUidIdentifier(
+      varId = generateLetUidIdentifier(
+        scope.parent,
         typeof className === "string" ? className : "decorated_class",
       );
     }
@@ -1005,7 +1007,7 @@ function transformClass(
     hint: string,
     assignments: t.AssignmentExpression[],
   ) => {
-    const localEvaluatedId = scopeParent.generateDeclaredUidIdentifier(hint);
+    const localEvaluatedId = generateLetUidIdentifier(scopeParent, hint);
     assignments.push(t.assignmentExpression("=", localEvaluatedId, expression));
     return t.cloneNode(localEvaluatedId);
   };
@@ -1048,11 +1050,15 @@ function transformClass(
         /* fallthrough */
         default:
           if (element.node.static) {
-            staticInitLocal ??=
-              scopeParent.generateDeclaredUidIdentifier("initStatic");
+            staticInitLocal ??= generateLetUidIdentifier(
+              scopeParent,
+              "initStatic",
+            );
           } else {
-            protoInitLocal ??=
-              scopeParent.generateDeclaredUidIdentifier("initProto");
+            protoInitLocal ??= generateLetUidIdentifier(
+              scopeParent,
+              "initProto",
+            );
           }
           break;
       }
@@ -1142,8 +1148,7 @@ function transformClass(
         } else if (scopeParent.isStatic(expression.object)) {
           object = t.cloneNode(expression.object);
         } else {
-          decoratorReceiverId ??=
-            scopeParent.generateDeclaredUidIdentifier("obj");
+          decoratorReceiverId ??= generateLetUidIdentifier(scopeParent, "obj");
           object = t.assignmentExpression(
             "=",
             t.cloneNode(decoratorReceiverId),
@@ -1170,7 +1175,7 @@ function transformClass(
   let classDecorations: t.Expression[] = [];
   let classDecorationsId: t.Identifier;
   if (classDecorators) {
-    classInitLocal = scopeParent.generateDeclaredUidIdentifier("initClass");
+    classInitLocal = generateLetUidIdentifier(scopeParent, "initClass");
     needsDeclaraionForClassBinding = path.isClassDeclaration();
     ({ id: classIdLocal, path } = replaceClassWithVar(path, className));
 
@@ -1346,8 +1351,10 @@ function transformClass(
           }
 
           const newId = generateClassPrivateUid();
-          const newFieldInitId =
-            element.scope.parent.generateDeclaredUidIdentifier(`init_${name}`);
+          const newFieldInitId = generateLetUidIdentifier(
+            scopeParent,
+            `init_${name}`,
+          );
           const newValue = t.callExpression(
             t.cloneNode(newFieldInitId),
             params,
@@ -1359,12 +1366,8 @@ function transformClass(
           if (isPrivate) {
             privateMethods = extractProxyAccessorsFor(newId, version);
 
-            const getId = newPath.scope.parent.generateDeclaredUidIdentifier(
-              `get_${name}`,
-            );
-            const setId = newPath.scope.parent.generateDeclaredUidIdentifier(
-              `set_${name}`,
-            );
+            const getId = generateLetUidIdentifier(scopeParent, `get_${name}`);
+            const setId = generateLetUidIdentifier(scopeParent, `set_${name}`);
 
             addCallAccessorsFor(version, newPath, key, getId, setId, isStatic);
 
@@ -1385,9 +1388,7 @@ function transformClass(
             locals = [newFieldInitId];
           }
         } else if (kind === FIELD) {
-          const initId = element.scope.parent.generateDeclaredUidIdentifier(
-            `init_${name}`,
-          );
+          const initId = generateLetUidIdentifier(scopeParent, `init_${name}`);
           const valuePath = (
             element as NodePath<t.ClassProperty | t.ClassPrivateProperty>
           ).get("value");
@@ -1406,7 +1407,8 @@ function transformClass(
             privateMethods = extractProxyAccessorsFor(key, version);
           }
         } else if (isPrivate) {
-          const callId = element.scope.parent.generateDeclaredUidIdentifier(
+          const callId = generateLetUidIdentifier(
+            element.scope.parent,
             `call_${name}`,
           );
           locals = [callId];
@@ -1508,7 +1510,8 @@ function transformClass(
 
       if (hasDecorators && version === "2023-11") {
         if (kind === FIELD || kind === ACCESSOR) {
-          const initExtraId = scopeParent.generateDeclaredUidIdentifier(
+          const initExtraId = generateLetUidIdentifier(
+            scopeParent,
             `init_extra_${name}`,
           );
           locals.push(initExtraId);
@@ -2138,6 +2141,12 @@ function isDecoratedAnonymousClassExpression(path: NodePath) {
   return (
     path.isClassExpression({ id: null }) && shouldTransformClass(path.node)
   );
+}
+
+function generateLetUidIdentifier(scope: Scope, name: string) {
+  const id = scope.generateUidIdentifier(name);
+  scope.push({ id, kind: "let" });
+  return t.cloneNode(id);
 }
 
 export default function (

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1407,10 +1407,7 @@ function transformClass(
             privateMethods = extractProxyAccessorsFor(key, version);
           }
         } else if (isPrivate) {
-          const callId = generateLetUidIdentifier(
-            element.scope.parent,
-            `call_${name}`,
-          );
+          const callId = generateLetUidIdentifier(scopeParent, `call_${name}`);
           locals = [callId];
 
           const replaceSupers = new ReplaceSupers({

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _Foo;
+var _Foo;
+let _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
+var _Foo;
+let _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _Foo_brand = /*#__PURE__*/new WeakSet();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
+var _Foo;
+let _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7;
+let _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
+let _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/public/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a, _init_b, _init_computedKey;
+let _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
+let _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-accessors/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _init_a, _init_b, _init_computedKey;
+let _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/super-in-nested-constructor-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/super-in-nested-constructor-expression/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 class Foo extends Bar {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-assumption-constantSuper/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions-static-blocks/output.js
@@ -1,5 +1,5 @@
-let _A2, _C2, _D2, _ref, _G2, _ref2, _H2, _K2;
-var _initClass, _A, _Class, _A3, _initClass2, _C, _Class2, _C3, _initClass3, _D, _Class3, _D3, _initClass4, _decorated_class, _Class4, _Class5, _initClass5, _G, _Class6, _G3, _initClass6, _decorated_class2, _Class7, _Class8, _initClass7, _H, _Class9, _H3, _initClass8, _K, _Class10, _K3;
+var _Class, _A3, _Class2, _C3, _Class3, _D3, _Class4, _Class5, _Class6, _G3, _Class7, _Class8, _Class9, _H3, _Class10, _K3;
+let _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _ref, _initClass5, _G, _G2, _initClass6, _decorated_class2, _ref2, _initClass7, _H, _H2, _initClass8, _K, _K2;
 const dec = () => {};
 const A = (new (_A2 = (_A3 = class A {}, [_A, _initClass] = babelHelpers.applyDecs(_A3, [], [dec]), _A3), (_Class = class extends babelHelpers.identity {
   constructor() {
@@ -41,8 +41,8 @@ const J = (new (_K2 = (_K3 = class K extends L {}, [_K, _initClass8] = babelHelp
   }
 }, babelHelpers.defineProperty(_Class10, _K2, void 0), _Class10))(), _K);
 function classFactory() {
-  let _ref3;
-  var _initClass9, _decorated_class3, _Class11, _Class12;
+  var _Class11, _Class12;
+  let _initClass9, _decorated_class3, _ref3;
   return new (_ref3 = (_Class12 = class _ref3 {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs(_Class12, [], [dec]), _Class12), (_Class11 = class extends babelHelpers.identity {
     constructor() {
       super(_decorated_class3), (() => {})(), _initClass9();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/expressions/output.js
@@ -1,4 +1,5 @@
-var _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _Class, _initClass5, _G, _G2, _initClass6, _decorated_class2, _Class2, _initClass7, _H, _H2, _initClass8, _K, _K2;
+var _A2, _C2, _D2, _Class, _G2, _Class2, _H2, _K2;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = ((_A2 = class A {}, [_A, _initClass] = babelHelpers.applyDecs(_A2, [], [dec]), _initClass()), _A);
 const B = ((_C2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs(_C2, [], [dec]), _initClass2()), _C);
@@ -8,6 +9,7 @@ const F = [((_G2 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs(_G2, [
 const H = ((_H2 = class H extends I {}, [_H, _initClass7] = babelHelpers.applyDecs(_H2, [], [dec]), _initClass7()), _H);
 const J = ((_K2 = class K extends L {}, [_K, _initClass8] = babelHelpers.applyDecs(_K2, [], [dec]), _initClass8()), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _Class3;
+  var _Class3;
+  let _initClass9, _decorated_class3;
   return (_Class3 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs(_Class3, [], [dec]), _initClass9()), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/inheritance/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar2, _initClass2, _Foo2;
+var _Bar2, _Foo2;
+let _initClass, _initClass2;
 const dec1 = () => {};
 const dec2 = () => {};
 let _Bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/initializers/output.js
@@ -1,5 +1,5 @@
-let _Foo2, _Bar2;
-var _initClass, _Class, _Foo3, _initClass2, _Class2, _Bar3;
+var _Class, _Foo3, _Class2, _Bar3;
+let _initClass, _Foo2, _initClass2, _Bar2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs(_Foo3, [], [dec]), _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _x, _A, _Class_brand, _B, _Foo3;
+var _Class, _x, _A, _Class_brand, _B, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let hasX, hasA, hasM;
 let _Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-static-this/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _Foo3;
+var _Class, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs(_Foo3, [], [dec]), _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement-with-expr/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar, _Bar2;
+var _Bar2;
+let _initClass, _Bar;
 const dec = () => {};
 const Foo = ((_Bar2 = class Bar {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes--to-es2015/replacement/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _Foo3;
+var _Class, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs(_Foo3, [], [dec]), _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/expressions-static-blocks/output.js
@@ -1,4 +1,4 @@
-var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = (new class extends babelHelpers.identity {
   static [class A {
@@ -80,7 +80,7 @@ const J = (new class extends babelHelpers.identity {
   }
 }(), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3;
+  let _initClass9, _decorated_class3;
   return new class extends babelHelpers.identity {
     static [class {
       static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/expressions/output.js
@@ -1,4 +1,4 @@
-var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = (class A {
   static {
@@ -64,7 +64,7 @@ const J = (class K extends L {
   }
 }, _K);
 function classFactory() {
-  var _initClass9, _decorated_class3;
+  let _initClass9, _decorated_class3;
   return class {
     static {
       [_decorated_class3, _initClass9] = babelHelpers.applyDecs(this, [], [dec]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/inheritance/output.js
@@ -1,4 +1,4 @@
-var _initClass, _classDecs, _initClass2, _classDecs2;
+let _initClass, _classDecs, _initClass2, _classDecs2;
 const dec = () => {};
 _classDecs = [dec1];
 let _Bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/initializers/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initClass2;
+let _initClass, _initClass2;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement-static-installed-on-correct-class/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let hasX, hasA, hasM;
 let _Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement-static-this/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement-with-expr/output.js
@@ -1,4 +1,4 @@
-var _initClass, _Bar;
+let _initClass, _Bar;
 const dec = () => {};
 const Foo = (class Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-classes/replacement/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,5 +1,5 @@
-let _computedKey, _computedKey2;
-var _initProto, _Foo;
+var _Foo;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,5 +1,5 @@
-let _computedKey, _computedKey2;
-var _initProto, _Foo;
+var _Foo;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _Foo;
+var _Foo;
+let _initProto, _init_a;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys--to-es2015/methods-with-same-key/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,5 +1,4 @@
-let _computedKey, _computedKey2;
-var _initProto;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/computed-keys-same-value/output.js
@@ -1,5 +1,4 @@
-let _computedKey, _computedKey2;
-var _initProto;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a;
+let _initProto, _init_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-duplicated-keys/methods-with-same-key/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-anonymous/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _A;
 class A {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/default-named/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _default2;
 class _default {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/member-decorator/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/member-decorator/output.mjs
@@ -1,4 +1,4 @@
-var _xDecs, _init_x;
+let _xDecs, _init_x;
 export class A {
   static {
     [_init_x] = babelHelpers.applyDecs(this, [[_xDecs, 0, "x"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-exported/named/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _A;
 class A {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _Foo;
+var _Foo;
+let _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _Foo;
+var _Foo;
+let _init_a, _init_b;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _Foo;
+var _Foo;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7;
+let _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-fields/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _call_a2, _Foo;
+var _Foo;
+let _initProto, _call_a, _call_a2;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _call_a2, _Foo;
+var _Foo;
+let _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a, _call_a2;
+let _initProto, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a, _call_a2;
+let _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters-and-setters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-getters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static callA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-methods/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,5 @@
-let _ref;
-var _initProto, _methodDecs, _A;
+var _A;
+let _initProto, _methodDecs, _ref;
 const dec = () => {};
 _ref = (_methodDecs = deco, "method");
 class A extends B {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc--to-es2015/valid-expression-formats/output.js
@@ -1,5 +1,5 @@
-let _ref;
-var _initProto, _initClass, _classDecs, _methodDecs, _Foo2;
+var _Foo2;
+let _initProto, _initClass, _classDecs, _methodDecs, _ref;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
@@ -11,8 +11,8 @@ class Foo {
   }
   [_ref]() {}
   makeClass() {
-    let _ref2;
-    var _barDecs, _init_bar, _Nested;
+    var _Nested;
+    let _barDecs, _init_bar, _ref2;
     return _ref2 = (_barDecs = babelHelpers.classPrivateFieldGet2(_a, this), "bar"), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, _ref2, _init_bar(this));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/all-decorators/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
+let _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
 const dec = () => {};
 let _Class;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,4 +1,4 @@
-var _initProto, _methodDecs, _initProto2, _methodDecs2;
+let _initProto, _methodDecs, _initProto2, _methodDecs2;
 const dec = () => {};
 class A extends B {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,5 @@
 {
-  var _initProto;
+  let _initProto;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -41,7 +41,7 @@
     }
   }
   {
-    var _initProto2;
+    let _initProto2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -68,8 +68,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        let _computedKey;
-        var _initProto3;
+        let _initProto3, _computedKey;
         let key;
         class A extends B {
           static {
@@ -94,7 +93,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _noopDecs;
+        let _initProto4, _noopDecs;
         class A extends B {
           static {
             [_initProto4] = babelHelpers.applyDecs(this, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], []);
@@ -113,7 +112,7 @@
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5;
+    let _initProto5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -137,7 +136,7 @@
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6;
+    let _initProto6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
@@ -146,7 +145,7 @@
         [_initProto6] = babelHelpers.applyDecs(this, [[dec, 2, "method"]], []);
       }
       constructor() {
-        var _initProto7, _noopDecs2;
+        let _initProto7, _noopDecs2;
         new class Dummy extends B {
           static {
             [_initProto7] = babelHelpers.applyDecs(this, [[_noopDecs2, 2, "noop"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/super-in-nested-constructor-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/super-in-nested-constructor-expression/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 class Foo extends Bar {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-misc/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initClass, _classDecs, _methodDecs;
+let _initProto, _initClass, _classDecs, _methodDecs;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
@@ -9,7 +9,7 @@ class Foo {
   #a = void _initProto(this);
   [(_methodDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]], "method")]() {}
   makeClass() {
-    var _barDecs, _init_bar;
+    let _barDecs, _init_bar;
     return class Nested {
       static {
         [_init_bar] = babelHelpers.applyDecs(this, [[_barDecs, 0, "bar"]], []);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static setA(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static set a(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2021-12-setters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _Foo;
+var _Foo;
+let _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
+var _Foo;
+let _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _Foo_brand = /*#__PURE__*/new WeakSet();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
+var _Foo;
+let _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7;
+let _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
+let _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/public/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a, _init_b, _init_computedKey;
+let _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
+let _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-accessors/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _init_a, _init_b, _init_computedKey;
+let _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/super-in-nested-constructor-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/super-in-nested-constructor-expression/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 class Foo extends Bar {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-assumption-constantSuper/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/decorator-access-modified-fields/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/decorator-access-modified-fields/output.js
@@ -1,4 +1,5 @@
-var _initClass, _init_m, _C2;
+var _C2;
+let _initClass, _init_m;
 var value;
 const classDec = Class => {
   value = new Class().p;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/decorator-access-modified-methods/output.js
@@ -1,4 +1,5 @@
-var _initProto, _initClass, _C2;
+var _C2;
+let _initProto, _initClass;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions-static-blocks/output.js
@@ -1,5 +1,5 @@
-let _A2, _C2, _D2, _ref, _G2, _ref2, _H2, _K2;
-var _initClass, _A, _Class, _A3, _initClass2, _C, _Class2, _C3, _initClass3, _D, _Class3, _D3, _initClass4, _decorated_class, _Class4, _Class5, _initClass5, _G, _Class6, _G3, _initClass6, _decorated_class2, _Class7, _Class8, _initClass7, _H, _Class9, _H3, _initClass8, _K, _Class10, _K3;
+var _Class, _A3, _Class2, _C3, _Class3, _D3, _Class4, _Class5, _Class6, _G3, _Class7, _Class8, _Class9, _H3, _Class10, _K3;
+let _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _ref, _initClass5, _G, _G2, _initClass6, _decorated_class2, _ref2, _initClass7, _H, _H2, _initClass8, _K, _K2;
 const dec = () => {};
 const A = (new (_A2 = (_A3 = class A {}, [_A, _initClass] = babelHelpers.applyDecs2203R(_A3, [], [dec]).c, _A3), (_Class = class extends babelHelpers.identity {
   constructor() {
@@ -41,8 +41,8 @@ const J = (new (_K2 = (_K3 = class K extends L {}, [_K, _initClass8] = babelHelp
   }
 }, babelHelpers.defineProperty(_Class10, _K2, void 0), _Class10))(), _K);
 function classFactory() {
-  let _ref3;
-  var _initClass9, _decorated_class3, _Class11, _Class12;
+  var _Class11, _Class12;
+  let _initClass9, _decorated_class3, _ref3;
   return new (_ref3 = (_Class12 = class _ref3 {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2203R(_Class12, [], [dec]).c, _Class12), (_Class11 = class extends babelHelpers.identity {
     constructor() {
       super(_decorated_class3), (() => {})(), _initClass9();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/expressions/output.js
@@ -1,4 +1,5 @@
-var _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _Class, _initClass5, _G, _G2, _initClass6, _decorated_class2, _Class2, _initClass7, _H, _H2, _initClass8, _K, _K2;
+var _A2, _C2, _D2, _Class, _G2, _Class2, _H2, _K2;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = ((_A2 = class A {}, [_A, _initClass] = babelHelpers.applyDecs2203R(_A2, [], [dec]).c, _initClass()), _A);
 const B = ((_C2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs2203R(_C2, [], [dec]).c, _initClass2()), _C);
@@ -8,6 +9,7 @@ const F = [((_G2 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs2203R(_
 const H = ((_H2 = class H extends I {}, [_H, _initClass7] = babelHelpers.applyDecs2203R(_H2, [], [dec]).c, _initClass7()), _H);
 const J = ((_K2 = class K extends L {}, [_K, _initClass8] = babelHelpers.applyDecs2203R(_K2, [], [dec]).c, _initClass8()), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _Class3;
+  var _Class3;
+  let _initClass9, _decorated_class3;
   return (_Class3 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2203R(_Class3, [], [dec]).c, _initClass9()), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/inheritance/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar2, _initClass2, _Foo2;
+var _Bar2, _Foo2;
+let _initClass, _initClass2;
 const dec1 = () => {};
 const dec2 = () => {};
 let _Bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/initializers/output.js
@@ -1,5 +1,5 @@
-let _Foo2, _Bar2;
-var _initClass, _Class, _Foo3, _initClass2, _Class2, _Bar3;
+var _Class, _Foo3, _Class2, _Bar3;
+let _initClass, _Foo2, _initClass2, _Bar2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2203R(_Foo3, [], [dec]).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _x, _A, _Class_brand, _B, _Foo3;
+var _Class, _x, _A, _Class_brand, _B, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let hasX, hasA, hasM;
 let _Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-static-this/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _Foo3;
+var _Class, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2203R(_Foo3, [], [dec]).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement-with-expr/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar, _Bar2;
+var _Bar2;
+let _initClass, _Bar;
 const dec = () => {};
 const Foo = ((_Bar2 = class Bar {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes--to-es2015/replacement/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _Foo3;
+var _Class, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2203R(_Foo3, [], [dec]).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/decorator-access-modified-fields/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/decorator-access-modified-fields/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_m;
+let _initClass, _init_m;
 var value;
 const classDec = Class => {
   value = new Class().p;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initClass;
+let _initProto, _initClass;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/expressions-static-blocks/output.js
@@ -1,4 +1,4 @@
-var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = (new class extends babelHelpers.identity {
   static [class A {
@@ -80,7 +80,7 @@ const J = (new class extends babelHelpers.identity {
   }
 }(), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3;
+  let _initClass9, _decorated_class3;
   return new class extends babelHelpers.identity {
     static [class {
       static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/expressions/output.js
@@ -1,4 +1,4 @@
-var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = (class A {
   static {
@@ -64,7 +64,7 @@ const J = (class K extends L {
   }
 }, _K);
 function classFactory() {
-  var _initClass9, _decorated_class3;
+  let _initClass9, _decorated_class3;
   return class {
     static {
       [_decorated_class3, _initClass9] = babelHelpers.applyDecs2203R(this, [], [dec]).c;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/inheritance/output.js
@@ -1,4 +1,4 @@
-var _initClass, _classDecs, _initClass2, _classDecs2;
+let _initClass, _classDecs, _initClass2, _classDecs2;
 const dec = () => {};
 _classDecs = [dec1];
 let _Bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/initializers/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initClass2;
+let _initClass, _initClass2;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement-static-installed-on-correct-class/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let hasX, hasA, hasM;
 let _Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement-static-this/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement-with-expr/output.js
@@ -1,4 +1,4 @@
-var _initClass, _Bar;
+let _initClass, _Bar;
 const dec = () => {};
 const Foo = (class Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-classes/replacement/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,5 +1,5 @@
-let _computedKey, _computedKey2;
-var _initProto, _Foo;
+var _Foo;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,5 +1,5 @@
-let _computedKey, _computedKey2;
-var _initProto, _Foo;
+var _Foo;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _Foo;
+var _Foo;
+let _initProto, _init_a;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys--to-es2015/methods-with-same-key/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,5 +1,4 @@
-let _computedKey, _computedKey2;
-var _initProto;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/computed-keys-same-value/output.js
@@ -1,5 +1,4 @@
-let _computedKey, _computedKey2;
-var _initProto;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a;
+let _initProto, _init_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-duplicated-keys/methods-with-same-key/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/default-anonymous/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _A;
 class A {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/default-named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/default-named/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _default2;
 class _default {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/member-decorator/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/member-decorator/output.mjs
@@ -1,4 +1,4 @@
-var _xDecs, _init_x;
+let _xDecs, _init_x;
 export class A {
   static {
     [_init_x] = babelHelpers.applyDecs2203R(this, [[_xDecs, 0, "x"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-exported/named/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _A;
 class A {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _Foo;
+var _Foo;
+let _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _Foo;
+var _Foo;
+let _init_a, _init_b;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _Foo;
+var _Foo;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7;
+let _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-fields/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _call_a2, _Foo;
+var _Foo;
+let _initProto, _call_a, _call_a2;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _call_a2, _Foo;
+var _Foo;
+let _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a, _call_a2;
+let _initProto, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a, _call_a2;
+let _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters-and-setters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-getters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static callA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-methods/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,6 @@
 {
-  var _initProto, _A;
+  var _A;
+  let _initProto;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -40,7 +41,8 @@
     }
   }
   {
-    var _initProto2, _A2;
+    var _A2;
+    let _initProto2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -66,8 +68,8 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        let _computedKey;
-        var _initProto3, _A3;
+        var _A3;
+        let _initProto3, _computedKey;
         let key;
         _computedKey = (key = super(5).method(), log.push(key), key);
         class A extends B {
@@ -91,8 +93,8 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        let _ref;
-        var _initProto4, _noopDecs, _A4;
+        var _A4;
+        let _initProto4, _noopDecs, _ref;
         _ref = (_noopDecs = noop(log.push(super(7).method())), "method");
         class A extends B {
           constructor() {
@@ -111,7 +113,8 @@
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5, _A5;
+    var _A5;
+    let _initProto5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -134,14 +137,15 @@
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6, _A6;
+    var _A6;
+    let _initProto6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        let _ref3;
-        var _initProto7, _noopDecs2, _Dummy2;
+        var _Dummy2;
+        let _initProto7, _noopDecs2, _ref3;
         new (_ref3 = (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), "noop"), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc--to-es2015/valid-expression-formats/output.js
@@ -1,5 +1,5 @@
-let _ref;
-var _initProto, _initClass, _classDecs, _methodDecs, _Foo2;
+var _Foo2;
+let _initProto, _initClass, _classDecs, _methodDecs, _ref;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
@@ -11,8 +11,8 @@ class Foo {
   }
   [_ref]() {}
   makeClass() {
-    let _ref2;
-    var _barDecs, _init_bar, _Nested;
+    var _Nested;
+    let _barDecs, _init_bar, _ref2;
     return _ref2 = (_barDecs = babelHelpers.classPrivateFieldGet2(_a, this), "bar"), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, _ref2, _init_bar(this));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/all-decorators/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
+let _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
 const dec = () => {};
 let _Class;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,4 +1,4 @@
-var _initProto, _methodDecs, _initProto2, _methodDecs2;
+let _initProto, _methodDecs, _initProto2, _methodDecs2;
 const dec = () => {};
 class A extends B {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,5 @@
 {
-  var _initProto;
+  let _initProto;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -41,7 +41,7 @@
     }
   }
   {
-    var _initProto2;
+    let _initProto2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -68,8 +68,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        let _computedKey;
-        var _initProto3;
+        let _initProto3, _computedKey;
         let key;
         class A extends B {
           static {
@@ -94,7 +93,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _noopDecs;
+        let _initProto4, _noopDecs;
         class A extends B {
           static {
             [_initProto4] = babelHelpers.applyDecs2203R(this, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], []).e;
@@ -113,7 +112,7 @@
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5;
+    let _initProto5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -137,7 +136,7 @@
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6;
+    let _initProto6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
@@ -146,7 +145,7 @@
         [_initProto6] = babelHelpers.applyDecs2203R(this, [[dec, 2, "method"]], []).e;
       }
       constructor() {
-        var _initProto7, _noopDecs2;
+        let _initProto7, _noopDecs2;
         new class Dummy extends B {
           static {
             [_initProto7] = babelHelpers.applyDecs2203R(this, [[_noopDecs2, 2, "noop"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/super-in-nested-constructor-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/super-in-nested-constructor-expression/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 class Foo extends Bar {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-misc/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initClass, _classDecs, _methodDecs;
+let _initProto, _initClass, _classDecs, _methodDecs;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
@@ -12,7 +12,7 @@ class Foo {
   #a = void _initProto(this);
   [(_methodDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]], "method")]() {}
   makeClass() {
-    var _barDecs, _init_bar;
+    let _barDecs, _init_bar;
     return class Nested {
       static {
         [_init_bar] = babelHelpers.applyDecs2203R(this, [[_barDecs, 0, "bar"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static setA(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static set a(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2022-03-setters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _Foo;
+var _Foo;
+let _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
+var _Foo;
+let _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _Foo_brand = /*#__PURE__*/new WeakSet();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
+var _Foo;
+let _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7;
+let _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
+let _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/public/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a, _init_b, _init_computedKey;
+let _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
+let _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-accessors/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _init_a, _init_b, _init_computedKey;
+let _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/super-in-nested-constructor-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/super-in-nested-constructor-expression/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 class Foo extends Bar {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-assumption-constantSuper/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/decorator-access-modified-fields/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/decorator-access-modified-fields/output.js
@@ -1,4 +1,5 @@
-var _initClass, _init_m, _C2;
+var _C2;
+let _initClass, _init_m;
 var value;
 const classDec = Class => {
   value = new Class().p;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/decorator-access-modified-methods/output.js
@@ -1,4 +1,5 @@
-var _initProto, _initClass, _C2;
+var _C2;
+let _initProto, _initClass;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/expressions-static-blocks/output.js
@@ -1,5 +1,5 @@
-let _A2, _C2, _D2, _ref, _G2, _ref2, _H2, _K2;
-var _initClass, _A, _Class, _A3, _initClass2, _C, _Class2, _C3, _initClass3, _D, _Class3, _D3, _initClass4, _decorated_class, _Class4, _Class5, _initClass5, _G, _Class6, _G3, _initClass6, _decorated_class2, _Class7, _Class8, _initClass7, _H, _Class9, _H3, _initClass8, _K, _Class10, _K3;
+var _Class, _A3, _Class2, _C3, _Class3, _D3, _Class4, _Class5, _Class6, _G3, _Class7, _Class8, _Class9, _H3, _Class10, _K3;
+let _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _ref, _initClass5, _G, _G2, _initClass6, _decorated_class2, _ref2, _initClass7, _H, _H2, _initClass8, _K, _K2;
 const dec = () => {};
 const A = (new (_A2 = (_A3 = class A {}, [_A, _initClass] = babelHelpers.applyDecs2301(_A3, [], [dec]).c, _A3), (_Class = class extends babelHelpers.identity {
   constructor() {
@@ -41,8 +41,8 @@ const J = (new (_K2 = (_K3 = class K extends L {}, [_K, _initClass8] = babelHelp
   }
 }, babelHelpers.defineProperty(_Class10, _K2, void 0), _Class10))(), _K);
 function classFactory() {
-  let _ref3;
-  var _initClass9, _decorated_class3, _Class11, _Class12;
+  var _Class11, _Class12;
+  let _initClass9, _decorated_class3, _ref3;
   return new (_ref3 = (_Class12 = class _ref3 {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2301(_Class12, [], [dec]).c, _Class12), (_Class11 = class extends babelHelpers.identity {
     constructor() {
       super(_decorated_class3), (() => {})(), _initClass9();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/expressions/output.js
@@ -1,4 +1,5 @@
-var _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _Class, _initClass5, _G, _G2, _initClass6, _decorated_class2, _Class2, _initClass7, _H, _H2, _initClass8, _K, _K2;
+var _A2, _C2, _D2, _Class, _G2, _Class2, _H2, _K2;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = ((_A2 = class A {}, [_A, _initClass] = babelHelpers.applyDecs2301(_A2, [], [dec]).c, _initClass()), _A);
 const B = ((_C2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs2301(_C2, [], [dec]).c, _initClass2()), _C);
@@ -8,6 +9,7 @@ const F = [((_G2 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs2301(_G
 const H = ((_H2 = class H extends I {}, [_H, _initClass7] = babelHelpers.applyDecs2301(_H2, [], [dec]).c, _initClass7()), _H);
 const J = ((_K2 = class K extends L {}, [_K, _initClass8] = babelHelpers.applyDecs2301(_K2, [], [dec]).c, _initClass8()), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _Class3;
+  var _Class3;
+  let _initClass9, _decorated_class3;
   return (_Class3 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2301(_Class3, [], [dec]).c, _initClass9()), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/inheritance/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar2, _initClass2, _Foo2;
+var _Bar2, _Foo2;
+let _initClass, _initClass2;
 const dec1 = () => {};
 const dec2 = () => {};
 let _Bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/initializers/output.js
@@ -1,5 +1,5 @@
-let _Foo2, _Bar2;
-var _initClass, _Class, _Foo3, _initClass2, _Class2, _Bar3;
+var _Class, _Foo3, _Class2, _Bar3;
+let _initClass, _Foo2, _initClass2, _Bar2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2301(_Foo3, [], [dec]).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _x, _A, _Class_brand, _B, _Foo3;
+var _Class, _x, _A, _Class_brand, _B, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let hasX, hasA, hasM;
 let _Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-static-this/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _Foo3;
+var _Class, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2301(_Foo3, [], [dec]).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement-with-expr/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar, _Bar2;
+var _Bar2;
+let _initClass, _Bar;
 const dec = () => {};
 const Foo = ((_Bar2 = class Bar {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes--to-es2015/replacement/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _Foo3;
+var _Class, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2301(_Foo3, [], [dec]).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/decorator-access-modified-fields/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/decorator-access-modified-fields/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_m;
+let _initClass, _init_m;
 var value;
 const classDec = Class => {
   value = new Class().p;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initClass;
+let _initProto, _initClass;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/expressions-static-blocks/output.js
@@ -1,4 +1,4 @@
-var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = (new class extends babelHelpers.identity {
   static [class A {
@@ -80,7 +80,7 @@ const J = (new class extends babelHelpers.identity {
   }
 }(), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3;
+  let _initClass9, _decorated_class3;
   return new class extends babelHelpers.identity {
     static [class {
       static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/expressions/output.js
@@ -1,4 +1,4 @@
-var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = (class A {
   static {
@@ -64,7 +64,7 @@ const J = (class K extends L {
   }
 }, _K);
 function classFactory() {
-  var _initClass9, _decorated_class3;
+  let _initClass9, _decorated_class3;
   return class {
     static {
       [_decorated_class3, _initClass9] = babelHelpers.applyDecs2301(this, [], [dec]).c;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/inheritance/output.js
@@ -1,4 +1,4 @@
-var _initClass, _classDecs, _initClass2, _classDecs2;
+let _initClass, _classDecs, _initClass2, _classDecs2;
 const dec = () => {};
 _classDecs = [dec1];
 let _Bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/initializers/output.js
@@ -1,4 +1,4 @@
-var _initClass, _initClass2;
+let _initClass, _initClass2;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement-static-installed-on-correct-class/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let hasX, hasA, hasM;
 let _Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement-static-this/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement-with-expr/output.js
@@ -1,4 +1,4 @@
-var _initClass, _Bar;
+let _initClass, _Bar;
 const dec = () => {};
 const Foo = (class Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-classes/replacement/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,5 +1,5 @@
-let _computedKey, _computedKey2;
-var _initProto, _Foo;
+var _Foo;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,5 +1,5 @@
-let _computedKey, _computedKey2;
-var _initProto, _Foo;
+var _Foo;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _Foo;
+var _Foo;
+let _initProto, _init_a;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys--to-es2015/methods-with-same-key/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,5 +1,4 @@
-let _computedKey, _computedKey2;
-var _initProto;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/computed-keys-same-value/output.js
@@ -1,5 +1,4 @@
-let _computedKey, _computedKey2;
-var _initProto;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a;
+let _initProto, _init_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-duplicated-keys/methods-with-same-key/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/default-anonymous/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _A;
 class A {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/default-named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/default-named/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _default2;
 class _default {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/member-decorator/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/member-decorator/output.mjs
@@ -1,4 +1,4 @@
-var _xDecs, _init_x;
+let _xDecs, _init_x;
 export class A {
   static {
     [_init_x] = babelHelpers.applyDecs2301(this, [[_xDecs, 0, "x"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-exported/named/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _A;
 class A {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _Foo;
+var _Foo;
+let _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _Foo;
+var _Foo;
+let _init_a, _init_b;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _Foo;
+var _Foo;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7;
+let _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-fields/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _call_a2, _Foo;
+var _Foo;
+let _initProto, _call_a, _call_a2;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _call_a2, _Foo;
+var _Foo;
+let _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a, _call_a2;
+let _initProto, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a, _call_a2;
+let _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters-and-setters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-getters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static callA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-methods/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,6 @@
 {
-  var _initProto, _A;
+  var _A;
+  let _initProto;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -40,7 +41,8 @@
     }
   }
   {
-    var _initProto2, _A2;
+    var _A2;
+    let _initProto2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -66,8 +68,8 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        let _computedKey;
-        var _initProto3, _A3;
+        var _A3;
+        let _initProto3, _computedKey;
         let key;
         _computedKey = (key = super(5).method(), log.push(key), key);
         class A extends B {
@@ -91,8 +93,8 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        let _ref;
-        var _initProto4, _noopDecs, _A4;
+        var _A4;
+        let _initProto4, _noopDecs, _ref;
         _ref = (_noopDecs = noop(log.push(super(7).method())), "method");
         class A extends B {
           constructor() {
@@ -111,7 +113,8 @@
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5, _A5;
+    var _A5;
+    let _initProto5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -134,14 +137,15 @@
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6, _A6;
+    var _A6;
+    let _initProto6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        let _ref3;
-        var _initProto7, _noopDecs2, _Dummy2;
+        var _Dummy2;
+        let _initProto7, _noopDecs2, _ref3;
         new (_ref3 = (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), "noop"), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc--to-es2015/valid-expression-formats/output.js
@@ -1,5 +1,5 @@
-let _ref;
-var _initProto, _initClass, _classDecs, _methodDecs, _Foo2;
+var _Foo2;
+let _initProto, _initClass, _classDecs, _methodDecs, _ref;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
@@ -11,8 +11,8 @@ class Foo {
   }
   [_ref]() {}
   makeClass() {
-    let _ref2;
-    var _barDecs, _init_bar, _Nested;
+    var _Nested;
+    let _barDecs, _init_bar, _ref2;
     return _ref2 = (_barDecs = babelHelpers.classPrivateFieldGet2(_a, this), "bar"), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, _ref2, _init_bar(this));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/all-decorators/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
+let _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
 const dec = () => {};
 let _Class;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,4 +1,4 @@
-var _initProto, _methodDecs, _initProto2, _methodDecs2;
+let _initProto, _methodDecs, _initProto2, _methodDecs2;
 const dec = () => {};
 class A extends B {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,5 @@
 {
-  var _initProto;
+  let _initProto;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -41,7 +41,7 @@
     }
   }
   {
-    var _initProto2;
+    let _initProto2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -68,8 +68,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        let _computedKey;
-        var _initProto3;
+        let _initProto3, _computedKey;
         let key;
         class A extends B {
           static {
@@ -94,7 +93,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _noopDecs;
+        let _initProto4, _noopDecs;
         class A extends B {
           static {
             [_initProto4] = babelHelpers.applyDecs2301(this, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], []).e;
@@ -113,7 +112,7 @@
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5;
+    let _initProto5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -137,7 +136,7 @@
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6;
+    let _initProto6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
@@ -146,7 +145,7 @@
         [_initProto6] = babelHelpers.applyDecs2301(this, [[dec, 2, "method"]], []).e;
       }
       constructor() {
-        var _initProto7, _noopDecs2;
+        let _initProto7, _noopDecs2;
         new class Dummy extends B {
           static {
             [_initProto7] = babelHelpers.applyDecs2301(this, [[_noopDecs2, 2, "noop"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/super-in-nested-constructor-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/super-in-nested-constructor-expression/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 class Foo extends Bar {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/super-in-private-accessor/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/super-in-private-method/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-misc/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initClass, _classDecs, _methodDecs;
+let _initProto, _initClass, _classDecs, _methodDecs;
 const dec = () => {};
 _classDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]];
 let _Foo;
@@ -12,7 +12,7 @@ class Foo {
   #a = void _initProto(this);
   [(_methodDecs = [dec, call(), chain.expr(), arbitrary + expr, array[expr]], "method")]() {}
   makeClass() {
-    var _barDecs, _init_bar;
+    let _barDecs, _init_bar;
     return class Nested {
       static {
         [_init_bar] = babelHelpers.applyDecs2301(this, [[_barDecs, 0, "bar"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static setA(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static set a(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-01-setters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _Foo;
+var _Foo;
+let _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
+var _Foo;
+let _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _Foo_brand = /*#__PURE__*/new WeakSet();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b, _Foo;
+var _Foo;
+let _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7;
+let _initStatic, _init_a, _init_a2, _get_a, _set_a, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
+let _initProto, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/public/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a, _init_b, _init_computedKey;
+let _initProto, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
+let _initStatic, _init_a, _get_a, _set_a, _init_b, _get_b, _set_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-accessors/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _init_a, _init_b, _init_computedKey;
+let _initStatic, _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-assumption-constantSuper/super-in-nested-constructor-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-assumption-constantSuper/super-in-nested-constructor-expression/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar;
+var _Bar;
+let _initClass;
 const dec = () => {};
 let _Foo;
 class Foo extends (_Bar = Bar) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-assumption-constantSuper/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-assumption-constantSuper/super-in-private-accessor/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_x, _Bar;
+var _Bar;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-assumption-constantSuper/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-assumption-constantSuper/super-in-private-method/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_x, _Bar;
+var _Bar;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/decorator-access-modified-fields/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/decorator-access-modified-fields/output.js
@@ -1,4 +1,5 @@
-var _initClass, _init_m, _C2;
+var _C2;
+let _initClass, _init_m;
 var value;
 const classDec = Class => {
   value = new Class().p;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/decorator-access-modified-methods/output.js
@@ -1,4 +1,5 @@
-var _initProto, _initClass, _C2;
+var _C2;
+let _initProto, _initClass;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/expressions-static-blocks/output.js
@@ -1,5 +1,5 @@
-let _A2, _C2, _D2, _ref, _G2, _ref2, _H2, _K2;
-var _initClass, _A, _Class, _A3, _initClass2, _C, _Class2, _C3, _initClass3, _D, _Class3, _D3, _initClass4, _decorated_class, _Class4, _Class5, _initClass5, _G, _Class6, _G3, _initClass6, _decorated_class2, _Class7, _Class8, _initClass7, _H, _I, _Class9, _H3, _initClass8, _K, _L, _Class10, _K3;
+var _Class, _A3, _Class2, _C3, _Class3, _D3, _Class4, _Class5, _Class6, _G3, _Class7, _Class8, _I, _Class9, _H3, _L, _Class10, _K3;
+let _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _ref, _initClass5, _G, _G2, _initClass6, _decorated_class2, _ref2, _initClass7, _H, _H2, _initClass8, _K, _K2;
 const dec = () => {};
 const A = (new (_A2 = (_A3 = class A {}, [_A, _initClass] = babelHelpers.applyDecs2305(_A3, [], [dec]).c, _A3), (_Class = class extends babelHelpers.identity {
   constructor() {
@@ -41,8 +41,8 @@ const J = (new (_K2 = (_K3 = class K extends (_L = L) {}, [_K, _initClass8] = ba
   }
 }, babelHelpers.defineProperty(_Class10, _K2, void 0), _Class10))(), _K);
 function classFactory() {
-  let _ref3;
-  var _initClass9, _decorated_class3, _Class11, _Class12;
+  var _Class11, _Class12;
+  let _initClass9, _decorated_class3, _ref3;
   return new (_ref3 = (_Class12 = class _ref3 {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2305(_Class12, [], [dec]).c, _Class12), (_Class11 = class extends babelHelpers.identity {
     constructor() {
       super(_decorated_class3), (() => {})(), _initClass9();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/expressions/output.js
@@ -1,4 +1,5 @@
-var _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _Class, _initClass5, _G, _G2, _initClass6, _decorated_class2, _Class2, _initClass7, _H, _I, _H2, _initClass8, _K, _L, _K2;
+var _A2, _C2, _D2, _Class, _G2, _Class2, _I, _H2, _L, _K2;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = ((_A2 = class A {}, [_A, _initClass] = babelHelpers.applyDecs2305(_A2, [], [dec]).c, _initClass()), _A);
 const B = ((_C2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs2305(_C2, [], [dec]).c, _initClass2()), _C);
@@ -8,6 +9,7 @@ const F = [((_G2 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs2305(_G
 const H = ((_H2 = class H extends (_I = I) {}, [_H, _initClass7] = babelHelpers.applyDecs2305(_H2, [], [dec], 0, void 0, _I).c, _initClass7()), _H);
 const J = ((_K2 = class K extends (_L = L) {}, [_K, _initClass8] = babelHelpers.applyDecs2305(_K2, [], [dec], 0, void 0, _L).c, _initClass8()), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _Class3;
+  var _Class3;
+  let _initClass9, _decorated_class3;
   return (_Class3 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2305(_Class3, [], [dec]).c, _initClass9()), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/inheritance/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar2, _initClass2, _Bar3, _Foo2;
+var _Bar2, _Bar3, _Foo2;
+let _initClass, _initClass2;
 const dec1 = () => {};
 const dec2 = () => {};
 let _Bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/initializers/output.js
@@ -1,5 +1,5 @@
-let _Foo2, _Bar2;
-var _initClass, _Class, _Foo3, _initClass2, _Foo4, _Class2, _Bar3;
+var _Class, _Foo3, _Foo4, _Class2, _Bar3;
+let _initClass, _Foo2, _initClass2, _Bar2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2305(_Foo3, [], [dec]).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _x, _A, _Class_brand, _B, _Foo3;
+var _Class, _x, _A, _Class_brand, _B, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let hasX, hasA, hasM;
 let _Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-static-this/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _Foo3;
+var _Class, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2305(_Foo3, [], [dec]).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement-with-expr/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar, _Bar2;
+var _Bar2;
+let _initClass, _Bar;
 const dec = () => {};
 const Foo = ((_Bar2 = class Bar {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes--to-es2015/replacement/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _Foo3;
+var _Class, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2305(_Foo3, [], [dec]).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/decorator-access-modified-fields/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/decorator-access-modified-fields/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_m;
+let _initClass, _init_m;
 var value;
 const classDec = Class => {
   value = new Class().p;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initClass;
+let _initProto, _initClass;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/expressions-static-blocks/output.js
@@ -1,4 +1,5 @@
-var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _I, _initClass8, _K, _L;
+var _I, _L;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = (new class extends babelHelpers.identity {
   static [class A {
@@ -80,7 +81,7 @@ const J = (new class extends babelHelpers.identity {
   }
 }(), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3;
+  let _initClass9, _decorated_class3;
   return new class extends babelHelpers.identity {
     static [class {
       static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/expressions/output.js
@@ -1,4 +1,5 @@
-var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _I, _initClass8, _K, _L;
+var _I, _L;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = (class A {
   static {
@@ -64,7 +65,7 @@ const J = (class K extends (_L = L) {
   }
 }, _K);
 function classFactory() {
-  var _initClass9, _decorated_class3;
+  let _initClass9, _decorated_class3;
   return class {
     static {
       [_decorated_class3, _initClass9] = babelHelpers.applyDecs2305(this, [], [dec]).c;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/inheritance/output.js
@@ -1,4 +1,5 @@
-var _initClass, _classDecs, _initClass2, _classDecs2, _Bar2;
+var _Bar2;
+let _initClass, _classDecs, _initClass2, _classDecs2;
 const dec = () => {};
 _classDecs = [dec1];
 let _Bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/initializers/output.js
@@ -1,4 +1,5 @@
-var _initClass, _initClass2, _Foo2;
+var _Foo2;
+let _initClass, _initClass2;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement-static-installed-on-correct-class/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let hasX, hasA, hasM;
 let _Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement-static-this/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement-with-expr/output.js
@@ -1,4 +1,4 @@
-var _initClass, _Bar;
+let _initClass, _Bar;
 const dec = () => {};
 const Foo = (class Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-classes/replacement/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,5 +1,5 @@
-let _computedKey, _computedKey2;
-var _initProto, _Foo;
+var _Foo;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,5 +1,5 @@
-let _computedKey, _computedKey2;
-var _initProto, _Foo;
+var _Foo;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _Foo;
+var _Foo;
+let _initProto, _init_a;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys--to-es2015/methods-with-same-key/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,5 +1,4 @@
-let _computedKey, _computedKey2;
-var _initProto;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/computed-keys-same-value/output.js
@@ -1,5 +1,4 @@
-let _computedKey, _computedKey2;
-var _initProto;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a;
+let _initProto, _init_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-duplicated-keys/methods-with-same-key/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/default-anonymous/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _A;
 class A {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/default-named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/default-named/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _default2;
 class _default {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/member-decorator/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/member-decorator/output.mjs
@@ -1,4 +1,4 @@
-var _xDecs, _init_x;
+let _xDecs, _init_x;
 export class A {
   static {
     [_init_x] = babelHelpers.applyDecs2305(this, [[_xDecs, 0, "x"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-exported/named/output.mjs
@@ -1,4 +1,4 @@
-var _initClass, _classDecs;
+let _initClass, _classDecs;
 _classDecs = [dec];
 let _A;
 class A {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7, _Foo;
+var _Foo;
+let _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _Foo;
+var _Foo;
+let _init_a, _init_b;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _Foo;
+var _Foo;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_b, _init_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _init_computedKey7;
+let _init_a, _init_a2, _init_computedKey, _init_computedKey2, _init_computedKey3, _init_computedKey4, _init_computedKey5, _init_computedKey6, _computedKey, _init_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b;
+let _init_a, _init_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-fields/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_b, _init_computedKey;
+let _init_a, _init_b, _init_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _call_a2, _Foo;
+var _Foo;
+let _initProto, _call_a, _call_a2;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _call_a2, _Foo;
+var _Foo;
+let _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a, _call_a2;
+let _initProto, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a, _call_a2;
+let _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters-and-setters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-getters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static callA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-methods/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,6 @@
 {
-  var _initProto, _A;
+  var _A;
+  let _initProto;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -40,7 +41,8 @@
     }
   }
   {
-    var _initProto2, _A2;
+    var _A2;
+    let _initProto2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -66,8 +68,8 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        let _computedKey;
-        var _initProto3, _A3;
+        var _A3;
+        let _initProto3, _computedKey;
         let key;
         _computedKey = (key = super(5).method(), log.push(key), key);
         class A extends B {
@@ -91,8 +93,8 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        let _ref;
-        var _initProto4, _noopDecs, _A4;
+        var _A4;
+        let _initProto4, _noopDecs, _ref;
         _ref = (_noopDecs = noop(log.push(super(7).method())), "method");
         class A extends B {
           constructor() {
@@ -111,7 +113,8 @@
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5, _A5;
+    var _A5;
+    let _initProto5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -134,14 +137,15 @@
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6, _A6;
+    var _A6;
+    let _initProto6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        let _ref3;
-        var _initProto7, _noopDecs2, _Dummy2;
+        var _Dummy2;
+        let _initProto7, _noopDecs2, _ref3;
         new (_ref3 = (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), "noop"), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/super-in-decorator/output.js
@@ -1,7 +1,7 @@
 class A extends B {
   m() {
-    let _ref;
-    var _initProto, _initClass, _classDecs, _m2Decs, _C2;
+    var _C2;
+    let _initProto, _initClass, _classDecs, _m2Decs, _ref;
     _classDecs = [this, super.dec1];
     let _C;
     _ref = (_m2Decs = [this, super.dec2], "m2");

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/this/output.js
@@ -1,5 +1,5 @@
-let _ref;
-var _initClass, _obj, _classDecs, _xDecs, _init_x, _yDecs, _init_y, _A2;
+var _A2;
+let _initClass, _obj, _classDecs, _xDecs, _init_x, _yDecs, _init_y, _ref;
 _classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj = o2, _obj.dec];
 let _A;
 _ref = (_xDecs = [_obj = o2, _obj.dec, _obj = o3.o, _obj.dec], _yDecs = [_obj = o2, _obj.dec, void 0, dec], "x");

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc--to-es2015/valid-expression-formats/output.js
@@ -1,5 +1,5 @@
-let _ref;
-var _initProto, _initClass, _obj, _classDecs, _methodDecs, _Foo2;
+var _Foo2;
+let _initProto, _initClass, _obj, _classDecs, _methodDecs, _ref;
 const dec = () => {};
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
 let _Foo;
@@ -11,8 +11,8 @@ class Foo {
   }
   [_ref]() {}
   makeClass() {
-    let _ref2;
-    var _barDecs, _init_bar, _Nested;
+    var _Nested;
+    let _barDecs, _init_bar, _ref2;
     return _ref2 = (_barDecs = babelHelpers.classPrivateFieldGet2(_a, this), "bar"), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, _ref2, _init_bar(this));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/all-decorators/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
+let _initProto, _initStatic, _initClass, _init_a, _init_d, _init_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_i, _init_m, _init_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r;
 const dec = () => {};
 let _Class;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,4 +1,5 @@
-var _initProto, _methodDecs, _B, _initProto2, _methodDecs2, _B2;
+var _B, _B2;
+let _initProto, _methodDecs, _initProto2, _methodDecs2;
 const dec = () => {};
 class A extends (_B = B) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,5 @@
 {
-  var _initProto;
+  let _initProto;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -41,7 +41,7 @@
     }
   }
   {
-    var _initProto2;
+    let _initProto2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -68,8 +68,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        let _computedKey;
-        var _initProto3;
+        let _initProto3, _computedKey;
         let key;
         class A extends B {
           static {
@@ -94,7 +93,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _noopDecs;
+        let _initProto4, _noopDecs;
         class A extends B {
           static {
             [_initProto4] = babelHelpers.applyDecs2305(this, [[dec, 2, "method"], [_noopDecs, 2, "noop"]], [], 0, void 0, B).e;
@@ -113,7 +112,7 @@
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5;
+    let _initProto5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -137,7 +136,7 @@
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6;
+    let _initProto6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
@@ -146,7 +145,7 @@
         [_initProto6] = babelHelpers.applyDecs2305(this, [[dec, 2, "method"]], [], 0, void 0, B).e;
       }
       constructor() {
-        var _initProto7, _noopDecs2;
+        let _initProto7, _noopDecs2;
         new class Dummy extends B {
           static {
             [_initProto7] = babelHelpers.applyDecs2305(this, [[_noopDecs2, 2, "noop"]], [], 0, void 0, B).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-shadowed-private-method-valid/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/setting-shadowed-private-method-valid/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-decorator/output.js
@@ -1,6 +1,6 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _classDecs, _m2Decs;
+    let _initProto, _initClass, _classDecs, _m2Decs;
     _classDecs = [this, super.dec1];
     let _C;
     class C {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-nested-constructor-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-nested-constructor-expression/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar;
+var _Bar;
+let _initClass;
 const dec = () => {};
 let _Foo;
 class Foo extends (_Bar = Bar) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-private-accessor/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_x, _Bar;
+var _Bar;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/super-in-private-method/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_x, _Bar;
+var _Bar;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/this/output.js
@@ -1,4 +1,4 @@
-var _initClass, _obj, _classDecs, _xDecs, _init_x, _yDecs, _init_y;
+let _initClass, _obj, _classDecs, _xDecs, _init_x, _yDecs, _init_y;
 _classDecs = [_obj = o1, _obj.dec, void 0, dec, _obj = o2, _obj.dec];
 let _A;
 class A {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-misc/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initClass, _obj, _classDecs, _methodDecs;
+let _initProto, _initClass, _obj, _classDecs, _methodDecs;
 const dec = () => {};
 _classDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]];
 let _Foo;
@@ -12,7 +12,7 @@ class Foo {
   #a = void _initProto(this);
   [(_methodDecs = [void 0, dec, void 0, call(), void 0, chain.expr(), void 0, arbitrary + expr, _obj = array, _obj[expr]], "method")]() {}
   makeClass() {
-    var _barDecs, _init_bar;
+    let _barDecs, _init_bar;
     return class Nested {
       static {
         [_init_bar] = babelHelpers.applyDecs2305(this, [[_barDecs, 16, "bar"]], []).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering--to-es2015/initializers-and-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering--to-es2015/initializers-and-static-blocks/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initProto, _initStatic, _initClass, _init_field, _init_field2, _init_accessor, _init_accessor2, _ref, _Class, _B, _Foo3, _A;
+var _ref, _Class, _B, _Foo3, _A;
+let _initProto, _initStatic, _initClass, _init_field, _init_field2, _init_accessor, _init_accessor2, _Foo2;
 const log = [];
 const classDec1 = (cls, ctxClass) => {
   log.push("c2");

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering/initializers-and-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-ordering/initializers-and-static-blocks/output.js
@@ -1,4 +1,5 @@
-var _initProto, _initStatic, _initClass, _init_field, _init_field2, _init_accessor, _init_accessor2, _ref;
+var _ref;
+let _initProto, _initStatic, _initClass, _init_field, _init_field2, _init_accessor, _init_accessor2;
 const log = [];
 const classDec1 = (cls, ctxClass) => {
   log.push("c2");

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static setA(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static set a(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-05-setters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _init_a, _init_extra_a, _init_a2, _get_a, _set_a, _init_extra_a2, _init_computedKey, _init_extra_computedKey, _init_computedKey2, _init_extra_computedKey2, _init_computedKey3, _init_extra_computedKey3, _init_computedKey4, _init_extra_computedKey4, _init_computedKey5, _init_extra_computedKey5, _init_computedKey6, _init_extra_computedKey6, _init_computedKey7, _init_extra_computedKey7, _Foo;
+var _Foo;
+let _init_a, _init_extra_a, _init_a2, _get_a, _set_a, _init_extra_a2, _init_computedKey, _init_extra_computedKey, _init_computedKey2, _init_extra_computedKey2, _init_computedKey3, _init_extra_computedKey3, _init_computedKey4, _init_extra_computedKey4, _init_computedKey5, _init_extra_computedKey5, _init_computedKey6, _init_extra_computedKey6, _computedKey, _init_computedKey7, _init_extra_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b, _Foo;
+var _Foo;
+let _init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _Foo_brand = /*#__PURE__*/new WeakSet();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
 const dec = () => {};
 var _A = /*#__PURE__*/new WeakMap();
 var _B = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b, _Foo;
+var _Foo;
+let _init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _init_a, _init_extra_a, _init_a2, _get_a, _set_a, _init_extra_a2, _init_computedKey, _init_extra_computedKey, _init_computedKey2, _init_extra_computedKey2, _init_computedKey3, _init_extra_computedKey3, _init_computedKey4, _init_extra_computedKey4, _init_computedKey5, _init_extra_computedKey5, _init_computedKey6, _init_extra_computedKey6, _init_computedKey7, _init_extra_computedKey7;
+let _init_a, _init_extra_a, _init_a2, _get_a, _set_a, _init_extra_a2, _init_computedKey, _init_extra_computedKey, _init_computedKey2, _init_extra_computedKey2, _init_computedKey3, _init_extra_computedKey3, _init_computedKey4, _init_extra_computedKey4, _init_computedKey5, _init_extra_computedKey5, _init_computedKey6, _init_extra_computedKey6, _computedKey, _init_computedKey7, _init_extra_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b;
+let _init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
+let _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b;
+let _init_a, _get_a, _set_a, _init_extra_a, _init_b, _get_b, _set_b, _init_extra_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
+let _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-assumption-constantSuper/super-in-nested-constructor-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-assumption-constantSuper/super-in-nested-constructor-expression/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar;
+var _Bar;
+let _initClass;
 const dec = () => {};
 let _Foo;
 class Foo extends (_Bar = Bar) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-assumption-constantSuper/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-assumption-constantSuper/super-in-private-accessor/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_x, _Bar;
+var _Bar;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-assumption-constantSuper/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-assumption-constantSuper/super-in-private-method/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_x, _Bar;
+var _Bar;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/decorator-access-modified-fields/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/decorator-access-modified-fields/output.js
@@ -1,4 +1,5 @@
-var _initClass, _init_m, _init_extra_m, _C2;
+var _C2;
+let _initClass, _init_m, _init_extra_m;
 var value;
 const classDec = Class => {
   value = new Class().p;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/decorator-access-modified-methods/output.js
@@ -1,4 +1,5 @@
-var _initProto, _initClass, _C2;
+var _C2;
+let _initProto, _initClass;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/expressions-static-blocks/output.js
@@ -1,5 +1,5 @@
-let _A2, _C2, _D2, _ref, _G2, _ref2, _H2, _K2;
-var _initClass, _A, _Class, _A3, _initClass2, _C, _Class2, _C3, _initClass3, _D, _Class3, _D3, _initClass4, _decorated_class, _Class4, _Class5, _initClass5, _G, _Class6, _G3, _initClass6, _decorated_class2, _Class7, _Class8, _initClass7, _H, _I, _Class9, _H3, _initClass8, _K, _L, _Class10, _K3;
+var _Class, _A3, _Class2, _C3, _Class3, _D3, _Class4, _Class5, _Class6, _G3, _Class7, _Class8, _I, _Class9, _H3, _L, _Class10, _K3;
+let _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _ref, _initClass5, _G, _G2, _initClass6, _decorated_class2, _ref2, _initClass7, _H, _H2, _initClass8, _K, _K2;
 const dec = () => {};
 const A = (new (_A2 = (_A3 = class A {}, [_A, _initClass] = babelHelpers.applyDecs2311(_A3, [dec], []).c, _A3), (_Class = class extends babelHelpers.identity {
   constructor() {
@@ -41,8 +41,8 @@ const J = (new (_K2 = (_K3 = class K extends (_L = L) {}, [_K, _initClass8] = ba
   }
 }, babelHelpers.defineProperty(_Class10, _K2, void 0), _Class10))(), _K);
 function classFactory() {
-  let _ref3;
-  var _initClass9, _decorated_class3, _Class11, _Class12;
+  var _Class11, _Class12;
+  let _initClass9, _decorated_class3, _ref3;
   return new (_ref3 = (_Class12 = class _ref3 {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2311(_Class12, [dec], []).c, _Class12), (_Class11 = class extends babelHelpers.identity {
     constructor() {
       super(_decorated_class3), (() => {})(), _initClass9();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/expressions/output.js
@@ -1,4 +1,5 @@
-var _initClass, _A, _A2, _initClass2, _C, _C2, _initClass3, _D, _D2, _initClass4, _decorated_class, _Class, _initClass5, _G, _G2, _initClass6, _decorated_class2, _Class2, _initClass7, _H, _I, _H2, _initClass8, _K, _L, _K2;
+var _A2, _C2, _D2, _Class, _G2, _Class2, _I, _H2, _L, _K2;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = ((_A2 = class A {}, [_A, _initClass] = babelHelpers.applyDecs2311(_A2, [dec], []).c, _initClass()), _A);
 const B = ((_C2 = class C {}, [_C, _initClass2] = babelHelpers.applyDecs2311(_C2, [dec], []).c, _initClass2()), _C);
@@ -8,6 +9,7 @@ const F = [((_G2 = class G {}, [_G, _initClass5] = babelHelpers.applyDecs2311(_G
 const H = ((_H2 = class H extends (_I = I) {}, [_H, _initClass7] = babelHelpers.applyDecs2311(_H2, [dec], [], 0, void 0, _I).c, _initClass7()), _H);
 const J = ((_K2 = class K extends (_L = L) {}, [_K, _initClass8] = babelHelpers.applyDecs2311(_K2, [dec], [], 0, void 0, _L).c, _initClass8()), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3, _Class3;
+  var _Class3;
+  let _initClass9, _decorated_class3;
   return (_Class3 = class {}, [_decorated_class3, _initClass9] = babelHelpers.applyDecs2311(_Class3, [dec], []).c, _initClass9()), _decorated_class3;
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/inheritance/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar2, _initClass2, _Bar3, _Foo2;
+var _Bar2, _Bar3, _Foo2;
+let _initClass, _initClass2;
 const dec1 = () => {};
 const dec2 = () => {};
 let _Bar;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/initializers/output.js
@@ -1,5 +1,5 @@
-let _Foo2, _Bar2;
-var _initClass, _Class, _Foo3, _initClass2, _Foo4, _Class2, _Bar3;
+var _Class, _Foo3, _Foo4, _Class2, _Bar3;
+let _initClass, _Foo2, _initClass2, _Bar2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2311(_Foo3, [dec], []).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-decorator-initializer-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-decorator-initializer-this/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initStatic, _initClass, _init_accessor, _init_extra_accessor, _init_property, _init_extra_property, _Class, _A, _Foo3;
+var _Class, _A, _Foo3;
+let _initStatic, _initClass, _init_accessor, _init_extra_accessor, _init_property, _init_extra_property, _Foo2;
 let original, replaced, accessorThis, getterThis, setterThis, methodThis, propertyThis, classThis;
 function dec(Klass, context) {
   original = Klass;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-installed-on-correct-class/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _x, _A, _Class_brand, _B, _Foo3;
+var _Class, _x, _A, _Class_brand, _B, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let hasX, hasA, hasM;
 let _Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-this/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _Foo3;
+var _Class, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2311(_Foo3, [dec], []).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-with-expr/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar, _Bar2;
+var _Bar2;
+let _initClass, _Bar;
 const dec = () => {};
 const Foo = ((_Bar2 = class Bar {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement/output.js
@@ -1,5 +1,5 @@
-let _Foo2;
-var _initClass, _Class, _Foo3;
+var _Class, _Foo3;
+let _initClass, _Foo2;
 const dec = () => {};
 let _Foo;
 new (_Foo2 = (_Foo3 = class Foo {}, [_Foo, _initClass] = babelHelpers.applyDecs2311(_Foo3, [dec], []).c, _Foo3), (_Class = class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/decorator-access-modified-fields/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/decorator-access-modified-fields/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_m, _init_extra_m;
+let _initClass, _init_m, _init_extra_m;
 var value;
 const classDec = Class => {
   value = new Class().p;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/decorator-access-modified-methods/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/decorator-access-modified-methods/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initClass;
+let _initProto, _initClass;
 var value;
 const classDec = Class => {
   value = new Class().m();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/expressions-static-blocks/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/expressions-static-blocks/output.js
@@ -1,4 +1,5 @@
-var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _I, _initClass8, _K, _L;
+var _I, _L;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = (new class extends babelHelpers.identity {
   static [class A {
@@ -80,7 +81,7 @@ const J = (new class extends babelHelpers.identity {
   }
 }(), _K);
 function classFactory() {
-  var _initClass9, _decorated_class3;
+  let _initClass9, _decorated_class3;
   return new class extends babelHelpers.identity {
     static [class {
       static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/expressions/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/expressions/output.js
@@ -1,4 +1,5 @@
-var _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _I, _initClass8, _K, _L;
+var _I, _L;
+let _initClass, _A, _initClass2, _C, _initClass3, _D, _initClass4, _decorated_class, _initClass5, _G, _initClass6, _decorated_class2, _initClass7, _H, _initClass8, _K;
 const dec = () => {};
 const A = (class A {
   static {
@@ -64,7 +65,7 @@ const J = (class K extends (_L = L) {
   }
 }, _K);
 function classFactory() {
-  var _initClass9, _decorated_class3;
+  let _initClass9, _decorated_class3;
   return class {
     static {
       [_decorated_class3, _initClass9] = babelHelpers.applyDecs2311(this, [dec], []).c;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/inheritance/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/inheritance/output.js
@@ -1,4 +1,5 @@
-var _initClass, _initClass2, _Bar2;
+var _Bar2;
+let _initClass, _initClass2;
 const dec = () => {};
 let _Bar;
 class Bar {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/initializers/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/initializers/output.js
@@ -1,4 +1,5 @@
-var _initClass, _initClass2, _Foo2;
+var _Foo2;
+let _initClass, _initClass2;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-decorator-initializer-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-decorator-initializer-this/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _initClass, _init_accessor, _init_extra_accessor, _init_property, _init_extra_property;
+let _initStatic, _initClass, _init_accessor, _init_extra_accessor, _init_property, _init_extra_property;
 let original, replaced, accessorThis, getterThis, setterThis, methodThis, propertyThis, classThis;
 function dec(Klass, context) {
   original = Klass;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-installed-on-correct-class/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-installed-on-correct-class/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let hasX, hasA, hasM;
 let _Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-this/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-with-expr/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-with-expr/output.js
@@ -1,4 +1,4 @@
-var _initClass, _Bar;
+let _initClass, _Bar;
 const dec = () => {};
 const Foo = (class Bar {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement/output.js
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 const dec = () => {};
 let _Foo;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys--to-es2015/computed-keys-same-ast/output.js
@@ -1,5 +1,5 @@
-let _computedKey, _computedKey2;
-var _initProto, _Foo;
+var _Foo;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKey());
 _computedKey2 = babelHelpers.toPropertyKey(getKey());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys--to-es2015/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys--to-es2015/computed-keys-same-value/output.js
@@ -1,5 +1,5 @@
-let _computedKey, _computedKey2;
-var _initProto, _Foo;
+var _Foo;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 _computedKey = babelHelpers.toPropertyKey(getKeyI());
 _computedKey2 = babelHelpers.toPropertyKey(getKeyJ());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys--to-es2015/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys--to-es2015/method-and-field/output.js
@@ -1,4 +1,5 @@
-var _initProto, _init_a, _init_extra_a, _Foo;
+var _Foo;
+let _initProto, _init_a, _init_extra_a;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys--to-es2015/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys--to-es2015/methods-with-same-key/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys/computed-keys-same-ast/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys/computed-keys-same-ast/output.js
@@ -1,5 +1,4 @@
-let _computedKey, _computedKey2;
-var _initProto;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys/computed-keys-same-value/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys/computed-keys-same-value/output.js
@@ -1,5 +1,4 @@
-let _computedKey, _computedKey2;
-var _initProto;
+let _initProto, _computedKey, _computedKey2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys/method-and-field/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys/method-and-field/output.js
@@ -1,4 +1,4 @@
-var _initProto, _init_a, _init_extra_a;
+let _initProto, _init_a, _init_extra_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys/methods-with-same-key/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-duplicated-keys/methods-with-same-key/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-exported/default-anonymous/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-exported/default-anonymous/output.mjs
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 let _A;
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-exported/default-named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-exported/default-named/output.mjs
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 let _default2;
 class _default {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-exported/member-decorator/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-exported/member-decorator/output.mjs
@@ -1,4 +1,4 @@
-var _init_x, _init_extra_x;
+let _init_x, _init_extra_x;
 export class A {
   static {
     [_init_x, _init_extra_x] = babelHelpers.applyDecs2311(this, [], [[dec, 0, "x"]]).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-exported/named/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-exported/named/output.mjs
@@ -1,4 +1,4 @@
-var _initClass;
+let _initClass;
 let _A;
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _init_a, _init_extra_a, _init_a2, _init_extra_a2, _init_computedKey, _init_extra_computedKey, _init_computedKey2, _init_extra_computedKey2, _init_computedKey3, _init_extra_computedKey3, _init_computedKey4, _init_extra_computedKey4, _init_computedKey5, _init_extra_computedKey5, _init_computedKey6, _init_extra_computedKey6, _init_computedKey7, _init_extra_computedKey7, _Foo;
+var _Foo;
+let _init_a, _init_extra_a, _init_a2, _init_extra_a2, _init_computedKey, _init_extra_computedKey, _init_computedKey2, _init_extra_computedKey2, _init_computedKey3, _init_extra_computedKey3, _init_computedKey4, _init_extra_computedKey4, _init_computedKey5, _init_extra_computedKey5, _init_computedKey6, _init_extra_computedKey6, _computedKey, _init_computedKey7, _init_extra_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b, _Foo;
+var _Foo;
+let _init_a, _init_extra_a, _init_b, _init_extra_b;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 var _b = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b, _Foo;
+var _Foo;
+let _init_a, _init_extra_a, _init_b, _init_extra_b;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey, _Foo;
+var _Foo;
+let _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
 const dec = () => {};
 class Foo {}
 _Foo = Foo;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _init_a, _init_extra_a, _init_a2, _init_extra_a2, _init_computedKey, _init_extra_computedKey, _init_computedKey2, _init_extra_computedKey2, _init_computedKey3, _init_extra_computedKey3, _init_computedKey4, _init_extra_computedKey4, _init_computedKey5, _init_extra_computedKey5, _init_computedKey6, _init_extra_computedKey6, _init_computedKey7, _init_extra_computedKey7;
+let _init_a, _init_extra_a, _init_a2, _init_extra_a2, _init_computedKey, _init_extra_computedKey, _init_computedKey2, _init_extra_computedKey2, _init_computedKey3, _init_extra_computedKey3, _init_computedKey4, _init_extra_computedKey4, _init_computedKey5, _init_extra_computedKey5, _init_computedKey6, _init_extra_computedKey6, _computedKey, _init_computedKey7, _init_extra_computedKey7;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields/private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b;
+let _init_a, _init_extra_a, _init_b, _init_extra_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields/public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
+let _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields/static-private/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b;
+let _init_a, _init_extra_a, _init_b, _init_extra_b;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-fields/static-public/output.js
@@ -1,4 +1,4 @@
-var _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
+let _init_a, _init_extra_a, _init_b, _init_extra_b, _init_computedKey, _init_extra_computedKey;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _call_a2, _Foo;
+var _Foo;
+let _initProto, _call_a, _call_a2;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _call_a2, _Foo;
+var _Foo;
+let _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static getA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static get a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a, _call_a2;
+let _initProto, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a, _call_a2;
+let _initStatic, _call_a, _call_a2;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters-and-setters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-getters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private-async-and-generator/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _call_g, _call_ag, _Foo;
+var _Foo;
+let _initProto, _call_a, _call_g, _call_ag;
 var _ag = /*#__PURE__*/new WeakMap();
 var _g = /*#__PURE__*/new WeakMap();
 var _a = /*#__PURE__*/new WeakMap();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _a = /*#__PURE__*/new WeakMap();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static callA() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static a() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private-async-and-generator/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a, _call_g, _call_ag;
+let _initProto, _call_a, _call_g, _call_ag;
 class Foo {
   static {
     [_call_a, _call_g, _call_ag, _initProto] = babelHelpers.applyDecs2311(this, [], [[dec, 2, "a", async function () {}], [dec, 2, "g", function* () {}], [dec, 2, "ag", async function* () {}]], 0, _ => #a in _).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-methods/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/class-in-for-loop/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/class-in-for-loop/exec.js
@@ -1,7 +1,7 @@
 {
   const logs = [];
   const classes = [];
-  function noop() {}
+  const noop = () => {}
 
   for (let i = 0; i < 2; i++) {
     classes.push(class C {
@@ -19,7 +19,7 @@
 {
   const logs = [];
   const classes = [];
-  function noop() {}
+  const noop = () => {}
 
   for (let i = 0; i < 2; i++) {
     classes.push(@noop class C {
@@ -37,7 +37,7 @@
 {
   const logs = [];
   const classes = [];
-  function noop() {}
+  const noop = () => {}
 
   for (let i = 0; i < 2; i++) {
     classes.push(@noop class C {
@@ -50,4 +50,45 @@
   }
 
   expect(logs.join()).toBe("0,1");
+}
+
+{
+  const logs = [];
+  const classes = [];
+  const setValueTo = i => () => () => i
+
+  for (let i = 0; i < 2; i++) {
+    classes.push(class C {
+      @setValueTo(i) [i];
+    })
+  }
+
+  for (const clazz of classes) {
+    const c = new clazz();
+    const key = Reflect.ownKeys(c)[0];
+    logs.push([key, c[key]].join(":"));
+  }
+
+  expect(logs.join()).toBe("0:0,1:1");
+}
+
+{
+  const logs = [];
+  const classes = [];
+  const noop = () => {}
+  const setValueTo = i => (_, { access, addInitializer }) => addInitializer(function() { access.set(this, i) })
+
+  for (let i = 0; i < 2; i++) {
+    classes.push(@noop class C {
+      @setValueTo(i) [i];
+    })
+  }
+
+  for (const clazz of classes) {
+    const c = new clazz();
+    const key = Reflect.ownKeys(c)[0];
+    logs.push([key, c[key]].join(":"));
+  }
+
+  expect(logs.join()).toBe("0:0,1:1");
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,6 @@
 {
-  var _initProto, _A;
+  var _A;
+  let _initProto;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -40,7 +41,8 @@
     }
   }
   {
-    var _initProto2, _A2;
+    var _A2;
+    let _initProto2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -66,8 +68,8 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        let _computedKey;
-        var _initProto3, _A3;
+        var _A3;
+        let _initProto3, _computedKey;
         let key;
         _computedKey = (key = super(5).method(), log.push(key), key);
         class A extends B {
@@ -91,8 +93,8 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        let _ref;
-        var _initProto4, _noopDecs, _A4;
+        var _A4;
+        let _initProto4, _noopDecs, _ref;
         _ref = (_noopDecs = noop(log.push(super(7).method())), "method");
         class A extends B {
           constructor() {
@@ -111,7 +113,8 @@
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5, _A5;
+    var _A5;
+    let _initProto5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -134,14 +137,15 @@
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6, _A6;
+    var _A6;
+    let _initProto6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
     class A extends B {
       constructor() {
-        let _ref3;
-        var _initProto7, _noopDecs2, _Dummy2;
+        var _Dummy2;
+        let _initProto7, _noopDecs2, _ref3;
         new (_ref3 = (_noopDecs2 = noop(log.push(_initProto6(super(11)).method())), "noop"), (_Dummy2 = class Dummy extends B {
           constructor() {
             log.push(_initProto7(super(12)).method());

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/private-name-in-class-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/private-name-in-class-decorator/output.js
@@ -1,8 +1,8 @@
 let called = false;
 class A {
   constructor() {
-    let _B2;
-    var _initClass, _Class, _Class_brand, _B3;
+    var _Class, _Class_brand, _B3;
+    let _initClass, _B2;
     let _B;
     new (_Class_brand = /*#__PURE__*/new WeakSet(), _B2 = (_B3 = class B extends A {}, [_B, _initClass] = babelHelpers.applyDecs2311(_B3, [_x], [], 0, void 0, A).c, _B3), (_Class = class extends babelHelpers.identity {
       constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/super-in-decorator/output.js
@@ -1,7 +1,7 @@
 class A extends B {
   m() {
-    let _ref;
-    var _initProto, _initClass, _classDecs, _m2Decs, _C2;
+    var _C2;
+    let _initProto, _initClass, _classDecs, _m2Decs, _ref;
     _classDecs = [this, super.dec1];
     let _C;
     _ref = (_m2Decs = [this, super.dec2], "m2");

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/this/output.js
@@ -1,4 +1,5 @@
-var _initClass, _obj, _init_x, _init_extra_x, _init_y, _init_extra_y, _A2;
+var _A2;
+let _initClass, _obj, _init_x, _init_extra_x, _init_y, _init_extra_y;
 let _A;
 class A {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc--to-es2015/valid-expression-formats/output.js
@@ -1,4 +1,5 @@
-var _initProto, _initClass, _obj, _Foo2;
+var _Foo2;
+let _initProto, _initClass, _obj;
 const dec = () => {};
 let _Foo;
 var _a = /*#__PURE__*/new WeakMap();
@@ -8,8 +9,8 @@ class Foo {
   }
   method() {}
   makeClass() {
-    let _ref;
-    var _barDecs, _init_bar, _init_extra_bar, _Nested;
+    var _Nested;
+    let _barDecs, _init_bar, _init_extra_bar, _ref;
     return _ref = (_barDecs = babelHelpers.classPrivateFieldGet2(_a, this), "bar"), (_Nested = class Nested {
       constructor() {
         babelHelpers.defineProperty(this, _ref, _init_bar(this));

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/all-decorators/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/all-decorators/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initStatic, _initClass, _init_a, _init_extra_a, _init_d, _init_extra_d, _init_e, _init_extra_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_extra_h, _init_i, _init_extra_i, _init_m, _init_extra_m, _init_n, _init_extra_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r, _init_extra_r;
+let _initProto, _initStatic, _initClass, _init_a, _init_extra_a, _init_d, _init_extra_d, _init_e, _init_extra_e, _call_f, _call_g, _call_g2, _init_h, _get_h, _set_h, _init_extra_h, _init_i, _init_extra_i, _init_m, _init_extra_m, _init_n, _init_extra_n, _call_o, _call_p, _call_q, _init_r, _get_r, _set_r, _init_extra_r;
 const dec = () => {};
 let _Class;
 new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/class-in-for-loop/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/class-in-for-loop/exec.js
@@ -1,7 +1,7 @@
 {
   const logs = [];
   const classes = [];
-  function noop() {}
+  const noop = () => {}
 
   for (let i = 0; i < 2; i++) {
     classes.push(class C {
@@ -19,7 +19,7 @@
 {
   const logs = [];
   const classes = [];
-  function noop() {}
+  const noop = () => {}
 
   for (let i = 0; i < 2; i++) {
     classes.push(@noop class C {
@@ -37,7 +37,7 @@
 {
   const logs = [];
   const classes = [];
-  function noop() {}
+  const noop = () => {}
 
   for (let i = 0; i < 2; i++) {
     classes.push(@noop class C {
@@ -50,4 +50,45 @@
   }
 
   expect(logs.join()).toBe("0,1");
+}
+
+{
+  const logs = [];
+  const classes = [];
+  const setValueTo = i => () => () => i
+
+  for (let i = 0; i < 2; i++) {
+    classes.push(class C {
+      @setValueTo(i) [i];
+    })
+  }
+
+  for (const clazz of classes) {
+    const c = new clazz();
+    const key = Reflect.ownKeys(c)[0];
+    logs.push([key, c[key]].join(":"));
+  }
+
+  expect(logs.join()).toBe("0:0,1:1");
+}
+
+{
+  const logs = [];
+  const classes = [];
+  const noop = () => {}
+  const setValueTo = i => (_, { access, addInitializer }) => addInitializer(function() { access.set(this, i) })
+
+  for (let i = 0; i < 2; i++) {
+    classes.push(@noop class C {
+      @setValueTo(i) [i];
+    })
+  }
+
+  for (const clazz of classes) {
+    const c = new clazz();
+    const key = Reflect.ownKeys(c)[0];
+    logs.push([key, c[key]].join(":"));
+  }
+
+  expect(logs.join()).toBe("0:0,1:1");
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/initProto-existing-derived-constructor-multiple-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/initProto-existing-derived-constructor-multiple-super/output.js
@@ -1,4 +1,5 @@
-var _initProto, _B, _initProto2, _B2;
+var _B, _B2;
+let _initProto, _initProto2;
 const dec = () => {};
 class A extends (_B = B) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/initProto-existing-derived-constructor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/initProto-existing-derived-constructor/output.js
@@ -1,5 +1,5 @@
 {
-  var _initProto;
+  let _initProto;
   let self, a, initCalled;
   function deco(_, context) {
     context.addInitializer(() => {
@@ -41,7 +41,7 @@
     }
   }
   {
-    var _initProto2;
+    let _initProto2;
     "super() nested within another constructor should not be transformed";
     let log = [];
     class A extends B {
@@ -68,8 +68,7 @@
     let log = [];
     new class Dummy extends B {
       constructor() {
-        let _computedKey;
-        var _initProto3;
+        let _initProto3, _computedKey;
         let key;
         class A extends B {
           static {
@@ -94,7 +93,7 @@
     const noop = () => fn => fn;
     new class extends B {
       constructor() {
-        var _initProto4, _noopDecs;
+        let _initProto4, _noopDecs;
         class A extends B {
           static {
             [_initProto4] = babelHelpers.applyDecs2311(this, [], [[dec, 2, "method"], [_noopDecs, 2, "noop"]], 0, void 0, B).e;
@@ -113,7 +112,7 @@
     expect(log + "").toBe("7,108");
   }
   {
-    var _initProto5;
+    let _initProto5;
     "super() within decorated derived constructor should be transformed: computed key";
     let log = [];
     class A extends B {
@@ -137,7 +136,7 @@
     expect(log + "").toBe("109,10");
   }
   {
-    var _initProto6;
+    let _initProto6;
     "super() within decorated derived constructor should be transformed: decorator expression";
     let log = [];
     const noop = () => fn => fn;
@@ -146,7 +145,7 @@
         [_initProto6] = babelHelpers.applyDecs2311(this, [], [[dec, 2, "method"]], 0, void 0, B).e;
       }
       constructor() {
-        var _initProto7, _noopDecs2;
+        let _initProto7, _noopDecs2;
         new class Dummy extends B {
           static {
             [_initProto7] = babelHelpers.applyDecs2311(this, [], [[_noopDecs2, 2, "noop"]], 0, void 0, B).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/private-name-in-class-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/private-name-in-class-decorator/output.js
@@ -4,7 +4,7 @@ class A {
     called = true;
   }
   constructor() {
-    var _initClass, _classDecs;
+    let _initClass, _classDecs;
     _classDecs = [A, A.#x];
     let _B;
     new class extends babelHelpers.identity {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/setting-shadowed-private-method-valid/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/setting-shadowed-private-method-valid/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_x;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-decorator/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-decorator/output.js
@@ -1,6 +1,6 @@
 class A extends B {
   m() {
-    var _initProto, _initClass, _classDecs, _m2Decs;
+    let _initProto, _initClass, _classDecs, _m2Decs;
     _classDecs = [this, super.dec1];
     let _C;
     class C {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-nested-constructor-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-nested-constructor-expression/output.js
@@ -1,4 +1,5 @@
-var _initClass, _Bar;
+var _Bar;
+let _initClass;
 const dec = () => {};
 let _Foo;
 class Foo extends (_Bar = Bar) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-private-accessor/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-private-accessor/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_x, _Bar;
+var _Bar;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-private-method/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/super-in-private-method/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_x, _Bar;
+var _Bar;
+let _initProto, _call_x;
 const dec = () => {};
 class Foo extends (_Bar = Bar) {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/this/output.js
@@ -1,4 +1,4 @@
-var _initClass, _obj, _init_x, _init_extra_x, _init_y, _init_extra_y;
+let _initClass, _obj, _init_x, _init_extra_x, _init_y, _init_extra_y;
 let _A;
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/valid-expression-formats/output.js
@@ -1,4 +1,4 @@
-var _initProto, _initClass, _obj;
+let _initProto, _initClass, _obj;
 const dec = () => {};
 let _Foo;
 class Foo {
@@ -11,7 +11,7 @@ class Foo {
   #a = void _initProto(this);
   method() {}
   makeClass() {
-    var _barDecs, _init_bar, _init_extra_bar;
+    let _barDecs, _init_bar, _init_extra_bar;
     return class Nested {
       static {
         [_init_bar, _init_extra_bar] = babelHelpers.applyDecs2311(this, [], [[_barDecs, 16, "bar"]]).e;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering--to-es2015/decorators-evaluation-with-this-caching/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering--to-es2015/decorators-evaluation-with-this-caching/output.js
@@ -1,4 +1,5 @@
-var _initProto, _obj, _A;
+var _A;
+let _initProto, _obj;
 let fn, obj;
 class A {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering/decorators-evaluation-with-this-caching/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering/decorators-evaluation-with-this-caching/output.js
@@ -1,4 +1,4 @@
-var _initProto, _obj;
+let _initProto, _obj;
 let fn, obj;
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering/field-initializers-after-methods-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-ordering/field-initializers-after-methods-private/output.js
@@ -1,4 +1,4 @@
-var _fooDecs, _init_foo, _init_extra_foo;
+let _fooDecs, _init_foo, _init_extra_foo;
 var counter = 0;
 class A {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/context-name/output.js
@@ -1,5 +1,5 @@
-let _computedKey;
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/private/output.js
@@ -1,4 +1,5 @@
-var _initProto, _call_a, _Foo;
+var _Foo;
+let _initProto, _call_a;
 const dec = () => {};
 var _Foo_brand = /*#__PURE__*/new WeakSet();
 class Foo {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/public/output.js
@@ -1,4 +1,5 @@
-var _initProto, _Foo;
+var _Foo;
+let _initProto;
 const dec = () => {};
 class Foo {
   constructor() {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/static-private/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _call_a, _Foo;
+var _Foo;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static setA(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters--to-es2015/static-public/output.js
@@ -1,4 +1,5 @@
-var _initStatic, _Foo;
+var _Foo;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static set a(v) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters/context-name/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters/context-name/output.js
@@ -1,5 +1,4 @@
-let _computedKey;
-var _initStatic, _call_a;
+let _initStatic, _call_a, _computedKey;
 const logs = [];
 const dec = (value, context) => {
   logs.push(context.name);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters/private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters/private/output.js
@@ -1,4 +1,4 @@
-var _initProto, _call_a;
+let _initProto, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters/public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters/public/output.js
@@ -1,4 +1,4 @@
-var _initProto;
+let _initProto;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters/static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters/static-private/output.js
@@ -1,4 +1,4 @@
-var _initStatic, _call_a;
+let _initStatic, _call_a;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters/static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-setters/static-public/output.js
@@ -1,4 +1,4 @@
-var _initStatic;
+let _initStatic;
 const dec = () => {};
 class Foo {
   static {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/computed-key-ts-as-expression/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/computed-key-ts-as-expression/output.js
@@ -4,8 +4,7 @@ function noopFactory() {
   };
 }
 {
-  var _pDecs, _init_p, _init_extra_p;
-  let _computedKey;
+  let _computedKey, _pDecs, _init_p, _init_extra_p;
   class C {
     static {
       [_init_p, _init_extra_p] = babelHelpers.applyDecs2311(this, [], [[_pDecs, 0, "p", o => o.#p, (o, v) => o.#p = v]], 0, _ => #p in _).e;
@@ -19,8 +18,7 @@ function noopFactory() {
   expect(new C()).toHaveProperty("a2");
 }
 {
-  var _pDecs2, _init_p2, _init_extra_p2;
-  let _computedKey3;
+  let _computedKey3, _pDecs2, _init_p2, _init_extra_p2;
   class C {
     static {
       [_init_p2, _init_extra_p2] = babelHelpers.applyDecs2311(this, [], [[_pDecs2, 0, "p", o => o.#p, (o, v) => o.#p = v]], 0, _ => #p in _).e;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/class-decorator/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-at/class-decorator/output.js
@@ -1,4 +1,5 @@
-var _initClass, _decorated_class, _Class;
+var _Class;
+let _initClass, _decorated_class;
 const expectedValue = 42;
 function decorator(target) {
   target.decoratorValue = expectedValue;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/class-decorator/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/hack-double-caret/class-decorator/output.js
@@ -1,4 +1,5 @@
-var _initClass, _decorated_class, _Class;
+var _Class;
+let _initClass, _decorated_class;
 const expectedValue = 42;
 function decorator(target) {
   target.decoratorValue = expectedValue;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-call-in-decorator/output.js
@@ -6,8 +6,8 @@ let Hello = /*#__PURE__*/babelHelpers.createClass(function Hello() {
 });
 let Outer = /*#__PURE__*/function (_Hello) {
   function Outer() {
-    let _ref;
-    var _helloDecs, _init_hello, _init_extra_hello, _Inner;
+    var _Inner;
+    let _helloDecs, _init_hello, _init_extra_hello, _ref;
     var _this;
     babelHelpers.classCallCheck(this, Outer);
     _ref = (_helloDecs = _this = babelHelpers.callSuper(this, Outer), "hello");

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
@@ -13,7 +13,8 @@ let Hello = /*#__PURE__*/function () {
 }();
 let Outer = /*#__PURE__*/function (_Hello) {
   function Outer() {
-    var _init_hello, _init_extra_hello, _Inner;
+    var _Inner;
+    let _init_hello, _init_extra_hello;
     var _thisSuper, _this;
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.callSuper(this, Outer);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Babel does not bind decorators correctly when the class is within a for loop ([REPL](https://babeljs.io/repl/build/56450#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=N4KABGDGD2B2DOAXMAbaBzeYC8YDaAugNzhRxJQoCG88AplroSRDAsvYgGpUoCudACrQcYAJY4AfGAAUASimyF2aWJCkAZtABOslHWQTcABiLiwAHjAAmM2IDU9haAitqtBgDoADn3gALGUh3LABhMBdXCAABTh5-IWgZMQU8MWJSCABfOVIs9QgtXSDyZGCqAC8KsGgNShp6eGdMsnYoUVg6AHd6qvkWVzYKAGs6AE9RACU6DX1IRE9oLtgAaXH4ILk8YwyotEwfP0C8UbGAGigT8YICTwAraDFYGQAiAC4XuTkB_NIh6H0nn2Mn28Huj2eXxAWSAA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=true&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env&prettier=false&targets=&version=7.24.0%2Bpr.16325&externalPlugins=%40babel%2Fplugin-proposal-decorators%407.23.9&assumptions=%7B%7D))
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This issue is very similar to https://github.com/babel/babel/pull/10029/files#r287785963. In the REPL example
```js
{
  const logs = [];
  const classes = [];
  const setValueTo = i => () => () => i

  for (let i = 0; i < 2; i++) {
    classes.push(class C {
      @setValueTo(i) [i];
    })
  }

  for (const clazz of classes) {
    const c = new clazz();
    const key = Reflect.ownKeys(c)[0];
    logs.push([key, c[key]].join(":"));
  }

  console.log(logs.join())
}
```
It should print `0:0,1:1` while currently it prints `0:1,1:1`.

To address this issue we have to register all decorator memoisers as let bindings. I suggest we also add a `kind: "var" | "let"` parameter to `Scope#generateDeclaredUidIdentifier(name: string)` so that in Babel 8 we can just switch to the official scope method.

As usual, please review this PR by commits. (I promise this PR has <100 commits :))

c.f. https://github.com/babel/babel/pull/16325#discussion_r1512907461