### PR TITLE
Improve async dispose fallback

### DIFF
--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -188,10 +188,10 @@ export default Object.freeze({
     "7.22.0",
     'export default function _using(o,n,e){if(null==n)return n;if(Object(n)!==n)throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");if(e)var r=n[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==r&&(r=n[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof r)throw new TypeError("Property [Symbol.dispose] is not a function.");return o.push({v:n,d:r,a:e}),n}',
   ),
-  // size: 922, gzip size: 481
+  // size: 922, gzip size: 496
   usingCtx: helper(
     "7.23.9",
-    'export default function _usingCtx(){var r="function"==typeof SuppressedError?SuppressedError:function(r,n){var e=Error();return e.name="SuppressedError",e.error=r,e.suppressed=n,e},n={},e=[];function using(r,n){if(null!=n){if(Object(n)!==n)throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");if(r)var o=n[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")];if(null==o&&(o=n[Symbol.dispose||Symbol.for("Symbol.dispose")]),"function"!=typeof o)throw new TypeError("Property [Symbol.dispose] is not a function.");e.push({v:n,d:o,a:r})}else r&&e.push({d:n,a:r});return n}return{e:n,u:using.bind(null,!1),a:using.bind(null,!0),d:function(){var o=this.e;function next(){for(;r=e.pop();)try{var r,t=r.d&&r.d.call(r.v);if(r.a)return Promise.resolve(t).then(next,err)}catch(r){return err(r)}if(o!==n)throw o}function err(e){return o=o!==n?new r(e,o):e,next()}return next()}}}',
+    'export default function _usingCtx(){var r="function"==typeof SuppressedError?SuppressedError:function(r,e){var n=Error();return n.name="SuppressedError",n.error=r,n.suppressed=e,n},e={},n=[];function using(r,e){if(null!=e){if(Object(e)!==e)throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");if(r)var o=e[Symbol.asyncDispose||Symbol.for("Symbol.asyncDispose")],t=3;if(void 0===o&&(o=e[Symbol.dispose||Symbol.for("Symbol.dispose")],t&=2),"function"!=typeof o)throw new TypeError("Object is not disposable.");n.push({v:e,d:o,k:t})}else r&&n.push({d:e,k:2});return e}return{e:e,u:using.bind(null,!1),a:using.bind(null,!0),d:function(){var o=this.e;function next(){for(;r=n.pop();)try{var r,t=r.d&&r.d.call(r.v);if(r.k)return Promise.resolve(1&r.k&&t).then(next,err)}catch(r){return err(r)}if(o!==e)throw o}function err(n){return o=o!==e?new r(n,o):n,next()}return next()}}}',
   ),
   // size: 1252, gzip size: 572
   wrapRegExp: helper(

--- a/packages/babel-helpers/src/helpers/usingCtx.ts
+++ b/packages/babel-helpers/src/helpers/usingCtx.ts
@@ -32,7 +32,7 @@ export default function _usingCtx() {
         var dispose =
           value[Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")];
       }
-      if (dispose == null) {
+      if (dispose === undefined) {
         dispose = value[Symbol.dispose || Symbol.for("Symbol.dispose")];
       }
       if (typeof dispose !== "function") {

--- a/packages/babel-helpers/src/helpers/usingCtx.ts
+++ b/packages/babel-helpers/src/helpers/usingCtx.ts
@@ -82,7 +82,7 @@ export default function _usingCtx() {
             if (resource.k) {
               return Promise.resolve(
                 // provide 0 here for minification gain
-                resource.k & DisposeFlag.ASYNC_FLAG ? disposalResult : 0,
+                resource.k & DisposeFlag.ASYNC_FLAG && disposalResult,
               ).then(next, err);
             }
           } catch (e) {

--- a/packages/babel-helpers/src/helpers/usingCtx.ts
+++ b/packages/babel-helpers/src/helpers/usingCtx.ts
@@ -44,7 +44,12 @@ export default function _usingCtx() {
         kind = isAwait ? DisposeKind.AWAIT_SYNC : DisposeKind.SYNC;
       }
       if (typeof dispose !== "function") {
-        throw new TypeError(`Property [Symbol.dispose] is not a function.`);
+        throw new TypeError(
+          "Property [Symbol." +
+            // kind == DisposeKind.AWAIT_ASYNC
+            (kind & DisposeKind.AWAIT_ASYNC ? "asyncDispose" : "dispose") +
+            "] is not a function.",
+        );
       }
       stack.push({ v: value, d: dispose, k: kind });
     } else if (isAwait) {

--- a/packages/babel-helpers/src/helpers/usingCtx.ts
+++ b/packages/babel-helpers/src/helpers/usingCtx.ts
@@ -81,7 +81,7 @@ export default function _usingCtx() {
               disposalResult = resource.d && resource.d.call(resource.v);
             if (resource.k) {
               return Promise.resolve(
-                // provide 0 here for minification gain
+                // do not await the promise returned from the sync @@dispose
                 resource.k & DisposeFlag.ASYNC_FLAG && disposalResult,
               ).then(next, err);
             }

--- a/packages/babel-helpers/src/helpers/usingCtx.ts
+++ b/packages/babel-helpers/src/helpers/usingCtx.ts
@@ -53,11 +53,7 @@ export default function _usingCtx() {
         kind &= DisposeFlag.ASYNC_MASK;
       }
       if (typeof dispose !== "function") {
-        throw new TypeError(
-          "Property [Symbol." +
-            (kind & DisposeFlag.ASYNC_FLAG ? "asyncDispose" : "dispose") +
-            "] is not a function.",
-        );
+        throw new TypeError("Object is not disposable.");
       }
       stack.push({ v: value, d: dispose, k: kind });
     } else if (isAwait) {

--- a/packages/babel-helpers/src/helpers/usingCtx.ts
+++ b/packages/babel-helpers/src/helpers/usingCtx.ts
@@ -2,17 +2,17 @@
 
 const enum DisposeFlag {
   // set when the dispose function is a [Symbol.asyncDispose] method
-  ASYNC_FLAG = 1,
-  // alias of AWAIT_FLAG: set when the resource is an `await using` disposable
-  ASYNC_MASK = 2,
+  ASYNC_DISPOSE = 1,
+  // alias of AWAIT_USING: set when the resource is an `await using` disposable
+  ASYNC_DISPOSE_MASK = 2,
 }
 
 const enum DisposeKind {
-  SYNC = 0,
+  USING_DISPOSE = 0,
   // AWAIT_FLAG
-  AWAIT_SYNC = 2,
-  // AWAIT_FLAG | ASYNC_FLAG
-  AWAIT_ASYNC = 3,
+  AWAIT_USING_DISPOSE = 2,
+  // Flag.AWAIT_USING | Flag.ASYNC_DISPOSE
+  AWAIT_USING_ASYNC_DISPOSE = 3,
 }
 
 type Stack = {
@@ -46,11 +46,11 @@ export default function _usingCtx() {
       if (isAwait) {
         var dispose =
             value[Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")],
-          kind = DisposeKind.AWAIT_ASYNC;
+          kind = DisposeKind.AWAIT_USING_ASYNC_DISPOSE;
       }
       if (dispose === undefined) {
         dispose = value[Symbol.dispose || Symbol.for("Symbol.dispose")];
-        kind &= DisposeFlag.ASYNC_MASK;
+        kind &= DisposeFlag.ASYNC_DISPOSE_MASK;
       }
       if (typeof dispose !== "function") {
         throw new TypeError("Object is not disposable.");
@@ -58,7 +58,7 @@ export default function _usingCtx() {
       stack.push({ v: value, d: dispose, k: kind });
     } else if (isAwait) {
       // provide the nullish `value` as `d` for minification gain
-      stack.push({ d: value, k: DisposeKind.AWAIT_SYNC });
+      stack.push({ d: value, k: DisposeKind.AWAIT_USING_DISPOSE });
     }
     return value;
   }
@@ -82,7 +82,7 @@ export default function _usingCtx() {
             if (resource.k) {
               return Promise.resolve(
                 // do not await the promise returned from the sync @@dispose
-                resource.k & DisposeFlag.ASYNC_FLAG && disposalResult,
+                resource.k & DisposeFlag.ASYNC_DISPOSE && disposalResult,
               ).then(next, err);
             }
           } catch (e) {

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/invalid-not-a-function.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/invalid-not-a-function.js
@@ -9,8 +9,16 @@ expect(
 expect(
   (async function () {
     await using foo = {
+      [Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")]: 3,
+    };
+  })()
+).rejects.toThrow("Property [Symbol.asyncDispose] is not a function.");
+
+expect(
+  (async function () {
+    await using foo = {
       [Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")]: null,
       [Symbol.dispose || Symbol.for("Symbol.dispose")]() {},
     };
   })()
-).rejects.toThrow(TypeError);
+).rejects.toThrow("Property [Symbol.asyncDispose] is not a function.");

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/invalid-not-a-function.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/invalid-not-a-function.js
@@ -12,7 +12,7 @@ expect(
       [Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")]: 3,
     };
   })()
-).rejects.toThrow("Property [Symbol.asyncDispose] is not a function.");
+).rejects.toThrow("Object is not disposable.");
 
 expect(
   (async function () {
@@ -21,4 +21,4 @@ expect(
       [Symbol.dispose || Symbol.for("Symbol.dispose")]() {},
     };
   })()
-).rejects.toThrow("Property [Symbol.asyncDispose] is not a function.");
+).rejects.toThrow("Object is not disposable.");

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/invalid-not-a-function.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/invalid-not-a-function.js
@@ -1,3 +1,16 @@
-return expect(async function () {
-  await using foo = { [Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")]: 3 };
-}()).rejects.toThrow(TypeError);
+expect(
+  (async function () {
+    await using foo = {
+      [Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")]: 3,
+    };
+  })()
+).rejects.toThrow(TypeError);
+
+expect(
+  (async function () {
+    await using foo = {
+      [Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")]: null,
+      [Symbol.dispose || Symbol.for("Symbol.dispose")]() {},
+    };
+  })()
+).rejects.toThrow(TypeError);

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/sync-fallback-promise.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-async/sync-fallback-promise.js
@@ -1,0 +1,35 @@
+return (async () => {
+  const log = [];
+
+  const promiseDispose = new Promise((resolve, _) => {
+    setTimeout(() => {
+      log.push("y dispose promise body");
+      resolve();
+    }, 0);
+  });
+
+  {
+    await using x = {
+      [Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")]() {
+        log.push("x asyncDispose body");
+      },
+    };
+    await using y = {
+      [Symbol.dispose || Symbol.for("Symbol.dispose")]() {
+        log.push("y dispose body");
+        return promiseDispose;
+      },
+    };
+  }
+
+  log.push("body");
+
+  await promiseDispose;
+
+  expect(log).toEqual([
+    "y dispose body",
+    "x asyncDispose body",
+    "body",
+    "y dispose promise body",
+  ]);
+})();

--- a/packages/babel-runtime-corejs3/helpers/esm/usingCtx.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/usingCtx.js
@@ -6,46 +6,47 @@ import _pushInstanceProperty from "core-js-pure/features/instance/push.js";
 import _bindInstanceProperty from "core-js-pure/features/instance/bind.js";
 import _Promise from "core-js-pure/features/promise/index.js";
 export default function _usingCtx() {
-  var r = "function" == typeof _SuppressedError ? _SuppressedError : function (r, n) {
-      var e = Error();
-      return e.name = "SuppressedError", e.error = r, e.suppressed = n, e;
+  var r = "function" == typeof _SuppressedError ? _SuppressedError : function (r, e) {
+      var n = Error();
+      return n.name = "SuppressedError", n.error = r, n.suppressed = e, n;
     },
-    n = {},
-    e = [];
-  function using(r, n) {
-    if (null != n) {
-      if (Object(n) !== n) throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");
-      if (r) var o = n[_Symbol$asyncDispose || _Symbol$for("Symbol.asyncDispose")];
-      if (null == o && (o = n[_Symbol$dispose || _Symbol$for("Symbol.dispose")]), "function" != typeof o) throw new TypeError("Property [Symbol.dispose] is not a function.");
-      _pushInstanceProperty(e).call(e, {
-        v: n,
+    e = {},
+    n = [];
+  function using(r, e) {
+    if (null != e) {
+      if (Object(e) !== e) throw new TypeError("using declarations can only be used with objects, functions, null, or undefined.");
+      if (r) var o = e[_Symbol$asyncDispose || _Symbol$for("Symbol.asyncDispose")],
+        t = 3;
+      if (void 0 === o && (o = e[_Symbol$dispose || _Symbol$for("Symbol.dispose")], t &= 2), "function" != typeof o) throw new TypeError("Object is not disposable.");
+      _pushInstanceProperty(n).call(n, {
+        v: e,
         d: o,
-        a: r
+        k: t
       });
-    } else r && _pushInstanceProperty(e).call(e, {
-      d: n,
-      a: r
+    } else r && _pushInstanceProperty(n).call(n, {
+      d: e,
+      k: 2
     });
-    return n;
+    return e;
   }
   return {
-    e: n,
+    e: e,
     u: _bindInstanceProperty(using).call(using, null, !1),
     a: _bindInstanceProperty(using).call(using, null, !0),
     d: function d() {
       var o = this.e;
       function next() {
-        for (; r = e.pop();) try {
+        for (; r = n.pop();) try {
           var r,
             t = r.d && r.d.call(r.v);
-          if (r.a) return _Promise.resolve(t).then(next, err);
+          if (r.k) return _Promise.resolve(1 & r.k && t).then(next, err);
         } catch (r) {
           return err(r);
         }
-        if (o !== n) throw o;
+        if (o !== e) throw o;
       }
-      function err(e) {
-        return o = o !== n ? new r(e, o) : e, next();
+      function err(n) {
+        return o = o !== e ? new r(n, o) : n, next();
       }
       return next();
     }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | See below
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR aligns our implementation to spec [7.5.6 GetDisposeMethod](https://arai-a.github.io/ecma262-compare/?from=5d8f62d6ab761960206c3f6ddf4992534fe9726f&to=PR/3000/355326679d8a288868f145b326b2f697caf58363&id=sec-getdisposemethod)

```
1. If hint is async-dispose, then
  a. Let method be ? GetMethod(V, @@asyncDispose).
  b. If method is undefined, then
    i. Set method to ? GetMethod(V, @@dispose).
    ii. If method is not undefined, then
      1. Let closure be a new Abstract Closure with no parameters that captures method and performs the following steps when called:
        a. Let O be the this value.
        b. Perform ? Call(method, O).
        c. Return undefined.
      2. NOTE: This function is not observable to user code. It is used to ensure that a Promise returned from a synchronous @@dispose method will not be awaited.
      3. Return CreateBuiltinFunction(closure, 0, "", « »).
2. Else,
  a. Let method be ? GetMethod(V, @@dispose).
3. Return method.
```

There are two behaviour changes:
1. Only fallback to the `[Symbol.dispose]` method if the `[Symbol.asyncDispose]` method is `undefined`, previously we fallback when it is `null`
2. Do not await the promise returned from a sync `[Symbol.dispose]` method.

In this PR we also improve the error message when `[Symbol.asyncDispose]` method is not a function, previously we throw `[Symbol.dispose]` is not a function, which could be very confusing.