### PR TITLE
Run Babel transform tests on old node if possible

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,7 +295,7 @@ Other than normal Babel options, `options.json` can contain other properties to 
 
 - **`minNodeVersion`** (string)
 
-  If the test requires a minimum Node version, you can add `minNodeVersion` (must be in semver format).
+  If an `exec.js`` test requires a minimum Node version, you can add `minNodeVersion` (must be in semver format).
 
   ```jsonc
   // options.json example
@@ -303,6 +303,8 @@ Other than normal Babel options, `options.json` can contain other properties to 
     "minNodeVersion": "5.0.0"
   }
   ```
+
+  Use `minNodeVersionInputJs` if an `input.js` test requires a minimum Node version.
 
 - **`externalHelpers`** (boolean)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,7 +304,7 @@ Other than normal Babel options, `options.json` can contain other properties to 
   }
   ```
 
-  Use `minNodeVersionInputJs` if an `input.js` test requires a minimum Node version.
+  Use `minNodeVersionTransform` if an `input.js` test requires a minimum Node version.
 
 - **`externalHelpers`** (boolean)
 

--- a/packages/babel-helper-fixtures/data/schema.json
+++ b/packages/babel-helper-fixtures/data/schema.json
@@ -31,7 +31,7 @@
           "type": "string",
           "pattern": "^\\d+(\\.\\d+){0,2}$"
         },
