### PR TITLE
Fix decorated class static field private access

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1771,12 +1771,9 @@ function transformClass(
                 t.callExpression(
                   t.memberExpression(
                     privateMethodDelegateId,
-                    t.identifier("call"),
+                    t.identifier("apply"),
                   ),
-                  [
-                    t.thisExpression(),
-                    t.spreadElement(t.identifier("arguments")),
-                  ],
+                  [t.thisExpression(), t.identifier("arguments")],
                 ),
               ),
             ]);

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1752,9 +1752,9 @@ function transformClass(
                 t.callExpression(
                   t.memberExpression(
                     privateMethodDelegateId,
-                    t.identifier("call"),
+                    t.identifier("apply"),
                   ),
-                  [t.thisExpression(), t.spreadElement(t.identifier("arg"))],
+                  [t.thisExpression(), t.identifier("arg")],
                 ),
               ),
             ]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/exec.js
@@ -1,0 +1,66 @@
+{
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, OriginalFoo;
+
+  class Base {
+    static id(v) { return v; }
+  }
+
+  class Bar extends Base {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo extends class {} {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static #method() {
+      staticThis = super.id(this);
+      hasX = (o) => #x in o;
+      getX = (o) => o.#x;
+      setX = (o, v) => o.#x = v;
+      hasA = (o) => #a in o;
+      getA = (o) => o.#a;
+      setA = (o, v) => o.#a = v;
+      hasM = (o) => #m in o;
+      callM = (o) => o.#m();
+    };
+
+    static method() {
+      Foo.#method()
+    }
+  }
+
+  OriginalFoo.method();
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/input.js
@@ -1,0 +1,25 @@
+const dec = () => {};
+let hasX, hasA, hasM;
+
+class Base {
+  static id(v) { return v; }
+}
+
+@dec
+class Foo extends Base {
+  #x;
+  accessor #a;
+  #m() {}
+
+  x;
+  accessor a;
+  m() {}
+
+  static #method() {
+    super.id(this);
+    hasX = o => #x in o;
+    hasA = o => #a in o;
+    hasM = o => #m in o;
+  }
+}
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/options.json
@@ -1,0 +1,5 @@
+{
+  "assumptions": {
+    "ignoreFunctionLength": true
+  }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/output.js
@@ -1,0 +1,49 @@
+var _Class, _Class_brand, _Foo3, _x, _A, _Foo3_brand, _B;
+let _initClass, _method, _Foo2;
+const dec = () => {};
+let hasX, hasA, hasM;
+class Base {
+  static id(v) {
+    return v;
+  }
+}
+let _Foo;
+new (_Class_brand = /*#__PURE__*/new WeakSet(), _Foo2 = (_x = /*#__PURE__*/new WeakMap(), _A = /*#__PURE__*/new WeakMap(), _Foo3_brand = /*#__PURE__*/new WeakSet(), _B = /*#__PURE__*/new WeakMap(), (_Foo3 = class Foo extends Base {
+  constructor(...args) {
+    super(...args);
+    babelHelpers.classPrivateMethodInitSpec(this, _Foo3_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _x, void 0);
+    babelHelpers.classPrivateFieldInitSpec(this, _A, void 0);
+    babelHelpers.defineProperty(this, "x", void 0);
+    babelHelpers.classPrivateFieldInitSpec(this, _B, void 0);
+  }
+  get a() {
+    return babelHelpers.classPrivateFieldGet2(_B, this);
+  }
+  set a(v) {
+    babelHelpers.classPrivateFieldSet2(_B, this, v);
+  }
+  m() {}
+}, (() => {
+  [_Foo, _initClass] = babelHelpers.applyDecs2311(_Foo3, [dec], [], 0, void 0, Base).c;
+  _method = function () {
+    babelHelpers.get(babelHelpers.getPrototypeOf(_Foo), "id", this).call(this, this);
+    hasX = o => _x.has(babelHelpers.checkInRHS(o));
+    hasA = o => _Foo3_brand.has(babelHelpers.checkInRHS(o));
+    hasM = o => _Foo3_brand.has(babelHelpers.checkInRHS(o));
+  };
+})(), _Foo3)), (_Class = class extends babelHelpers.identity {
+  constructor() {
+    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _Class_brand), this), _initClass();
+  }
+}, babelHelpers.defineProperty(_Class, _Foo2, void 0), _Class))();
+function _get_a(_this) {
+  return babelHelpers.classPrivateFieldGet2(_A, _this);
+}
+function _set_a(_this2, v) {
+  babelHelpers.classPrivateFieldSet2(_A, _this2, v);
+}
+function _m() {}
+function _method2(...arg) {
+  return _method.call(this, ...arg);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/output.js
@@ -45,5 +45,5 @@ function _set_a(_this2, v) {
 }
 function _m() {}
 function _method2(...arg) {
-  return _method.call(this, ...arg);
+  return _method.apply(this, arg);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super/exec.js
@@ -1,0 +1,68 @@
+{
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, thisMethodLength, OriginalFoo;
+
+  class Base {
+    static id(v) { return v; }
+  }
+
+  class Bar extends Base {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo extends class {} {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static #method(_) {
+      staticThis = super.id(this);
+      thisMethodLength = super.id(this.#method.length);
+      hasX = super.id((o) => #x in o);
+      getX = super.id((o) => o.#x);
+      setX = super.id((o, v) => o.#x = v);
+      hasA = super.id((o) => #a in o);
+      getA = super.id((o) => o.#a);
+      setA = super.id((o, v) => o.#a = v);
+      hasM = super.id((o) => #m in o);
+      callM = super.id((o) => o.#m());
+    };
+
+    static method() {
+      Foo.#method()
+    }
+  }
+
+  OriginalFoo.method();
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+  expect(thisMethodLength).toBe(1);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super/input.js
@@ -1,0 +1,25 @@
+const dec = () => {};
+let hasX, hasA, hasM;
+
+class Base {
+  static id(v) { return v; }
+}
+
+@dec
+class Foo extends Base {
+  #x;
+  accessor #a;
+  #m() {}
+
+  x;
+  accessor a;
+  m() {}
+
+  static #method() {
+    super.id(this);
+    hasX = o => #x in o;
+    hasA = o => #a in o;
+    hasM = o => #m in o;
+  }
+}
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super/output.js
@@ -1,0 +1,49 @@
+var _Class, _Class_brand, _Foo3, _x, _A, _Foo3_brand, _B;
+let _initClass, _method, _Foo2;
+const dec = () => {};
+let hasX, hasA, hasM;
+class Base {
+  static id(v) {
+    return v;
+  }
+}
+let _Foo;
+new (_Class_brand = /*#__PURE__*/new WeakSet(), _Foo2 = (_x = /*#__PURE__*/new WeakMap(), _A = /*#__PURE__*/new WeakMap(), _Foo3_brand = /*#__PURE__*/new WeakSet(), _B = /*#__PURE__*/new WeakMap(), (_Foo3 = class Foo extends Base {
+  constructor(...args) {
+    super(...args);
+    babelHelpers.classPrivateMethodInitSpec(this, _Foo3_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _x, void 0);
+    babelHelpers.classPrivateFieldInitSpec(this, _A, void 0);
+    babelHelpers.defineProperty(this, "x", void 0);
+    babelHelpers.classPrivateFieldInitSpec(this, _B, void 0);
+  }
+  get a() {
+    return babelHelpers.classPrivateFieldGet2(_B, this);
+  }
+  set a(v) {
+    babelHelpers.classPrivateFieldSet2(_B, this, v);
+  }
+  m() {}
+}, (() => {
+  [_Foo, _initClass] = babelHelpers.applyDecs2311(_Foo3, [dec], [], 0, void 0, Base).c;
+  _method = function () {
+    babelHelpers.get(babelHelpers.getPrototypeOf(_Foo), "id", this).call(this, this);
+    hasX = o => _x.has(babelHelpers.checkInRHS(o));
+    hasA = o => _Foo3_brand.has(babelHelpers.checkInRHS(o));
+    hasM = o => _Foo3_brand.has(babelHelpers.checkInRHS(o));
+  };
+})(), _Foo3)), (_Class = class extends babelHelpers.identity {
+  constructor() {
+    (super(_Foo), babelHelpers.classPrivateMethodInitSpec(this, _Class_brand), this), _initClass();
+  }
+}, babelHelpers.defineProperty(_Class, _Foo2, void 0), _Class))();
+function _get_a(_this) {
+  return babelHelpers.classPrivateFieldGet2(_A, _this);
+}
+function _set_a(_this2, v) {
+  babelHelpers.classPrivateFieldSet2(_A, _this2, v);
+}
+function _m() {}
+function _method2() {
+  return _method.call(this, ...arguments);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-method-private-instance-element-super/output.js
@@ -45,5 +45,5 @@ function _set_a(_this2, v) {
 }
 function _m() {}
 function _method2() {
-  return _method.call(this, ...arguments);
+  return _method.apply(this, arguments);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-environment-super/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-environment-super/exec.js
@@ -1,0 +1,38 @@
+{
+  "different private/super access in a static private method";
+
+  const dummy = () => {}
+
+  let b;
+
+  const idFactory = (hint) => {
+    return class { static ["id" + hint](v) { return v } }
+  }
+
+  class C extends idFactory("C") { #x = "C#x"; }
+
+  const dec = (b) => {
+    originalB = b;
+    return C;
+  }
+
+  class A extends idFactory("A") {
+    #x = "A#x";
+    static *[Symbol.iterator]() {
+      @dec
+      class B extends idFactory("B") {
+        #x = "B#x";
+        @(yield super.idA(o => o.#x), dummy)
+        static *#iter() {
+          yield super.idC(o => o.#x);
+        }
+        static *iter() {
+          yield* super.idB(C.#iter());
+        }
+      }
+      b = new originalB();
+      yield* originalB.iter();
+    }
+  }
+  expect([...A].map(fn => fn(b)).join()).toBe("B#x,B#x");
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-access/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-access/exec.js
@@ -1,0 +1,243 @@
+{
+  "instance private access in a static block";
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static {
+      staticThis = this;
+      hasX = (o) => #x in o;
+      getX = (o) => o.#x;
+      setX = (o, v) => o.#x = v;
+      hasA = (o) => #a in o;
+      getA = (o) => o.#a;
+      setA = (o, v) => o.#a = v;
+      hasM = (o) => #m in o;
+      callM = (o) => o.#m();
+    }
+  }
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+}
+
+{
+  "instance private access in a static field initializer";
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static field = (
+      staticThis = this,
+      hasX = (o) => #x in o,
+      getX = (o) => o.#x,
+      setX = (o, v) => o.#x = v,
+      hasA = (o) => #a in o,
+      getA = (o) => o.#a,
+      setA = (o, v) => o.#a = v,
+      hasM = (o) => #m in o,
+      callM = (o) => o.#m()
+    );
+  }
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+}
+
+{
+  "instance private access in the body of a static private method";
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, thisMethodLength, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static #method(_) {
+      staticThis = this;
+      thisMethodLength = this.#method.length;
+      hasX = (o) => #x in o;
+      getX = (o) => o.#x;
+      setX = (o, v) => o.#x = v;
+      hasA = (o) => #a in o;
+      getA = (o) => o.#a;
+      setA = (o, v) => o.#a = v;
+      hasM = (o) => #m in o;
+      callM = (o) => o.#m();
+    };
+
+    static {
+      this.#method()
+    }
+  }
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+  expect(thisMethodLength).toBe(1);
+}
+
+{
+  "instance private access in the params of a static private method";
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, thisMethodLength, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static #method(v = (
+      staticThis = this,
+      thisMethodLength = this.#method.length,
+      hasX = (o) => #x in o,
+      getX = (o) => o.#x,
+      setX = (o, v) => o.#x = v,
+      hasA = (o) => #a in o,
+      getA = (o) => o.#a,
+      setA = (o, v) => o.#a = v,
+      hasM = (o) => #m in o,
+      callM = (o) => o.#m()
+    )) {};
+
+    static {
+      this.#method()
+    }
+  }
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+  expect(thisMethodLength).toBe(1);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-access/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-access/exec.js
@@ -241,3 +241,70 @@
   expect(staticThis).toBe(Bar);
   expect(thisMethodLength).toBe(1);
 }
+
+{
+  "instance private access in everywhere mentioned above";
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, thisMethodLength, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static #method({
+      [(staticThis = this, thisMethodLength = this.#method.length, getX = (o) => o.#x)]: _
+    } = (
+      hasM = (o) => #m in o
+    )) {
+      hasA = (o) => #a in o;
+    }
+
+    static {
+      hasX = (o) => #x in o;
+      getA = (o) => o.#a;
+      callM = (o) => o.#m();
+      this.#method();
+    }
+
+    static #field = (
+      setX = (o, v) => o.#x = v,
+      setA = (o, v) => o.#a = v
+    );
+  }
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+  expect(thisMethodLength).toBe(1);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-access/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-access/input.js
@@ -1,0 +1,20 @@
+const dec = () => {};
+let hasX, hasA, hasM;
+
+@dec
+class Foo {
+  #x;
+  accessor #a;
+  #m() {}
+
+  x;
+  accessor a;
+  m() {}
+
+  static {
+    hasX = o => #x in o;
+    hasA = o => #a in o;
+    hasM = o => #m in o;
+  }
+}
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-access/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-access/output.js
@@ -1,0 +1,39 @@
+var _Class, _Foo3, _x, _A, _Foo3_brand, _B;
+let _initClass, _staticBlock, _Foo2;
+const dec = () => {};
+let hasX, hasA, hasM;
+let _Foo;
+new (_Foo2 = (_x = /*#__PURE__*/new WeakMap(), _A = /*#__PURE__*/new WeakMap(), _Foo3_brand = /*#__PURE__*/new WeakSet(), _B = /*#__PURE__*/new WeakMap(), (_Foo3 = class Foo {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Foo3_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _x, void 0);
+    babelHelpers.classPrivateFieldInitSpec(this, _A, void 0);
+    babelHelpers.defineProperty(this, "x", void 0);
+    babelHelpers.classPrivateFieldInitSpec(this, _B, void 0);
+  }
+  get a() {
+    return babelHelpers.classPrivateFieldGet2(_B, this);
+  }
+  set a(v) {
+    babelHelpers.classPrivateFieldSet2(_B, this, v);
+  }
+  m() {}
+}, (() => {
+  [_Foo, _initClass] = babelHelpers.applyDecs2311(_Foo3, [dec], []).c;
+  _staticBlock = function () {
+    hasX = o => _x.has(babelHelpers.checkInRHS(o));
+    hasA = o => _Foo3_brand.has(babelHelpers.checkInRHS(o));
+    hasM = o => _Foo3_brand.has(babelHelpers.checkInRHS(o));
+  };
+})(), _Foo3)), (_Class = class extends babelHelpers.identity {
+  constructor() {
+    super(_Foo), _staticBlock.call(this), _initClass();
+  }
+}, babelHelpers.defineProperty(_Class, _Foo2, void 0), _Class))();
+function _get_a(_this) {
+  return babelHelpers.classPrivateFieldGet2(_A, _this);
+}
+function _set_a(_this2, v) {
+  babelHelpers.classPrivateFieldSet2(_A, _this2, v);
+}
+function _m() {}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-destructuring/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-destructuring/exec.js
@@ -1,0 +1,33 @@
+{
+  "instance private destructuring in a static block";
+  let getX, getA, callM, staticThis, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x = "#x";
+    accessor #a = "#a";
+    #m() { return "#m" }
+
+    static {
+      staticThis = this;
+      getX = ({ #x: x }) => x;
+      getA = ({ #a: a }) => a;
+      callM = ({ #m: m }) => m();
+    }
+  }
+
+  const foo = new OriginalFoo();
+
+  expect(getX(foo)).toBe("#x");
+  expect(getA(foo)).toBe("#a");
+  expect(callM(foo)).toBe("#m");
+
+  expect(staticThis).toBe(Bar);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-destructuring/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-destructuring/input.js
@@ -1,0 +1,17 @@
+const dec = () => {};
+let getX, getA, callM;
+
+@dec
+class Foo {
+  #x = "#x";
+  accessor #a = "#a";
+  #m() { return "#m" }
+
+  static {
+    staticThis = this;
+    getX = ({ #x: x }) => x;
+    getA = ({ #a: a }) => a;
+    callM = ({ #m: m }) => m();
+  }
+}
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-destructuring/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-destructuring/options.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "proposal-destructuring-private",
+    ["proposal-decorators", { "version": "2023-11" }],
+    "transform-class-properties",
+    "transform-private-methods",
+    "transform-class-static-block"
+  ]
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-destructuring/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes--to-es2015/replacement-static-private-instance-element-destructuring/output.js
@@ -1,0 +1,42 @@
+var _Class, _Foo3, _x, _A, _Foo3_brand;
+let _initClass, _staticBlock, _Foo2;
+const dec = () => {};
+let getX, getA, callM;
+let _Foo;
+new (_Foo2 = (_x = /*#__PURE__*/new WeakMap(), _A = /*#__PURE__*/new WeakMap(), _Foo3_brand = /*#__PURE__*/new WeakSet(), (_Foo3 = class Foo {
+  constructor() {
+    babelHelpers.classPrivateMethodInitSpec(this, _Foo3_brand);
+    babelHelpers.classPrivateFieldInitSpec(this, _x, "#x");
+    babelHelpers.classPrivateFieldInitSpec(this, _A, "#a");
+  }
+}, (() => {
+  [_Foo, _initClass] = babelHelpers.applyDecs2311(_Foo3, [dec], []).c;
+  _staticBlock = function () {
+    staticThis = this;
+    getX = _p => {
+      var x = babelHelpers.classPrivateFieldGet2(_x, _p);
+      return x;
+    };
+    getA = _p2 => {
+      var a = babelHelpers.classPrivateGetter(_Foo3_brand, _p2, _get_a);
+      return a;
+    };
+    callM = _p3 => {
+      var m = babelHelpers.assertClassBrand(_Foo3_brand, _p3, _m);
+      return m();
+    };
+  };
+})(), _Foo3)), (_Class = class extends babelHelpers.identity {
+  constructor() {
+    super(_Foo), _staticBlock.call(this), _initClass();
+  }
+}, babelHelpers.defineProperty(_Class, _Foo2, void 0), _Class))();
+function _get_a(_this) {
+  return babelHelpers.classPrivateFieldGet2(_A, _this);
+}
+function _set_a(_this2, v) {
+  babelHelpers.classPrivateFieldSet2(_A, _this2, v);
+}
+function _m() {
+  return "#m";
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/.replacement-static-private-environment-super-2/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/.replacement-static-private-environment-super-2/exec.js
@@ -1,0 +1,34 @@
+{
+  "different private/super access in a static method";
+
+  let b;
+
+  const idFactory = (hint) => {
+    return class { static ["id" + hint](v) { return v } }
+  }
+
+  class C extends idFactory("C") { #x = "C#x"; }
+
+  const dec = (b) => {
+    originalB = b;
+    return C;
+  }
+
+  const fns = [];
+
+  class A extends idFactory("A") {
+    #x = "A#x";
+    static {
+      @dec
+      class B extends idFactory("B") {
+        #x = "B#x";
+        static [(fns.push(super.idA(o => o.#x)), "iter")] = () => {
+          fns.push(o => o.#x);
+        }
+      }
+      b = new originalB();
+      B.iter();
+    }
+  }
+  expect(fns.map(fn => fn(b)).join()).toBe("B#x,B#x");
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/options.json
@@ -1,3 +1,4 @@
 {
-  "plugins": [["proposal-decorators", { "version": "2023-11" }]]
+  "plugins": [["proposal-decorators", { "version": "2023-11" }]],
+  "minNodeVersion": "16.11.0"
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/exec.js
@@ -1,0 +1,66 @@
+{
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, OriginalFoo;
+
+  class Base {
+    static id(v) { return v; }
+  }
+
+  class Bar extends Base {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo extends class {} {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static #method() {
+      staticThis = super.id(this);
+      hasX = (o) => #x in o;
+      getX = (o) => o.#x;
+      setX = (o, v) => o.#x = v;
+      hasA = (o) => #a in o;
+      getA = (o) => o.#a;
+      setA = (o, v) => o.#a = v;
+      hasM = (o) => #m in o;
+      callM = (o) => o.#m();
+    };
+
+    static method() {
+      Foo.#method()
+    }
+  }
+
+  OriginalFoo.method();
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/input.js
@@ -1,0 +1,25 @@
+const dec = () => {};
+let hasX, hasA, hasM;
+
+class Base {
+  static id(v) { return v; }
+}
+
+@dec
+class Foo extends Base {
+  #x;
+  accessor #a;
+  #m() {}
+
+  x;
+  accessor a;
+  m() {}
+
+  static #method() {
+    super.id(this);
+    hasX = o => #x in o;
+    hasA = o => #a in o;
+    hasM = o => #m in o;
+  }
+}
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/options.json
@@ -1,0 +1,5 @@
+{
+  "assumptions": {
+    "ignoreFunctionLength": true
+  }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/output.js
@@ -1,0 +1,46 @@
+let _initClass, _method;
+const dec = () => {};
+let hasX, hasA, hasM;
+class Base {
+  static id(v) {
+    return v;
+  }
+}
+let _Foo;
+new class extends babelHelpers.identity {
+  static [class Foo extends Base {
+    static {
+      [_Foo, _initClass] = babelHelpers.applyDecs2311(this, [dec], [], 0, void 0, Base).c;
+      _method = function () {
+        babelHelpers.get(babelHelpers.getPrototypeOf(_Foo), "id", this).call(this, this);
+        hasX = o => #x in o;
+        hasA = o => #a in o;
+        hasM = o => #m in o;
+      };
+    }
+    #x;
+    #A;
+    get #a() {
+      return this.#A;
+    }
+    set #a(v) {
+      this.#A = v;
+    }
+    #m() {}
+    x;
+    #B;
+    get a() {
+      return this.#B;
+    }
+    set a(v) {
+      this.#B = v;
+    }
+    m() {}
+  }];
+  #method(...arg) {
+    return _method.call(this, ...arg);
+  }
+  constructor() {
+    super(_Foo), _initClass();
+  }
+}();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super-assumption-ignoreFunctionLength/output.js
@@ -38,7 +38,7 @@ new class extends babelHelpers.identity {
     m() {}
   }];
   #method(...arg) {
-    return _method.call(this, ...arg);
+    return _method.apply(this, arg);
   }
   constructor() {
     super(_Foo), _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super/exec.js
@@ -1,0 +1,68 @@
+{
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, thisMethodLength, OriginalFoo;
+
+  class Base {
+    static id(v) { return v; }
+  }
+
+  class Bar extends Base {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo extends class {} {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static #method(_) {
+      staticThis = super.id(this);
+      thisMethodLength = super.id(this.#method.length);
+      hasX = super.id((o) => #x in o);
+      getX = super.id((o) => o.#x);
+      setX = super.id((o, v) => o.#x = v);
+      hasA = super.id((o) => #a in o);
+      getA = super.id((o) => o.#a);
+      setA = super.id((o, v) => o.#a = v);
+      hasM = super.id((o) => #m in o);
+      callM = super.id((o) => o.#m());
+    };
+
+    static method() {
+      Foo.#method()
+    }
+  }
+
+  OriginalFoo.method();
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+  expect(thisMethodLength).toBe(1);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super/input.js
@@ -1,0 +1,25 @@
+const dec = () => {};
+let hasX, hasA, hasM;
+
+class Base {
+  static id(v) { return v; }
+}
+
+@dec
+class Foo extends Base {
+  #x;
+  accessor #a;
+  #m() {}
+
+  x;
+  accessor a;
+  m() {}
+
+  static #method() {
+    super.id(this);
+    hasX = o => #x in o;
+    hasA = o => #a in o;
+    hasM = o => #m in o;
+  }
+}
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super/output.js
@@ -38,7 +38,7 @@ new class extends babelHelpers.identity {
     m() {}
   }];
   #method() {
-    return _method.call(this, ...arguments);
+    return _method.apply(this, arguments);
   }
   constructor() {
     super(_Foo), _initClass();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-method-private-instance-element-super/output.js
@@ -1,0 +1,46 @@
+let _initClass, _method;
+const dec = () => {};
+let hasX, hasA, hasM;
+class Base {
+  static id(v) {
+    return v;
+  }
+}
+let _Foo;
+new class extends babelHelpers.identity {
+  static [class Foo extends Base {
+    static {
+      [_Foo, _initClass] = babelHelpers.applyDecs2311(this, [dec], [], 0, void 0, Base).c;
+      _method = function () {
+        babelHelpers.get(babelHelpers.getPrototypeOf(_Foo), "id", this).call(this, this);
+        hasX = o => #x in o;
+        hasA = o => #a in o;
+        hasM = o => #m in o;
+      };
+    }
+    #x;
+    #A;
+    get #a() {
+      return this.#A;
+    }
+    set #a(v) {
+      this.#A = v;
+    }
+    #m() {}
+    x;
+    #B;
+    get a() {
+      return this.#B;
+    }
+    set a(v) {
+      this.#B = v;
+    }
+    m() {}
+  }];
+  #method() {
+    return _method.call(this, ...arguments);
+  }
+  constructor() {
+    super(_Foo), _initClass();
+  }
+}();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-environment-super/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-environment-super/exec.js
@@ -1,0 +1,38 @@
+{
+  "different private/super access in a static private method";
+
+  const dummy = () => {}
+
+  let b;
+
+  const idFactory = (hint) => {
+    return class { static ["id" + hint](v) { return v } }
+  }
+
+  class C extends idFactory("C") { #x = "C#x"; }
+
+  const dec = (b) => {
+    originalB = b;
+    return C;
+  }
+
+  class A extends idFactory("A") {
+    #x = "A#x";
+    static *[Symbol.iterator]() {
+      @dec
+      class B extends idFactory("B") {
+        #x = "B#x";
+        @(yield super.idA(o => o.#x), dummy)
+        static *#iter() {
+          yield super.idC(o => o.#x);
+        }
+        static *iter() {
+          yield* super.idB(C.#iter());
+        }
+      }
+      b = new originalB();
+      yield* originalB.iter();
+    }
+  }
+  expect([...A].map(fn => fn(b)).join()).toBe("B#x,B#x");
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-environment-super/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-environment-super/options.json
@@ -1,0 +1,3 @@
+{
+  "minNodeVersion": "18.0.0"
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-access/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-access/exec.js
@@ -1,0 +1,243 @@
+{
+  "instance private access in a static block";
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static {
+      staticThis = this;
+      hasX = (o) => #x in o;
+      getX = (o) => o.#x;
+      setX = (o, v) => o.#x = v;
+      hasA = (o) => #a in o;
+      getA = (o) => o.#a;
+      setA = (o, v) => o.#a = v;
+      hasM = (o) => #m in o;
+      callM = (o) => o.#m();
+    }
+  }
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+}
+
+{
+  "instance private access in a static field initializer";
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static field = (
+      staticThis = this,
+      hasX = (o) => #x in o,
+      getX = (o) => o.#x,
+      setX = (o, v) => o.#x = v,
+      hasA = (o) => #a in o,
+      getA = (o) => o.#a,
+      setA = (o, v) => o.#a = v,
+      hasM = (o) => #m in o,
+      callM = (o) => o.#m()
+    );
+  }
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+}
+
+{
+  "instance private access in the body of a static private method";
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, thisMethodLength, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static #method(_) {
+      staticThis = this;
+      thisMethodLength = this.#method.length;
+      hasX = (o) => #x in o;
+      getX = (o) => o.#x;
+      setX = (o, v) => o.#x = v;
+      hasA = (o) => #a in o;
+      getA = (o) => o.#a;
+      setA = (o, v) => o.#a = v;
+      hasM = (o) => #m in o;
+      callM = (o) => o.#m();
+    };
+
+    static {
+      this.#method()
+    }
+  }
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+  expect(thisMethodLength).toBe(1);
+}
+
+{
+  "instance private access in the params of a static private method";
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, thisMethodLength, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static #method(v = (
+      staticThis = this,
+      thisMethodLength = this.#method.length,
+      hasX = (o) => #x in o,
+      getX = (o) => o.#x,
+      setX = (o, v) => o.#x = v,
+      hasA = (o) => #a in o,
+      getA = (o) => o.#a,
+      setA = (o, v) => o.#a = v,
+      hasM = (o) => #m in o,
+      callM = (o) => o.#m()
+    )) {};
+
+    static {
+      this.#method()
+    }
+  }
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+  expect(thisMethodLength).toBe(1);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-access/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-access/exec.js
@@ -241,3 +241,70 @@
   expect(staticThis).toBe(Bar);
   expect(thisMethodLength).toBe(1);
 }
+
+{
+  "instance private access in everywhere mentioned above";
+  let hasX, getX, setX, hasA, getA, setA, hasM, callM, staticThis, thisMethodLength, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x;
+    accessor #a;
+    #m() { return "#m" }
+
+    x;
+    accessor a;
+    m() {}
+
+    static #method({
+      [(staticThis = this, thisMethodLength = this.#method.length, getX = (o) => o.#x)]: _
+    } = (
+      hasM = (o) => #m in o
+    )) {
+      hasA = (o) => #a in o;
+    }
+
+    static {
+      hasX = (o) => #x in o;
+      getA = (o) => o.#a;
+      callM = (o) => o.#m();
+      this.#method();
+    }
+
+    static #field = (
+      setX = (o, v) => o.#x = v,
+      setA = (o, v) => o.#a = v
+    );
+  }
+
+  const foo = new OriginalFoo();
+  const bar = new Foo();
+
+  expect(hasX(foo)).toBe(true);
+  expect(getX((setX(foo, "#x"), foo))).toBe("#x");
+  expect(hasA(foo)).toBe(true);
+  expect(getA((setA(foo, "#a"), foo))).toBe("#a");
+  expect(hasM(foo)).toBe(true);
+  expect(callM(foo)).toBe("#m");
+  expect(hasX(bar)).toBe(false);
+  expect(hasA(bar)).toBe(false);
+  expect(hasM(bar)).toBe(false);
+
+  expect(foo.hasOwnProperty("x")).toBe(true);
+  expect(bar.hasOwnProperty("x")).toBe(false);
+
+  expect(OriginalFoo.prototype.hasOwnProperty("a")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("a")).toBe(false);
+  expect(OriginalFoo.prototype.hasOwnProperty("m")).toBe(true);
+  expect(Bar.prototype.hasOwnProperty("m")).toBe(false);
+
+  expect(staticThis).toBe(Bar);
+  expect(thisMethodLength).toBe(1);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-access/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-access/input.js
@@ -1,0 +1,20 @@
+const dec = () => {};
+let hasX, hasA, hasM;
+
+@dec
+class Foo {
+  #x;
+  accessor #a;
+  #m() {}
+
+  x;
+  accessor a;
+  m() {}
+
+  static {
+    hasX = o => #x in o;
+    hasA = o => #a in o;
+    hasM = o => #m in o;
+  }
+}
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-access/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-access/output.js
@@ -1,0 +1,37 @@
+let _initClass, _staticBlock;
+const dec = () => {};
+let hasX, hasA, hasM;
+let _Foo;
+new class extends babelHelpers.identity {
+  static [class Foo {
+    static {
+      [_Foo, _initClass] = babelHelpers.applyDecs2311(this, [dec], []).c;
+      _staticBlock = function () {
+        hasX = o => #x in o;
+        hasA = o => #a in o;
+        hasM = o => #m in o;
+      };
+    }
+    #x;
+    #A;
+    get #a() {
+      return this.#A;
+    }
+    set #a(v) {
+      this.#A = v;
+    }
+    #m() {}
+    x;
+    #B;
+    get a() {
+      return this.#B;
+    }
+    set a(v) {
+      this.#B = v;
+    }
+    m() {}
+  }];
+  constructor() {
+    super(_Foo), _staticBlock.call(this), _initClass();
+  }
+}();

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-destructuring/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-destructuring/exec.js
@@ -1,0 +1,33 @@
+{
+  "instance private destructuring in a static block";
+  let getX, getA, callM, staticThis, OriginalFoo;
+
+  class Bar {}
+
+  const dec = (Foo) => {
+    OriginalFoo = Foo;
+    return Bar;
+  };
+
+  @dec
+  class Foo {
+    #x = "#x";
+    accessor #a = "#a";
+    #m() { return "#m" }
+
+    static {
+      staticThis = this;
+      getX = ({ #x: x }) => x;
+      getA = ({ #a: a }) => a;
+      callM = ({ #m: m }) => m();
+    }
+  }
+
+  const foo = new OriginalFoo();
+
+  expect(getX(foo)).toBe("#x");
+  expect(getA(foo)).toBe("#a");
+  expect(callM(foo)).toBe("#m");
+
+  expect(staticThis).toBe(Bar);
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-destructuring/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-destructuring/input.js
@@ -1,0 +1,17 @@
+const dec = () => {};
+let getX, getA, callM;
+
+@dec
+class Foo {
+  #x = "#x";
+  accessor #a = "#a";
+  #m() { return "#m" }
+
+  static {
+    staticThis = this;
+    getX = ({ #x: x }) => x;
+    getA = ({ #a: a }) => a;
+    callM = ({ #m: m }) => m();
+  }
+}
+

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-destructuring/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-destructuring/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "proposal-destructuring-private",
+    ["proposal-decorators", { "version": "2023-11" }]
+  ]
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-destructuring/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/replacement-static-private-instance-element-destructuring/output.js
@@ -1,0 +1,40 @@
+let _initClass, _staticBlock;
+const dec = () => {};
+let getX, getA, callM;
+let _Foo;
+new class extends babelHelpers.identity {
+  static [class Foo {
+    static {
+      [_Foo, _initClass] = babelHelpers.applyDecs2311(this, [dec], []).c;
+      _staticBlock = function () {
+        staticThis = this;
+        getX = _p => {
+          var x = _p.#x;
+          return x;
+        };
+        getA = _p2 => {
+          var a = _p2.#a;
+          return a;
+        };
+        callM = _p3 => {
+          var m = _p3.#m;
+          return m();
+        };
+      };
+    }
+    #x = "#x";
+    #A = "#a";
+    get #a() {
+      return this.#A;
+    }
+    set #a(v) {
+      this.#A = v;
+    }
+    #m() {
+      return "#m";
+    }
+  }];
+  constructor() {
+    super(_Foo), _staticBlock.call(this), _initClass();
+  }
+}();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/16176
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
To recap, when a class is decorated we move non-static elements into an inner class since they will be defined on the class prototype before the class is replaced in the class decorator. However, the static class element can still capture the instance private elements. By splitting the class the static class element can no longer resolve the private name defined by an instance element.

In this PR we move the closure of static element into the inner class, to ensure that they can still resolve the private name. For static private methods, we have to also replace the super usage.

This PR also respects the `ignoreFunctionLength` compiler assumption when generating the delegate for the static private methods.