### PR TITLE
Remove `JSXNamespacedName` from valid `CallExpression` args

### DIFF
--- a/packages/babel-plugin-proposal-partial-application/src/index.ts
+++ b/packages/babel-plugin-proposal-partial-application/src/index.ts
@@ -36,14 +36,7 @@ export default declare(api => {
           );
           node.argument = t.cloneNode(id);
         } else {
-          init.push(
-            t.assignmentExpression(
-              "=",
-              t.cloneNode(id),
-              // @ts-expect-error Fixme: may need to handle JSXNamespacedName here
-              node,
-            ),
-          );
+          init.push(t.assignmentExpression("=", t.cloneNode(id), node));
           args[i] = t.cloneNode(id);
         }
       }

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -375,9 +375,7 @@ export interface BreakStatement extends BaseNode {
 export interface CallExpression extends BaseNode {
   type: "CallExpression";
   callee: Expression | Super | V8IntrinsicIdentifier;
-  arguments: Array<
-    Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder
-  >;
+  arguments: Array<Expression | SpreadElement | ArgumentPlaceholder>;
   optional?: true | false | null;
   typeArguments?: TypeParameterInstantiation | null;
   typeParameters?: TSTypeParameterInstantiation | null;
@@ -556,9 +554,7 @@ export interface MemberExpression extends BaseNode {
 export interface NewExpression extends BaseNode {
   type: "NewExpression";
   callee: Expression | Super | V8IntrinsicIdentifier;
-  arguments: Array<
-    Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder
-  >;
+  arguments: Array<Expression | SpreadElement | ArgumentPlaceholder>;
   optional?: true | false | null;
   typeArguments?: TypeParameterInstantiation | null;
   typeParameters?: TSTypeParameterInstantiation | null;
@@ -1003,9 +999,7 @@ export interface OptionalMemberExpression extends BaseNode {
 export interface OptionalCallExpression extends BaseNode {
   type: "OptionalCallExpression";
   callee: Expression;
-  arguments: Array<
-    Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder
-  >;
+  arguments: Array<Expression | SpreadElement | ArgumentPlaceholder>;
   optional: boolean;
   typeArguments?: TypeParameterInstantiation | null;
   typeParameters?: TSTypeParameterInstantiation | null;
@@ -5039,13 +5033,7 @@ export interface ParentMaps {
     | JSXClosingElement
     | JSXMemberExpression
     | JSXOpeningElement;
-  JSXNamespacedName:
-    | CallExpression
-    | JSXAttribute
-    | JSXClosingElement
-    | JSXOpeningElement
-    | NewExpression
-    | OptionalCallExpression;
+  JSXNamespacedName: JSXAttribute | JSXClosingElement | JSXOpeningElement;
   JSXOpeningElement: JSXElement;
   JSXOpeningFragment: JSXFragment;
   JSXSpreadAttribute: JSXOpeningElement;

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -98,9 +98,7 @@ export function breakStatement(
 }
 export function callExpression(
   callee: t.Expression | t.Super | t.V8IntrinsicIdentifier,
-  _arguments: Array<
-    t.Expression | t.SpreadElement | t.JSXNamespacedName | t.ArgumentPlaceholder
-  >,
+  _arguments: Array<t.Expression | t.SpreadElement | t.ArgumentPlaceholder>,
 ): t.CallExpression {
   return validateNode<t.CallExpression>({
     type: "CallExpression",
@@ -330,9 +328,7 @@ export function memberExpression(
 }
 export function newExpression(
   callee: t.Expression | t.Super | t.V8IntrinsicIdentifier,
-  _arguments: Array<
-    t.Expression | t.SpreadElement | t.JSXNamespacedName | t.ArgumentPlaceholder
-  >,
+  _arguments: Array<t.Expression | t.SpreadElement | t.ArgumentPlaceholder>,
 ): t.NewExpression {
   return validateNode<t.NewExpression>({
     type: "NewExpression",
@@ -878,9 +874,7 @@ export function optionalMemberExpression(
 }
 export function optionalCallExpression(
   callee: t.Expression,
-  _arguments: Array<
-    t.Expression | t.SpreadElement | t.JSXNamespacedName | t.ArgumentPlaceholder
-  >,
+  _arguments: Array<t.Expression | t.SpreadElement | t.ArgumentPlaceholder>,
   optional: boolean,
 ): t.OptionalCallExpression {
   return validateNode<t.OptionalCallExpression>({

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -186,12 +186,7 @@ defineType("CallExpression", {
       validate: chain(
         assertValueType("array"),
         assertEach(
-          assertNodeType(
-            "Expression",
-            "SpreadElement",
-            "JSXNamespacedName",
-            "ArgumentPlaceholder",
-          ),
+          assertNodeType("Expression", "SpreadElement", "ArgumentPlaceholder"),
         ),
       ),
     },
@@ -2242,12 +2237,7 @@ defineType("OptionalCallExpression", {
       validate: chain(
         assertValueType("array"),
         assertEach(
-          assertNodeType(
-            "Expression",
-            "SpreadElement",
-            "JSXNamespacedName",
-            "ArgumentPlaceholder",
-          ),
+          assertNodeType("Expression", "SpreadElement", "ArgumentPlaceholder"),
         ),
       ),
     },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16420
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`JSXNamespacedName` is used for namespaced XML properties in things like `<div namespace:name="value">`, but `fn(namespace:name)` doesn't make any sense.