### PR TITLE
Optimize the use of `assertThisInitialized` after `super()`

### DIFF
--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/output.js
@@ -18,7 +18,7 @@ let Outer = /*#__PURE__*/function (_Hello) {
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.callSuper(this, Outer);
     var _A = /*#__PURE__*/new WeakMap();
-    _computedKey = babelHelpers.toPropertyKey(babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper));
+    _computedKey = babelHelpers.toPropertyKey(babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper));
     let Inner = /*#__PURE__*/function (_computedKey4, _computedKey5) {
       function Inner() {
         babelHelpers.classCallCheck(this, Inner);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-accessor-key/output.js
@@ -14,11 +14,11 @@ let Hello = /*#__PURE__*/function () {
 let Outer = /*#__PURE__*/function (_Hello) {
   function Outer() {
     let _computedKey;
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.callSuper(this, Outer);
     var _A = /*#__PURE__*/new WeakMap();
-    _computedKey = babelHelpers.toPropertyKey(babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper));
+    _computedKey = babelHelpers.toPropertyKey(babelHelpers.get((_this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _this).call(_this));
     let Inner = /*#__PURE__*/function (_computedKey4, _computedKey5) {
       function Inner() {
         babelHelpers.classCallCheck(this, Inner);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
@@ -15,7 +15,7 @@ let Outer = /*#__PURE__*/function (_Hello) {
   function Outer() {
     var _Inner;
     let _init_hello, _init_extra_hello;
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.callSuper(this, Outer);
     let Inner = /*#__PURE__*/babelHelpers.createClass(function Inner() {
@@ -24,7 +24,7 @@ let Outer = /*#__PURE__*/function (_Hello) {
       _init_extra_hello(this);
     });
     _Inner = Inner;
-    [_init_hello, _init_extra_hello] = babelHelpers.applyDecs2311(_Inner, [], [[babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Outer.prototype)), "dec", _thisSuper), 0, "hello"]]).e;
+    [_init_hello, _init_extra_hello] = babelHelpers.applyDecs2311(_Inner, [], [[babelHelpers.get((_this, babelHelpers.getPrototypeOf(Outer.prototype)), "dec", _this), 0, "hello"]]).e;
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
   babelHelpers.inherits(Outer, _Hello);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-decorator/output.js
@@ -24,7 +24,7 @@ let Outer = /*#__PURE__*/function (_Hello) {
       _init_extra_hello(this);
     });
     _Inner = Inner;
-    [_init_hello, _init_extra_hello] = babelHelpers.applyDecs2311(_Inner, [], [[babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "dec", _thisSuper), 0, "hello"]]).e;
+    [_init_hello, _init_extra_hello] = babelHelpers.applyDecs2311(_Inner, [], [[babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Outer.prototype)), "dec", _thisSuper), 0, "hello"]]).e;
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
   babelHelpers.inherits(Outer, _Hello);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
@@ -17,7 +17,7 @@ let Outer = /*#__PURE__*/function (_Hello) {
     var _thisSuper, _this;
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.callSuper(this, Outer);
-    _babelHelpers$get$cal = babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper);
+    _babelHelpers$get$cal = babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper);
     let Inner = /*#__PURE__*/babelHelpers.createClass(function Inner() {
       babelHelpers.classCallCheck(this, Inner);
       babelHelpers.defineProperty(this, _babelHelpers$get$cal, 'hello');

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/nested-class/super-property-in-key/output.js
@@ -14,10 +14,10 @@ let Hello = /*#__PURE__*/function () {
 let Outer = /*#__PURE__*/function (_Hello) {
   function Outer() {
     let _babelHelpers$get$cal;
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.callSuper(this, Outer);
-    _babelHelpers$get$cal = babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper);
+    _babelHelpers$get$cal = babelHelpers.get((_this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _this).call(_this);
     let Inner = /*#__PURE__*/babelHelpers.createClass(function Inner() {
       babelHelpers.classCallCheck(this, Inner);
       babelHelpers.defineProperty(this, _babelHelpers$get$cal, 'hello');

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/derived/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/derived/output.js
@@ -16,7 +16,7 @@ var Bar = /*#__PURE__*/function (_Foo2) {
     var _this;
     babelHelpers.classCallCheck(this, Bar);
     _this = babelHelpers.callSuper(this, Bar, [...args]);
-    Object.defineProperty(babelHelpers.assertThisInitialized(_this), _prop2, {
+    Object.defineProperty(_this, _prop2, {
       writable: true,
       value: "bar"
     });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/foobar/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/foobar/output.js
@@ -6,7 +6,7 @@ let Child = /*#__PURE__*/function (_Parent) {
     var _this;
     babelHelpers.classCallCheck(this, Child);
     _this = babelHelpers.callSuper(this, Child);
-    Object.defineProperty(babelHelpers.assertThisInitialized(_this), _scopedFunctionWithThis, {
+    Object.defineProperty(_this, _scopedFunctionWithThis, {
       writable: true,
       value: function () {
         _this.name = {};

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed-redeclared/output.js
@@ -20,7 +20,7 @@ var Foo = /*#__PURE__*/function () {
           var _this;
           babelHelpers.classCallCheck(this, Nested);
           _this = babelHelpers.callSuper(this, Nested, [...args]);
-          Object.defineProperty(babelHelpers.assertThisInitialized(_this), _foo2, {
+          Object.defineProperty(_this, _foo2, {
             writable: true,
             value: 3
           });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/nested-class-extends-computed/output.js
@@ -19,7 +19,7 @@ var Foo = /*#__PURE__*/function () {
           var _this;
           babelHelpers.classCallCheck(this, Nested);
           _this = babelHelpers.callSuper(this, Nested, [...args]);
-          Object.defineProperty(babelHelpers.assertThisInitialized(_this), _foo2, {
+          Object.defineProperty(_this, _foo2, {
             writable: true,
             value: 3
           });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/super-statement/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/super-statement/output.js
@@ -6,7 +6,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
     var _this;
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.callSuper(this, Foo);
-    Object.defineProperty(babelHelpers.assertThisInitialized(_this), _bar, {
+    Object.defineProperty(_this, _bar, {
       writable: true,
       value: "foo"
     });

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/derived/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/derived/output.js
@@ -13,7 +13,7 @@ let Bar = /*#__PURE__*/function (_Foo2) {
     var _this;
     babelHelpers.classCallCheck(this, Bar);
     _this = babelHelpers.callSuper(this, Bar, [...args]);
-    babelHelpers.classPrivateFieldInitSpec(babelHelpers.assertThisInitialized(_this), _prop2, "bar");
+    babelHelpers.classPrivateFieldInitSpec(_this, _prop2, "bar");
     return _this;
   }
   babelHelpers.inherits(Bar, _Foo2);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/foobar/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/foobar/output.js
@@ -6,7 +6,7 @@ let Child = /*#__PURE__*/function (_Parent) {
     var _this;
     babelHelpers.classCallCheck(this, Child);
     _this = babelHelpers.callSuper(this, Child);
-    babelHelpers.classPrivateFieldInitSpec(babelHelpers.assertThisInitialized(_this), _scopedFunctionWithThis, () => {
+    babelHelpers.classPrivateFieldInitSpec(_this, _scopedFunctionWithThis, () => {
       _this.name = {};
     });
     return _this;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed-redeclared/output.js
@@ -17,7 +17,7 @@ let Foo = /*#__PURE__*/function () {
           var _this;
           babelHelpers.classCallCheck(this, Nested);
           _this = babelHelpers.callSuper(this, Nested, [...args]);
-          babelHelpers.classPrivateFieldInitSpec(babelHelpers.assertThisInitialized(_this), _foo2, 3);
+          babelHelpers.classPrivateFieldInitSpec(_this, _foo2, 3);
           return _this;
         }
         babelHelpers.inherits(Nested, _ref);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/nested-class-extends-computed/output.js
@@ -16,7 +16,7 @@ let Foo = /*#__PURE__*/function () {
           var _this;
           babelHelpers.classCallCheck(this, Nested);
           _this = babelHelpers.callSuper(this, Nested, [...args]);
-          babelHelpers.classPrivateFieldInitSpec(babelHelpers.assertThisInitialized(_this), _foo2, 3);
+          babelHelpers.classPrivateFieldInitSpec(_this, _foo2, 3);
           return _this;
         }
         babelHelpers.inherits(Nested, _ref);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/super-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/super-call/output.js
@@ -19,7 +19,7 @@ let B = /*#__PURE__*/function (_A) {
     var _thisSuper, _this;
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.callSuper(this, B, [...args]);
-    babelHelpers.classPrivateFieldInitSpec(babelHelpers.assertThisInitialized(_this), _foo, babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(B.prototype)), "foo", _thisSuper).call(_thisSuper));
+    babelHelpers.classPrivateFieldInitSpec(_this, _foo, babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(B.prototype)), "foo", _thisSuper).call(_thisSuper));
     return _this;
   }
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/private/super-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/private/super-call/output.js
@@ -16,10 +16,10 @@ let B = /*#__PURE__*/function (_A) {
   "use strict";
 
   function B(...args) {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.callSuper(this, B, [...args]);
-    babelHelpers.classPrivateFieldInitSpec(_this, _foo, babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(B.prototype)), "foo", _thisSuper).call(_thisSuper));
+    babelHelpers.classPrivateFieldInitSpec(_this, _foo, babelHelpers.get((_this, babelHelpers.getPrototypeOf(B.prototype)), "foo", _this).call(_this));
     return _this;
   }
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/super-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/super-call/output.js
@@ -18,7 +18,7 @@ var B = /*#__PURE__*/function (_A) {
     var _thisSuper, _this;
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.callSuper(this, B, [...args]);
-    _this.foo = babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(B.prototype)), "foo", _thisSuper).call(_thisSuper);
+    _this.foo = babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(B.prototype)), "foo", _thisSuper).call(_thisSuper);
     return _this;
   }
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/super-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/super-call/output.js
@@ -15,10 +15,10 @@ var B = /*#__PURE__*/function (_A) {
   "use strict";
 
   function B(...args) {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.callSuper(this, B, [...args]);
-    _this.foo = babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(B.prototype)), "foo", _thisSuper).call(_thisSuper);
+    _this.foo = babelHelpers.get((_this, babelHelpers.getPrototypeOf(B.prototype)), "foo", _this).call(_this);
     return _this;
   }
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/derived/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/derived/output.js
@@ -5,7 +5,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
     var _this;
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.callSuper(this, Foo, [...args]);
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo");
+    babelHelpers.defineProperty(_this, "bar", "foo");
     return _this;
   }
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/foobar/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/foobar/output.js
@@ -5,7 +5,7 @@ var Child = /*#__PURE__*/function (_Parent) {
     var _this;
     babelHelpers.classCallCheck(this, Child);
     _this = babelHelpers.callSuper(this, Child);
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "scopedFunctionWithThis", function () {
+    babelHelpers.defineProperty(_this, "scopedFunctionWithThis", function () {
       _this.name = {};
     });
     return _this;

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/super-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/super-call/output.js
@@ -18,7 +18,7 @@ var B = /*#__PURE__*/function (_A) {
     var _thisSuper, _this;
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.callSuper(this, B, [...args]);
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "foo", babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(B.prototype)), "foo", _thisSuper).call(_thisSuper));
+    babelHelpers.defineProperty(_this, "foo", babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(B.prototype)), "foo", _thisSuper).call(_thisSuper));
     return _this;
   }
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/super-call/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/super-call/output.js
@@ -15,10 +15,10 @@ var B = /*#__PURE__*/function (_A) {
   "use strict";
 
   function B(...args) {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, B);
     _this = babelHelpers.callSuper(this, B, [...args]);
-    babelHelpers.defineProperty(_this, "foo", babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(B.prototype)), "foo", _thisSuper).call(_thisSuper));
+    babelHelpers.defineProperty(_this, "foo", babelHelpers.get((_this, babelHelpers.getPrototypeOf(B.prototype)), "foo", _this).call(_this));
     return _this;
   }
   babelHelpers.inherits(B, _A);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/public/super-statement/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/public/super-statement/output.js
@@ -5,7 +5,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
     var _this;
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.callSuper(this, Foo);
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "bar", "foo");
+    babelHelpers.defineProperty(_this, "bar", "foo");
     return _this;
   }
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/6154/output.js
@@ -5,14 +5,14 @@ var Test = /*#__PURE__*/babelHelpers.createClass(function Test() {
   babelHelpers.classCallCheck(this, Test);
   var Other = /*#__PURE__*/function (_Test) {
     function Other() {
-      var _thisSuper, _this;
+      var _this;
       babelHelpers.classCallCheck(this, Other);
       for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
         args[_key] = arguments[_key];
       }
       _this = babelHelpers.callSuper(this, Other, [].concat(args));
       babelHelpers.defineProperty(_this, "a", function () {
-        return babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Other.prototype)), "test", _thisSuper);
+        return babelHelpers.get((_this, babelHelpers.getPrototypeOf(Other.prototype)), "test", _this);
       });
       return _this;
     }

--- a/packages/babel-plugin-transform-class-properties/test/fixtures/regression/6154/output.js
+++ b/packages/babel-plugin-transform-class-properties/test/fixtures/regression/6154/output.js
@@ -11,8 +11,8 @@ var Test = /*#__PURE__*/babelHelpers.createClass(function Test() {
         args[_key] = arguments[_key];
       }
       _this = babelHelpers.callSuper(this, Other, [].concat(args));
-      babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "a", function () {
-        return babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Other.prototype)), "test", _thisSuper);
+      babelHelpers.defineProperty(_this, "a", function () {
+        return babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Other.prototype)), "test", _thisSuper);
       });
       return _this;
     }

--- a/packages/babel-plugin-transform-classes/test/fixtures/assumption-constantSuper/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/assumption-constantSuper/accessing-super-class/output.js
@@ -7,11 +7,11 @@ var Test = /*#__PURE__*/function (_Foo) {
     babelHelpers.classCallCheck(this, Test);
     woops.super.test();
     _this = babelHelpers.callSuper(this, Test);
-    _Foo.prototype.test.call(babelHelpers.assertThisInitialized(_this));
+    _Foo.prototype.test.call(_this);
     _this = babelHelpers.callSuper(this, Test, arguments);
     _this = babelHelpers.callSuper(this, Test, ["test"].concat(Array.prototype.slice.call(arguments)));
-    _Foo.prototype.test.apply(babelHelpers.assertThisInitialized(_this), arguments);
-    (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, [babelHelpers.assertThisInitialized(_this), "test"].concat(Array.prototype.slice.call(arguments)));
+    _Foo.prototype.test.apply(_this, arguments);
+    (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, [_this, "test"].concat(Array.prototype.slice.call(arguments)));
     return _this;
   }
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/assumption-constantSuper/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/assumption-constantSuper/calling-super-properties/output.js
@@ -6,7 +6,7 @@ var Test = /*#__PURE__*/function (_Foo) {
     babelHelpers.classCallCheck(this, Test);
     _this = babelHelpers.callSuper(this, Test);
     _Foo.prototype.test.whatever();
-    _Foo.prototype.test.call(babelHelpers.assertThisInitialized(_this));
+    _Foo.prototype.test.call(_this);
     return _this;
   }
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/assumption-superIsCallableConstructor/super-class-this-usage/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/assumption-superIsCallableConstructor/super-class-this-usage/output.js
@@ -5,7 +5,7 @@ var Test = /*#__PURE__*/function (_Foo) {
     var _this;
     babelHelpers.classCallCheck(this, Test);
     _this = _Foo.call(this) || this;
-    babelHelpers.assertThisInitialized(_this);
+    _this;
     _this.prop = 1;
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/accessing-super-class/output.js
@@ -6,11 +6,11 @@ var Test = /*#__PURE__*/function (_Foo) {
     var _this;
     woops.super.test();
     _this = _Foo.call(this) || this;
-    _Foo.prototype.test.call(babelHelpers.assertThisInitialized(_this));
+    _Foo.prototype.test.call(_this);
     _this = _Foo.apply(this, arguments) || this;
     _this = _Foo.call.apply(_Foo, [this, "test"].concat(Array.prototype.slice.call(arguments))) || this;
-    _Foo.prototype.test.apply(babelHelpers.assertThisInitialized(_this), arguments);
-    (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, [babelHelpers.assertThisInitialized(_this), "test"].concat(Array.prototype.slice.call(arguments)));
+    _Foo.prototype.test.apply(_this, arguments);
+    (_Foo$prototype$test = _Foo.prototype.test).call.apply(_Foo$prototype$test, [_this, "test"].concat(Array.prototype.slice.call(arguments)));
     return _this;
   }
   babelHelpers.inheritsLoose(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/loose/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/loose/calling-super-properties/output.js
@@ -5,7 +5,7 @@ var Test = /*#__PURE__*/function (_Foo) {
     var _this;
     _this = _Foo.call(this) || this;
     _Foo.prototype.test.whatever();
-    _Foo.prototype.test.call(babelHelpers.assertThisInitialized(_this));
+    _Foo.prototype.test.call(_this);
     return _this;
   }
   babelHelpers.inheritsLoose(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-2/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-2/input.js
@@ -1,0 +1,6 @@
+class Foo extends Bar {
+  constructor() {
+    if (dynamic()) super();
+    this;
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-2/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-2/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-classes"]
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-2/output.js
@@ -1,0 +1,13 @@
+let Foo = /*#__PURE__*/function (_Bar) {
+  "use strict";
+
+  function Foo() {
+    var _this;
+    babelHelpers.classCallCheck(this, Foo);
+    if (dynamic()) _this = babelHelpers.callSuper(this, Foo);
+    babelHelpers.assertThisInitialized(_this);
+    return babelHelpers.assertThisInitialized(_this);
+  }
+  babelHelpers.inherits(Foo, _Bar);
+  return babelHelpers.createClass(Foo);
+}(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-3/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-3/input.js
@@ -1,0 +1,5 @@
+class Foo extends Bar {
+  constructor() {
+    super(this);
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-3/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-3/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-classes"]
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super-3/output.js
@@ -1,0 +1,11 @@
+let Foo = /*#__PURE__*/function (_Bar) {
+  "use strict";
+
+  function Foo() {
+    var _this;
+    babelHelpers.classCallCheck(this, Foo);
+    return _this = babelHelpers.callSuper(this, Foo, [babelHelpers.assertThisInitialized(_this)]);
+  }
+  babelHelpers.inherits(Foo, _Bar);
+  return babelHelpers.createClass(Foo);
+}(Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super/input.js
@@ -1,0 +1,6 @@
+class Foo extends Bar {
+  constructor() {
+    this;
+    super();
+  }
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super/options.json
+++ b/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-classes"]
+}

--- a/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/misc/this-before-super/output.js
@@ -1,13 +1,11 @@
-var _bar = /*#__PURE__*/new WeakMap();
 let Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   function Foo() {
     var _this;
     babelHelpers.classCallCheck(this, Foo);
-    _this = babelHelpers.callSuper(this, Foo);
-    babelHelpers.classPrivateFieldInitSpec(_this, _bar, "foo");
-    return _this;
+    babelHelpers.assertThisInitialized(_this);
+    return _this = babelHelpers.callSuper(this, Foo);
   }
   babelHelpers.inherits(Foo, _Bar);
   return babelHelpers.createClass(Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/3028/output.js
@@ -13,7 +13,7 @@ var a1 = /*#__PURE__*/function (_b) {
     babelHelpers.classCallCheck(this, a1);
     _this = babelHelpers.callSuper(this, a1);
     _this.x = function () {
-      return babelHelpers.assertThisInitialized(_this);
+      return _this;
     };
     return _this;
   }
@@ -26,7 +26,7 @@ var a2 = exports["default"] = /*#__PURE__*/function (_b2) {
     babelHelpers.classCallCheck(this, a2);
     _this2 = babelHelpers.callSuper(this, a2);
     _this2.x = function () {
-      return babelHelpers.assertThisInitialized(_this2);
+      return _this2;
     };
     return _this2;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
@@ -15,13 +15,13 @@ var ColorPoint = /*#__PURE__*/function (_Point) {
   "use strict";
 
   function ColorPoint() {
-    var _thisSuper, _thisSuper2, _this;
+    var _this;
     babelHelpers.classCallCheck(this, ColorPoint);
     _this = babelHelpers.callSuper(this, ColorPoint);
     _this.x = 2;
-    babelHelpers.set((_thisSuper = _this, babelHelpers.getPrototypeOf(ColorPoint.prototype)), "x", 3, _thisSuper, true);
+    babelHelpers.set((_this, babelHelpers.getPrototypeOf(ColorPoint.prototype)), "x", 3, _this, true);
     expect(_this.x).toBe(3); // A
-    expect(babelHelpers.get((_thisSuper2 = _this, babelHelpers.getPrototypeOf(ColorPoint.prototype)), "x", _thisSuper2)).toBeUndefined(); // B
+    expect(babelHelpers.get((_this, babelHelpers.getPrototypeOf(ColorPoint.prototype)), "x", _this)).toBeUndefined(); // B
     return _this;
   }
   babelHelpers.inherits(ColorPoint, _Point);

--- a/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/regression/5769/output.js
@@ -19,9 +19,9 @@ var ColorPoint = /*#__PURE__*/function (_Point) {
     babelHelpers.classCallCheck(this, ColorPoint);
     _this = babelHelpers.callSuper(this, ColorPoint);
     _this.x = 2;
-    babelHelpers.set((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(ColorPoint.prototype)), "x", 3, _thisSuper, true);
+    babelHelpers.set((_thisSuper = _this, babelHelpers.getPrototypeOf(ColorPoint.prototype)), "x", 3, _thisSuper, true);
     expect(_this.x).toBe(3); // A
-    expect(babelHelpers.get((_thisSuper2 = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(ColorPoint.prototype)), "x", _thisSuper2)).toBeUndefined(); // B
+    expect(babelHelpers.get((_thisSuper2 = _this, babelHelpers.getPrototypeOf(ColorPoint.prototype)), "x", _thisSuper2)).toBeUndefined(); // B
     return _this;
   }
   babelHelpers.inherits(ColorPoint, _Point);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
@@ -3,15 +3,15 @@ var Test = /*#__PURE__*/function (_Foo) {
 
   function Test() {
     var _babelHelpers$get;
-    var _thisSuper, _thisSuper2, _thisSuper3, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Test);
     woops.super.test();
     _this = babelHelpers.callSuper(this, Test);
-    babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper).call(_thisSuper);
+    babelHelpers.get((_this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _this).call(_this);
     _this = babelHelpers.callSuper(this, Test, arguments);
     _this = babelHelpers.callSuper(this, Test, ["test"].concat(Array.prototype.slice.call(arguments)));
-    babelHelpers.get((_thisSuper2 = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper2).apply(_thisSuper2, arguments);
-    (_babelHelpers$get = babelHelpers.get((_thisSuper3 = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper3)).call.apply(_babelHelpers$get, [_thisSuper3, "test"].concat(Array.prototype.slice.call(arguments)));
+    babelHelpers.get((_this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _this).apply(_this, arguments);
+    (_babelHelpers$get = babelHelpers.get((_this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _this)).call.apply(_babelHelpers$get, [_this, "test"].concat(Array.prototype.slice.call(arguments)));
     return _this;
   }
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-class/output.js
@@ -7,11 +7,11 @@ var Test = /*#__PURE__*/function (_Foo) {
     babelHelpers.classCallCheck(this, Test);
     woops.super.test();
     _this = babelHelpers.callSuper(this, Test);
-    babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper).call(_thisSuper);
+    babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper).call(_thisSuper);
     _this = babelHelpers.callSuper(this, Test, arguments);
     _this = babelHelpers.callSuper(this, Test, ["test"].concat(Array.prototype.slice.call(arguments)));
-    babelHelpers.get((_thisSuper2 = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper2).apply(_thisSuper2, arguments);
-    (_babelHelpers$get = babelHelpers.get((_thisSuper3 = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper3)).call.apply(_babelHelpers$get, [_thisSuper3, "test"].concat(Array.prototype.slice.call(arguments)));
+    babelHelpers.get((_thisSuper2 = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper2).apply(_thisSuper2, arguments);
+    (_babelHelpers$get = babelHelpers.get((_thisSuper3 = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper3)).call.apply(_babelHelpers$get, [_thisSuper3, "test"].concat(Array.prototype.slice.call(arguments)));
     return _this;
   }
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
@@ -5,8 +5,8 @@ var Test = /*#__PURE__*/function (_Foo) {
     var _thisSuper, _thisSuper2, _this;
     babelHelpers.classCallCheck(this, Test);
     _this = babelHelpers.callSuper(this, Test);
-    babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper);
-    babelHelpers.get((_thisSuper2 = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper2).whatever;
+    babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper);
+    babelHelpers.get((_thisSuper2 = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper2).whatever;
     return _this;
   }
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-properties/output.js
@@ -2,11 +2,11 @@ var Test = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   function Test() {
-    var _thisSuper, _thisSuper2, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Test);
     _this = babelHelpers.callSuper(this, Test);
-    babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper);
-    babelHelpers.get((_thisSuper2 = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper2).whatever;
+    babelHelpers.get((_this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _this);
+    babelHelpers.get((_this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _this).whatever;
     return _this;
   }
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-property-optional-chain/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-property-optional-chain/output.js
@@ -3,10 +3,10 @@ var Test = /*#__PURE__*/function (_Foo) {
 
   function Test() {
     var _babelHelpers$get, _babelHelpers$get2;
-    var _thisSuper, _thisSuper2, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Test);
-    (_babelHelpers$get = babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "foo", _thisSuper)) === null || _babelHelpers$get === void 0 || _babelHelpers$get.bar;
-    (_babelHelpers$get2 = babelHelpers.get((_thisSuper2 = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "foo", _thisSuper2)) === null || _babelHelpers$get2 === void 0 || _babelHelpers$get2.call(_thisSuper2);
+    (_babelHelpers$get = babelHelpers.get((babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "foo", babelHelpers.assertThisInitialized(_this))) === null || _babelHelpers$get === void 0 || _babelHelpers$get.bar;
+    (_babelHelpers$get2 = babelHelpers.get((babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "foo", babelHelpers.assertThisInitialized(_this))) === null || _babelHelpers$get2 === void 0 || _babelHelpers$get2.call(babelHelpers.assertThisInitialized(_this));
     return babelHelpers.assertThisInitialized(_this);
   }
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
@@ -2,11 +2,11 @@ var Test = /*#__PURE__*/function (_Foo) {
   "use strict";
 
   function Test() {
-    var _thisSuper, _thisSuper2, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Test);
     _this = babelHelpers.callSuper(this, Test);
-    babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper).whatever();
-    babelHelpers.get((_thisSuper2 = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper2).call(_thisSuper2);
+    babelHelpers.get((_this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _this).whatever();
+    babelHelpers.get((_this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _this).call(_this);
     return _this;
   }
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/calling-super-properties/output.js
@@ -5,8 +5,8 @@ var Test = /*#__PURE__*/function (_Foo) {
     var _thisSuper, _thisSuper2, _this;
     babelHelpers.classCallCheck(this, Test);
     _this = babelHelpers.callSuper(this, Test);
-    babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper).whatever();
-    babelHelpers.get((_thisSuper2 = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper2).call(_thisSuper2);
+    babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper).whatever();
+    babelHelpers.get((_thisSuper2 = _this, babelHelpers.getPrototypeOf(Test.prototype)), "test", _thisSuper2).call(_thisSuper2);
     return _this;
   }
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/name-collisions-with-class-ref-in-computed-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/name-collisions-with-class-ref-in-computed-key/output.js
@@ -2,7 +2,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   function Foo() {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.callSuper(this, Foo);
     var X = /*#__PURE__*/function (_ref) {
@@ -15,7 +15,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
       }]);
     }((() => {
       var _Foo;
-      babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Foo.prototype)), "method", _thisSuper).call(_thisSuper);
+      babelHelpers.get((_this, babelHelpers.getPrototypeOf(Foo.prototype)), "method", _this).call(_this);
     })());
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/name-collisions-with-class-ref-in-computed-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/name-collisions-with-class-ref-in-computed-key/output.js
@@ -15,7 +15,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
       }]);
     }((() => {
       var _Foo;
-      babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "method", _thisSuper).call(_thisSuper);
+      babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Foo.prototype)), "method", _thisSuper).call(_thisSuper);
     })());
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/name-collisions-with-class-ref-in-constructor/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/name-collisions-with-class-ref-in-constructor/output.js
@@ -13,12 +13,12 @@ var Foo = /*#__PURE__*/function (_Base) {
   "use strict";
 
   function Foo() {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Foo);
     _this = babelHelpers.callSuper(this, Foo);
     if (true) {
       var _Foo;
-      babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Foo.prototype)), "method", _thisSuper).call(_thisSuper);
+      babelHelpers.get((_this, babelHelpers.getPrototypeOf(Foo.prototype)), "method", _this).call(_this);
     }
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/name-collisions-with-class-ref-in-constructor/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/name-collisions-with-class-ref-in-constructor/output.js
@@ -18,7 +18,7 @@ var Foo = /*#__PURE__*/function (_Base) {
     _this = babelHelpers.callSuper(this, Foo);
     if (true) {
       var _Foo;
-      babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "method", _thisSuper).call(_thisSuper);
+      babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Foo.prototype)), "method", _thisSuper).call(_thisSuper);
     }
     return _this;
   }

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
@@ -13,7 +13,7 @@ var Hello = /*#__PURE__*/function () {
 }();
 var Outer = /*#__PURE__*/function (_Hello) {
   function Outer() {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.callSuper(this, Outer);
     var Inner = /*#__PURE__*/function (_babelHelpers$get$cal) {
@@ -26,7 +26,7 @@ var Outer = /*#__PURE__*/function (_Hello) {
           return 'hello';
         }
       }]);
-    }(babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper));
+    }(babelHelpers.get((_this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _this).call(_this));
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
   babelHelpers.inherits(Outer, _Hello);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-class-super-property-in-key/output.js
@@ -26,7 +26,7 @@ var Outer = /*#__PURE__*/function (_Hello) {
           return 'hello';
         }
       }]);
-    }(babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper));
+    }(babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper));
     return babelHelpers.possibleConstructorReturn(_this, new Inner());
   }
   babelHelpers.inherits(Outer, _Hello);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
