### PR TITLE
Improve `@babel/parser` AST types

### DIFF
--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -117,7 +117,6 @@ export default abstract class ExpressionParser extends LValParser {
       prop.type === "SpreadElement" ||
       this.isObjectMethod(prop) ||
       prop.computed ||
-      // @ts-expect-error prop must be an ObjectProperty
       prop.shorthand
     ) {
       return;

--- a/packages/babel-parser/src/parser/lval.ts
+++ b/packages/babel-parser/src/parser/lval.ts
@@ -17,7 +17,6 @@ import type {
   PrivateName,
   ObjectExpression,
   ObjectPattern,
-  ArrayExpression,
   ArrayPattern,
   AssignmentProperty,
   Assignable,
@@ -138,7 +137,7 @@ export default abstract class LValParser extends NodeUtils {
         break;
 
       case "ObjectExpression":
-        node.type = "ObjectPattern";
+        (node as Node).type = "ObjectPattern";
         for (
           let i = 0, length = node.properties.length, last = length - 1;
           i < length;
@@ -150,7 +149,7 @@ export default abstract class LValParser extends NodeUtils {
 
           if (
             isLast &&
-            prop.type === "RestElement" &&
+            (prop as Node).type === "RestElement" &&
             node.extra?.trailingCommaLoc
           ) {
             this.raise(Errors.RestTrailingComma, node.extra.trailingCommaLoc);
@@ -178,7 +177,7 @@ export default abstract class LValParser extends NodeUtils {
       }
 
       case "ArrayExpression":
-        node.type = "ArrayPattern";
+        (node as Node).type = "ArrayPattern";
         this.toAssignableList(
           node.elements,
           node.extra?.trailingCommaLoc,
@@ -191,7 +190,7 @@ export default abstract class LValParser extends NodeUtils {
           this.raise(Errors.MissingEqInAssignment, node.left.loc.end);
         }
 
-        node.type = "AssignmentPattern";
+        (node as Node).type = "AssignmentPattern";
         delete node.operator;
         this.toAssignable(node.left, isLHS);
         break;
@@ -220,7 +219,7 @@ export default abstract class LValParser extends NodeUtils {
         prop.key,
       );
     } else if (prop.type === "SpreadElement") {
-      prop.type = "RestElement";
+      (prop as Node).type = "RestElement";
       const arg = prop.argument;
       this.checkToRestConversion(arg, /* allowPattern */ false);
       this.toAssignable(arg, isLHS);
@@ -276,15 +275,13 @@ export default abstract class LValParser extends NodeUtils {
 
       case "ObjectExpression": {
         const last = node.properties.length - 1;
-        return (node.properties as ObjectExpression["properties"]).every(
-          (prop, i) => {
-            return (
-              prop.type !== "ObjectMethod" &&
-              (i === last || prop.type !== "SpreadElement") &&
-              this.isAssignable(prop)
-            );
-          },
-        );
+        return node.properties.every((prop, i) => {
+          return (
+            prop.type !== "ObjectMethod" &&
+            (i === last || prop.type !== "SpreadElement") &&
+            this.isAssignable(prop)
+          );
+        });
       }
 
       case "ObjectProperty":
@@ -294,7 +291,7 @@ export default abstract class LValParser extends NodeUtils {
         return this.isAssignable(node.argument);
 
       case "ArrayExpression":
-        return (node as ArrayExpression).elements.every(
+        return node.elements.every(
           element => element === null || this.isAssignable(element),
         );
 

--- a/packages/babel-parser/src/parser/node.ts
+++ b/packages/babel-parser/src/parser/node.ts
@@ -131,9 +131,7 @@ export abstract class NodeUtils extends UtilParser {
           " Instead use resetEndLocation() or change type directly.",
       );
     }
-    // @ts-expect-error migrate to Babel types AST typings
-    node.type = type;
-    // @ts-expect-error migrate to Babel types AST typings
+    (node as T).type = type;
     node.end = endLoc.index;
     node.loc.end = endLoc;
     if (this.options.ranges) node.range[1] = endLoc.index;

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -647,7 +647,6 @@ export default abstract class StatementParser extends ExpressionParser {
       return this.parseLabeledStatement(
         node as Undone<N.LabeledStatement>,
         maybeName,
-        // @ts-expect-error migrate to Babel types
         expr,
         flags,
       );
@@ -1723,12 +1722,16 @@ export default abstract class StatementParser extends ExpressionParser {
     return this.match(tt.parenL);
   }
 
+  nameIsConstructor(key: N.Expression | N.PrivateName): boolean {
+    return (
+      (key.type === "Identifier" && key.name === "constructor") ||
+      (key.type === "StringLiteral" && key.value === "constructor")
+    );
+  }
+
   isNonstaticConstructor(method: N.ClassMethod | N.ClassProperty): boolean {
     return (
-      !method.computed &&
-      !method.static &&
-      (method.key.name === "constructor" || // Identifier
-        method.key.value === "constructor") // String literal
+      !method.computed && !method.static && this.nameIsConstructor(method.key)
     );
   }
 
@@ -1918,9 +1921,10 @@ export default abstract class StatementParser extends ExpressionParser {
     }
 
     const isContextual =
-      tokenIsIdentifier(this.state.type) && !this.state.containsEsc;
-    const isPrivate = this.match(tt.privateName);
+      !this.state.containsEsc && tokenIsIdentifier(this.state.type);
     const key = this.parseClassElementName(member);
+    const maybeContextualKw = isContextual ? (key as N.Identifier).name : null;
+    const isPrivate = this.isPrivateName(key);
     const maybeQuestionTokenStartLoc = this.state.startLoc;
 
     this.parsePostMemberNameModifiers(publicMember);
@@ -1964,11 +1968,7 @@ export default abstract class StatementParser extends ExpressionParser {
       } else {
         this.pushClassProperty(classBody, publicProp);
       }
-    } else if (
-      isContextual &&
-      key.name === "async" &&
-      !this.isLineTerminator()
-    ) {
+    } else if (maybeContextualKw === "async" && !this.isLineTerminator()) {
       // an async method
       this.resetPreviousNodeTrailingComments(key);
       const isGenerator = this.eat(tt.star);
@@ -2006,14 +2006,13 @@ export default abstract class StatementParser extends ExpressionParser {
         );
       }
     } else if (
-      isContextual &&
-      (key.name === "get" || key.name === "set") &&
+      (maybeContextualKw === "get" || maybeContextualKw === "set") &&
       !(this.match(tt.star) && this.isLineTerminator())
     ) {
       // `get\n*` is an uninitialized property named 'get' followed by a generator.
       // a getter or setter
       this.resetPreviousNodeTrailingComments(key);
-      method.kind = key.name;
+      method.kind = maybeContextualKw;
       // The so-called parsed name would have been "get/set": get the real name.
       const isPrivate = this.match(tt.privateName);
       this.parseClassElementName(publicMethod);
@@ -2036,11 +2035,7 @@ export default abstract class StatementParser extends ExpressionParser {
       }
 
       this.checkGetterSetterParams(publicMethod);
-    } else if (
-      isContextual &&
-      key.name === "accessor" &&
-      !this.isLineTerminator()
-    ) {
+    } else if (maybeContextualKw === "accessor" && !this.isLineTerminator()) {
       this.expectPlugin("decoratorAutoAccessors");
       this.resetPreviousNodeTrailingComments(key);
 
@@ -2064,7 +2059,7 @@ export default abstract class StatementParser extends ExpressionParser {
   parseClassElementName(
     this: Parser,
     member: Undone<N.ClassMember>,
-  ): N.Expression | N.Identifier {
+  ): N.Expression | N.Identifier | N.PrivateName {
     const { type, value } = this.state;
     if (
       (type === tt.name || type === tt.string) &&
@@ -2083,7 +2078,8 @@ export default abstract class StatementParser extends ExpressionParser {
       return key;
     }
 
-    return this.parsePropertyName(member);
+    this.parsePropertyName(member);
+    return member.key;
   }
 
   parseClassStaticBlock(
@@ -2121,10 +2117,7 @@ export default abstract class StatementParser extends ExpressionParser {
     classBody: Undone<N.ClassBody>,
     prop: N.ClassProperty,
   ) {
-    if (
-      !prop.computed &&
-      (prop.key.name === "constructor" || prop.key.value === "constructor")
-    ) {
+    if (!prop.computed && this.nameIsConstructor(prop.key)) {
       // Non-computed field, which is either an identifier named "constructor"
       // or a string literal named "constructor"
       this.raise(Errors.ConstructorClassField, prop.key);
@@ -2154,15 +2147,10 @@ export default abstract class StatementParser extends ExpressionParser {
     prop: N.ClassAccessorProperty,
     isPrivate: boolean,
   ) {
-    if (!isPrivate && !prop.computed) {
-      // Not private, so not node is not a PrivateName and we can safely cast
-      const key = prop.key as N.Expression;
-
-      if (key.name === "constructor" || key.value === "constructor") {
-        // Non-computed field, which is either an identifier named "constructor"
-        // or a string literal named "constructor"
-        this.raise(Errors.ConstructorClassField, key);
-      }
+    if (!isPrivate && !prop.computed && this.nameIsConstructor(prop.key)) {
+      // Non-computed field, which is either an identifier named "constructor"
+      // or a string literal named "constructor"
+      this.raise(Errors.ConstructorClassField, prop.key);
     }
 
     const node = this.parseClassAccessorProperty(prop);
@@ -2508,7 +2496,9 @@ export default abstract class StatementParser extends ExpressionParser {
     return this.isUnparsedContextual(next, "function");
   }
 
-  parseExportDefaultExpression(this: Parser): N.Expression | N.Declaration {
+  parseExportDefaultExpression(
+    this: Parser,
+  ): N.ExportDefaultDeclaration["declaration"] {
     const expr = this.startNode();
 
     if (this.match(tt._function)) {

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -2105,7 +2105,7 @@ export default abstract class StatementParser extends ExpressionParser {
     // ClassStaticBlockStatementList:
     //   StatementList[~Yield, ~Await, ~Return] opt
     this.prodParam.enter(ParamKind.PARAM);
-    const body: N.Node[] = (member.body = []);
+    const body: N.Statement[] = (member.body = []);
     this.parseBlockOrModuleBlockBody(body, undefined, false, tt.braceR);
     this.prodParam.exit();
     this.scope.exit();

--- a/packages/babel-parser/src/parser/util.ts
+++ b/packages/babel-parser/src/parser/util.ts
@@ -9,8 +9,10 @@ import type State from "../tokenizer/state.ts";
 import type {
   EstreePropertyDefinition,
   Node,
+  ObjectMethod,
   ObjectProperty,
-} from "../types.ts";
+  PrivateName,
+} from "../types.d.ts";
 import { lineBreak, skipWhiteSpaceToLineBreak } from "../util/whitespace.ts";
 import { isIdentifierChar } from "../util/identifier.ts";
 import ClassScopeHandler from "../util/class-scope.ts";
@@ -265,7 +267,7 @@ export default abstract class UtilParser extends Tokenizer {
    * Test if given node is a PrivateName
    * will be overridden in ESTree plugin
    */
-  isPrivateName(node: Node): boolean {
+  isPrivateName(node: Node): node is PrivateName {
     return node.type === "PrivateName";
   }
 
@@ -274,7 +276,7 @@ export default abstract class UtilParser extends Tokenizer {
    * WITHOUT `#`
    * @see {@link https://tc39.es/ecma262/#sec-static-semantics-stringvalue}
    */
-  getPrivateNameSV(node: Node): string {
+  getPrivateNameSV(node: PrivateName): string {
     return node.id.name;
   }
 
@@ -297,7 +299,7 @@ export default abstract class UtilParser extends Tokenizer {
     return node.type === "ObjectProperty";
   }
 
-  isObjectMethod(node: Node): boolean {
+  isObjectMethod(node: Node): node is ObjectMethod {
     return node.type === "ObjectMethod";
   }
 

--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -135,8 +135,7 @@ export default (superClass: typeof Parser) =>
     }
 
     getObjectOrClassMethodParams(method: N.ObjectMethod | N.ClassMethod) {
-      return (method as any as N.EstreeProperty | N.EstreeMethodDefinition)
-        .value.params;
+      return (method as unknown as N.EstreeMethodDefinition).value.params;
     }
 
     isValidDirective(stmt: N.Statement): boolean {
@@ -295,6 +294,11 @@ export default (superClass: typeof Parser) =>
       );
     }
 
+    nameIsConstructor(key: N.Expression | N.PrivateName): boolean {
+      if (key.type === "Literal") return key.value === "constructor";
+      return super.nameIsConstructor(key);
+    }
+
     parseClassProperty(...args: [N.ClassProperty]): any {
       const propertyNode = super.parseClassProperty(...args) as any;
       if (!process.env.BABEL_8_BREAKING) {
@@ -419,16 +423,17 @@ export default (superClass: typeof Parser) =>
 
       if (node.callee.type === "Import") {
         (node as N.Node as N.EstreeImportExpression).type = "ImportExpression";
-        (node as N.Node as N.EstreeImportExpression).source = node.arguments[0];
+        (node as N.Node as N.EstreeImportExpression).source = node
+          .arguments[0] as N.Expression;
         if (
           this.hasPlugin("importAttributes") ||
           this.hasPlugin("importAssertions")
         ) {
           (node as N.Node as N.EstreeImportExpression).options =
-            node.arguments[1] ?? null;
+            (node.arguments[1] as N.Expression) ?? null;
           // compatibility with previous ESTree AST
           (node as N.Node as N.EstreeImportExpression).attributes =
-            node.arguments[1] ?? null;
+            (node.arguments[1] as N.Expression) ?? null;
         }
         // arguments isn't optional in the type definition
         delete node.arguments;
@@ -511,7 +516,7 @@ export default (superClass: typeof Parser) =>
       startLoc: Position,
       noCalls: boolean | undefined | null,
       state: N.ParseSubscriptState,
-    ) {
+    ): N.Expression {
       const node = super.parseSubscript(base, startLoc, noCalls, state);
 
       if (state.optionalChainMember) {
@@ -520,7 +525,9 @@ export default (superClass: typeof Parser) =>
           node.type === "OptionalMemberExpression" ||
           node.type === "OptionalCallExpression"
         ) {
-          node.type = node.type.substring(8); // strip Optional prefix
+          // strip Optional prefix
+          (node as unknown as N.CallExpression | N.MemberExpression).type =
+            node.type.substring(8) as "CallExpression" | "MemberExpression";
         }
         if (state.stop) {
           const chain = this.startNodeAtNode<N.EstreeChainExpression>(node);
@@ -531,6 +538,7 @@ export default (superClass: typeof Parser) =>
         node.type === "MemberExpression" ||
         node.type === "CallExpression"
       ) {
+        // @ts-expect-error not in the type definitions
         node.optional = false;
       }
 

--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -3755,7 +3755,9 @@ export default (superClass: typeof Parser) =>
       }
     }
 
-    flowParseEnumDeclaration(node: Undone<N.Node>): N.Node {
+    flowParseEnumDeclaration(
+      node: Undone<N.FlowEnumDeclaration>,
+    ): N.FlowEnumDeclaration {
       const id = this.parseIdentifier();
       node.id = id;
       node.body = this.flowEnumBody(this.startNode(), id);

--- a/packages/babel-parser/src/plugins/jsx/index.ts
+++ b/packages/babel-parser/src/plugins/jsx/index.ts
@@ -311,7 +311,10 @@ export default (superClass: typeof Parser) =>
 
     // Parses any type of JSX attribute value.
 
-    jsxParseAttributeValue(): N.Expression {
+    jsxParseAttributeValue():
+      | N.JSXExpressionContainer
+      | N.JSXElement
+      | N.StringLiteral {
       let node;
       switch (this.state.type) {
         case tt.braceL:
@@ -326,7 +329,7 @@ export default (superClass: typeof Parser) =>
 
         case tt.jsxTagStart:
         case tt.string:
-          return this.parseExprAtom();
+          return this.parseExprAtom() as N.JSXElement | N.StringLiteral;
 
         default:
           throw this.raise(JsxErrors.UnsupportedJsxValue, this.state.startLoc);
@@ -474,7 +477,7 @@ export default (superClass: typeof Parser) =>
               break;
 
             case tt.jsxText:
-              children.push(this.parseExprAtom());
+              children.push(this.parseLiteral(this.state.value, "JSXText"));
               break;
 
             case tt.braceL: {
@@ -559,9 +562,7 @@ export default (superClass: typeof Parser) =>
     // ==================================
 
     parseExprAtom(refExpressionErrors?: ExpressionErrors | null): N.Expression {
-      if (this.match(tt.jsxText)) {
-        return this.parseLiteral(this.state.value, "JSXText");
-      } else if (this.match(tt.jsxTagStart)) {
+      if (this.match(tt.jsxTagStart)) {
         return this.jsxParseElement();
       } else if (
         this.match(tt.lt) &&

--- a/packages/babel-parser/src/plugins/placeholders.ts
+++ b/packages/babel-parser/src/plugins/placeholders.ts
@@ -179,8 +179,9 @@ export default (superClass: typeof Parser) =>
     // @ts-expect-error Plugin will override parser interface
     parseExpressionStatement(
       node: MaybePlaceholder<"Statement">,
-      expr: N.Expression,
+      expr: MaybePlaceholder<"Expression">,
     ): MaybePlaceholder<"Statement"> {
+      // @ts-expect-error placeholder typings
       if (expr.type !== "Placeholder" || expr.extra?.parenthesized) {
         // @ts-expect-error placeholder typings
         return super.parseExpressionStatement(node, expr);
@@ -196,7 +197,9 @@ export default (superClass: typeof Parser) =>
       }
 
       this.semicolon();
-      (node as unknown as N.Placeholder<"Statement">).name = expr.name;
+      (node as unknown as N.Placeholder<"Statement">).name = (
+        expr as N.Placeholder
+      ).name;
       return this.finishPlaceholder(node, "Statement");
     }
 

--- a/packages/babel-parser/src/plugins/placeholders.ts
+++ b/packages/babel-parser/src/plugins/placeholders.ts
@@ -196,7 +196,7 @@ export default (superClass: typeof Parser) =>
       }
 
       this.semicolon();
-      node.name = expr.name;
+      (node as unknown as N.Placeholder<"Statement">).name = expr.name;
       return this.finishPlaceholder(node, "Statement");
     }
 

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -1214,7 +1214,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       return this.finishNode(node, "TSLiteralType");
     }
 
-    parseTemplateSubstitution(): N.TsType | N.Node {
+    parseTemplateSubstitution(): N.TsType | N.Expression {
       if (this.state.inType) return this.tsParseType();
       return super.parseTemplateSubstitution();
     }
@@ -2243,7 +2243,9 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
     // Used when parsing type arguments from ES productions, where the first token
     // has been created without state.inType. Thus we need to rescan the lt token.
-    tsParseTypeArgumentsInExpression(): N.TsTypeParameterInstantiation | void {
+    tsParseTypeArgumentsInExpression():
+      | N.TsTypeParameterInstantiation
+      | undefined {
       if (this.reScan_lt() !== tt.lt) return;
       return this.tsParseTypeArguments();
     }
@@ -2409,7 +2411,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       }
     }
 
-    tsCheckForInvalidTypeCasts(items: Array<N.Expression | undefined | null>) {
+    tsCheckForInvalidTypeCasts(items: Array<N.Expression | N.SpreadElement>) {
       items.forEach(node => {
         if (node?.type === "TSTypeCastExpression") {
           this.raise(TSErrors.UnexpectedTypeAnnotation, node.typeAnnotation);
@@ -2813,7 +2815,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       );
     }
 
-    parseExportDefaultExpression(): N.Expression | N.Declaration {
+    parseExportDefaultExpression(): N.ExportDefaultDeclaration["declaration"] {
       if (this.isAbstractClass()) {
         const cls = this.startNode<N.Class>();
         this.next(); // Skip "abstract"
@@ -3089,14 +3091,13 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
     // Note: These "type casts" are *not* valid TS expressions.
     // But we parse them here and change them when completing the arrow function.
-    parseParenItem(
-      node: N.Expression,
-
+    parseParenItem<T extends N.Expression | N.RestElement | N.SpreadElement>(
+      node: T,
       startLoc: Position,
-    ): N.Expression {
-      node = super.parseParenItem(node, startLoc);
+    ): T | N.TsTypeCastExpression {
+      const newNode = super.parseParenItem(node, startLoc);
       if (this.eat(tt.question)) {
-        node.optional = true;
+        (newNode as N.Identifier).optional = true;
         // Include questionmark in location of node
         // Don't use this.finishNode() as otherwise we might process comments twice and
         // include already consumed parens
@@ -3105,7 +3106,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
       if (this.match(tt.colon)) {
         const typeCastNode = this.startNodeAt<N.TsTypeCastExpression>(startLoc);
-        typeCastNode.expression = node;
+        typeCastNode.expression = node as N.Expression;
         typeCastNode.typeAnnotation = this.tsParseTypeAnnotation();
 
         return this.finishNode(typeCastNode, "TSTypeCastExpression");
@@ -3312,7 +3313,12 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     ) {
       if (node.type === "TSDeclareMethod") return;
       // This happens when using the "estree" plugin.
-      if (node.type === "MethodDefinition" && !node.value.body) return;
+      if (
+        node.type === "MethodDefinition" &&
+        !Object.hasOwn(node.value, "body")
+      ) {
+        return;
+      }
 
       super.declareClassPrivateMethodInScope(node, kind);
     }
@@ -3321,7 +3327,6 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       super.parseClassSuper(node);
       // handle `extends f<<T>
       if (node.superClass && (this.match(tt.lt) || this.match(tt.bitShiftL))) {
-        // @ts-expect-error refine typings
         node.superTypeParameters = this.tsParseTypeArgumentsInExpression();
       }
       if (this.eatContextual(tt._implements)) {
@@ -3329,15 +3334,15 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       }
     }
 
-    parseObjPropValue(
-      prop: Undone<N.ObjectMethod | N.ObjectProperty>,
+    parseObjPropValue<T extends N.ObjectMember>(
+      prop: Undone<T>,
       startLoc: Position | undefined | null,
       isGenerator: boolean,
       isAsync: boolean,
       isPattern: boolean,
       isAccessor: boolean,
       refExpressionErrors?: ExpressionErrors | null,
-    ) {
+    ): T {
       const typeParameters = this.tsTryParseTypeParameters(
         this.tsParseConstModifier,
       );
@@ -3443,7 +3448,8 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       if (!state || state === this.state) state = this.state.clone();
 
       let typeParameters: N.TsTypeParameterDeclaration | undefined | null;
-      const arrow = this.tryParse(abort => {
+      // We need to explicitly annotate 'abort' for microsoft/TypeScript#58170
+      const arrow = this.tryParse((abort: () => never) => {
         // This is similar to TypeScript's `tryParseParenthesizedArrowFunctionExpression`.
         typeParameters = this.tsParseTypeParameters(this.tsParseConstModifier);
         const expr = super.parseMaybeAssign(
@@ -3471,7 +3477,8 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
             !expr.typeParameters.extra?.trailingComma
           ) {
             // report error if single type parameter used without trailing comma.
-            const parameter = expr.typeParameters.params[0];
+            const parameter = expr.typeParameters
+              .params[0] as N.TsTypeParameter;
             if (!parameter.constraint) {
               // A single type parameter must either have constraints
               // or a trailing comma, otherwise it's ambiguous with JSX.
@@ -3479,7 +3486,9 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
                 TSErrors.SingleTypeParameterWithoutTrailingComma,
                 createPositionWithColumnOffset(parameter.loc.end, 1),
                 {
-                  typeParameterName: parameter.name.name,
+                  typeParameterName: process.env.BABEL_8_BREAKING
+                    ? (parameter.name as N.Identifier).name
+                    : (parameter.name as string),
                 },
               );
             }
@@ -3495,7 +3504,6 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         // in case of <T>(x) => 2, we don't consider <T>(x) as a type assertion
         // because of this error.
         if (typeParameters) this.reportReservedArrowTypeParam(typeParameters);
-        // @ts-expect-error refine typings
         return arrow.node;
       }
 
@@ -3526,7 +3534,6 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         /*:: invariant(arrow.failState) */
         this.state = arrow.failState;
         if (typeParameters) this.reportReservedArrowTypeParam(typeParameters);
-        // @ts-expect-error refine typings
         return arrow.node;
       }
 
@@ -3718,7 +3725,9 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         const typeArguments = this.tsParseTypeArgumentsInExpression();
 
         if (this.match(tt.parenL)) {
-          const call = super.parseMaybeDecoratorArguments(expr);
+          const call = super.parseMaybeDecoratorArguments(
+            expr,
+          ) as N.CallExpression;
           call.typeParameters = typeArguments;
           return call;
         }
@@ -3820,16 +3829,14 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       for (let i = 0; i < exprList.length; i++) {
         const expr = exprList[i];
         if (expr?.type === "TSTypeCastExpression") {
-          exprList[i] = this.typeCastToParameter(
-            expr as N.TsTypeCastExpression,
-          );
+          exprList[i] = this.typeCastToParameter(expr);
         }
       }
       super.toAssignableList(exprList, trailingCommaLoc, isLHS);
     }
 
-    typeCastToParameter(node: N.TsTypeCastExpression): N.Node {
-      node.expression.typeAnnotation = node.typeAnnotation;
+    typeCastToParameter(node: N.TsTypeCastExpression): N.Expression {
+      (node.expression as N.Identifier).typeAnnotation = node.typeAnnotation;
 
       this.resetEndLocation(node.expression, node.typeAnnotation.loc.end);
 
@@ -3858,10 +3865,8 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       // handles `<Component<<T>`
       if (this.match(tt.lt) || this.match(tt.bitShiftL)) {
         const typeArguments = this.tsTryParseAndCatch(() =>
-          // @ts-expect-error: refine typings
           this.tsParseTypeArgumentsInExpression(),
         );
-        // @ts-expect-error: refine typings
         if (typeArguments) node.typeParameters = typeArguments;
       }
       return super.jsxParseOpeningElementAfterName(node);
@@ -4229,7 +4234,7 @@ function isNumber(expression: N.Expression, estree: boolean): boolean {
 
 function isNegativeNumber(expression: N.Expression, estree: boolean): boolean {
   if (expression.type === "UnaryExpression") {
-    const { operator, argument } = expression as N.UnaryExpression;
+    const { operator, argument } = expression;
     if (operator === "-" && isNumber(argument, estree)) {
       return true;
     }

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -1477,8 +1477,11 @@ export default abstract class Tokenizer extends CommentsParser {
    *
    * If `errorRecovery` is `true`, the error is pushed to the errors array and
    * returned. If `errorRecovery` is `false`, the error is instead thrown.
+   *
+   * The return type is marked as `never` for simplicity, as error recovery
+   * will create types in an invalid AST shape.
    */
-  raise<ErrorDetails>(
+  raise<ErrorDetails = {}>(
     toParseError: ParseErrorConstructor<ErrorDetails>,
     at: Position | Undone<Node>,
     details: ErrorDetails = {} as ErrorDetails,

--- a/packages/babel-parser/src/types.d.ts
+++ b/packages/babel-parser/src/types.d.ts
@@ -67,7 +67,53 @@ type NodeAny<T extends string, KnownProps = {}> = NodeBase & {
   [key: string]: any;
 } & KnownProps;
 export type Expression = Node;
-export type Statement = Node;
+export type Statement =
+  | BlockStatement
+  | BreakStatement
+  | ContinueStatement
+  | DebuggerStatement
+  | DoWhileStatement
+  | EmptyStatement
+  | ExpressionStatement
+  | ForInStatement
+  | ForStatement
+  | FunctionDeclaration
+  | IfStatement
+  | LabeledStatement
+  | ReturnStatement
+  | SwitchStatement
+  | ThrowStatement
+  | TryStatement
+  | VariableDeclaration
+  | WhileStatement
+  | WithStatement
+  | ClassDeclaration
+  | ExportAllDeclaration
+  | ExportDefaultDeclaration
+  | ExportNamedDeclaration
+  | ForOfStatement
+  | ImportDeclaration
+  | FlowDeclareClass
+  | FlowDeclareFunction
+  | FlowDeclareInterface
+  | FlowDeclareModule
+  | FlowDeclareModuleExports
+  | FlowDeclareTypeAlias
+  | FlowDeclareOpaqueType
+  | FlowDeclareVariable
+  | FlowDeclareExportDeclaration
+  | FlowEnumDeclaration
+  | FlowInterface
+  | FlowOpaqueType
+  | FlowTypeAlias
+  | TSDeclareFunction
+  | TsInterfaceDeclaration
+  | TsTypeAliasDeclaration
+  | TsEnumDeclaration
+  | TsModuleDeclaration
+  | TsImportEqualsDeclaration
+  | TsExportAssignment
+  | TsNamespaceExportDeclaration;
 export type Pattern =
   | Identifier
   | ObjectPattern
@@ -1151,6 +1197,7 @@ export type FlowTypeAlias = NodeAny<"TypeAlias">;
 export type FlowOpaqueType = NodeAny<"OpaqueType">;
 export type FlowObjectTypeIndexer = NodeAny<"ObjectTypeIndexer">;
 export type FlowObjectTypeInternalSlot = NodeAny<"ObjectTypeInternalSlot">;
+export type FlowEnumDeclaration = NodeAny<"EnumDeclaration">;
 export type FlowFunctionTypeAnnotation = NodeAny<"FunctionTypeAnnotation">;
 export type FlowObjectTypeProperty = NodeAny<"ObjectTypeProperty">;
 export type FlowObjectTypeSpreadProperty = NodeAny<"ObjectTypeSpreadProperty">;

--- a/packages/babel-parser/src/types.d.ts
+++ b/packages/babel-parser/src/types.d.ts
@@ -1013,26 +1013,29 @@ export interface PipelineBareFunction extends NodeBase {
 
 // JSX (TODO: Not in spec)
 
-export type JSXIdentifier = Node;
-export type JSXNamespacedName = Node;
-export type JSXMemberExpression = Node;
-export type JSXEmptyExpression = Node;
-export type JSXSpreadChild = Node;
-export type JSXExpressionContainer = Node;
-export type JSXAttribute = Node;
-export type JSXSpreadAttribute = Node;
+export type JSXIdentifier = NodeAny<"JSXIdentifier">;
+export type JSXNamespacedName = NodeAny<"JSXNamespacedName">;
+export type JSXMemberExpression = NodeAny<"JSXMemberExpression">;
+export type JSXEmptyExpression = NodeAny<"JSXEmptyExpression">;
+export type JSXSpreadChild = NodeAny<"JSXSpreadChild">;
+export type JSXExpressionContainer = NodeAny<"JSXExpressionContainer">;
+export type JSXAttribute = NodeAny<"JSXAttribute">;
+export type JSXSpreadAttribute = NodeAny<"JSXSpreadAttribute">;
 export interface JSXOpeningElement extends NodeBase {
   type: "JSXOpeningElement";
   name: JSXNamespacedName | JSXMemberExpression;
   typeParameters?: TypeParameterInstantiationBase | null; // TODO: Not in spec,
-  attributes: JSXAttribute[];
+  attributes: (JSXAttribute | JSXSpreadAttribute)[];
   selfClosing: boolean;
 }
-export type JSXClosingElement = Node;
-export type JSXElement = Node;
-export type JSXOpeningFragment = Node;
-export type JSXClosingFragment = Node;
-export type JSXFragment = Node;
+export type JSXClosingElement = NodeAny<"JSXClosingElement">;
+export type JSXElement = NodeAny<"JSXElement">;
+export type JSXOpeningFragment = NodeAny<"JSXOpeningFragment">;
+export type JSXClosingFragment = NodeAny<"JSXClosingFragment">;
+export type JSXFragment = NodeAny<"JSXFragment">;
+export type JSXElementTag = JSXOpeningElement | JSXClosingElement;
+export type JSXFragmentTag = JSXOpeningFragment | JSXClosingFragment;
+export type JSXTag = JSXElementTag | JSXFragmentTag;
 
 // Flow/TypeScript common (TODO: Not in spec)
 

--- a/packages/babel-parser/src/types.d.ts
+++ b/packages/babel-parser/src/types.d.ts
@@ -62,6 +62,10 @@ export interface Node extends NodeBase {
   type: string;
   [key: string]: any;
 }
+type NodeAny<T extends string, KnownProps = {}> = NodeBase & {
+  type: T;
+  [key: string]: any;
+} & KnownProps;
 export type Expression = Node;
 export type Statement = Node;
 export type Pattern =
@@ -1038,7 +1042,7 @@ export interface TypeAnnotationBase extends NodeBase {
 
 export interface TypeAnnotation extends NodeBase {
   type: "TypeAnnotation";
-  typeAnnotation: FlowTypeAnnotation;
+  typeAnnotation: FlowType;
 }
 
 export interface TsTypeAnnotation extends NodeBase {
@@ -1113,37 +1117,81 @@ export interface TsTypeCastExpression extends NodeBase {
   typeAnnotation: TsTypeAnnotation;
 }
 
-export type FlowType = Node;
-export type FlowPredicate = Node;
-export type FlowDeclare = Node;
-export type FlowDeclareClass = Node;
-export type FlowDeclareExportDeclaration = Node;
-export type FlowDeclareFunction = Node;
-export type FlowDeclareVariable = Node;
-export type FlowDeclareModule = Node;
-export type FlowDeclareModuleExports = Node;
-export type FlowDeclareTypeAlias = Node;
-export type FlowDeclareOpaqueType = Node;
-export type FlowDeclareInterface = Node;
-export type FlowInterface = Node;
-export type FlowInterfaceExtends = Node;
-export type FlowTypeAlias = Node;
-export type FlowOpaqueType = Node;
-export type FlowObjectTypeIndexer = Node;
-export type FlowObjectTypeInternalSlot = Node;
-export type FlowFunctionTypeAnnotation = Node;
-export type FlowObjectTypeProperty = Node;
-export type FlowObjectTypeSpreadProperty = Node;
-export type FlowObjectTypeCallProperty = Node;
-export type FlowObjectTypeAnnotation = Node;
-export type FlowQualifiedTypeIdentifier = Node;
-export type FlowGenericTypeAnnotation = Node;
-export type FlowTypeofTypeAnnotation = Node;
-export type FlowTupleTypeAnnotation = Node;
-export type FlowFunctionTypeParam = Node;
-export type FlowTypeAnnotation = Node;
-export type FlowVariance = Node;
-export type FlowClassImplements = Node;
+export type FlowPredicate =
+  | NodeAny<"DeclaredPredicate">
+  | NodeAny<"InferredPredicate">;
+export type FlowDeclare =
+  | FlowDeclareClass
+  | FlowDeclareExportDeclaration
+  | FlowDeclareFunction
+  | FlowDeclareVariable
+  | FlowDeclareModule
+  | FlowDeclareModuleExports
+  | FlowDeclareTypeAlias
+  | FlowDeclareOpaqueType
+  | FlowDeclareInterface;
+export type FlowDeclareClass = NodeAny<"DeclareClass">;
+export type FlowDeclareExportDeclaration =
+  | NodeAny<"DeclareExportDeclaration">
+  | NodeAny<"DeclareExportDefaultDeclaration">
+  | NodeAny<"DeclareExportAllDeclaration">;
+export type FlowDeclareFunction = NodeAny<"DeclareFunction">;
+export type FlowDeclareVariable = NodeAny<"DeclareVariable">;
+export type FlowDeclareModule = NodeAny<"DeclareModule">;
+export type FlowDeclareModuleExports = NodeAny<"DeclareModuleExports">;
+export type FlowDeclareTypeAlias = NodeAny<"DeclareTypeAlias">;
+export type FlowDeclareOpaqueType = NodeAny<"DeclareOpaqueType">;
+export type FlowDeclareInterface = NodeAny<"DeclareInterface">;
+export type FlowInterface = NodeAny<"InterfaceDeclaration">;
+export type FlowInterfaceExtends = NodeAny<"InterfaceExtends">;
+export type FlowTypeAlias = NodeAny<"TypeAlias">;
+export type FlowOpaqueType = NodeAny<"OpaqueType">;
+export type FlowObjectTypeIndexer = NodeAny<"ObjectTypeIndexer">;
+export type FlowObjectTypeInternalSlot = NodeAny<"ObjectTypeInternalSlot">;
+export type FlowFunctionTypeAnnotation = NodeAny<"FunctionTypeAnnotation">;
+export type FlowObjectTypeProperty = NodeAny<"ObjectTypeProperty">;
+export type FlowObjectTypeSpreadProperty = NodeAny<"ObjectTypeSpreadProperty">;
+export type FlowObjectTypeCallProperty = NodeAny<"ObjectTypeCallProperty">;
+export type FlowObjectTypeAnnotation = NodeAny<"ObjectTypeAnnotation">;
+export type FlowQualifiedTypeIdentifier = NodeAny<"QualifiedTypeIdentifier">;
+export type FlowGenericTypeAnnotation = NodeAny<"GenericTypeAnnotation">;
+export type FlowTypeofTypeAnnotation = NodeAny<"TypeofTypeAnnotation">;
+export type FlowTupleTypeAnnotation = NodeAny<"TupleTypeAnnotation">;
+export type FlowFunctionTypeParam = NodeAny<"FunctionTypeParam">;
+export type FlowOtherTypeAnnotation = NodeAny<
+  | "AnyTypeAnnotation"
+  | "BooleanTypeAnnotation"
+  | "MixedTypeAnnotation"
+  | "EmptyTypeAnnotation"
+  | "ExistsTypeAnnotation"
+  | "NumberTypeAnnotation"
+  | "StringTypeAnnotation"
+  | "SymbolTypeAnnotation"
+  | "NullLiteralTypeAnnotation"
+  | "VoidTypeAnnotation"
+  | "ThisTypeAnnotation"
+  | "ArrayTypeAnnotation"
+  | "NullableTypeAnnotation"
+  | "IntersectionTypeAnnotation"
+  | "UnionTypeAnnotation"
+>;
+export type FlowType =
+  | FlowFunctionTypeAnnotation
+  | FlowObjectTypeAnnotation
+  | FlowGenericTypeAnnotation
+  | FlowTypeofTypeAnnotation
+  | FlowTupleTypeAnnotation
+  | FlowInterfaceType
+  | FlowIndexedAccessType
+  | FlowOptionalIndexedAccessType
+  | FlowOtherTypeAnnotation
+  | StringLiteralTypeAnnotation
+  | BooleanLiteralTypeAnnotation
+  | NumberLiteralTypeAnnotation
+  | BigIntLiteralTypeAnnotation
+  | Identifier;
+export type FlowVariance = NodeAny<"Variance">;
+export type FlowClassImplements = NodeAny<"ClassImplements">;
 
 export interface FlowInterfaceType extends NodeBase {
   type: "InterfaceTypeAnnotation";

--- a/packages/babel-parser/src/types.d.ts
+++ b/packages/babel-parser/src/types.d.ts
@@ -7,9 +7,7 @@ import type { ParseError } from "./parse-error.ts";
 /*
  * If making any changes to the AST, update:
  * - This repository:
- *   - This file
- *   - `ast` directory
- * - Babel repository:
+ *   - This file (including the `Node` alias at the bottom)
  *   - packages/babel-types/src/definitions
  *   - packages/babel-generators/src/generators
  */
@@ -55,13 +53,6 @@ export interface NodeBase {
   };
 }
 
-// Using a union type for `Node` makes type-checking too slow.
-// Instead, add an index signature to allow a Node to be treated as anything.
-// todo(flow->ts): this probably should be replaced with union
-export interface Node extends NodeBase {
-  type: string;
-  [key: string]: any;
-}
 type NodeAny<T extends string, KnownProps = {}> = NodeBase & {
   type: T;
   [key: string]: any;
@@ -647,7 +638,12 @@ export type BinaryOperator =
   | "in"
   | "instanceof";
 
-export type Assignable = Pattern | ParenthesizedExpression | MemberExpression;
+export type Assignable =
+  | Pattern
+  | MemberExpression
+  | ParenthesizedExpression
+  | TsTypeCastExpression
+  | TypeCastExpression;
 
 export interface AssignmentExpression extends NodeBase {
   type: "AssignmentExpression";
@@ -1105,6 +1101,7 @@ export interface ExportAllDeclaration extends NodeBase {
   source: Literal;
   exportKind?: "type" | "value"; // TODO: Not in spec,
   assertions?: ImportAttribute[];
+  attributes?: ImportAttribute[];
 }
 
 export interface PipelineTopicExpression extends NodeBase {
@@ -1142,6 +1139,7 @@ export type JSXFragment = NodeAny<"JSXFragment">;
 export type JSXElementTag = JSXOpeningElement | JSXClosingElement;
 export type JSXFragmentTag = JSXOpeningFragment | JSXClosingFragment;
 export type JSXTag = JSXElementTag | JSXFragmentTag;
+export type JSXText = NodeAny<"JSXText">;
 
 // Flow/TypeScript common (TODO: Not in spec)
 
@@ -1258,6 +1256,14 @@ export type FlowOpaqueType = NodeAny<"OpaqueType">;
 export type FlowObjectTypeIndexer = NodeAny<"ObjectTypeIndexer">;
 export type FlowObjectTypeInternalSlot = NodeAny<"ObjectTypeInternalSlot">;
 export type FlowEnumDeclaration = NodeAny<"EnumDeclaration">;
+export type FlowEnumBody = NodeAny<
+  "EnumBooleanBody" | "EnumNumberBody" | "EnumStringBody" | "EnumSymbolBody"
+>;
+export type FlowEnumMember =
+  | NodeAny<"EnumBooleanMember">
+  | NodeAny<"EnumNumberMember">
+  | NodeAny<"EnumStringMember">
+  | NodeAny<"EnumDefaultedMember">;
 export type FlowFunctionTypeAnnotation = NodeAny<"FunctionTypeAnnotation">;
 export type FlowObjectTypeProperty = NodeAny<"ObjectTypeProperty">;
 export type FlowObjectTypeSpreadProperty = NodeAny<"ObjectTypeSpreadProperty">;
@@ -1346,6 +1352,7 @@ export interface BigIntLiteralTypeAnnotation extends NodeBase {
 export interface EstreeLiteral extends NodeBase {
   type: "Literal";
   value: any;
+  decimal?: string;
 }
 
 interface EstreeRegExpLiteralRegex {
@@ -1364,8 +1371,9 @@ export interface EstreeBigIntLiteral extends EstreeLiteral {
 
 export interface EstreeProperty extends NodeBase {
   type: "Property";
+  method: boolean;
   shorthand: boolean;
-  key: Expression;
+  key: Expression | EstreePrivateIdentifier;
   computed: boolean;
   value: Expression;
   decorators: Decorator[];
@@ -1868,3 +1876,235 @@ export interface ParseClassMemberState {
   hadConstructor: boolean;
   hadSuperClass: boolean;
 }
+
+export type Node =
+  | ArgumentPlaceholder
+  | ArrayExpression
+  | ArrayPattern
+  | ArrowFunctionExpression
+  | AssignmentExpression
+  | AssignmentPattern
+  | AwaitExpression
+  | BigIntLiteral
+  | BigIntLiteralTypeAnnotation
+  | BinaryExpression
+  | BindExpression
+  | BlockStatement
+  | BooleanLiteral
+  | BooleanLiteralTypeAnnotation
+  | BreakStatement
+  | CallExpression
+  | CatchClause
+  | ClassAccessorProperty
+  | ClassBody
+  | ClassDeclaration
+  | ClassExpression
+  | ClassMethod
+  | ClassPrivateMethod
+  | ClassPrivateProperty
+  | ClassProperty
+  | ConditionalExpression
+  | ContinueStatement
+  | DebuggerStatement
+  | DecimalLiteral
+  | Decorator
+  | Directive
+  | DirectiveLiteral
+  | DoExpression
+  | DoWhileStatement
+  | EmptyStatement
+  | EstreeChainExpression
+  | EstreeLiteral
+  | EstreeMethodDefinition
+  | EstreePrivateIdentifier
+  | EstreeProperty
+  | EstreePropertyDefinition
+  | ExportAllDeclaration
+  | ExportDefaultDeclaration
+  | ExportDefaultSpecifier
+  | ExportNamedDeclaration
+  | ExportNamespaceSpecifier
+  | ExportSpecifier
+  | ExpressionStatement
+  | File
+  | FlowClassImplements
+  | FlowDeclareClass
+  | FlowDeclareExportDeclaration
+  | FlowDeclareFunction
+  | FlowDeclareInterface
+  | FlowDeclareModule
+  | FlowDeclareModuleExports
+  | FlowDeclareOpaqueType
+  | FlowDeclareTypeAlias
+  | FlowDeclareVariable
+  | FlowEnumBody
+  | FlowEnumDeclaration
+  | FlowEnumMember
+  | FlowFunctionTypeAnnotation
+  | FlowFunctionTypeParam
+  | FlowGenericTypeAnnotation
+  | FlowIndexedAccessType
+  | FlowInterface
+  | FlowInterfaceExtends
+  | FlowInterfaceType
+  | FlowObjectTypeAnnotation
+  | FlowObjectTypeCallProperty
+  | FlowObjectTypeIndexer
+  | FlowObjectTypeInternalSlot
+  | FlowObjectTypeProperty
+  | FlowObjectTypeSpreadProperty
+  | FlowOpaqueType
+  | FlowOptionalIndexedAccessType
+  | FlowOtherTypeAnnotation
+  | FlowPredicate
+  | FlowPredicate
+  | FlowQualifiedTypeIdentifier
+  | FlowTupleTypeAnnotation
+  | FlowTypeAlias
+  | FlowTypeofTypeAnnotation
+  | FlowVariance
+  | ForInStatement
+  | ForOfStatement
+  | ForStatement
+  | FunctionDeclaration
+  | FunctionExpression
+  | Identifier
+  | IfStatement
+  | Import
+  | ImportAttribute
+  | ImportDeclaration
+  | ImportDefaultSpecifier
+  | ImportExpression
+  | ImportExpression
+  | ImportNamespaceSpecifier
+  | ImportSpecifier
+  | InterpreterDirective
+  | JSXAttribute
+  | JSXClosingElement
+  | JSXClosingFragment
+  | JSXElement
+  | JSXEmptyExpression
+  | JSXExpressionContainer
+  | JSXFragment
+  | JSXIdentifier
+  | JSXMemberExpression
+  | JSXNamespacedName
+  | JSXOpeningElement
+  | JSXOpeningFragment
+  | JSXSpreadAttribute
+  | JSXSpreadChild
+  | JSXText
+  | LabeledStatement
+  | Literal
+  | LogicalExpression
+  | MemberExpression
+  | MetaProperty
+  | ModuleExpression
+  | NewExpression
+  | NullLiteral
+  | NumberLiteralTypeAnnotation
+  | NumericLiteral
+  | ObjectExpression
+  | ObjectMethod
+  | ObjectPattern
+  | ObjectProperty
+  | OptionalCallExpression
+  | OptionalMemberExpression
+  | ParenthesizedExpression
+  | PipelineBareAwaitedFunctionBody
+  | PipelineBareConstructorBody
+  | PipelineBareFunction
+  | PipelineBareFunctionBody
+  | PipelineBody
+  | PipelinePrimaryTopicReference
+  | PipelineTopicBody
+  | PipelineTopicExpression
+  | Placeholder
+  | PrivateName
+  | Program
+  | RecordExpression
+  | RegExpLiteral
+  | RestElement
+  | ReturnStatement
+  | SequenceExpression
+  | SpreadElement
+  | StaticBlock
+  | StringLiteral
+  | StringLiteralTypeAnnotation
+  | Super
+  | SwitchCase
+  | SwitchStatement
+  | TSDeclareFunction
+  | TSDeclareMethod
+  | TSInterfaceBody
+  | TSParameterProperty
+  | TaggedTemplateExpression
+  | TemplateElement
+  | TemplateLiteral
+  | ThisExpression
+  | ThrowStatement
+  | TopicReference
+  | TryStatement
+  | TsArrayType
+  | TsAsExpression
+  | TsCallSignatureDeclaration
+  | TsConditionalType
+  | TsConstructSignatureDeclaration
+  | TsConstructorType
+  | TsEnumDeclaration
+  | TsEnumMember
+  | TsExportAssignment
+  | TsExpressionWithTypeArguments
+  | TsExternalModuleReference
+  | TsFunctionType
+  | TsImportEqualsDeclaration
+  | TsImportType
+  | TsIndexSignature
+  | TsIndexedAccessType
+  | TsInferType
+  | TsInstantiationExpression
+  | TsInterfaceDeclaration
+  | TsIntersectionType
+  | TsKeywordType
+  | TsLiteralType
+  | TsMappedType
+  | TsMethodSignature
+  | TsModuleBlock
+  | TsModuleDeclaration
+  | TsNamedTupleMember
+  | TsNamespaceExportDeclaration
+  | TsNonNullExpression
+  | TsOptionalType
+  | TsParenthesizedType
+  | TsPropertySignature
+  | TsQualifiedName
+  | TsRestType
+  | TsSatisfiesExpression
+  | TsThisType
+  | TsTupleType
+  | TsTypeAliasDeclaration
+  | TsTypeAnnotation
+  | TsTypeAssertion
+  | TsTypeCastExpression
+  | TsTypeLiteral
+  | TsTypeOperator
+  | TsTypeParameter
+  | TsTypeParameterDeclaration
+  | TsTypeParameterInstantiation
+  | TsTypePredicate
+  | TsTypeQuery
+  | TsTypeReference
+  | TsUnionType
+  | TupleExpression
+  | TypeAnnotation
+  | TypeCastExpression
+  | TypeParameter
+  | TypeParameterDeclaration
+  | TypeParameterInstantiation
+  | UnaryExpression
+  | UpdateExpression
+  | VariableDeclaration
+  | VariableDeclarator
+  | WhileStatement
+  | WithStatement
+  | YieldExpression;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`@babel/parser`'s AST types used `Node` as a base class for every node, effectively making it equivalent to "any" for nodes (since it had `type: string`). This PR replaces it with a proper union of all the possible nodes, like we do in `@babel/parser`.

I was experimenting with merging our type definitions in `@babel/parser`, and `@babel/types`, but it might not be possible because:
- `@babel/parser` has more nodes (ESTree, placeholders)
- `@babel/types` has node locations as optional

I will still try to add a test to assert that the types are samewhat compatible, in a future PR.