### PR TITLE
Restore previous `FORCE_COLOR=0` behavior

### DIFF
--- a/packages/babel-code-frame/src/index.ts
+++ b/packages/babel-code-frame/src/index.ts
@@ -4,7 +4,8 @@ import _colors, { createColors } from "picocolors";
 import type { Colors, Formatter } from "picocolors/types";
 // See https://github.com/alexeyraspopov/picocolors/issues/62
 const colors =
-  typeof process === "object" && process.env.FORCE_COLOR === "0"
+  typeof process === "object" &&
+  (process.env.FORCE_COLOR === "0" || process.env.FORCE_COLOR === "false")
     ? createColors(false)
     : _colors;
 

--- a/packages/babel-code-frame/src/index.ts
+++ b/packages/babel-code-frame/src/index.ts
@@ -1,7 +1,12 @@
 import highlight, { shouldHighlight } from "@babel/highlight";
 
-import colors, { createColors } from "picocolors";
+import _colors, { createColors } from "picocolors";
 import type { Colors, Formatter } from "picocolors/types";
+// See https://github.com/alexeyraspopov/picocolors/issues/62
+const colors =
+  typeof process === "object" && process.env.FORCE_COLOR === "0"
+    ? createColors(false)
+    : _colors;
 
 const compose: <T, U, V>(f: (gv: U) => V, g: (v: T) => U) => (v: T) => V =
   (f, g) => v =>

--- a/packages/babel-highlight/src/index.ts
+++ b/packages/babel-highlight/src/index.ts
@@ -8,8 +8,13 @@ import {
   isKeyword,
 } from "@babel/helper-validator-identifier";
 
-import colors, { createColors } from "picocolors";
+import _colors, { createColors } from "picocolors";
 import type { Colors, Formatter } from "picocolors/types";
+// See https://github.com/alexeyraspopov/picocolors/issues/62
+const colors =
+  typeof process === "object" && process.env.FORCE_COLOR === "0"
+    ? createColors(false)
+    : _colors;
 
 const compose: <T, U, V>(f: (gv: U) => V, g: (v: T) => U) => (v: T) => V =
   (f, g) => v =>

--- a/packages/babel-highlight/src/index.ts
+++ b/packages/babel-highlight/src/index.ts
@@ -12,7 +12,8 @@ import _colors, { createColors } from "picocolors";
 import type { Colors, Formatter } from "picocolors/types";
 // See https://github.com/alexeyraspopov/picocolors/issues/62
 const colors =
-  typeof process === "object" && process.env.FORCE_COLOR === "0"
+  typeof process === "object" &&
+  (process.env.FORCE_COLOR === "0" || process.env.FORCE_COLOR === "false")
     ? createColors(false)
     : _colors;
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

See https://github.com/alexeyraspopov/picocolors/issues/62 and https://github.com/jestjs/jest/pull/14976#discussion_r1530185144. Until the last released we interpreted `FORCE_COLOR=0` as disabling color. There is no consensus among tools about what `FORCE_COLOR=0` does, but we should not change this behavior in a patch release.