### PR TITLE
Await nullish async disposable

### DIFF
--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -188,10 +188,10 @@ export default Object.freeze({
     "7.22.0",
     'export default function _using(o,n,e){if(null==n)return n;if(Object(n)!==n)throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");if(e)var r=n[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==r&&(r=n[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof r)throw new TypeError("Property [Symbol.dispose] is not a function.");return o.push({v:n,d:r,a:e}),n}',
   ),
-  // size: 918, gzip size: 479
+  // size: 922, gzip size: 481
   usingCtx: helper(
     "7.23.9",
-    'export default function _usingCtx(){var r="function"==typeof SuppressedError?SuppressedError:function(r,n){var e=Error();return e.name="SuppressedError",e.suppressed=n,e.error=r,e},n={},e=[];function using(r,n){if(null!=n){if(Object(n)!==n)throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");if(r)var o=n[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==o&&(o=n[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof o)throw new TypeError("Property [Symbol.dispose] is not a function.");e.push({v:n,d:o,a:r})}else r&&e.push({a:r});return n}return{e:n,u:using.bind(null,!1),a:using.bind(null,!0),d:function(){var o=this.e;function next(){for(;r=e.pop();)try{var r,t=r.d&&r.d.call(r.v);if(r.a)return Promise.resolve(t).then(next,err)}catch(r){return err(r)}if(o!==n)throw o}function err(e){return o=o!==n?new r(o,e):e,next()}return next()}}}',
+    'export default function _usingCtx(){var r="function"==typeof SuppressedError?SuppressedError:function(r,n){var e=Error();return e.name="SuppressedError",e.suppressed=n,e.error=r,e},n={},e=[];function using(r,n){if(null!=n){if(Object(n)!==n)throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");if(r)var o=n[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==o&&(o=n[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof o)throw new TypeError("Property [Symbol.dispose] is not a function.");e.push({v:n,d:o,a:r})}else r&&e.push({d:n,a:r});return n}return{e:n,u:using.bind(null,!1),a:using.bind(null,!0),d:function(){var o=this.e;function next(){for(;r=e.pop();)try{var r,t=r.d&&r.d.call(r.v);if(r.a)return Promise.resolve(t).then(next,err)}catch(r){return err(r)}if(o!==n)throw o}function err(e){return o=o!==n?new r(o,e):e,next()}return next()}}}',
   ),
   // size: 1252, gzip size: 572
   wrapRegExp: helper(

--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -188,10 +188,10 @@ export default Object.freeze({
     "7.22.0",
     'export default function _using(o,n,e){if(null==n)return n;if(Object(n)!==n)throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");if(e)var r=n[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==r&&(r=n[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof r)throw new TypeError("Property [Symbol.dispose] is not a function.");return o.push({v:n,d:r,a:e}),n}',
   ),
-  // size: 891, gzip size: 466
+  // size: 918, gzip size: 479
   usingCtx: helper(
     "7.23.9",
-    'export default function _usingCtx(){var r="function"==typeof SuppressedError?SuppressedError:function(r,n){var e=Error();return e.name="SuppressedError",e.suppressed=n,e.error=r,e},n={},e=[];function using(r,n){if(null!=n){if(Object(n)!==n)throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");if(r)var o=n[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==o&&(o=n[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof o)throw new TypeError("Property [Symbol.dispose] is not a function.");e.push({v:n,d:o,a:r})}return n}return{e:n,u:using.bind(null,!1),a:using.bind(null,!0),d:function(){var o=this.e;function next(){for(;r=e.pop();)try{var r,t=r.d.call(r.v);if(r.a)return Promise.resolve(t).then(next,err)}catch(r){return err(r)}if(o!==n)throw o}function err(e){return o=o!==n?new r(o,e):e,next()}return next()}}}',
+    'export default function _usingCtx(){var r="function"==typeof SuppressedError?SuppressedError:function(r,n){var e=Error();return e.name="SuppressedError",e.suppressed=n,e.error=r,e},n={},e=[];function using(r,n){if(null!=n){if(Object(n)!==n)throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");if(r)var o=n[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==o&&(o=n[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof o)throw new TypeError("Property [Symbol.dispose] is not a function.");e.push({v:n,d:o,a:r})}else r&&e.push({a:r});return n}return{e:n,u:using.bind(null,!1),a:using.bind(null,!0),d:function(){var o=this.e;function next(){for(;r=e.pop();)try{var r,t=r.d&&r.d.call(r.v);if(r.a)return Promise.resolve(t).then(next,err)}catch(r){return err(r)}if(o!==n)throw o}function err(e){return o=o!==n?new r(o,e):e,next()}return next()}}}',
   ),
   // size: 1252, gzip size: 572
   wrapRegExp: helper(

--- a/packages/babel-helpers/src/helpers/usingCtx.ts
+++ b/packages/babel-helpers/src/helpers/usingCtx.ts
@@ -2,7 +2,7 @@
 
 type Stack = {
   v?: any;
-  d?: () => any;
+  d: false | (() => any);
   a: boolean;
 };
 
@@ -40,7 +40,8 @@ export default function _usingCtx() {
       }
       stack.push({ v: value, d: dispose, a: isAwait });
     } else if (isAwait) {
-      stack.push({ a: isAwait });
+      // provide the nullish `value` as `d` for minification gain
+      stack.push({ d: value, a: isAwait });
     }
     return value;
   }

--- a/packages/babel-helpers/src/helpers/usingCtx.ts
+++ b/packages/babel-helpers/src/helpers/usingCtx.ts
@@ -2,7 +2,7 @@
 
 type Stack = {
   v?: any;
-  d: false | (() => any);
+  d: null | undefined | (() => any);
   a: boolean;
 };
 

--- a/packages/babel-helpers/src/helpers/usingCtx.ts
+++ b/packages/babel-helpers/src/helpers/usingCtx.ts
@@ -1,8 +1,8 @@
 /* @minVersion 7.23.9 */
 
 type Stack = {
-  v: any;
-  d: () => any;
+  v?: any;
+  d?: () => any;
   a: boolean;
 };
 
@@ -39,6 +39,8 @@ export default function _usingCtx() {
         throw new TypeError(`Property [Symbol.dispose] is not a function.`);
       }
       stack.push({ v: value, d: dispose, a: isAwait });
+    } else if (isAwait) {
+      stack.push({ a: isAwait });
     }
     return value;
   }
