### PR TITLE
Remove `./helpers/esm` exports from `@babel/runtime` and drop Node.js 13.0-13.1

### DIFF
--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -16,6 +16,11 @@ import polyfillCorejs3 from "babel-plugin-polyfill-corejs3";
 const require = createRequire(import.meta.url);
 const runtimeVersion = require("@babel/runtime/package.json").version;
 
+// env vars from the cli are always strings, so !!ENV_VAR returns true for "false"
+function bool(value) {
+  return Boolean(value) && value !== "false" && value !== "0";
+}
+
 function outputFile(filePath, data) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, data);
@@ -26,7 +31,7 @@ function corejsVersion(pkgName, depName) {
 }
 
 writeHelpers("@babel/runtime");
-if (!process.env.BABEL_8_BREAKING) {
+if (!bool(process.env.BABEL_8_BREAKING)) {
   writeHelpers("@babel/runtime-corejs2", {
     polyfillProvider: [
       polyfillCorejs2,
@@ -48,7 +53,7 @@ writeHelpers("@babel/runtime-corejs3", {
   ],
 });
 
-if (!process.env.BABEL_8_BREAKING) {
+if (!bool(process.env.BABEL_8_BREAKING)) {
   writeCoreJS({
     corejs: 2,
     proposals: true,
@@ -181,7 +186,7 @@ function writeHelpers(runtimeName, { polyfillProvider } = {}) {
       { esm: true, polyfillProvider }
     );
 
-    if (process.env.BABEL_8_BREAKING) {
+    if (bool(process.env.BABEL_8_BREAKING)) {
       // Note: This does not work in Node.js 13.0 and 13.1, which support
       // the `exports` field only as strings and not as objects.
       // For other Node.js versions:

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -181,25 +181,44 @@ function writeHelpers(runtimeName, { polyfillProvider } = {}) {
       { esm: true, polyfillProvider }
     );
 
-    // Node.js versions >=13.0.0, <13.7.0 support the `exports` field but
-    // not conditional exports (`require`/`node`/`default`)
-    // We can specify exports with an array of fallbacks:
-    // - Node.js >=13.7.0 and bundlers will successfully load the first
-    //   array entry:
-    //    * Node.js will always load the CJS file
-    //    * Modern tools when using "import" will load the ESM file
-    //    * Everything else (old tools, or require() in tools) will
-    //      load the CJS file
-    // - Node.js 13.2-13.7 will ignore the "node" and "import" conditions,
-    //   will fallback to "default" and load the CJS file
-    // - Node.js <13.2.0 will fail resolving the first array entry, and will
-    //   fallback to the second entry (the CJS file)
-    // In Babel 8 we can simplify this.
-    helperSubExports[`./${path.posix.join("helpers", helperName)}`] = [
-      { node: cjs, import: esm, default: cjs },
-      cjs,
-    ];
-    if (!process.env.BABEL_8_BREAKING) {
+    if (process.env.BABEL_8_BREAKING) {
+      // Note: This does not work in Node.js 13.0 and 13.1, which support
+      // the `exports` field only as strings and not as objects.
+      // For other Node.js versions:
+      // - <13.0.0 does not support `exports` at all, so
+      //   @babel/runtime/helpers/foo will automatically resolve to
+      //   @babel/runtime/helpers/foo.js
+      // - >=13.2.0 < 13.7.0 ignore the `node` and `import` conditions, so
+      //   they will always fallback to `default` and correctly load the
+      //   CJS helper.
+      // - Node.js >=13.7.0 and bundlers will successfully parse `conditions`
+      //    * Node.js will always load the CJS file
+      //    * Modern tools when using "import" will load the ESM file
+      //    * Tools when using require() will load the CJS file
+      helperSubExports[`./${path.posix.join("helpers", helperName)}`] = {
+        node: cjs,
+        import: esm,
+        default: cjs,
+      };
+    } else {
+      // Node.js versions >=13.0.0, <13.7.0 support the `exports` field but
+      // not conditional exports (`require`/`node`/`default`)
+      // We can specify exports with an array of fallbacks:
+      // - Node.js >=13.7.0 and bundlers will successfully load the first
+      //   array entry:
+      //    * Node.js will always load the CJS file
+      //    * Modern tools when using "import" will load the ESM file
+      //    * Everything else (old tools, or require() in tools) will
+      //      load the CJS file
+      // - Node.js 13.2-13.7 will ignore the "node" and "import" conditions,
+      //   will fallback to "default" and load the CJS file
+      // - Node.js <13.2.0 will fail resolving the first array entry, and will
+      //   fallback to the second entry (the CJS file)
+      // In Babel 8 we can simplify this.
+      helperSubExports[`./${path.posix.join("helpers", helperName)}`] = [
+        { node: cjs, import: esm, default: cjs },
+        cjs,
+      ];
       // This is needed for backwards compatibility, but new versions of Babel
       // do not emit imports to the /esm/ directory anymore.
       helperSubExports[`./${path.posix.join("helpers", "esm", helperName)}`] =

--- a/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -199,9 +199,12 @@ function writeHelpers(runtimeName, { polyfillProvider } = {}) {
       { node: cjs, import: esm, default: cjs },
       cjs,
     ];
-    // For backward compatibility. We can remove this in Babel 8.
-    helperSubExports[`./${path.posix.join("helpers", "esm", helperName)}`] =
-      esm;
+    if (!process.env.BABEL_8_BREAKING) {
+      // This is needed for backwards compatibility, but new versions of Babel
+      // do not emit imports to the /esm/ directory anymore.
+      helperSubExports[`./${path.posix.join("helpers", "esm", helperName)}`] =
+        esm;
+    }
   }
 
   writeHelperExports(runtimeName, helperSubExports);

--- a/scripts/assert-dir-git-clean.js
+++ b/scripts/assert-dir-git-clean.js
@@ -9,6 +9,13 @@ if (execSync("git status --porcelain=v1", { encoding: "utf8" })) {
     `Please re-run "${fixCommand}" and checkout the following changes to git`
   );
   execSync("git status", { stdio: "inherit" });
+
+  if (process.env.GITHUB_ACTIONS) {
+    console.log("::group::git diff");
+    execSync("git diff", { stdio: "inherit" });
+    console.log("::endgroup::");
+  }
+
   // eslint-disable-next-line no-process-exit
   process.exit(1);
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


They are not actually needed anymore, given that we use `exports` with an `import` condition. They are there just because Babel emitted `/esm/` imports when using `useESModule: true`, before that `package.json#exports` was a thing.

This PR also simplify the conditions object, and as a side effects drops support for Node.js 13.0 and 13.1. In general I'd like to keep `@babel/runtime` as maximally compatible as possible, but this should be fine.

Now `package.json` is like this:
```json
  "exports": {
    "./helpers/AsyncGenerator": {
      "node": "./helpers/AsyncGenerator.js",
      "import": "./helpers/esm/AsyncGenerator.js",
      "default": "./helpers/AsyncGenerator.js"
    },
    "./helpers/OverloadYield": {
      "node": "./helpers/OverloadYield.js",
      "import": "./helpers/esm/OverloadYield.js",
      "default": "./helpers/OverloadYield.js"
    },
```