### PR TITLE
Make sure to use Babel 8 core in Babel 7-8 tests

### DIFF
--- a/packages/babel-core/cjs-proxy.cjs
+++ b/packages/babel-core/cjs-proxy.cjs
@@ -19,7 +19,13 @@ const functionNames = [
   "transformFromAst",
   "parse",
 ];
-const propertyNames = ["types", "tokTypes", "traverse", "template"];
+const propertyNames = [
+  "buildExternalHelpers",
+  "types",
+  "tokTypes",
+  "traverse",
+  "template",
+];
 
 for (const name of functionNames) {
   exports[name] = function (...args) {

--- a/packages/babel-core/src/config/helpers/config-api.ts
+++ b/packages/babel-core/src/config/helpers/config-api.ts
@@ -126,7 +126,10 @@ function assertVersion(range: string | number): void {
     throw new Error("Expected string or integer value.");
   }
 
-  if (semver.satisfies(coreVersion, range)) return;
+  // We want "*" to also allow any pre-release, but we do not pass
+  // the includePrerelease option to semver.satisfies because we
+  // do not want ^7.0.0 to match 8.0.0-alpha.1.
+  if (range === "*" || semver.satisfies(coreVersion, range)) return;
 
   const limit = Error.stackTraceLimit;
 

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -280,13 +280,13 @@ gen_enforced_dependency(WorkspaceCwd, '@babel/core', 'workspace:^', 'devDependen
  */
 function enforceBabelCoreNotInDeps({ Yarn }) {
   for (const workspace of Yarn.workspaces()) {
-    if (
-      workspace.pkg.peerDependencies.has("@babel/core") &&
-      !workspace.manifest.dependencies?.["@babel/core"]
-    ) {
-      if (
-        process.env.BABEL_CORE_DEV_DEP_VERSION &&
-        workspace.ident &&
+    if (process.env.BABEL_CORE_DEV_DEP_VERSION && workspace.ident) {
+      if (workspace.ident === "@babel/helper-transform-fixture-test-runner") {
+        workspace.set(
+          "dependencies['@babel/core']",
+          process.env.BABEL_CORE_DEV_DEP_VERSION
+        );
+      } else if (
         babel7plugins_babel8core.has(
           workspace.ident.replace("@babel/", "babel-")
         )
@@ -295,9 +295,15 @@ function enforceBabelCoreNotInDeps({ Yarn }) {
           "devDependencies['@babel/core']",
           process.env.BABEL_CORE_DEV_DEP_VERSION
         );
-      } else {
-        workspace.set("devDependencies['@babel/core']", "workspace:^");
       }
+      continue;
+    }
+
+    if (
+      workspace.pkg.peerDependencies.has("@babel/core") &&
+      !workspace.manifest.dependencies?.["@babel/core"]
+    ) {
+      workspace.set("devDependencies['@babel/core']", "workspace:^");
     }
     if (
       workspace.ident !== null &&


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR makes sure that `@babel/helper-transform-fixture-test-runner`'s dependency is on Babel 8 when testing Babel 7 plugins with Babel 8 core. `@babel/helper-transform-fixture-test-runner` uses `buildExternalHelpers`, so I added it to the CJS proxy.