@@ -17,7 +17,7 @@ var Outer = /*#__PURE__*/function (_Hello) {
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.callSuper(this, Outer);
     var Inner = {
-      [babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper)]() {
+      [babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper)]() {
         return 'hello';
       }
     };

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/nested-object-super-property-in-key/output.js
@@ -13,11 +13,11 @@ var Hello = /*#__PURE__*/function () {
 }();
 var Outer = /*#__PURE__*/function (_Hello) {
   function Outer() {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Outer);
     _this = babelHelpers.callSuper(this, Outer);
     var Inner = {
-      [babelHelpers.get((_thisSuper = _this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _thisSuper).call(_thisSuper)]() {
+      [babelHelpers.get((_this, babelHelpers.getPrototypeOf(Outer.prototype)), "toString", _this).call(_this)]() {
         return 'hello';
       }
     };

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
@@ -2,9 +2,9 @@ var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   function Foo() {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Foo);
-    babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "foo", _thisSuper).call(_thisSuper, _this = babelHelpers.callSuper(this, Foo));
+    babelHelpers.get((babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this), _this = babelHelpers.callSuper(this, Foo));
     return _this;
   }
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
@@ -2,9 +2,9 @@ var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   function Foo() {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Foo);
-    babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "foo", _thisSuper).call(_thisSuper);
+    babelHelpers.get((babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
     return _this = babelHelpers.callSuper(this, Foo);
   }
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
@@ -2,10 +2,10 @@ var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   function Foo() {
-    var _thisSuper, _thisSuper2, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Foo);
-    var t = () => babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "test", _thisSuper).call(_thisSuper);
-    babelHelpers.get((_thisSuper2 = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "foo", _thisSuper2).call(_thisSuper2);
+    var t = () => babelHelpers.get((babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
+    babelHelpers.get((babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "foo", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
     return _this = babelHelpers.callSuper(this, Foo);
   }
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
@@ -2,9 +2,9 @@ var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   function Foo() {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Foo);
-    var t = () => babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "test", _thisSuper).call(_thisSuper);
+    var t = () => babelHelpers.get((babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
     _this = babelHelpers.callSuper(this, Foo);
     t();
     return _this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
@@ -2,9 +2,9 @@ var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   function Foo() {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Foo);
-    var t = () => babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "test", _thisSuper).call(_thisSuper);
+    var t = () => babelHelpers.get((babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), "test", babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
     return _this = babelHelpers.callSuper(this, Foo);
   }
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
@@ -2,9 +2,9 @@ var Foo = /*#__PURE__*/function (_Bar) {
   "use strict";
 
   function Foo() {
-    var _thisSuper, _this;
+    var _this;
     babelHelpers.classCallCheck(this, Foo);
-    babelHelpers.get((_thisSuper = babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), (_this = babelHelpers.callSuper(this, Foo)).method, _thisSuper).call(_thisSuper);
+    babelHelpers.get((babelHelpers.assertThisInitialized(_this), babelHelpers.getPrototypeOf(Foo.prototype)), (_this = babelHelpers.callSuper(this, Foo)).method, babelHelpers.assertThisInitialized(_this)).call(babelHelpers.assertThisInitialized(_this));
     return _this;
   }
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
+++ b/packages/babel-plugin-transform-parameters/test/fixtures/regression/6057-expanded/output.js
@@ -13,7 +13,7 @@ var App = exports["default"] = /*#__PURE__*/function (_Component) {
       args[_key] = arguments[_key];
     }
     _this = babelHelpers.callSuper(this, App, [].concat(args));
-    babelHelpers.defineProperty(babelHelpers.assertThisInitialized(_this), "exportType", '');
+    babelHelpers.defineProperty(_this, "exportType", '');
     return _this;
   }
   babelHelpers.inherits(App, _Component);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/regression/12863/output.mjs
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/regression/12863/output.mjs
@@ -3,7 +3,6 @@ import _createClass from "@babel/runtime-corejs3/helpers/createClass";
 import _classCallCheck from "@babel/runtime-corejs3/helpers/classCallCheck";
 import _possibleConstructorReturn from "@babel/runtime-corejs3/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime-corejs3/helpers/getPrototypeOf";
-import _assertThisInitialized from "@babel/runtime-corejs3/helpers/assertThisInitialized";
 import _inherits from "@babel/runtime-corejs3/helpers/inherits";
 import _defineProperty from "@babel/runtime-corejs3/helpers/defineProperty";
 import _concatInstanceProperty from "@babel/runtime-corejs3/core-js-stable/instance/concat";
@@ -15,7 +14,7 @@ let B = /*#__PURE__*/function (_A) {
     var _this;
     _classCallCheck(this, B);
     _this = _callSuper(this, B, _concatInstanceProperty(_context = []).call(_context, args));
-    _defineProperty(_assertThisInitialized(_this), "b", 8);
+    _defineProperty(_this, "b", 8);
     return _this;
   }
   _inherits(B, _A);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes https://github.com/babel/babel/pull/8405 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As we optimized `possibleConstructorReturn`, this PR reduces the use of `assertThisInitialized`.
Although this only works in simple `super()` positions, this should be enough.