@@ -58,7 +60,7 @@ export default function _usingCtx() {
         while ((resource = stack.pop())) {
           try {
             var resource,
-              disposalResult = resource.d.call(resource.v);
+              disposalResult = resource.d && resource.d.call(resource.v);
             if (resource.a) {
               return Promise.resolve(disposalResult).then(next, err);
             }

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/using-null-multiple.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/using-null-multiple.js
@@ -1,0 +1,25 @@
+return (async function () {
+  const log = [];
+
+  function disposable(name) {
+    return {
+      async [Symbol.dispose || Symbol.for("Symbol.dispose")]() {
+        log.push(name);
+      },
+    };
+  }
+
+  async function f() {
+    using y = disposable("y");
+    await using x = null;
+    log.push("f body");
+  }
+
+  const promise = f();
+
+  log.push("body");
+
+  await promise;
+
+  expect(log).toEqual(["f body", "body", "y"]);
+})();

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/using-undefined-multiple.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/using-undefined-multiple.js
@@ -1,0 +1,25 @@
+return (async function () {
+  const log = [];
+
+  function disposable(name) {
+    return {
+      async [Symbol.dispose || Symbol.for("Symbol.dispose")]() {
+        log.push(name);
+      },
+    };
+  }
+
+  async function f() {
+    using y = disposable("y");
+    await using x = undefined;
+    log.push("f body");
+  }
+
+  const promise = f();
+
+  log.push("body");
+
+  await promise;
+
+  expect(log).toEqual(["f body", "body", "y"]);
+})();

--- a/packages/babel-runtime-corejs3/helpers/esm/usingCtx.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/usingCtx.js
@@ -23,6 +23,7 @@ export default function _usingCtx() {
         a: r
       });
     } else r && _pushInstanceProperty(e).call(e, {
+      d: n,
       a: r
     });
     return n;

--- a/packages/babel-runtime-corejs3/helpers/esm/usingCtx.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/usingCtx.js
@@ -22,7 +22,9 @@ export default function _usingCtx() {
         d: o,
         a: r
       });
-    }
+    } else r && _pushInstanceProperty(e).call(e, {
+      a: r
+    });
     return n;
   }
   return {
@@ -34,7 +36,7 @@ export default function _usingCtx() {
       function next() {
         for (; r = e.pop();) try {
           var r,
-            t = r.d.call(r.v);
+            t = r.d && r.d.call(r.v);
           if (r.a) return _Promise.resolve(t).then(next, err);
         } catch (r) {
           return err(r);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | When an async-disposable is nullish, Babel does not await its disposing process ([REPL](https://babel.dev/repl#?browsers=chrome%2032&build=&builtIns=false&corejs=3.21&spec=false&loose=true&code_lz=BQQwzgngdgxgBAMwK6wC4EsD2U7AJRwDeAUHHDNmKnADaYDmcAvHANoC6A3MaYijBmxwAJujAAHTGBAAjGgFNgUEAFt5BEmTIAneaiTacmrWXDR4rAMoQVMzDQB0oiVPlwAPu7jXb9hwkxtYAAiHztHZ0kweWC8dnwiXhMyOnoHcSQwAAslVXVuZLgAXwAaJOKC4p5TSFg-NCwcBATjMkz0KEYIZhExKNkFEIhYytMAdxB0anbOuAAPHqgkGhpR2gZ0zJzghDg7YWG8SqLq8kpqcW1MFTE3Fmaj09TN7JD9w-5eEAmpuEvr26fMgUKBgezyBypYCpPDEIp4fBAA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=true&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=&prettier=false&targets=&version=7.24.4&externalPlugins=%40babel%2Fplugin-proposal-explicit-resource-management%407.24.1&assumptions=%7B%7D))
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In the REPL example,
```js
(async function () {
  const log = [];

  function disposable(name) {
    return {
      async [Symbol.dispose || Symbol.for("Symbol.dispose")]() {
        log.push(name);
      },
    };
  }

  async function f() {
    using y = disposable("y");
    await using x = null;
    log.push("f body");
  }

  const promise = f();

  log.push("body");

  await promise;

  console.log(log)
})()
```
It should log `"f body", "body", "y"`, but currently it logs `"f body", "y", "body"`. 

Per [spec 7.5.7 Dispose](https://arai-a.github.io/ecma262-compare/?from=5d8f62d6ab761960206c3f6ddf4992534fe9726f&to=PR/3000/355326679d8a288868f145b326b2f697caf58363&id=sec-dispose), if `hint` is `async-dispose`, the result should be awaited, even if it is nullish. Therefore the disposing of the next resource `y` should follow `log.push("body")`.