### PR TITLE
Always pass type argument to `.startNode`

### DIFF
--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -214,7 +214,7 @@ export default abstract class ExpressionParser extends LValParser {
     const startLoc = this.state.startLoc;
     const expr = this.parseMaybeAssign(refExpressionErrors);
     if (this.match(tt.comma)) {
-      const node = this.startNodeAt(startLoc);
+      const node = this.startNodeAt<N.SequenceExpression>(startLoc);
       node.expressions = [expr];
       while (this.eat(tt.comma)) {
         node.expressions.push(this.parseMaybeAssign(refExpressionErrors));
@@ -366,7 +366,7 @@ export default abstract class ExpressionParser extends LValParser {
     refExpressionErrors?: ExpressionErrors | null,
   ): N.Expression {
     if (this.eat(tt.question)) {
-      const node = this.startNodeAt(startLoc);
+      const node = this.startNodeAt<N.ConditionalExpression>(startLoc);
       node.test = expr;
       node.consequent = this.parseMaybeAssignAllowIn();
       this.expect(tt.colon);
@@ -826,7 +826,7 @@ export default abstract class ExpressionParser extends LValParser {
     noCalls: boolean | undefined | null,
     state: N.ParseSubscriptState,
   ): N.Expression {
-    const node = this.startNodeAt(startLoc);
+    const node = this.startNodeAt<N.BindExpression>(startLoc);
     node.object = base;
     this.next(); // eat '::'
     node.callee = this.parseNoCallExpr();
@@ -1120,7 +1120,7 @@ export default abstract class ExpressionParser extends LValParser {
         }
 
       case tt._this:
-        node = this.startNode();
+        node = this.startNode<N.ThisExpression>();
         this.next();
         return this.finishNode(node, "ThisExpression");
 
@@ -1213,7 +1213,7 @@ export default abstract class ExpressionParser extends LValParser {
       // BindExpression[Yield]
       //   :: MemberExpression[?Yield]
       case tt.doubleColon: {
-        node = this.startNode();
+        node = this.startNode<N.BindExpression>();
         this.next();
         node.object = null;
         const callee = (node.callee = this.parseNoCallExpr());
@@ -2728,7 +2728,7 @@ export default abstract class ExpressionParser extends LValParser {
       if (!allowPlaceholder) {
         this.raise(Errors.UnexpectedArgumentPlaceholder, this.state.startLoc);
       }
-      const node = this.startNode();
+      const node = this.startNode<N.ArgumentPlaceholder>();
       this.next();
       elt = this.finishNode(node, "ArgumentPlaceholder");
     } else {

--- a/packages/babel-parser/src/parser/index.ts
+++ b/packages/babel-parser/src/parser/index.ts
@@ -38,14 +38,14 @@ export default class Parser extends StatementParser {
 
   parse(): N.File {
     this.enterInitialScopes();
-    const file = this.startNode() as N.File;
-    const program = this.startNode() as N.Program;
+    const file = this.startNode<N.File>();
+    const program = this.startNode<N.Program>();
     this.nextToken();
     file.errors = null;
     this.parseTopLevel(file, program);
     file.errors = this.state.errors;
     file.comments.length = this.state.commentsLen;
-    return file;
+    return file as N.File;
   }
 }
 

--- a/packages/babel-parser/src/parser/node.ts
+++ b/packages/babel-parser/src/parser/node.ts
@@ -96,17 +96,19 @@ export function cloneStringLiteral(node: any): any {
 export type Undone<T extends NodeType> = Omit<T, "type">;
 
 export abstract class NodeUtils extends UtilParser {
-  startNode<T extends NodeType>(): Undone<T> {
+  startNode<T extends NodeType = never>(): Undone<T> {
     const loc = this.state.startLoc;
     return new Node(this, loc.index, loc) as unknown as Undone<T>;
   }
 
-  startNodeAt<T extends NodeType>(loc: Position): Undone<T> {
+  startNodeAt<T extends NodeType = never>(loc: Position): Undone<T> {
     return new Node(this, loc.index, loc) as unknown as Undone<T>;
   }
 
   /** Start a new node with a previous node's location. */
-  startNodeAtNode<T extends NodeType>(type: Undone<NodeType>): Undone<T> {
+  startNodeAtNode<T extends NodeType = never>(
+    type: Undone<NodeType>,
+  ): Undone<T> {
     return this.startNodeAt(type.loc.start);
   }
 

--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -470,7 +470,6 @@ export default (superClass: typeof Parser) =>
         case "ExportNamedDeclaration":
           if (
             node.specifiers.length === 1 &&
-            // @ts-expect-error mutating AST types
             node.specifiers[0].type === "ExportNamespaceSpecifier"
           ) {
             // @ts-expect-error mutating AST types
@@ -524,7 +523,7 @@ export default (superClass: typeof Parser) =>
           node.type = node.type.substring(8); // strip Optional prefix
         }
         if (state.stop) {
-          const chain = this.startNodeAtNode(node);
+          const chain = this.startNodeAtNode<N.EstreeChainExpression>(node);
           chain.expression = node;
           return this.finishNode(chain, "ChainExpression");
         }

--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -356,7 +356,7 @@ export default (superClass: typeof Parser) =>
     }
 
     flowParsePredicate(): N.FlowPredicate {
-      const node = this.startNode();
+      const node = this.startNode<N.FlowPredicate>();
       const moduloLoc = this.state.startLoc;
       this.next(); // eat `%`
       this.expectContextual(tt._checks);
@@ -410,7 +410,7 @@ export default (superClass: typeof Parser) =>
 
       const id = (node.id = this.parseIdentifier());
 
-      const typeNode = this.startNode();
+      const typeNode = this.startNode<N.FlowDeclareFunction>();
       const typeContainer = this.startNode<N.TypeAnnotation>();
 
       if (this.match(tt.lt)) {
@@ -510,7 +510,7 @@ export default (superClass: typeof Parser) =>
         node.id = this.parseIdentifier();
       }
 
-      const bodyNode = (node.body = this.startNode());
+      const bodyNode = (node.body = this.startNode<N.BlockStatement>());
       // @ts-expect-error refine typings
       const body = (bodyNode.body = []);
       this.expect(tt.braceL);
@@ -739,7 +739,7 @@ export default (superClass: typeof Parser) =>
     }
 
     flowParseInterfaceExtends(): N.FlowInterfaceExtends {
-      const node = this.startNode();
+      const node = this.startNode<N.FlowInterfaceExtends>();
 
       node.id = this.flowParseQualifiedTypeIdentifier();
       if (this.match(tt.lt)) {
@@ -1100,7 +1100,7 @@ export default (superClass: typeof Parser) =>
       const oldInType = this.state.inType;
       this.state.inType = true;
 
-      const nodeStart = this.startNode();
+      const nodeStart = this.startNode<N.FlowObjectTypeAnnotation>();
 
       nodeStart.callProperties = [];
       nodeStart.properties = [];
@@ -1407,7 +1407,7 @@ export default (superClass: typeof Parser) =>
       startLoc: Position,
       id: N.Identifier,
     ): N.FlowGenericTypeAnnotation {
-      const node = this.startNodeAt(startLoc);
+      const node = this.startNodeAt<N.FlowGenericTypeAnnotation>(startLoc);
 
       node.typeParameters = null;
       node.id = this.flowParseQualifiedTypeIdentifier(startLoc, id);
@@ -1420,14 +1420,14 @@ export default (superClass: typeof Parser) =>
     }
 
     flowParseTypeofType(): N.FlowTypeofTypeAnnotation {
-      const node = this.startNode();
+      const node = this.startNode<N.FlowTypeofTypeAnnotation>();
       this.expect(tt._typeof);
       node.argument = this.flowParsePrimaryType();
       return this.finishNode(node, "TypeofTypeAnnotation");
     }
 
     flowParseTupleType(): N.FlowTupleTypeAnnotation {
-      const node = this.startNode();
+      const node = this.startNode<N.FlowTupleTypeAnnotation>();
       node.types = [];
       this.expect(tt.bracketL);
       // We allow trailing commas
@@ -1472,7 +1472,7 @@ export default (superClass: typeof Parser) =>
     reinterpretTypeAsFunctionTypeParam(
       type: N.FlowType,
     ): N.FlowFunctionTypeParam {
-      const node = this.startNodeAt(type.loc.start);
+      const node = this.startNodeAt<N.FlowFunctionTypeParam>(type.loc.start);
       node.name = null;
       node.optional = false;
       node.typeAnnotation = type;
@@ -1545,7 +1545,7 @@ export default (superClass: typeof Parser) =>
     // primitives with which other types are constructed.
     flowParsePrimaryType(): N.FlowTypeAnnotation {
       const startLoc = this.state.startLoc;
-      const node = this.startNode();
+      const node = this.startNode<N.FlowTypeAnnotation>();
       let tmp;
       let type;
       let isGroupedType = false;
@@ -1748,7 +1748,7 @@ export default (superClass: typeof Parser) =>
         (this.match(tt.bracketL) || this.match(tt.questionDot)) &&
         !this.canInsertSemicolon()
       ) {
-        const node = this.startNodeAt(startLoc);
+        const node = this.startNodeAt<N.FlowTypeAnnotation>(startLoc);
         const optional = this.eat(tt.questionDot);
         seenOptionalIndexedAccess = seenOptionalIndexedAccess || optional;
         this.expect(tt.bracketL);
@@ -1780,7 +1780,7 @@ export default (superClass: typeof Parser) =>
     }
 
     flowParsePrefixType(): N.FlowTypeAnnotation {
-      const node = this.startNode();
+      const node = this.startNode<N.FlowTypeAnnotation>();
       if (this.eat(tt.question)) {
         node.typeAnnotation = this.flowParsePrefixType();
         return this.finishNode(node, "NullableTypeAnnotation");
@@ -1793,7 +1793,9 @@ export default (superClass: typeof Parser) =>
       const param = this.flowParsePrefixType();
       if (!this.state.noAnonFunctionType && this.eat(tt.arrow)) {
         // TODO: This should be a type error. Passing in a SourceLocation, and it expects a Position.
-        const node = this.startNodeAt(param.loc.start);
+        const node = this.startNodeAt<N.FlowFunctionTypeAnnotation>(
+          param.loc.start,
+        );
         node.params = [this.reinterpretTypeAsFunctionTypeParam(param)];
         node.rest = null;
         node.this = null;
@@ -1805,7 +1807,7 @@ export default (superClass: typeof Parser) =>
     }
 
     flowParseIntersectionType(): N.FlowTypeAnnotation {
-      const node = this.startNode();
+      const node = this.startNode<N.FlowTypeAnnotation>();
       this.eat(tt.bitwiseAND);
       const type = this.flowParseAnonFunctionWithoutParens();
       node.types = [type];
@@ -1818,7 +1820,7 @@ export default (superClass: typeof Parser) =>
     }
 
     flowParseUnionType(): N.FlowTypeAnnotation {
-      const node = this.startNode();
+      const node = this.startNode<N.FlowTypeAnnotation>();
       this.eat(tt.bitwiseOR);
       const type = this.flowParseIntersectionType();
       node.types = [type];
@@ -1848,8 +1850,8 @@ export default (superClass: typeof Parser) =>
       }
     }
 
-    flowParseTypeAnnotation(): N.FlowTypeAnnotation {
-      const node = this.startNode<N.FlowTypeAnnotation>();
+    flowParseTypeAnnotation(): N.TypeAnnotation {
+      const node = this.startNode<N.TypeAnnotation>();
       node.typeAnnotation = this.flowParseTypeInitialiser();
       return this.finishNode(node, "TypeAnnotation");
     }
@@ -1861,7 +1863,6 @@ export default (superClass: typeof Parser) =>
         ? this.parseIdentifier()
         : this.flowParseRestrictedIdentifier();
       if (this.match(tt.colon)) {
-        // @ts-expect-error: refine typings
         ident.typeAnnotation = this.flowParseTypeAnnotation();
         this.resetEndLocation(ident);
       }
@@ -2053,7 +2054,7 @@ export default (superClass: typeof Parser) =>
       this.expect(tt.question);
       const state = this.state.clone();
       const originalNoArrowAt = this.state.noArrowAt;
-      const node = this.startNodeAt(startLoc);
+      const node = this.startNodeAt<N.ConditionalExpression>(startLoc);
       let { consequent, failed } = this.tryParseConditionalConsequent();
       let [valid, invalid] = this.getArrowLikeExpressions(consequent);
 
@@ -2205,7 +2206,7 @@ export default (superClass: typeof Parser) =>
       }
 
       if (this.match(tt.colon)) {
-        const typeCastNode = this.startNodeAt(startLoc);
+        const typeCastNode = this.startNodeAt<N.TypeCastExpression>(startLoc);
         typeCastNode.expression = node;
         typeCastNode.typeAnnotation = this.flowParseTypeAnnotation();
 
@@ -2475,7 +2476,6 @@ export default (superClass: typeof Parser) =>
     // parse class property type annotations
     parseClassProperty(node: N.ClassProperty): N.ClassProperty {
       if (this.match(tt.colon)) {
-        // @ts-expect-error refine typings
         node.typeAnnotation = this.flowParseTypeAnnotation();
       }
       return super.parseClassProperty(node);
@@ -2485,7 +2485,6 @@ export default (superClass: typeof Parser) =>
       node: N.ClassPrivateProperty,
     ): N.ClassPrivateProperty {
       if (this.match(tt.colon)) {
-        // @ts-expect-error refine typings
         node.typeAnnotation = this.flowParseTypeAnnotation();
       }
       return super.parseClassPrivateProperty(node);
@@ -2579,7 +2578,7 @@ export default (superClass: typeof Parser) =>
         this.next();
         const implemented: N.FlowClassImplements[] = (node.implements = []);
         do {
-          const node = this.startNode();
+          const node = this.startNode<N.FlowClassImplements>();
           node.id = this.flowParseRestrictedIdentifier(/*liberal*/ true);
           if (this.match(tt.lt)) {
             node.typeParameters = this.flowParseTypeParameterInstantiation();
@@ -2663,7 +2662,6 @@ export default (superClass: typeof Parser) =>
         (param as any as N.Identifier).optional = true;
       }
       if (this.match(tt.colon)) {
-        // @ts-expect-error: refine typings
         param.typeAnnotation = this.flowParseTypeAnnotation();
       } else if (this.isThisParam(param)) {
         this.raise(FlowErrors.ThisParamAnnotationRequired, param);
@@ -2873,7 +2871,6 @@ export default (superClass: typeof Parser) =>
     ): void {
       super.parseVarId(decl, kind);
       if (this.match(tt.colon)) {
-        // @ts-expect-error: refine typings
         decl.id.typeAnnotation = this.flowParseTypeAnnotation();
         this.resetEndLocation(decl.id); // set end position to end of type
       }
@@ -2887,7 +2884,6 @@ export default (superClass: typeof Parser) =>
       if (this.match(tt.colon)) {
         const oldNoAnonFunctionType = this.state.noAnonFunctionType;
         this.state.noAnonFunctionType = true;
-        // @ts-expect-error refine typings
         node.returnType = this.flowParseTypeAnnotation();
         this.state.noAnonFunctionType = oldNoAnonFunctionType;
       }
@@ -3146,7 +3142,7 @@ export default (superClass: typeof Parser) =>
       ) {
         this.next();
 
-        const node = this.startNodeAt(startLoc);
+        const node = this.startNodeAt<N.CallExpression>(startLoc);
         node.callee = base;
         node.arguments = super.parseCallExpressionArguments(tt.parenR, false);
         base = this.finishNode(node, "CallExpression");
@@ -3516,7 +3512,7 @@ export default (superClass: typeof Parser) =>
           hasUnknownMembers = true;
           break;
         }
-        const memberNode = this.startNode();
+        const memberNode = this.startNode<N.Node>();
         const { id, init } = this.flowEnumMemberRaw();
         const memberName = id.name;
         if (memberName === "") {

--- a/packages/babel-parser/src/plugins/jsx/index.ts
+++ b/packages/babel-parser/src/plugins/jsx/index.ts
@@ -261,7 +261,7 @@ export default (superClass: typeof Parser) =>
     // Parse next token as JSX identifier
 
     jsxParseIdentifier(): N.JSXIdentifier {
-      const node = this.startNode();
+      const node = this.startNode<N.JSXIdentifier>();
       if (this.match(tt.jsxName)) {
         node.name = this.state.value;
       } else if (tokenIsKeyword(this.state.type)) {
@@ -280,7 +280,7 @@ export default (superClass: typeof Parser) =>
       const name = this.jsxParseIdentifier();
       if (!this.eat(tt.colon)) return name;
 
-      const node = this.startNodeAt(startLoc);
+      const node = this.startNodeAt<N.JSXNamespacedName>(startLoc);
       node.namespace = name;
       node.name = this.jsxParseIdentifier();
       return this.finishNode(node, "JSXNamespacedName");
@@ -299,7 +299,7 @@ export default (superClass: typeof Parser) =>
         return node;
       }
       while (this.eat(tt.dot)) {
-        const newNode = this.startNodeAt(startLoc);
+        const newNode = this.startNodeAt<N.JSXMemberExpression>(startLoc);
         newNode.object = node;
         newNode.property = this.jsxParseIdentifier();
         node = this.finishNode(newNode, "JSXMemberExpression");
@@ -387,7 +387,7 @@ export default (superClass: typeof Parser) =>
     // Parses following JSX attribute name-value pair.
 
     jsxParseAttribute(): N.JSXAttribute {
-      const node = this.startNode();
+      const node = this.startNode<N.JSXAttribute | N.JSXSpreadAttribute>();
       if (this.match(tt.braceL)) {
         this.setContext(tc.brace);
         this.next();
@@ -435,7 +435,9 @@ export default (superClass: typeof Parser) =>
     // Parses JSX closing tag starting after "</".
 
     jsxParseClosingElementAt(startLoc: Position): N.JSXClosingElement {
-      const node = this.startNodeAt(startLoc);
+      const node = this.startNodeAt<N.JSXClosingFragment | N.JSXClosingElement>(
+        startLoc,
+      );
       if (this.eat(tt.jsxTagEnd)) {
         return this.finishNode(node, "JSXClosingFragment");
       }
@@ -448,7 +450,7 @@ export default (superClass: typeof Parser) =>
     // (starting after "<"), attributes, contents and closing tag.
 
     jsxParseElementAt(startLoc: Position): N.JSXElement {
-      const node = this.startNodeAt(startLoc);
+      const node = this.startNodeAt<N.JSXElement>(startLoc);
       const children = [];
       const openingElement = this.jsxParseOpeningElementAt(startLoc);
       let closingElement = null;

--- a/packages/babel-parser/src/plugins/placeholders.ts
+++ b/packages/babel-parser/src/plugins/placeholders.ts
@@ -43,7 +43,7 @@ export default (superClass: typeof Parser) =>
       expectedNode: T,
     ): /*?N.Placeholder<T>*/ MaybePlaceholder<T> | undefined | null {
       if (this.match(tt.placeholder)) {
-        const node = this.startNode();
+        const node = this.startNode<N.Placeholder<T>>();
         this.next();
         this.assertNoSpace();
 
@@ -276,7 +276,7 @@ export default (superClass: typeof Parser) =>
 
       // export %%NAME%% from "foo";
       this.expectPlugin("exportDefaultFrom");
-      const specifier = this.startNode();
+      const specifier = this.startNode<N.ExportDefaultSpecifier>();
       specifier.exported = placeholder;
       node.specifiers = [this.finishNode(specifier, "ExportDefaultSpecifier")];
 

--- a/packages/babel-parser/src/types.d.ts
+++ b/packages/babel-parser/src/types.d.ts
@@ -597,8 +597,8 @@ export interface OptionalCallExpression extends CallOrNewBase {
 }
 export interface BindExpression extends NodeBase {
   type: "BindExpression";
-  object: Array<Expression | undefined | null>;
-  callee: Expression[];
+  object: Expression | undefined | null;
+  callee: Expression;
 }
 
 export interface ConditionalExpression extends NodeBase {
@@ -954,7 +954,9 @@ export interface ImportNamespaceSpecifier extends ModuleSpecifier {
 export interface ExportNamedDeclaration extends NodeBase {
   type: "ExportNamedDeclaration";
   declaration: Declaration | undefined | null;
-  specifiers: Array<ExportSpecifier | ExportDefaultSpecifier>;
+  specifiers: Array<
+    ExportSpecifier | ExportDefaultSpecifier | ExportNamespaceSpecifier
+  >;
   source: Literal | undefined | null;
   exportKind?: "type" | "value"; // TODO: Not in spec,
   attributes?: ImportAttribute[];
@@ -972,6 +974,11 @@ export interface ExportSpecifier extends NodeBase {
 export interface ExportDefaultSpecifier extends NodeBase {
   type: "ExportDefaultSpecifier";
   exported: Identifier;
+}
+
+export interface ExportNamespaceSpecifier extends NodeBase {
+  type: "ExportNamespaceSpecifier";
+  exported: Identifier | StringLiteral;
 }
 
 export interface ExportDefaultDeclaration extends NodeBase {
@@ -1009,6 +1016,7 @@ export type JSXEmptyExpression = Node;
 export type JSXSpreadChild = Node;
 export type JSXExpressionContainer = Node;
 export type JSXAttribute = Node;
+export type JSXSpreadAttribute = Node;
 export interface JSXOpeningElement extends NodeBase {
   type: "JSXOpeningElement";
   name: JSXNamespacedName | JSXMemberExpression;
@@ -1239,6 +1247,11 @@ export interface EstreePropertyDefinition extends NodeBase {
   key: Expression | EstreePrivateIdentifier;
   computed: boolean;
   value: Expression;
+}
+
+export interface EstreeChainExpression extends NodeBase {
+  type: "ChainExpression";
+  expression: Expression;
 }
 
 // === === === ===
@@ -1679,7 +1692,7 @@ export interface TsInstantiationExpression extends NodeBase {
 export interface Placeholder<N extends PlaceholderTypes = PlaceholderTypes>
   extends NodeBase {
   type: "Placeholder";
-  id: Identifier;
+  name: Identifier;
   expectedNode: N;
 }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I was working on unifying AST type definitions across `@babel/parser` and `@babel/types`, and noticed that in many places in `@babel/parser` variables are typed as `N.Node` (which is the AST equivalent of `any`). This PR fixes that.

I plan to eventually open a PR to, when possible, move the type string from `finishNode` to `startNode` so that the type can be inferred better.