-        "minNodeVersionInputJs": {
+        "minNodeVersionTransform": {
           "description": "The minimum Node.js version the input.js transform test should run on",
           "type": "string",
           "pattern": "^\\d+(\\.\\d+){0,2}$"

--- a/packages/babel-helper-fixtures/data/schema.json
+++ b/packages/babel-helper-fixtures/data/schema.json
@@ -4,11 +4,14 @@
   "description": "JSON schema for Babel Fixture Test Runner",
   "allOf": [
     { "$ref": "#/definitions/TaskOption" },
-    { "$ref": "https://json.schemastore.org/babelrc", "$comment": "Todo: switch to our inhouse schema" }
+    {
+      "$ref": "https://json.schemastore.org/babelrc",
+      "$comment": "Todo: switch to our inhouse schema"
+    }
   ],
   "definitions": {
     "OS": {
-      "type":"string",
+      "type": "string",
       "description": "The possible values of `process.platform`. See https://nodejs.org/api/process.html#process_process_platform",
       "enum": ["aix", "darwin", "freebsd", "linux", "openbsd", "sunos", "win32"]
     },
@@ -17,14 +20,19 @@
       "properties": {
         "BABEL_8_BREAKING": {
           "description": "Whether this test should run when BABEL_8_BREAKING is enabled",
-          "type":"boolean"
+          "type": "boolean"
         },
         "ignoreOutput": {
           "description": "Whether the test should generate and compare with output.js",
           "type": "boolean"
         },
         "minNodeVersion": {
-          "description": "The minimum Node.js version this test should run on",
+          "description": "The minimum Node.js version the exec.js test should run on",
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+){0,2}$"
+        },
+        "minNodeVersionInputJs": {
+          "description": "The minimum Node.js version the input.js transform test should run on",
           "type": "string",
           "pattern": "^\\d+(\\.\\d+){0,2}$"
         },
@@ -39,12 +47,12 @@
         },
         "throws": {
           "description": "Expected thrown error message",
-          "type":"string",
+          "type": "string",
           "default": ""
         },
         "validateLogs": {
           "description": "Whether this test should validate the stdout and stderr",
-          "type":"boolean",
+          "type": "boolean",
           "default": false
         }
       }

--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -53,7 +53,7 @@ export interface TaskOptions extends InputOptions {
   externalHelpers?: boolean;
   ignoreOutput?: boolean;
   minNodeVersion?: string;
-  minNodeVersionInputJs?: string;
+  minNodeVersionTransform?: string;
   sourceMap?: boolean;
   os?: string | string[];
   validateLogs?: boolean;
@@ -281,12 +281,12 @@ function pushTask(
     delete taskOpts.minNodeVersion;
   }
 
-  if (taskOpts.minNodeVersionInputJs) {
-    const minimumVersion = semver.clean(taskOpts.minNodeVersionInputJs);
+  if (taskOpts.minNodeVersionTransform) {
+    const minimumVersion = semver.clean(taskOpts.minNodeVersionTransform);
 
     if (minimumVersion == null) {
       throw new Error(
-        `'minNodeVersionInputJs' has invalid semver format: ${taskOpts.minNodeVersionInputJs}`,
+        `'minNodeVersionTransform' has invalid semver format: ${taskOpts.minNodeVersionTransform}`,
       );
     }
 
@@ -295,7 +295,7 @@ function pushTask(
     }
 
     // Delete to avoid option validation error
-    delete taskOpts.minNodeVersionInputJs;
+    delete taskOpts.minNodeVersionTransform;
   }
 
   if (taskOpts.os) {

--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -269,7 +269,11 @@ function pushTask(
     }
 
     if (semver.lt(nodeVersion, minimumVersion)) {
-      return;
+      if (test.actual.code) {
+        test.exec.code = null;
+      } else {
+        return;
+      }
     }
 
     // Delete to avoid option validation error

--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -53,6 +53,7 @@ export interface TaskOptions extends InputOptions {
   externalHelpers?: boolean;
   ignoreOutput?: boolean;
   minNodeVersion?: string;
+  minNodeVersionInputJs?: string;
   sourceMap?: boolean;
   os?: string | string[];
   validateLogs?: boolean;
@@ -278,6 +279,23 @@ function pushTask(
 
     // Delete to avoid option validation error
     delete taskOpts.minNodeVersion;
+  }
+
+  if (taskOpts.minNodeVersionInputJs) {
+    const minimumVersion = semver.clean(taskOpts.minNodeVersionInputJs);
+
+    if (minimumVersion == null) {
+      throw new Error(
+        `'minNodeVersionInputJs' has invalid semver format: ${taskOpts.minNodeVersionInputJs}`,
+      );
+    }
+
+    if (semver.lt(nodeVersion, minimumVersion)) {
+      return;
+    }
+
+    // Delete to avoid option validation error
+    delete taskOpts.minNodeVersionInputJs;
   }
 
   if (taskOpts.os) {

--- a/packages/babel-helpers/test/fixtures/dependencies/options.json
+++ b/packages/babel-helpers/test/fixtures/dependencies/options.json
@@ -1,4 +1,4 @@
 {
-  "minNodeVersion": "12.22.0",
+  "minNodeVersionInputJs": "12.22.0",
   "externalHelpers": false
 }

--- a/packages/babel-helpers/test/fixtures/dependencies/options.json
+++ b/packages/babel-helpers/test/fixtures/dependencies/options.json
@@ -1,4 +1,4 @@
 {
-  "minNodeVersionInputJs": "12.22.0",
+  "minNodeVersionTransform": "12.22.0",
   "externalHelpers": false
 }

--- a/packages/babel-helpers/test/fixtures/misc/9496/options.json
+++ b/packages/babel-helpers/test/fixtures/misc/9496/options.json
@@ -1,4 +1,4 @@
 {
-  "minNodeVersion": "12.22.0",
+  "minNodeVersionInputJs": "12.22.0",
   "plugins": ["./plugin"]
 }

--- a/packages/babel-helpers/test/fixtures/misc/9496/options.json
+++ b/packages/babel-helpers/test/fixtures/misc/9496/options.json
@@ -1,4 +1,4 @@
 {
-  "minNodeVersionInputJs": "12.22.0",
+  "minNodeVersionTransform": "12.22.0",
   "plugins": ["./plugin"]
 }

--- a/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/options.json
+++ b/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/options.json
@@ -1,4 +1,4 @@
 {
-  "plugins": ["./plugin"],
-  "minNodeVersion": "12.0.0"
+  "minNodeVersionInputJs": "12.22.0",
+  "plugins": ["./plugin"]
 }

--- a/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/options.json
+++ b/packages/babel-helpers/test/fixtures/misc/arguments-identifier-in-function/options.json
@@ -1,4 +1,4 @@
 {
-  "minNodeVersionInputJs": "12.22.0",
+  "minNodeVersionTransform": "12.22.0",
   "plugins": ["./plugin"]
 }

--- a/packages/babel-helpers/test/fixtures/misc/declaration-name-conflict-helper-entrypoint/options.json
+++ b/packages/babel-helpers/test/fixtures/misc/declaration-name-conflict-helper-entrypoint/options.json
@@ -1,4 +1,4 @@
 {
-  "minNodeVersion": "12.22.0",
+  "minNodeVersionInputJs": "12.22.0",
   "plugins": ["./plugin"]
 }

--- a/packages/babel-helpers/test/fixtures/misc/declaration-name-conflict-helper-entrypoint/options.json
+++ b/packages/babel-helpers/test/fixtures/misc/declaration-name-conflict-helper-entrypoint/options.json
@@ -1,4 +1,4 @@
 {
-  "minNodeVersionInputJs": "12.22.0",
+  "minNodeVersionTransform": "12.22.0",
   "plugins": ["./plugin"]
 }

--- a/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/test/fixtures/integration/helper-function-name/options.json
+++ b/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/test/fixtures/integration/helper-function-name/options.json
@@ -1,5 +1,5 @@
 {
-  "minNodeVersionInputJs": "12.11.0",
+  "minNodeVersionTransform": "12.11.0",
   "plugins": [
     "./plugin.mjs",
     "bugfix-safari-id-destructuring-collision-in-function-expression"

--- a/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/test/fixtures/integration/helper-function-name/options.json
+++ b/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/test/fixtures/integration/helper-function-name/options.json
@@ -1,5 +1,5 @@
 {
-  "minNodeVersion": "12.11.0",
+  "minNodeVersionInputJs": "12.11.0",
   "plugins": [
     "./plugin.mjs",
     "bugfix-safari-id-destructuring-collision-in-function-expression"

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/smart/pipe-body-with-await/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/smart/pipe-body-with-await/options.json
@@ -1,5 +1,5 @@
 {
-  "minNodeVersionInputJs": "8.0.0",
+  "minNodeVersionTransform": "8.0.0",
   "parserOpts": {
     "allowReturnOutsideFunction": true
   }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/smart/pipe-body-with-await/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/smart/pipe-body-with-await/options.json
@@ -1,6 +1,6 @@
 {
-  "minNodeVersion": "8.0.0",
+  "minNodeVersionInputJs": "8.0.0",
   "parserOpts": {
-     "allowReturnOutsideFunction": true
-   }
+    "allowReturnOutsideFunction": true
+  }
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/smart/transform-await-and-arrow-functions/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/smart/transform-await-and-arrow-functions/options.json
@@ -6,5 +6,5 @@
   "parserOpts": {
     "allowReturnOutsideFunction": true
   },
-  "minNodeVersionInputJs": "8.0.0"
+  "minNodeVersionTransform": "8.0.0"
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/smart/transform-await-and-arrow-functions/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/smart/transform-await-and-arrow-functions/options.json
@@ -6,5 +6,5 @@
   "parserOpts": {
     "allowReturnOutsideFunction": true
   },
-  "minNodeVersion": "8.0.0"
+  "minNodeVersionInputJs": "8.0.0"
 }

--- a/packages/babel-plugin-transform-unicode-sets-regex/test/fixtures/basic/string-properties/options.json
+++ b/packages/babel-plugin-transform-unicode-sets-regex/test/fixtures/basic/string-properties/options.json
@@ -1,3 +1,3 @@
 {
-  "minNodeVersion": "12.0.0"
+  "minNodeVersionInputJs": "12.0.0"
 }

--- a/packages/babel-plugin-transform-unicode-sets-regex/test/fixtures/basic/string-properties/options.json
+++ b/packages/babel-plugin-transform-unicode-sets-regex/test/fixtures/basic/string-properties/options.json
@@ -1,3 +1,3 @@
 {
-  "minNodeVersionInputJs": "12.0.0"
+  "minNodeVersionTransform": "12.0.0"
 }

--- a/packages/babel-plugin-transform-unicode-sets-regex/test/fixtures/transform-u/string-properties/options.json
+++ b/packages/babel-plugin-transform-unicode-sets-regex/test/fixtures/transform-u/string-properties/options.json
@@ -1,3 +1,3 @@
 {
-  "minNodeVersion": "12.0.0"
+  "minNodeVersionInputJs": "12.0.0"
 }

--- a/packages/babel-plugin-transform-unicode-sets-regex/test/fixtures/transform-u/string-properties/options.json
+++ b/packages/babel-plugin-transform-unicode-sets-regex/test/fixtures/transform-u/string-properties/options.json
@@ -1,3 +1,3 @@
 {
-  "minNodeVersionInputJs": "12.0.0"
+  "minNodeVersionTransform": "12.0.0"
 }

--- a/packages/babel-preset-env/test/fixtures/preset-options-babel-7/unicode-sets-regex-chrome-111/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options-babel-7/unicode-sets-regex-chrome-111/options.json
@@ -1,5 +1,5 @@
 {
-  "minNodeVersion": "12.0.0",
+  "minNodeVersionInputJs": "12.0.0",
   "presets": [
     [
       "env",

--- a/packages/babel-preset-env/test/fixtures/preset-options-babel-7/unicode-sets-regex-chrome-111/options.json
+++ b/packages/babel-preset-env/test/fixtures/preset-options-babel-7/unicode-sets-regex-chrome-111/options.json
@@ -1,5 +1,5 @@
 {
-  "minNodeVersionInputJs": "12.0.0",
+  "minNodeVersionTransform": "12.0.0",
   "presets": [
     [
       "env",

--- a/packages/babel-preset-flow/test/fixtures/flow-parser/hermes/options.json
+++ b/packages/babel-preset-flow/test/fixtures/flow-parser/hermes/options.json
@@ -1,5 +1,5 @@
 {
   "BABEL_8_BREAKING": false,
   "presets": [["flow", { "experimental_useHermesParser": true }]],
-  "minNodeVersionInputJs": "12.0.0"
+  "minNodeVersionTransform": "12.0.0"
 }

--- a/packages/babel-preset-flow/test/fixtures/flow-parser/hermes/options.json
+++ b/packages/babel-preset-flow/test/fixtures/flow-parser/hermes/options.json
@@ -1,5 +1,5 @@
 {
   "BABEL_8_BREAKING": false,
   "presets": [["flow", { "experimental_useHermesParser": true }]],
-  "minNodeVersion": "12.0.0"
+  "minNodeVersionInputJs": "12.0.0"
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/pull/16344#discussion_r1521780953
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we revise the `minNodeVersion` option to be the minimal node requirements to run the `exec.js` test file, so the legacy node versions will still run the `input.js` transform tests.

The legacy node works in most transform tests, exceptions are those with a custom ESM babel plugins or the hermes parser
requiring node 12+.

If you want the old `minNodeVersion` behaviour, use `minNodeVersionInputJs` instead.

---

Test summary reported on Node.js 6

this PR: Tests:       49 skipped, 25344 passed, 25393 total
main: Tests:       49 skipped, 25128 passed, 25177 total