### PR TITLE
Fix incorrect function hoisting in some case statements

### DIFF
--- a/packages/babel-plugin-transform-block-scoped-functions/test/fixtures/block-scoped-functions/issue-14960/input.js
+++ b/packages/babel-plugin-transform-block-scoped-functions/test/fixtures/block-scoped-functions/issue-14960/input.js
@@ -1,0 +1,9 @@
+{
+  switch (1) {
+    case 1:
+      expect(f()).toBe(1);
+      function f() {
+        return 1;
+      }
+  }
+}

--- a/packages/babel-plugin-transform-block-scoped-functions/test/fixtures/block-scoped-functions/issue-14960/options.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/test/fixtures/block-scoped-functions/issue-14960/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-block-scoped-functions"]
+}

--- a/packages/babel-plugin-transform-block-scoped-functions/test/fixtures/block-scoped-functions/issue-14960/output.js
+++ b/packages/babel-plugin-transform-block-scoped-functions/test/fixtures/block-scoped-functions/issue-14960/output.js
@@ -1,0 +1,9 @@
+{
+  switch (1) {
+    case 1:
+      let f = function () {
+        return 1;
+      };
+      expect(f()).toBe(1);
+  }
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/switch/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/switch/output.js
@@ -19,6 +19,6 @@ switch (true) {
     var _c = 4;
     var _d = 5;
   case false:
-    class _e {}
     var _f = function () {};
+    class _e {}
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Mitigates #14960
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

The linked issue https://github.com/babel/babel/issues/14960 shows a case where babel breaks the behavior of a code snippet:

```js
switch ('what') {
default:
    console.log(a())
    function a() { return 1; }
}
```

The issue is that `function a() {}` gets converted into `var a = function() {}`, but isn't hoisted to the top as it should. Babel currently hoists functions correctly when they are in block statements, but not in case statements.
Fixing this problem in **all** cases is difficult, due to the issue pointed to in an answer to that ticket:

```js
switch (x) {
  case 0:
    let num = 3;
    log(0);
  default:
    log(1);
    function log(s) { console.log(s || num) }
}
```

In the example above, moving log to the first case breaks the second, but keeping the log in the second case does not address the first.

Nevertheless, the current behavior is a problem. This Pull Request addresses this by hoisting the function to the start of the matching case. This does not address all issues, but it shouldn't break anything that isn't already broken, and it should fix issues as the function is "more hoisted" than it used to be. Notably, this fixes issues with functions that are only ever referenced in the same case that declares them, which is the case I encountered.