### PR TITLE
Optimization: skip one unnecessary checking in the loop

### DIFF
--- a/packages/babel-types/src/validators/matchesPattern.ts
+++ b/packages/babel-types/src/validators/matchesPattern.ts
@@ -22,10 +22,10 @@ export default function matchesPattern(
   if (!isMemberExpression(member)) return false;
 
   const parts = Array.isArray(match) ? match : match.split(".");
-  const nodes = [];
+  const nodes = [member.property];
 
-  let node;
-  for (node = member; isMemberExpression(node); node = node.object) {
+  let node = member.object;
+  for (; isMemberExpression(node); node = node.object) {
     nodes.push(node.property);
   }
   nodes.push(node);


### PR DESCRIPTION
In the 22 line, we check that the `member` param is the `MemberExpression`. We can initialize the nodes array with the `property` key, and start the loop with the first `object`

