### PR TITLE
Make `NodePath<T | U>` distributive

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1876,10 +1876,8 @@ function transformClass(
 
       // update originalClassPath according to the new AST
       originalClassPath = (
-        newPath.get("callee").get("body") as NodePath<t.ClassBody>
-      )
-        .get("body")[0]
-        .get("key");
+        newPath.get("callee").get("body") as NodePath<t.Class>
+      ).get("body.0.key");
     }
   }
   if (!classInitInjected && classInitCall) {
@@ -2252,11 +2250,11 @@ function NamedEvaluationVisitoryFactory(
     // the object properties under object patterns
     ObjectExpression(path, state) {
       for (const propertyPath of path.get("properties")) {
+        if (!propertyPath.isObjectProperty()) continue;
         const { node } = propertyPath;
-        if (node.type !== "ObjectProperty") continue;
         const id = node.key;
         const initializer = skipTransparentExprWrappers(
-          propertyPath.get("value"),
+          propertyPath.get("value") as NodePath<t.Expression>,
         );
         if (isAnonymous(initializer)) {
           if (!node.computed) {
@@ -2274,7 +2272,7 @@ function NamedEvaluationVisitoryFactory(
             }
           } else {
             const ref = handleComputedProperty(
-              propertyPath as NodePath<t.ObjectProperty>,
+              propertyPath,
               // The key of a computed object property must not be a private name
               id as t.Expression,
               state,

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -1593,7 +1593,7 @@ export function buildFieldsInitNodes(
     // this maybe a bug for ts
     switch (true) {
       case isStaticBlock: {
-        const blockBody = (prop.node as t.StaticBlock).body;
+        const blockBody = prop.node.body;
         // We special-case the single expression case to avoid the iife, since
         // it's common.
         if (blockBody.length === 1 && t.isExpressionStatement(blockBody[0])) {
@@ -1640,16 +1640,13 @@ export function buildFieldsInitNodes(
         // It might still be possible to a computed static fields whose resulting
         // key is "name" or "length", but the assumption is telling us that it's
         // not going to happen.
-        // @ts-expect-error checked in switch
         if (!isNameOrLength(prop.node)) {
-          // @ts-expect-error checked in switch
           staticNodes.push(buildPublicFieldInitLoose(t.cloneNode(ref), prop));
           break;
         }
       // falls through
       case isStatic && isPublic && isField && !setPublicClassFields:
         staticNodes.push(
-          // @ts-expect-error checked in switch
           buildPublicFieldInitSpec(t.cloneNode(ref), prop, file),
         );
         break;
@@ -1681,7 +1678,6 @@ export function buildFieldsInitNodes(
         instanceNodes.unshift(
           buildPrivateMethodInitLoose(
             t.thisExpression(),
-            // @ts-expect-error checked in switch
             prop,
             privateNamesMap,
           ),
@@ -1689,7 +1685,6 @@ export function buildFieldsInitNodes(
         pureStaticNodes.push(
           buildPrivateMethodDeclaration(
             file,
-            // @ts-expect-error checked in switch
             prop,
             privateNamesMap,
             privateFieldsAsSymbolsOrProperties,
@@ -1703,7 +1698,6 @@ export function buildFieldsInitNodes(
         instanceNodes.unshift(
           buildPrivateInstanceMethodInitSpec(
             t.thisExpression(),
-            // @ts-expect-error checked in switch
             prop,
             privateNamesMap,
             file,
@@ -1712,7 +1706,6 @@ export function buildFieldsInitNodes(
         pureStaticNodes.push(
           buildPrivateMethodDeclaration(
             file,
-            // @ts-expect-error checked in switch
             prop,
             privateNamesMap,
             privateFieldsAsSymbolsOrProperties,
@@ -1732,7 +1725,6 @@ export function buildFieldsInitNodes(
         pureStaticNodes.push(
           buildPrivateMethodDeclaration(
             file,
-            // @ts-expect-error checked in switch
             prop,
             privateNamesMap,
             privateFieldsAsSymbolsOrProperties,
@@ -1746,7 +1738,6 @@ export function buildFieldsInitNodes(
         staticNodes.unshift(
           buildPrivateStaticMethodInitLoose(
             t.cloneNode(ref),
-            // @ts-expect-error checked in switch
             prop,
             file,
             privateNamesMap,
@@ -1755,7 +1746,6 @@ export function buildFieldsInitNodes(
         pureStaticNodes.push(
           buildPrivateMethodDeclaration(
             file,
-            // @ts-expect-error checked in switch
             prop,
             privateNamesMap,
             privateFieldsAsSymbolsOrProperties,
@@ -1763,13 +1753,11 @@ export function buildFieldsInitNodes(
         );
         break;
       case isInstance && isPublic && isField && setPublicClassFields:
-        // @ts-expect-error checked in switch
         instanceNodes.push(buildPublicFieldInitLoose(t.thisExpression(), prop));
         break;
       case isInstance && isPublic && isField && !setPublicClassFields:
         lastInstanceNodeReturnsThis = true;
         instanceNodes.push(
-          // @ts-expect-error checked in switch
           buildPublicFieldInitSpec(t.thisExpression(), prop, file),
         );
         break;

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -233,7 +233,7 @@ export function createClassFeaturePlugin({
         const innerBinding = path.node.id;
         let ref: t.Identifier | null;
         if (!innerBinding || !pathIsClassDeclaration) {
-          nameFunction(path);
+          nameFunction(path as NodePath<t.ClassExpression>);
           ref = path.scope.generateUidIdentifier(innerBinding?.name || "Class");
         }
         const classRefForDefine = ref ?? t.cloneNode(innerBinding);

--- a/packages/babel-helper-member-expression-to-functions/src/index.ts
+++ b/packages/babel-helper-member-expression-to-functions/src/index.ts
@@ -215,12 +215,9 @@ const handle = {
         );
       }
 
-      // @ts-expect-error isOptionalMemberExpression does not work with NodePath union
       const startingNode = startingOptional.isOptionalMemberExpression()
-        ? // @ts-expect-error isOptionalMemberExpression does not work with NodePath union
-          startingOptional.node.object
-        : // @ts-expect-error isOptionalMemberExpression does not work with NodePath union
-          startingOptional.node.callee;
+        ? startingOptional.node.object
+        : startingOptional.node.callee;
       const baseNeedsMemoised = scope.maybeGenerateMemoised(startingNode);
       const baseRef = baseNeedsMemoised ?? startingNode;
 

--- a/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
+++ b/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
@@ -549,7 +549,6 @@ function getLocalExportMetadata(
         declaration.isFunctionDeclaration() ||
         declaration.isClassDeclaration()
       ) {
-        // @ts-expect-error todo(flow->ts): improve babel-types
         getLocalMetadata(declaration.get("id")).names.push("default");
       } else {
         // These should have been removed by the nameAnonymousExports() call.
@@ -594,9 +593,7 @@ function removeImportExportDeclarations(programPath: NodePath<t.Program>) {
       ) {
         // @ts-expect-error todo(flow->ts): avoid mutations
         declaration._blockHoist = child.node._blockHoist;
-        child.replaceWith(
-          declaration as NodePath<t.FunctionDeclaration | t.ClassDeclaration>,
-        );
+        child.replaceWith(declaration);
       } else {
         // These should have been removed by the nameAnonymousExports() call.
         throw declaration.buildCodeFrameError(

--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
@@ -569,7 +569,7 @@ const rewriteReferencesVisitor: Visitor<RewriteReferencesVisitorState> = {
       }
 
       path.ensureBlock();
-      const bodyPath = path.get("body");
+      const bodyPath = path.get("body") as NodePath<t.BlockStatement>;
 
       const newLoopId = scope.generateUidIdentifierBasedOnNode(left);
       path

--- a/packages/babel-helper-split-export-declaration/src/index.ts
+++ b/packages/babel-helper-split-export-declaration/src/index.ts
@@ -74,10 +74,7 @@ export default function splitExportDeclaration(
     }
 
     return exportDeclaration;
-  } else if (
-    // @ts-expect-error TS can not narrow down to NodePath<t.ExportNamedDeclaration>
-    exportDeclaration.get("specifiers").length > 0
-  ) {
+  } else if (exportDeclaration.get("specifiers").length > 0) {
     throw new Error("It doesn't make sense to split exported specifiers.");
   }
 

--- a/packages/babel-helper-wrap-function/src/index.ts
+++ b/packages/babel-helper-wrap-function/src/index.ts
@@ -117,7 +117,7 @@ function plainFunction(
       | t.FunctionExpression
       | t.CallExpression;
   } else {
-    node = path.node as t.FunctionDeclaration | t.FunctionExpression;
+    node = path.node;
   }
 
   const isDeclaration = isFunctionDeclaration(node);

--- a/packages/babel-helpers/src/index.ts
+++ b/packages/babel-helpers/src/index.ts
@@ -59,7 +59,6 @@ function getHelperMetadata(file: File): HelperMetadata {
       }
       if (
         child.get("specifiers").length !== 1 ||
-        // @ts-expect-error isImportDefaultSpecifier does not work with NodePath union
         !child.get("specifiers.0").isImportDefaultSpecifier()
       ) {
         throw child.buildCodeFrameError(
@@ -223,7 +222,7 @@ function permuteHelperAST(
     exp.replaceWith(decl);
   } else if (id.type === "MemberExpression") {
     exportBindingAssignments.forEach(assignPath => {
-      const assign: NodePath<t.Expression> = path.get(assignPath);
+      const assign = path.get(assignPath) as NodePath<t.Expression>;
       assign.replaceWith(assignmentExpression("=", id, assign.node));
     });
     exp.replaceWith(decl);

--- a/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/src/index.ts
+++ b/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/src/index.ts
@@ -93,7 +93,10 @@ export default declare(({ types: t, traverse, assertVersion }) => {
             elem.node.computed &&
             containsClassExpression(elem.get("key"))
           ) {
-            wrap(elem.get("key"));
+            wrap(
+              // @ts-expect-error .key also includes t.PrivateName
+              elem.get("key") satisfies NodePath<t.Expression>,
+            );
           }
         }
       },

--- a/packages/babel-plugin-proposal-explicit-resource-management/src/index.ts
+++ b/packages/babel-plugin-proposal-explicit-resource-management/src/index.ts
@@ -194,7 +194,7 @@ export default declare(api => {
               continue;
             }
 
-            let { node } = stmt;
+            let node: t.Statement | t.Declaration = stmt.node;
             let shouldRemove = true;
 
             if (stmt.isExportDefaultDeclaration()) {

--- a/packages/babel-plugin-transform-block-scoping/src/index.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/index.ts
@@ -110,7 +110,7 @@ export default declare((api, opts: Options) => {
           if (needsBodyWrap) {
             const varPath = wrapLoopBody(path, captured, updatedBindingsUsages);
 
-            if (headPath?.isVariableDeclaration<t.Node>()) {
+            if (headPath?.isVariableDeclaration()) {
               // If we wrap the loop body, we transform the var
               // declaration in the loop head now, to avoid
               // invalid references that break other plugins:

--- a/packages/babel-plugin-transform-block-scoping/src/validation.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/validation.ts
@@ -76,7 +76,9 @@ function disallowConstantViolations(
             t.variableDeclarator(violation.scope.generateUidIdentifier(name)),
           ]),
         );
-      violation.node.body.body.unshift(t.expressionStatement(throwNode));
+      (violation.node.body as t.BlockStatement).body.unshift(
+        t.expressionStatement(throwNode),
+      );
     }
   }
 }

--- a/packages/babel-plugin-transform-destructuring/src/index.ts
+++ b/packages/babel-plugin-transform-destructuring/src/index.ts
@@ -80,7 +80,7 @@ export default declare((api, options: Options) => {
           ]);
 
           path.ensureBlock();
-          const statementBody = path.node.body.body;
+          const statementBody = (path.node.body as t.BlockStatement).body;
           const nodes = [];
           // todo: the completion of a for statement can only be observed from
           // a do block (or eval that we don't support),

--- a/packages/babel-plugin-transform-destructuring/src/util.ts
+++ b/packages/babel-plugin-transform-destructuring/src/util.ts
@@ -27,7 +27,7 @@ export function unshiftForXStatementBody(
     // var a = 0;for (const { #x: x, [a++]: y } of z) { const a = 1; }
     node.body = t.blockStatement([...newStatements, node.body]);
   } else {
-    node.body.body.unshift(...newStatements);
+    (node.body as t.BlockStatement).body.unshift(...newStatements);
   }
 }
 

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.ts
@@ -289,7 +289,10 @@ export default declare((api, opts: Options) => {
         container.push(declar);
       } else {
         parentPath.ensureBlock();
-        parentPath.get("body").unshiftContainer("body", declar);
+        (parentPath.get("body") as NodePath<t.BlockStatement>).unshiftContainer(
+          "body",
+          declar,
+        );
       }
       paramPath.replaceWith(t.cloneNode(uid));
     }
@@ -575,7 +578,7 @@ export default declare((api, opts: Options) => {
           ]);
 
           path.ensureBlock();
-          const body = path.node.body;
+          const body = path.node.body as t.BlockStatement;
 
           if (body.body.length === 0 && path.isCompletionRecord()) {
             body.body.unshift(

--- a/packages/babel-plugin-transform-optional-chaining/src/transform.ts
+++ b/packages/babel-plugin-transform-optional-chaining/src/transform.ts
@@ -41,7 +41,6 @@ function needsMemoize(
   ) {
     const { node } = optionalPath;
     const childPath = skipTransparentExprWrappers(
-      // @ts-expect-error isOptionalMemberExpression does not work with NodePath union
       optionalPath.isOptionalMemberExpression()
         ? optionalPath.get("object")
         : optionalPath.get("callee"),
@@ -98,7 +97,6 @@ export function transformOptionalChain(
     if (node.optional) {
       optionals.push(node);
     }
-    // @ts-expect-error isOptionalMemberExpression does not work with NodePath union
     if (optionalPath.isOptionalMemberExpression()) {
       // @ts-expect-error todo(flow->ts) avoid changing more type
       optionalPath.node.type = "MemberExpression";

--- a/packages/babel-plugin-transform-parameters/src/params.ts
+++ b/packages/babel-plugin-transform-parameters/src/params.ts
@@ -153,16 +153,17 @@ export default function convertFunctionParams(
 
   // ensure it's a block, useful for arrow functions
   path.ensureBlock();
+  const path2 = path as NodePath<typeof path.node & { body: t.BlockStatement }>;
 
   const { async, generator } = node;
   if (generator || state.needsOuterBinding || shadowedParams.size > 0) {
-    body.push(buildScopeIIFE(shadowedParams, path.node.body));
+    body.push(buildScopeIIFE(shadowedParams, path2.node.body));
 
     path.set("body", t.blockStatement(body as t.Statement[]));
 
     // We inject an arrow and then transform it to a normal function, to be
     // sure that we correctly handle this and arguments.
-    const bodyPath = path.get("body.body");
+    const bodyPath = path2.get("body.body");
     const arrowPath = bodyPath[bodyPath.length - 1].get(
       "argument.callee",
     ) as NodePath<t.ArrowFunctionExpression>;
@@ -177,16 +178,16 @@ export default function convertFunctionParams(
     node.async = false;
     if (async) {
       // If the default value of a parameter throws, it must reject asynchronously.
-      path.node.body = template.statement.ast`{
+      path2.node.body = template.statement.ast`{
         try {
-          ${path.node.body.body}
+          ${path2.node.body.body}
         } catch (e) {
           return Promise.reject(e);
         }
       }` as t.BlockStatement;
     }
   } else {
-    path.get("body").unshiftContainer("body", body);
+    path2.get("body").unshiftContainer("body", body);
   }
 
   return true;

--- a/packages/babel-plugin-transform-parameters/src/rest.ts
+++ b/packages/babel-plugin-transform-parameters/src/rest.ts
@@ -323,7 +323,9 @@ export default function convertFunctionRest(path: NodePath<t.Function>) {
       path.ensureBlock();
       path.set(
         "body",
-        t.blockStatement([buildScopeIIFE(shadowedParams, path.node.body)]),
+        t.blockStatement([
+          buildScopeIIFE(shadowedParams, path.node.body as t.BlockStatement),
+        ]),
       );
     }
   }

--- a/packages/babel-plugin-transform-private-property-in-object/src/index.ts
+++ b/packages/babel-plugin-transform-private-property-in-object/src/index.ts
@@ -83,7 +83,7 @@ export default declare((api, opt: Options) => {
   }
 
   function getWeakSetId<Ref extends t.Node>(
-    weakSets: WeakMap<Ref, t.Identifier>,
+    weakSets: WeakMap<t.Node, t.Identifier>,
     outerClass: NodePath<t.Class>,
     reference: NodePath<Ref>,
     name = "",

--- a/packages/babel-plugin-transform-react-jsx-self/src/index.ts
+++ b/packages/babel-plugin-transform-react-jsx-self/src/index.ts
@@ -31,7 +31,6 @@ function getThisFunctionParent(
   do {
     const { path } = scope;
     if (path.isFunctionParent() && !path.isArrowFunctionExpression()) {
-      // @ts-expect-error TS does not exclude ArrowFunctionExpression from FunctionParent
       return path;
     }
   } while ((scope = scope.parent));

--- a/packages/babel-plugin-transform-typeof-symbol/src/index.ts
+++ b/packages/babel-plugin-transform-typeof-symbol/src/index.ts
@@ -41,7 +41,6 @@ export default declare(api => {
         let isUnderHelper = path.findParent(path => {
           if (path.isFunction()) {
             return (
-              // @ts-expect-error the access is coupled with the shape of typeof helper
               path.get("body.directives.0")?.node.value.value ===
               "@babel/helpers - typeof"
             );

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -282,7 +282,9 @@ export default declare((api, opts: Options) => {
           }
 
           // remove type imports
-          for (let stmt of path.get("body")) {
+          for (let stmt of path.get("body") as Iterable<
+            NodePath<t.Statement | t.Expression>
+          >) {
             if (stmt.isImportDeclaration()) {
               if (!NEEDS_EXPLICIT_ESM.has(state.file.ast.program)) {
                 NEEDS_EXPLICIT_ESM.set(state.file.ast.program, true);

--- a/packages/babel-traverse/scripts/generators/validators.js
+++ b/packages/babel-traverse/scripts/generators/validators.js
@@ -21,7 +21,7 @@ interface BaseNodePathValidators {
 `;
 
   for (const type of [...t.TYPES].sort()) {
-    output += `is${type}<T extends t.Node>(this: NodePath<T>, opts?: Opts<t.${type}>): this is NodePath<T & t.${type}>;`;
+    output += `is${type}(this: NodePath, opts?: Opts<t.${type}>): this is NodePath<t.${type}>;`;
   }
 
   output += `

--- a/packages/babel-traverse/src/path/conversion.ts
+++ b/packages/babel-traverse/src/path/conversion.ts
@@ -55,7 +55,7 @@ export function ensureBlock(
   this: NodePath<
     t.Loop | t.WithStatement | t.Function | t.LabeledStatement | t.CatchClause
   >,
-) {
+): void {
   const body = this.get("body");
   const bodyNode = body.node;
 
@@ -67,6 +67,11 @@ export function ensureBlock(
   }
 
   if (body.isBlockStatement()) {
+    // @ts-expect-error TS throws because ensureBlock returns the body node path
+    // however, we don't use the return value and treat it as a transform and
+    // assertion utilities. For better type inference we annotate it as an
+    // assertion method
+    // TODO: Unify the implementation with the type definition
     return bodyNode;
   }
 
@@ -102,6 +107,11 @@ export function ensureBlock(
     key,
   );
 
+  // @ts-expect-error TS throws because ensureBlock returns the body node path
+  // however, we don't use the return value and treat it as a transform and
+  // assertion utilities. For better type inference we annotate it as an
+  // assertion method
+  // TODO: Unify the implementation with the type definition
   return this.node;
 }
 
@@ -177,7 +187,6 @@ export function arrowFunctionToExpression(
     allowInsertArrowWithRest,
   );
 
-  // @ts-expect-error TS requires explicit fn type annotation
   fn.ensureBlock();
   setType(fn, "FunctionExpression");
 
@@ -554,7 +563,7 @@ function standardizeSuperProperty(
 
     return [
       assignmentPath.get("left") as NodePath<t.MemberExpression>,
-      assignmentPath.get("right").get("left"),
+      assignmentPath.get("right").get("left") as NodePath<t.MemberExpression>,
     ];
   } else if (superProp.parentPath.isUpdateExpression()) {
     const updateExpr = superProp.parentPath;

--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -306,9 +306,8 @@ function _evaluate(path: NodePath, state: State): any {
         deopt(prop, state);
         return;
       }
-      const keyPath = (prop as NodePath<t.ObjectProperty>).get("key");
+      const keyPath = prop.get("key");
       let key;
-      // @ts-expect-error todo(flow->ts): type refinement issues ObjectMethod and SpreadElement somehow not excluded
       if (prop.node.computed) {
         key = keyPath.evaluate();
         if (!key.confident) {
@@ -323,7 +322,7 @@ function _evaluate(path: NodePath, state: State): any {
           keyPath.node as t.StringLiteral | t.NumericLiteral | t.BigIntLiteral
         ).value;
       }
-      const valuePath = (prop as NodePath<t.ObjectProperty>).get("value");
+      const valuePath = prop.get("value");
       let value = valuePath.evaluate();
       if (!value.confident) {
         deopt(value.deopt, state);

--- a/packages/babel-traverse/src/path/generated/validators.d.ts
+++ b/packages/babel-traverse/src/path/generated/validators.d.ts
@@ -15,1222 +15,1177 @@ type Opts<Obj> = Partial<{
 }>;
 
 interface BaseNodePathValidators {
-  isAccessor<T extends t.Node>(
-    this: NodePath<T>,
+  isAccessor(
+    this: NodePath,
     opts?: Opts<t.Accessor>,
-  ): this is NodePath<T & t.Accessor>;
-  isAnyTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Accessor>;
+  isAnyTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.AnyTypeAnnotation>,
-  ): this is NodePath<T & t.AnyTypeAnnotation>;
-  isArgumentPlaceholder<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.AnyTypeAnnotation>;
+  isArgumentPlaceholder(
+    this: NodePath,
     opts?: Opts<t.ArgumentPlaceholder>,
-  ): this is NodePath<T & t.ArgumentPlaceholder>;
-  isArrayExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ArgumentPlaceholder>;
+  isArrayExpression(
+    this: NodePath,
     opts?: Opts<t.ArrayExpression>,
-  ): this is NodePath<T & t.ArrayExpression>;
-  isArrayPattern<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ArrayExpression>;
+  isArrayPattern(
+    this: NodePath,
     opts?: Opts<t.ArrayPattern>,
-  ): this is NodePath<T & t.ArrayPattern>;
-  isArrayTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ArrayPattern>;
+  isArrayTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.ArrayTypeAnnotation>,
-  ): this is NodePath<T & t.ArrayTypeAnnotation>;
-  isArrowFunctionExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ArrayTypeAnnotation>;
+  isArrowFunctionExpression(
+    this: NodePath,
     opts?: Opts<t.ArrowFunctionExpression>,
-  ): this is NodePath<T & t.ArrowFunctionExpression>;
-  isAssignmentExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ArrowFunctionExpression>;
+  isAssignmentExpression(
+    this: NodePath,
     opts?: Opts<t.AssignmentExpression>,
-  ): this is NodePath<T & t.AssignmentExpression>;
-  isAssignmentPattern<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.AssignmentExpression>;
+  isAssignmentPattern(
+    this: NodePath,
     opts?: Opts<t.AssignmentPattern>,
-  ): this is NodePath<T & t.AssignmentPattern>;
-  isAwaitExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.AssignmentPattern>;
+  isAwaitExpression(
+    this: NodePath,
     opts?: Opts<t.AwaitExpression>,
-  ): this is NodePath<T & t.AwaitExpression>;
-  isBigIntLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.AwaitExpression>;
+  isBigIntLiteral(
+    this: NodePath,
     opts?: Opts<t.BigIntLiteral>,
-  ): this is NodePath<T & t.BigIntLiteral>;
-  isBinary<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.Binary>,
-  ): this is NodePath<T & t.Binary>;
-  isBinaryExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.BigIntLiteral>;
+  isBinary(this: NodePath, opts?: Opts<t.Binary>): this is NodePath<t.Binary>;
+  isBinaryExpression(
+    this: NodePath,
     opts?: Opts<t.BinaryExpression>,
-  ): this is NodePath<T & t.BinaryExpression>;
-  isBindExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.BinaryExpression>;
+  isBindExpression(
+    this: NodePath,
     opts?: Opts<t.BindExpression>,
-  ): this is NodePath<T & t.BindExpression>;
-  isBlock<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.Block>,
-  ): this is NodePath<T & t.Block>;
-  isBlockParent<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.BindExpression>;
+  isBlock(this: NodePath, opts?: Opts<t.Block>): this is NodePath<t.Block>;
+  isBlockParent(
+    this: NodePath,
     opts?: Opts<t.BlockParent>,
-  ): this is NodePath<T & t.BlockParent>;
-  isBlockStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.BlockParent>;
+  isBlockStatement(
+    this: NodePath,
     opts?: Opts<t.BlockStatement>,
-  ): this is NodePath<T & t.BlockStatement>;
-  isBooleanLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.BlockStatement>;
+  isBooleanLiteral(
+    this: NodePath,
     opts?: Opts<t.BooleanLiteral>,
-  ): this is NodePath<T & t.BooleanLiteral>;
-  isBooleanLiteralTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.BooleanLiteral>;
+  isBooleanLiteralTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.BooleanLiteralTypeAnnotation>,
-  ): this is NodePath<T & t.BooleanLiteralTypeAnnotation>;
-  isBooleanTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.BooleanLiteralTypeAnnotation>;
+  isBooleanTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.BooleanTypeAnnotation>,
-  ): this is NodePath<T & t.BooleanTypeAnnotation>;
-  isBreakStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.BooleanTypeAnnotation>;
+  isBreakStatement(
+    this: NodePath,
     opts?: Opts<t.BreakStatement>,
-  ): this is NodePath<T & t.BreakStatement>;
-  isCallExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.BreakStatement>;
+  isCallExpression(
+    this: NodePath,
     opts?: Opts<t.CallExpression>,
-  ): this is NodePath<T & t.CallExpression>;
-  isCatchClause<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.CallExpression>;
+  isCatchClause(
+    this: NodePath,
     opts?: Opts<t.CatchClause>,
-  ): this is NodePath<T & t.CatchClause>;
-  isClass<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.Class>,
-  ): this is NodePath<T & t.Class>;
-  isClassAccessorProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.CatchClause>;
+  isClass(this: NodePath, opts?: Opts<t.Class>): this is NodePath<t.Class>;
+  isClassAccessorProperty(
+    this: NodePath,
     opts?: Opts<t.ClassAccessorProperty>,
-  ): this is NodePath<T & t.ClassAccessorProperty>;
-  isClassBody<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ClassAccessorProperty>;
+  isClassBody(
+    this: NodePath,
     opts?: Opts<t.ClassBody>,
-  ): this is NodePath<T & t.ClassBody>;
-  isClassDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ClassBody>;
+  isClassDeclaration(
+    this: NodePath,
     opts?: Opts<t.ClassDeclaration>,
-  ): this is NodePath<T & t.ClassDeclaration>;
-  isClassExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ClassDeclaration>;
+  isClassExpression(
+    this: NodePath,
     opts?: Opts<t.ClassExpression>,
-  ): this is NodePath<T & t.ClassExpression>;
-  isClassImplements<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ClassExpression>;
+  isClassImplements(
+    this: NodePath,
     opts?: Opts<t.ClassImplements>,
-  ): this is NodePath<T & t.ClassImplements>;
-  isClassMethod<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ClassImplements>;
+  isClassMethod(
+    this: NodePath,
     opts?: Opts<t.ClassMethod>,
-  ): this is NodePath<T & t.ClassMethod>;
-  isClassPrivateMethod<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ClassMethod>;
+  isClassPrivateMethod(
+    this: NodePath,
     opts?: Opts<t.ClassPrivateMethod>,
-  ): this is NodePath<T & t.ClassPrivateMethod>;
-  isClassPrivateProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ClassPrivateMethod>;
+  isClassPrivateProperty(
+    this: NodePath,
     opts?: Opts<t.ClassPrivateProperty>,
-  ): this is NodePath<T & t.ClassPrivateProperty>;
-  isClassProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ClassPrivateProperty>;
+  isClassProperty(
+    this: NodePath,
     opts?: Opts<t.ClassProperty>,
-  ): this is NodePath<T & t.ClassProperty>;
-  isCompletionStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ClassProperty>;
+  isCompletionStatement(
+    this: NodePath,
     opts?: Opts<t.CompletionStatement>,
-  ): this is NodePath<T & t.CompletionStatement>;
-  isConditional<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.CompletionStatement>;
+  isConditional(
+    this: NodePath,
     opts?: Opts<t.Conditional>,
-  ): this is NodePath<T & t.Conditional>;
-  isConditionalExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Conditional>;
+  isConditionalExpression(
+    this: NodePath,
     opts?: Opts<t.ConditionalExpression>,
-  ): this is NodePath<T & t.ConditionalExpression>;
-  isContinueStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ConditionalExpression>;
+  isContinueStatement(
+    this: NodePath,
     opts?: Opts<t.ContinueStatement>,
-  ): this is NodePath<T & t.ContinueStatement>;
-  isDebuggerStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ContinueStatement>;
+  isDebuggerStatement(
+    this: NodePath,
     opts?: Opts<t.DebuggerStatement>,
-  ): this is NodePath<T & t.DebuggerStatement>;
-  isDecimalLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DebuggerStatement>;
+  isDecimalLiteral(
+    this: NodePath,
     opts?: Opts<t.DecimalLiteral>,
-  ): this is NodePath<T & t.DecimalLiteral>;
-  isDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DecimalLiteral>;
+  isDeclaration(
+    this: NodePath,
     opts?: Opts<t.Declaration>,
-  ): this is NodePath<T & t.Declaration>;
-  isDeclareClass<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Declaration>;
+  isDeclareClass(
+    this: NodePath,
     opts?: Opts<t.DeclareClass>,
-  ): this is NodePath<T & t.DeclareClass>;
-  isDeclareExportAllDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DeclareClass>;
+  isDeclareExportAllDeclaration(
+    this: NodePath,
     opts?: Opts<t.DeclareExportAllDeclaration>,
-  ): this is NodePath<T & t.DeclareExportAllDeclaration>;
-  isDeclareExportDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DeclareExportAllDeclaration>;
+  isDeclareExportDeclaration(
+    this: NodePath,
     opts?: Opts<t.DeclareExportDeclaration>,
-  ): this is NodePath<T & t.DeclareExportDeclaration>;
-  isDeclareFunction<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DeclareExportDeclaration>;
+  isDeclareFunction(
+    this: NodePath,
     opts?: Opts<t.DeclareFunction>,
-  ): this is NodePath<T & t.DeclareFunction>;
-  isDeclareInterface<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DeclareFunction>;
+  isDeclareInterface(
+    this: NodePath,
     opts?: Opts<t.DeclareInterface>,
-  ): this is NodePath<T & t.DeclareInterface>;
-  isDeclareModule<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DeclareInterface>;
+  isDeclareModule(
+    this: NodePath,
     opts?: Opts<t.DeclareModule>,
-  ): this is NodePath<T & t.DeclareModule>;
-  isDeclareModuleExports<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DeclareModule>;
+  isDeclareModuleExports(
+    this: NodePath,
     opts?: Opts<t.DeclareModuleExports>,
-  ): this is NodePath<T & t.DeclareModuleExports>;
-  isDeclareOpaqueType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DeclareModuleExports>;
+  isDeclareOpaqueType(
+    this: NodePath,
     opts?: Opts<t.DeclareOpaqueType>,
-  ): this is NodePath<T & t.DeclareOpaqueType>;
-  isDeclareTypeAlias<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DeclareOpaqueType>;
+  isDeclareTypeAlias(
+    this: NodePath,
     opts?: Opts<t.DeclareTypeAlias>,
-  ): this is NodePath<T & t.DeclareTypeAlias>;
-  isDeclareVariable<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DeclareTypeAlias>;
+  isDeclareVariable(
+    this: NodePath,
     opts?: Opts<t.DeclareVariable>,
-  ): this is NodePath<T & t.DeclareVariable>;
-  isDeclaredPredicate<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DeclareVariable>;
+  isDeclaredPredicate(
+    this: NodePath,
     opts?: Opts<t.DeclaredPredicate>,
-  ): this is NodePath<T & t.DeclaredPredicate>;
-  isDecorator<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DeclaredPredicate>;
+  isDecorator(
+    this: NodePath,
     opts?: Opts<t.Decorator>,
-  ): this is NodePath<T & t.Decorator>;
-  isDirective<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Decorator>;
+  isDirective(
+    this: NodePath,
     opts?: Opts<t.Directive>,
-  ): this is NodePath<T & t.Directive>;
-  isDirectiveLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Directive>;
+  isDirectiveLiteral(
+    this: NodePath,
     opts?: Opts<t.DirectiveLiteral>,
-  ): this is NodePath<T & t.DirectiveLiteral>;
-  isDoExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DirectiveLiteral>;
+  isDoExpression(
+    this: NodePath,
     opts?: Opts<t.DoExpression>,
-  ): this is NodePath<T & t.DoExpression>;
-  isDoWhileStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DoExpression>;
+  isDoWhileStatement(
+    this: NodePath,
     opts?: Opts<t.DoWhileStatement>,
-  ): this is NodePath<T & t.DoWhileStatement>;
-  isEmptyStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.DoWhileStatement>;
+  isEmptyStatement(
+    this: NodePath,
     opts?: Opts<t.EmptyStatement>,
-  ): this is NodePath<T & t.EmptyStatement>;
-  isEmptyTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EmptyStatement>;
+  isEmptyTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.EmptyTypeAnnotation>,
-  ): this is NodePath<T & t.EmptyTypeAnnotation>;
-  isEnumBody<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EmptyTypeAnnotation>;
+  isEnumBody(
+    this: NodePath,
     opts?: Opts<t.EnumBody>,
-  ): this is NodePath<T & t.EnumBody>;
-  isEnumBooleanBody<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EnumBody>;
+  isEnumBooleanBody(
+    this: NodePath,
     opts?: Opts<t.EnumBooleanBody>,
-  ): this is NodePath<T & t.EnumBooleanBody>;
-  isEnumBooleanMember<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EnumBooleanBody>;
+  isEnumBooleanMember(
+    this: NodePath,
     opts?: Opts<t.EnumBooleanMember>,
-  ): this is NodePath<T & t.EnumBooleanMember>;
-  isEnumDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EnumBooleanMember>;
+  isEnumDeclaration(
+    this: NodePath,
     opts?: Opts<t.EnumDeclaration>,
-  ): this is NodePath<T & t.EnumDeclaration>;
-  isEnumDefaultedMember<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EnumDeclaration>;
+  isEnumDefaultedMember(
+    this: NodePath,
     opts?: Opts<t.EnumDefaultedMember>,
-  ): this is NodePath<T & t.EnumDefaultedMember>;
-  isEnumMember<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EnumDefaultedMember>;
+  isEnumMember(
+    this: NodePath,
     opts?: Opts<t.EnumMember>,
-  ): this is NodePath<T & t.EnumMember>;
-  isEnumNumberBody<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EnumMember>;
+  isEnumNumberBody(
+    this: NodePath,
     opts?: Opts<t.EnumNumberBody>,
-  ): this is NodePath<T & t.EnumNumberBody>;
-  isEnumNumberMember<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EnumNumberBody>;
+  isEnumNumberMember(
+    this: NodePath,
     opts?: Opts<t.EnumNumberMember>,
-  ): this is NodePath<T & t.EnumNumberMember>;
-  isEnumStringBody<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EnumNumberMember>;
+  isEnumStringBody(
+    this: NodePath,
     opts?: Opts<t.EnumStringBody>,
-  ): this is NodePath<T & t.EnumStringBody>;
-  isEnumStringMember<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EnumStringBody>;
+  isEnumStringMember(
+    this: NodePath,
     opts?: Opts<t.EnumStringMember>,
-  ): this is NodePath<T & t.EnumStringMember>;
-  isEnumSymbolBody<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EnumStringMember>;
+  isEnumSymbolBody(
+    this: NodePath,
     opts?: Opts<t.EnumSymbolBody>,
-  ): this is NodePath<T & t.EnumSymbolBody>;
-  isExistsTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.EnumSymbolBody>;
+  isExistsTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.ExistsTypeAnnotation>,
-  ): this is NodePath<T & t.ExistsTypeAnnotation>;
-  isExportAllDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ExistsTypeAnnotation>;
+  isExportAllDeclaration(
+    this: NodePath,
     opts?: Opts<t.ExportAllDeclaration>,
-  ): this is NodePath<T & t.ExportAllDeclaration>;
-  isExportDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ExportAllDeclaration>;
+  isExportDeclaration(
+    this: NodePath,
     opts?: Opts<t.ExportDeclaration>,
-  ): this is NodePath<T & t.ExportDeclaration>;
-  isExportDefaultDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ExportDeclaration>;
+  isExportDefaultDeclaration(
+    this: NodePath,
     opts?: Opts<t.ExportDefaultDeclaration>,
-  ): this is NodePath<T & t.ExportDefaultDeclaration>;
-  isExportDefaultSpecifier<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ExportDefaultDeclaration>;
+  isExportDefaultSpecifier(
+    this: NodePath,
     opts?: Opts<t.ExportDefaultSpecifier>,
-  ): this is NodePath<T & t.ExportDefaultSpecifier>;
-  isExportNamedDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ExportDefaultSpecifier>;
+  isExportNamedDeclaration(
+    this: NodePath,
     opts?: Opts<t.ExportNamedDeclaration>,
-  ): this is NodePath<T & t.ExportNamedDeclaration>;
-  isExportNamespaceSpecifier<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ExportNamedDeclaration>;
+  isExportNamespaceSpecifier(
+    this: NodePath,
     opts?: Opts<t.ExportNamespaceSpecifier>,
-  ): this is NodePath<T & t.ExportNamespaceSpecifier>;
-  isExportSpecifier<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ExportNamespaceSpecifier>;
+  isExportSpecifier(
+    this: NodePath,
     opts?: Opts<t.ExportSpecifier>,
-  ): this is NodePath<T & t.ExportSpecifier>;
-  isExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ExportSpecifier>;
+  isExpression(
+    this: NodePath,
     opts?: Opts<t.Expression>,
-  ): this is NodePath<T & t.Expression>;
-  isExpressionStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Expression>;
+  isExpressionStatement(
+    this: NodePath,
     opts?: Opts<t.ExpressionStatement>,
-  ): this is NodePath<T & t.ExpressionStatement>;
-  isExpressionWrapper<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ExpressionStatement>;
+  isExpressionWrapper(
+    this: NodePath,
     opts?: Opts<t.ExpressionWrapper>,
-  ): this is NodePath<T & t.ExpressionWrapper>;
-  isFile<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.File>,
-  ): this is NodePath<T & t.File>;
-  isFlow<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.Flow>,
-  ): this is NodePath<T & t.Flow>;
-  isFlowBaseAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ExpressionWrapper>;
+  isFile(this: NodePath, opts?: Opts<t.File>): this is NodePath<t.File>;
+  isFlow(this: NodePath, opts?: Opts<t.Flow>): this is NodePath<t.Flow>;
+  isFlowBaseAnnotation(
+    this: NodePath,
     opts?: Opts<t.FlowBaseAnnotation>,
-  ): this is NodePath<T & t.FlowBaseAnnotation>;
-  isFlowDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.FlowBaseAnnotation>;
+  isFlowDeclaration(
+    this: NodePath,
     opts?: Opts<t.FlowDeclaration>,
-  ): this is NodePath<T & t.FlowDeclaration>;
-  isFlowPredicate<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.FlowDeclaration>;
+  isFlowPredicate(
+    this: NodePath,
     opts?: Opts<t.FlowPredicate>,
-  ): this is NodePath<T & t.FlowPredicate>;
-  isFlowType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.FlowPredicate>;
+  isFlowType(
+    this: NodePath,
     opts?: Opts<t.FlowType>,
-  ): this is NodePath<T & t.FlowType>;
-  isFor<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.For>,
-  ): this is NodePath<T & t.For>;
-  isForInStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.FlowType>;
+  isFor(this: NodePath, opts?: Opts<t.For>): this is NodePath<t.For>;
+  isForInStatement(
+    this: NodePath,
     opts?: Opts<t.ForInStatement>,
-  ): this is NodePath<T & t.ForInStatement>;
-  isForOfStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ForInStatement>;
+  isForOfStatement(
+    this: NodePath,
     opts?: Opts<t.ForOfStatement>,
-  ): this is NodePath<T & t.ForOfStatement>;
-  isForStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ForOfStatement>;
+  isForStatement(
+    this: NodePath,
     opts?: Opts<t.ForStatement>,
-  ): this is NodePath<T & t.ForStatement>;
-  isForXStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ForStatement>;
+  isForXStatement(
+    this: NodePath,
     opts?: Opts<t.ForXStatement>,
-  ): this is NodePath<T & t.ForXStatement>;
-  isFunction<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ForXStatement>;
+  isFunction(
+    this: NodePath,
     opts?: Opts<t.Function>,
-  ): this is NodePath<T & t.Function>;
-  isFunctionDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Function>;
+  isFunctionDeclaration(
+    this: NodePath,
     opts?: Opts<t.FunctionDeclaration>,
-  ): this is NodePath<T & t.FunctionDeclaration>;
-  isFunctionExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.FunctionDeclaration>;
+  isFunctionExpression(
+    this: NodePath,
     opts?: Opts<t.FunctionExpression>,
-  ): this is NodePath<T & t.FunctionExpression>;
-  isFunctionParent<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.FunctionExpression>;
+  isFunctionParent(
+    this: NodePath,
     opts?: Opts<t.FunctionParent>,
-  ): this is NodePath<T & t.FunctionParent>;
-  isFunctionTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.FunctionParent>;
+  isFunctionTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.FunctionTypeAnnotation>,
-  ): this is NodePath<T & t.FunctionTypeAnnotation>;
-  isFunctionTypeParam<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.FunctionTypeAnnotation>;
+  isFunctionTypeParam(
+    this: NodePath,
     opts?: Opts<t.FunctionTypeParam>,
-  ): this is NodePath<T & t.FunctionTypeParam>;
-  isGenericTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.FunctionTypeParam>;
+  isGenericTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.GenericTypeAnnotation>,
-  ): this is NodePath<T & t.GenericTypeAnnotation>;
-  isIdentifier<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.GenericTypeAnnotation>;
+  isIdentifier(
+    this: NodePath,
     opts?: Opts<t.Identifier>,
-  ): this is NodePath<T & t.Identifier>;
-  isIfStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Identifier>;
+  isIfStatement(
+    this: NodePath,
     opts?: Opts<t.IfStatement>,
-  ): this is NodePath<T & t.IfStatement>;
-  isImmutable<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.IfStatement>;
+  isImmutable(
+    this: NodePath,
     opts?: Opts<t.Immutable>,
-  ): this is NodePath<T & t.Immutable>;
-  isImport<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.Import>,
-  ): this is NodePath<T & t.Import>;
-  isImportAttribute<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Immutable>;
+  isImport(this: NodePath, opts?: Opts<t.Import>): this is NodePath<t.Import>;
+  isImportAttribute(
+    this: NodePath,
     opts?: Opts<t.ImportAttribute>,
-  ): this is NodePath<T & t.ImportAttribute>;
-  isImportDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ImportAttribute>;
+  isImportDeclaration(
+    this: NodePath,
     opts?: Opts<t.ImportDeclaration>,
-  ): this is NodePath<T & t.ImportDeclaration>;
-  isImportDefaultSpecifier<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ImportDeclaration>;
+  isImportDefaultSpecifier(
+    this: NodePath,
     opts?: Opts<t.ImportDefaultSpecifier>,
-  ): this is NodePath<T & t.ImportDefaultSpecifier>;
-  isImportExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ImportDefaultSpecifier>;
+  isImportExpression(
+    this: NodePath,
     opts?: Opts<t.ImportExpression>,
-  ): this is NodePath<T & t.ImportExpression>;
-  isImportNamespaceSpecifier<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ImportExpression>;
+  isImportNamespaceSpecifier(
+    this: NodePath,
     opts?: Opts<t.ImportNamespaceSpecifier>,
-  ): this is NodePath<T & t.ImportNamespaceSpecifier>;
-  isImportOrExportDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ImportNamespaceSpecifier>;
+  isImportOrExportDeclaration(
+    this: NodePath,
     opts?: Opts<t.ImportOrExportDeclaration>,
-  ): this is NodePath<T & t.ImportOrExportDeclaration>;
-  isImportSpecifier<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ImportOrExportDeclaration>;
+  isImportSpecifier(
+    this: NodePath,
     opts?: Opts<t.ImportSpecifier>,
-  ): this is NodePath<T & t.ImportSpecifier>;
-  isIndexedAccessType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ImportSpecifier>;
+  isIndexedAccessType(
+    this: NodePath,
     opts?: Opts<t.IndexedAccessType>,
-  ): this is NodePath<T & t.IndexedAccessType>;
-  isInferredPredicate<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.IndexedAccessType>;
+  isInferredPredicate(
+    this: NodePath,
     opts?: Opts<t.InferredPredicate>,
-  ): this is NodePath<T & t.InferredPredicate>;
-  isInterfaceDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.InferredPredicate>;
+  isInterfaceDeclaration(
+    this: NodePath,
     opts?: Opts<t.InterfaceDeclaration>,
-  ): this is NodePath<T & t.InterfaceDeclaration>;
-  isInterfaceExtends<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.InterfaceDeclaration>;
+  isInterfaceExtends(
+    this: NodePath,
     opts?: Opts<t.InterfaceExtends>,
-  ): this is NodePath<T & t.InterfaceExtends>;
-  isInterfaceTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.InterfaceExtends>;
+  isInterfaceTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.InterfaceTypeAnnotation>,
-  ): this is NodePath<T & t.InterfaceTypeAnnotation>;
-  isInterpreterDirective<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.InterfaceTypeAnnotation>;
+  isInterpreterDirective(
+    this: NodePath,
     opts?: Opts<t.InterpreterDirective>,
-  ): this is NodePath<T & t.InterpreterDirective>;
-  isIntersectionTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.InterpreterDirective>;
+  isIntersectionTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.IntersectionTypeAnnotation>,
-  ): this is NodePath<T & t.IntersectionTypeAnnotation>;
-  isJSX<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.JSX>,
-  ): this is NodePath<T & t.JSX>;
-  isJSXAttribute<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.IntersectionTypeAnnotation>;
+  isJSX(this: NodePath, opts?: Opts<t.JSX>): this is NodePath<t.JSX>;
+  isJSXAttribute(
+    this: NodePath,
     opts?: Opts<t.JSXAttribute>,
-  ): this is NodePath<T & t.JSXAttribute>;
-  isJSXClosingElement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXAttribute>;
+  isJSXClosingElement(
+    this: NodePath,
     opts?: Opts<t.JSXClosingElement>,
-  ): this is NodePath<T & t.JSXClosingElement>;
-  isJSXClosingFragment<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXClosingElement>;
+  isJSXClosingFragment(
+    this: NodePath,
     opts?: Opts<t.JSXClosingFragment>,
-  ): this is NodePath<T & t.JSXClosingFragment>;
-  isJSXElement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXClosingFragment>;
+  isJSXElement(
+    this: NodePath,
     opts?: Opts<t.JSXElement>,
-  ): this is NodePath<T & t.JSXElement>;
-  isJSXEmptyExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXElement>;
+  isJSXEmptyExpression(
+    this: NodePath,
     opts?: Opts<t.JSXEmptyExpression>,
-  ): this is NodePath<T & t.JSXEmptyExpression>;
-  isJSXExpressionContainer<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXEmptyExpression>;
+  isJSXExpressionContainer(
+    this: NodePath,
     opts?: Opts<t.JSXExpressionContainer>,
-  ): this is NodePath<T & t.JSXExpressionContainer>;
-  isJSXFragment<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXExpressionContainer>;
+  isJSXFragment(
+    this: NodePath,
     opts?: Opts<t.JSXFragment>,
-  ): this is NodePath<T & t.JSXFragment>;
-  isJSXIdentifier<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXFragment>;
+  isJSXIdentifier(
+    this: NodePath,
     opts?: Opts<t.JSXIdentifier>,
-  ): this is NodePath<T & t.JSXIdentifier>;
-  isJSXMemberExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXIdentifier>;
+  isJSXMemberExpression(
+    this: NodePath,
     opts?: Opts<t.JSXMemberExpression>,
-  ): this is NodePath<T & t.JSXMemberExpression>;
-  isJSXNamespacedName<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXMemberExpression>;
+  isJSXNamespacedName(
+    this: NodePath,
     opts?: Opts<t.JSXNamespacedName>,
-  ): this is NodePath<T & t.JSXNamespacedName>;
-  isJSXOpeningElement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXNamespacedName>;
+  isJSXOpeningElement(
+    this: NodePath,
     opts?: Opts<t.JSXOpeningElement>,
-  ): this is NodePath<T & t.JSXOpeningElement>;
-  isJSXOpeningFragment<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXOpeningElement>;
+  isJSXOpeningFragment(
+    this: NodePath,
     opts?: Opts<t.JSXOpeningFragment>,
-  ): this is NodePath<T & t.JSXOpeningFragment>;
-  isJSXSpreadAttribute<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXOpeningFragment>;
+  isJSXSpreadAttribute(
+    this: NodePath,
     opts?: Opts<t.JSXSpreadAttribute>,
-  ): this is NodePath<T & t.JSXSpreadAttribute>;
-  isJSXSpreadChild<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXSpreadAttribute>;
+  isJSXSpreadChild(
+    this: NodePath,
     opts?: Opts<t.JSXSpreadChild>,
-  ): this is NodePath<T & t.JSXSpreadChild>;
-  isJSXText<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXSpreadChild>;
+  isJSXText(
+    this: NodePath,
     opts?: Opts<t.JSXText>,
-  ): this is NodePath<T & t.JSXText>;
-  isLVal<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.LVal>,
-  ): this is NodePath<T & t.LVal>;
-  isLabeledStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.JSXText>;
+  isLVal(this: NodePath, opts?: Opts<t.LVal>): this is NodePath<t.LVal>;
+  isLabeledStatement(
+    this: NodePath,
     opts?: Opts<t.LabeledStatement>,
-  ): this is NodePath<T & t.LabeledStatement>;
-  isLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.LabeledStatement>;
+  isLiteral(
+    this: NodePath,
     opts?: Opts<t.Literal>,
-  ): this is NodePath<T & t.Literal>;
-  isLogicalExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Literal>;
+  isLogicalExpression(
+    this: NodePath,
     opts?: Opts<t.LogicalExpression>,
-  ): this is NodePath<T & t.LogicalExpression>;
-  isLoop<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.Loop>,
-  ): this is NodePath<T & t.Loop>;
-  isMemberExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.LogicalExpression>;
+  isLoop(this: NodePath, opts?: Opts<t.Loop>): this is NodePath<t.Loop>;
+  isMemberExpression(
+    this: NodePath,
     opts?: Opts<t.MemberExpression>,
-  ): this is NodePath<T & t.MemberExpression>;
-  isMetaProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.MemberExpression>;
+  isMetaProperty(
+    this: NodePath,
     opts?: Opts<t.MetaProperty>,
-  ): this is NodePath<T & t.MetaProperty>;
-  isMethod<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.Method>,
-  ): this is NodePath<T & t.Method>;
-  isMiscellaneous<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.MetaProperty>;
+  isMethod(this: NodePath, opts?: Opts<t.Method>): this is NodePath<t.Method>;
+  isMiscellaneous(
+    this: NodePath,
     opts?: Opts<t.Miscellaneous>,
-  ): this is NodePath<T & t.Miscellaneous>;
-  isMixedTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Miscellaneous>;
+  isMixedTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.MixedTypeAnnotation>,
-  ): this is NodePath<T & t.MixedTypeAnnotation>;
-  isModuleDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.MixedTypeAnnotation>;
+  isModuleDeclaration(
+    this: NodePath,
     opts?: Opts<t.ModuleDeclaration>,
-  ): this is NodePath<T & t.ModuleDeclaration>;
-  isModuleExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ModuleDeclaration>;
+  isModuleExpression(
+    this: NodePath,
     opts?: Opts<t.ModuleExpression>,
-  ): this is NodePath<T & t.ModuleExpression>;
-  isModuleSpecifier<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ModuleExpression>;
+  isModuleSpecifier(
+    this: NodePath,
     opts?: Opts<t.ModuleSpecifier>,
-  ): this is NodePath<T & t.ModuleSpecifier>;
-  isNewExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ModuleSpecifier>;
+  isNewExpression(
+    this: NodePath,
     opts?: Opts<t.NewExpression>,
-  ): this is NodePath<T & t.NewExpression>;
-  isNoop<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.Noop>,
-  ): this is NodePath<T & t.Noop>;
-  isNullLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.NewExpression>;
+  isNoop(this: NodePath, opts?: Opts<t.Noop>): this is NodePath<t.Noop>;
+  isNullLiteral(
+    this: NodePath,
     opts?: Opts<t.NullLiteral>,
-  ): this is NodePath<T & t.NullLiteral>;
-  isNullLiteralTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.NullLiteral>;
+  isNullLiteralTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.NullLiteralTypeAnnotation>,
-  ): this is NodePath<T & t.NullLiteralTypeAnnotation>;
-  isNullableTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.NullLiteralTypeAnnotation>;
+  isNullableTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.NullableTypeAnnotation>,
-  ): this is NodePath<T & t.NullableTypeAnnotation>;
-  isNumberLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.NullableTypeAnnotation>;
+  isNumberLiteral(
+    this: NodePath,
     opts?: Opts<t.NumberLiteral>,
-  ): this is NodePath<T & t.NumberLiteral>;
-  isNumberLiteralTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.NumberLiteral>;
+  isNumberLiteralTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.NumberLiteralTypeAnnotation>,
-  ): this is NodePath<T & t.NumberLiteralTypeAnnotation>;
-  isNumberTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.NumberLiteralTypeAnnotation>;
+  isNumberTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.NumberTypeAnnotation>,
-  ): this is NodePath<T & t.NumberTypeAnnotation>;
-  isNumericLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.NumberTypeAnnotation>;
+  isNumericLiteral(
+    this: NodePath,
     opts?: Opts<t.NumericLiteral>,
-  ): this is NodePath<T & t.NumericLiteral>;
-  isObjectExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.NumericLiteral>;
+  isObjectExpression(
+    this: NodePath,
     opts?: Opts<t.ObjectExpression>,
-  ): this is NodePath<T & t.ObjectExpression>;
-  isObjectMember<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ObjectExpression>;
+  isObjectMember(
+    this: NodePath,
     opts?: Opts<t.ObjectMember>,
-  ): this is NodePath<T & t.ObjectMember>;
-  isObjectMethod<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ObjectMember>;
+  isObjectMethod(
+    this: NodePath,
     opts?: Opts<t.ObjectMethod>,
-  ): this is NodePath<T & t.ObjectMethod>;
-  isObjectPattern<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ObjectMethod>;
+  isObjectPattern(
+    this: NodePath,
     opts?: Opts<t.ObjectPattern>,
-  ): this is NodePath<T & t.ObjectPattern>;
-  isObjectProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ObjectPattern>;
+  isObjectProperty(
+    this: NodePath,
     opts?: Opts<t.ObjectProperty>,
-  ): this is NodePath<T & t.ObjectProperty>;
-  isObjectTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ObjectProperty>;
+  isObjectTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.ObjectTypeAnnotation>,
-  ): this is NodePath<T & t.ObjectTypeAnnotation>;
-  isObjectTypeCallProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ObjectTypeAnnotation>;
+  isObjectTypeCallProperty(
+    this: NodePath,
     opts?: Opts<t.ObjectTypeCallProperty>,
-  ): this is NodePath<T & t.ObjectTypeCallProperty>;
-  isObjectTypeIndexer<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ObjectTypeCallProperty>;
+  isObjectTypeIndexer(
+    this: NodePath,
     opts?: Opts<t.ObjectTypeIndexer>,
-  ): this is NodePath<T & t.ObjectTypeIndexer>;
-  isObjectTypeInternalSlot<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ObjectTypeIndexer>;
+  isObjectTypeInternalSlot(
+    this: NodePath,
     opts?: Opts<t.ObjectTypeInternalSlot>,
-  ): this is NodePath<T & t.ObjectTypeInternalSlot>;
-  isObjectTypeProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ObjectTypeInternalSlot>;
+  isObjectTypeProperty(
+    this: NodePath,
     opts?: Opts<t.ObjectTypeProperty>,
-  ): this is NodePath<T & t.ObjectTypeProperty>;
-  isObjectTypeSpreadProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ObjectTypeProperty>;
+  isObjectTypeSpreadProperty(
+    this: NodePath,
     opts?: Opts<t.ObjectTypeSpreadProperty>,
-  ): this is NodePath<T & t.ObjectTypeSpreadProperty>;
-  isOpaqueType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ObjectTypeSpreadProperty>;
+  isOpaqueType(
+    this: NodePath,
     opts?: Opts<t.OpaqueType>,
-  ): this is NodePath<T & t.OpaqueType>;
-  isOptionalCallExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.OpaqueType>;
+  isOptionalCallExpression(
+    this: NodePath,
     opts?: Opts<t.OptionalCallExpression>,
-  ): this is NodePath<T & t.OptionalCallExpression>;
-  isOptionalIndexedAccessType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.OptionalCallExpression>;
+  isOptionalIndexedAccessType(
+    this: NodePath,
     opts?: Opts<t.OptionalIndexedAccessType>,
-  ): this is NodePath<T & t.OptionalIndexedAccessType>;
-  isOptionalMemberExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.OptionalIndexedAccessType>;
+  isOptionalMemberExpression(
+    this: NodePath,
     opts?: Opts<t.OptionalMemberExpression>,
-  ): this is NodePath<T & t.OptionalMemberExpression>;
-  isParenthesizedExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.OptionalMemberExpression>;
+  isParenthesizedExpression(
+    this: NodePath,
     opts?: Opts<t.ParenthesizedExpression>,
-  ): this is NodePath<T & t.ParenthesizedExpression>;
-  isPattern<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ParenthesizedExpression>;
+  isPattern(
+    this: NodePath,
     opts?: Opts<t.Pattern>,
-  ): this is NodePath<T & t.Pattern>;
-  isPatternLike<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Pattern>;
+  isPatternLike(
+    this: NodePath,
     opts?: Opts<t.PatternLike>,
-  ): this is NodePath<T & t.PatternLike>;
-  isPipelineBareFunction<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.PatternLike>;
+  isPipelineBareFunction(
+    this: NodePath,
     opts?: Opts<t.PipelineBareFunction>,
-  ): this is NodePath<T & t.PipelineBareFunction>;
-  isPipelinePrimaryTopicReference<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.PipelineBareFunction>;
+  isPipelinePrimaryTopicReference(
+    this: NodePath,
     opts?: Opts<t.PipelinePrimaryTopicReference>,
-  ): this is NodePath<T & t.PipelinePrimaryTopicReference>;
-  isPipelineTopicExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.PipelinePrimaryTopicReference>;
+  isPipelineTopicExpression(
+    this: NodePath,
     opts?: Opts<t.PipelineTopicExpression>,
-  ): this is NodePath<T & t.PipelineTopicExpression>;
-  isPlaceholder<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.PipelineTopicExpression>;
+  isPlaceholder(
+    this: NodePath,
     opts?: Opts<t.Placeholder>,
-  ): this is NodePath<T & t.Placeholder>;
-  isPrivate<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Placeholder>;
+  isPrivate(
+    this: NodePath,
     opts?: Opts<t.Private>,
-  ): this is NodePath<T & t.Private>;
-  isPrivateName<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Private>;
+  isPrivateName(
+    this: NodePath,
     opts?: Opts<t.PrivateName>,
-  ): this is NodePath<T & t.PrivateName>;
-  isProgram<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.PrivateName>;
+  isProgram(
+    this: NodePath,
     opts?: Opts<t.Program>,
-  ): this is NodePath<T & t.Program>;
-  isProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Program>;
+  isProperty(
+    this: NodePath,
     opts?: Opts<t.Property>,
-  ): this is NodePath<T & t.Property>;
-  isPureish<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Property>;
+  isPureish(
+    this: NodePath,
     opts?: Opts<t.Pureish>,
-  ): this is NodePath<T & t.Pureish>;
-  isQualifiedTypeIdentifier<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Pureish>;
+  isQualifiedTypeIdentifier(
+    this: NodePath,
     opts?: Opts<t.QualifiedTypeIdentifier>,
-  ): this is NodePath<T & t.QualifiedTypeIdentifier>;
-  isRecordExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.QualifiedTypeIdentifier>;
+  isRecordExpression(
+    this: NodePath,
     opts?: Opts<t.RecordExpression>,
-  ): this is NodePath<T & t.RecordExpression>;
-  isRegExpLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.RecordExpression>;
+  isRegExpLiteral(
+    this: NodePath,
     opts?: Opts<t.RegExpLiteral>,
-  ): this is NodePath<T & t.RegExpLiteral>;
-  isRegexLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.RegExpLiteral>;
+  isRegexLiteral(
+    this: NodePath,
     opts?: Opts<t.RegexLiteral>,
-  ): this is NodePath<T & t.RegexLiteral>;
-  isRestElement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.RegexLiteral>;
+  isRestElement(
+    this: NodePath,
     opts?: Opts<t.RestElement>,
-  ): this is NodePath<T & t.RestElement>;
-  isRestProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.RestElement>;
+  isRestProperty(
+    this: NodePath,
     opts?: Opts<t.RestProperty>,
-  ): this is NodePath<T & t.RestProperty>;
-  isReturnStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.RestProperty>;
+  isReturnStatement(
+    this: NodePath,
     opts?: Opts<t.ReturnStatement>,
-  ): this is NodePath<T & t.ReturnStatement>;
-  isScopable<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ReturnStatement>;
+  isScopable(
+    this: NodePath,
     opts?: Opts<t.Scopable>,
-  ): this is NodePath<T & t.Scopable>;
-  isSequenceExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Scopable>;
+  isSequenceExpression(
+    this: NodePath,
     opts?: Opts<t.SequenceExpression>,
-  ): this is NodePath<T & t.SequenceExpression>;
-  isSpreadElement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.SequenceExpression>;
+  isSpreadElement(
+    this: NodePath,
     opts?: Opts<t.SpreadElement>,
-  ): this is NodePath<T & t.SpreadElement>;
-  isSpreadProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.SpreadElement>;
+  isSpreadProperty(
+    this: NodePath,
     opts?: Opts<t.SpreadProperty>,
-  ): this is NodePath<T & t.SpreadProperty>;
-  isStandardized<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.SpreadProperty>;
+  isStandardized(
+    this: NodePath,
     opts?: Opts<t.Standardized>,
-  ): this is NodePath<T & t.Standardized>;
-  isStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Standardized>;
+  isStatement(
+    this: NodePath,
     opts?: Opts<t.Statement>,
-  ): this is NodePath<T & t.Statement>;
-  isStaticBlock<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Statement>;
+  isStaticBlock(
+    this: NodePath,
     opts?: Opts<t.StaticBlock>,
-  ): this is NodePath<T & t.StaticBlock>;
-  isStringLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.StaticBlock>;
+  isStringLiteral(
+    this: NodePath,
     opts?: Opts<t.StringLiteral>,
-  ): this is NodePath<T & t.StringLiteral>;
-  isStringLiteralTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.StringLiteral>;
+  isStringLiteralTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.StringLiteralTypeAnnotation>,
-  ): this is NodePath<T & t.StringLiteralTypeAnnotation>;
-  isStringTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.StringLiteralTypeAnnotation>;
+  isStringTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.StringTypeAnnotation>,
-  ): this is NodePath<T & t.StringTypeAnnotation>;
-  isSuper<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.Super>,
-  ): this is NodePath<T & t.Super>;
-  isSwitchCase<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.StringTypeAnnotation>;
+  isSuper(this: NodePath, opts?: Opts<t.Super>): this is NodePath<t.Super>;
+  isSwitchCase(
+    this: NodePath,
     opts?: Opts<t.SwitchCase>,
-  ): this is NodePath<T & t.SwitchCase>;
-  isSwitchStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.SwitchCase>;
+  isSwitchStatement(
+    this: NodePath,
     opts?: Opts<t.SwitchStatement>,
-  ): this is NodePath<T & t.SwitchStatement>;
-  isSymbolTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.SwitchStatement>;
+  isSymbolTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.SymbolTypeAnnotation>,
-  ): this is NodePath<T & t.SymbolTypeAnnotation>;
-  isTSAnyKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.SymbolTypeAnnotation>;
+  isTSAnyKeyword(
+    this: NodePath,
     opts?: Opts<t.TSAnyKeyword>,
-  ): this is NodePath<T & t.TSAnyKeyword>;
-  isTSArrayType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSAnyKeyword>;
+  isTSArrayType(
+    this: NodePath,
     opts?: Opts<t.TSArrayType>,
-  ): this is NodePath<T & t.TSArrayType>;
-  isTSAsExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSArrayType>;
+  isTSAsExpression(
+    this: NodePath,
     opts?: Opts<t.TSAsExpression>,
-  ): this is NodePath<T & t.TSAsExpression>;
-  isTSBaseType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSAsExpression>;
+  isTSBaseType(
+    this: NodePath,
     opts?: Opts<t.TSBaseType>,
-  ): this is NodePath<T & t.TSBaseType>;
-  isTSBigIntKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSBaseType>;
+  isTSBigIntKeyword(
+    this: NodePath,
     opts?: Opts<t.TSBigIntKeyword>,
-  ): this is NodePath<T & t.TSBigIntKeyword>;
-  isTSBooleanKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSBigIntKeyword>;
+  isTSBooleanKeyword(
+    this: NodePath,
     opts?: Opts<t.TSBooleanKeyword>,
-  ): this is NodePath<T & t.TSBooleanKeyword>;
-  isTSCallSignatureDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSBooleanKeyword>;
+  isTSCallSignatureDeclaration(
+    this: NodePath,
     opts?: Opts<t.TSCallSignatureDeclaration>,
-  ): this is NodePath<T & t.TSCallSignatureDeclaration>;
-  isTSConditionalType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSCallSignatureDeclaration>;
+  isTSConditionalType(
+    this: NodePath,
     opts?: Opts<t.TSConditionalType>,
-  ): this is NodePath<T & t.TSConditionalType>;
-  isTSConstructSignatureDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSConditionalType>;
+  isTSConstructSignatureDeclaration(
+    this: NodePath,
     opts?: Opts<t.TSConstructSignatureDeclaration>,
-  ): this is NodePath<T & t.TSConstructSignatureDeclaration>;
-  isTSConstructorType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSConstructSignatureDeclaration>;
+  isTSConstructorType(
+    this: NodePath,
     opts?: Opts<t.TSConstructorType>,
-  ): this is NodePath<T & t.TSConstructorType>;
-  isTSDeclareFunction<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSConstructorType>;
+  isTSDeclareFunction(
+    this: NodePath,
     opts?: Opts<t.TSDeclareFunction>,
-  ): this is NodePath<T & t.TSDeclareFunction>;
-  isTSDeclareMethod<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSDeclareFunction>;
+  isTSDeclareMethod(
+    this: NodePath,
     opts?: Opts<t.TSDeclareMethod>,
-  ): this is NodePath<T & t.TSDeclareMethod>;
-  isTSEntityName<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSDeclareMethod>;
+  isTSEntityName(
+    this: NodePath,
     opts?: Opts<t.TSEntityName>,
-  ): this is NodePath<T & t.TSEntityName>;
-  isTSEnumDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSEntityName>;
+  isTSEnumDeclaration(
+    this: NodePath,
     opts?: Opts<t.TSEnumDeclaration>,
-  ): this is NodePath<T & t.TSEnumDeclaration>;
-  isTSEnumMember<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSEnumDeclaration>;
+  isTSEnumMember(
+    this: NodePath,
     opts?: Opts<t.TSEnumMember>,
-  ): this is NodePath<T & t.TSEnumMember>;
-  isTSExportAssignment<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSEnumMember>;
+  isTSExportAssignment(
+    this: NodePath,
     opts?: Opts<t.TSExportAssignment>,
-  ): this is NodePath<T & t.TSExportAssignment>;
-  isTSExpressionWithTypeArguments<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSExportAssignment>;
+  isTSExpressionWithTypeArguments(
+    this: NodePath,
     opts?: Opts<t.TSExpressionWithTypeArguments>,
-  ): this is NodePath<T & t.TSExpressionWithTypeArguments>;
-  isTSExternalModuleReference<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSExpressionWithTypeArguments>;
+  isTSExternalModuleReference(
+    this: NodePath,
     opts?: Opts<t.TSExternalModuleReference>,
-  ): this is NodePath<T & t.TSExternalModuleReference>;
-  isTSFunctionType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSExternalModuleReference>;
+  isTSFunctionType(
+    this: NodePath,
     opts?: Opts<t.TSFunctionType>,
-  ): this is NodePath<T & t.TSFunctionType>;
-  isTSImportEqualsDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSFunctionType>;
+  isTSImportEqualsDeclaration(
+    this: NodePath,
     opts?: Opts<t.TSImportEqualsDeclaration>,
-  ): this is NodePath<T & t.TSImportEqualsDeclaration>;
-  isTSImportType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSImportEqualsDeclaration>;
+  isTSImportType(
+    this: NodePath,
     opts?: Opts<t.TSImportType>,
-  ): this is NodePath<T & t.TSImportType>;
-  isTSIndexSignature<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSImportType>;
+  isTSIndexSignature(
+    this: NodePath,
     opts?: Opts<t.TSIndexSignature>,
-  ): this is NodePath<T & t.TSIndexSignature>;
-  isTSIndexedAccessType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSIndexSignature>;
+  isTSIndexedAccessType(
+    this: NodePath,
     opts?: Opts<t.TSIndexedAccessType>,
-  ): this is NodePath<T & t.TSIndexedAccessType>;
-  isTSInferType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSIndexedAccessType>;
+  isTSInferType(
+    this: NodePath,
     opts?: Opts<t.TSInferType>,
-  ): this is NodePath<T & t.TSInferType>;
-  isTSInstantiationExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSInferType>;
+  isTSInstantiationExpression(
+    this: NodePath,
     opts?: Opts<t.TSInstantiationExpression>,
-  ): this is NodePath<T & t.TSInstantiationExpression>;
-  isTSInterfaceBody<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSInstantiationExpression>;
+  isTSInterfaceBody(
+    this: NodePath,
     opts?: Opts<t.TSInterfaceBody>,
-  ): this is NodePath<T & t.TSInterfaceBody>;
-  isTSInterfaceDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSInterfaceBody>;
+  isTSInterfaceDeclaration(
+    this: NodePath,
     opts?: Opts<t.TSInterfaceDeclaration>,
-  ): this is NodePath<T & t.TSInterfaceDeclaration>;
-  isTSIntersectionType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSInterfaceDeclaration>;
+  isTSIntersectionType(
+    this: NodePath,
     opts?: Opts<t.TSIntersectionType>,
-  ): this is NodePath<T & t.TSIntersectionType>;
-  isTSIntrinsicKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSIntersectionType>;
+  isTSIntrinsicKeyword(
+    this: NodePath,
     opts?: Opts<t.TSIntrinsicKeyword>,
-  ): this is NodePath<T & t.TSIntrinsicKeyword>;
-  isTSLiteralType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSIntrinsicKeyword>;
+  isTSLiteralType(
+    this: NodePath,
     opts?: Opts<t.TSLiteralType>,
-  ): this is NodePath<T & t.TSLiteralType>;
-  isTSMappedType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSLiteralType>;
+  isTSMappedType(
+    this: NodePath,
     opts?: Opts<t.TSMappedType>,
-  ): this is NodePath<T & t.TSMappedType>;
-  isTSMethodSignature<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSMappedType>;
+  isTSMethodSignature(
+    this: NodePath,
     opts?: Opts<t.TSMethodSignature>,
-  ): this is NodePath<T & t.TSMethodSignature>;
-  isTSModuleBlock<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSMethodSignature>;
+  isTSModuleBlock(
+    this: NodePath,
     opts?: Opts<t.TSModuleBlock>,
-  ): this is NodePath<T & t.TSModuleBlock>;
-  isTSModuleDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSModuleBlock>;
+  isTSModuleDeclaration(
+    this: NodePath,
     opts?: Opts<t.TSModuleDeclaration>,
-  ): this is NodePath<T & t.TSModuleDeclaration>;
-  isTSNamedTupleMember<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSModuleDeclaration>;
+  isTSNamedTupleMember(
+    this: NodePath,
     opts?: Opts<t.TSNamedTupleMember>,
-  ): this is NodePath<T & t.TSNamedTupleMember>;
-  isTSNamespaceExportDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSNamedTupleMember>;
+  isTSNamespaceExportDeclaration(
+    this: NodePath,
     opts?: Opts<t.TSNamespaceExportDeclaration>,
-  ): this is NodePath<T & t.TSNamespaceExportDeclaration>;
-  isTSNeverKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSNamespaceExportDeclaration>;
+  isTSNeverKeyword(
+    this: NodePath,
     opts?: Opts<t.TSNeverKeyword>,
-  ): this is NodePath<T & t.TSNeverKeyword>;
-  isTSNonNullExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSNeverKeyword>;
+  isTSNonNullExpression(
+    this: NodePath,
     opts?: Opts<t.TSNonNullExpression>,
-  ): this is NodePath<T & t.TSNonNullExpression>;
-  isTSNullKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSNonNullExpression>;
+  isTSNullKeyword(
+    this: NodePath,
     opts?: Opts<t.TSNullKeyword>,
-  ): this is NodePath<T & t.TSNullKeyword>;
-  isTSNumberKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSNullKeyword>;
+  isTSNumberKeyword(
+    this: NodePath,
     opts?: Opts<t.TSNumberKeyword>,
-  ): this is NodePath<T & t.TSNumberKeyword>;
-  isTSObjectKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSNumberKeyword>;
+  isTSObjectKeyword(
+    this: NodePath,
     opts?: Opts<t.TSObjectKeyword>,
-  ): this is NodePath<T & t.TSObjectKeyword>;
-  isTSOptionalType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSObjectKeyword>;
+  isTSOptionalType(
+    this: NodePath,
     opts?: Opts<t.TSOptionalType>,
-  ): this is NodePath<T & t.TSOptionalType>;
-  isTSParameterProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSOptionalType>;
+  isTSParameterProperty(
+    this: NodePath,
     opts?: Opts<t.TSParameterProperty>,
-  ): this is NodePath<T & t.TSParameterProperty>;
-  isTSParenthesizedType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSParameterProperty>;
+  isTSParenthesizedType(
+    this: NodePath,
     opts?: Opts<t.TSParenthesizedType>,
-  ): this is NodePath<T & t.TSParenthesizedType>;
-  isTSPropertySignature<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSParenthesizedType>;
+  isTSPropertySignature(
+    this: NodePath,
     opts?: Opts<t.TSPropertySignature>,
-  ): this is NodePath<T & t.TSPropertySignature>;
-  isTSQualifiedName<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSPropertySignature>;
+  isTSQualifiedName(
+    this: NodePath,
     opts?: Opts<t.TSQualifiedName>,
-  ): this is NodePath<T & t.TSQualifiedName>;
-  isTSRestType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSQualifiedName>;
+  isTSRestType(
+    this: NodePath,
     opts?: Opts<t.TSRestType>,
-  ): this is NodePath<T & t.TSRestType>;
-  isTSSatisfiesExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSRestType>;
+  isTSSatisfiesExpression(
+    this: NodePath,
     opts?: Opts<t.TSSatisfiesExpression>,
-  ): this is NodePath<T & t.TSSatisfiesExpression>;
-  isTSStringKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSSatisfiesExpression>;
+  isTSStringKeyword(
+    this: NodePath,
     opts?: Opts<t.TSStringKeyword>,
-  ): this is NodePath<T & t.TSStringKeyword>;
-  isTSSymbolKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSStringKeyword>;
+  isTSSymbolKeyword(
+    this: NodePath,
     opts?: Opts<t.TSSymbolKeyword>,
-  ): this is NodePath<T & t.TSSymbolKeyword>;
-  isTSThisType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSSymbolKeyword>;
+  isTSThisType(
+    this: NodePath,
     opts?: Opts<t.TSThisType>,
-  ): this is NodePath<T & t.TSThisType>;
-  isTSTupleType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSThisType>;
+  isTSTupleType(
+    this: NodePath,
     opts?: Opts<t.TSTupleType>,
-  ): this is NodePath<T & t.TSTupleType>;
-  isTSType<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.TSType>,
-  ): this is NodePath<T & t.TSType>;
-  isTSTypeAliasDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTupleType>;
+  isTSType(this: NodePath, opts?: Opts<t.TSType>): this is NodePath<t.TSType>;
+  isTSTypeAliasDeclaration(
+    this: NodePath,
     opts?: Opts<t.TSTypeAliasDeclaration>,
-  ): this is NodePath<T & t.TSTypeAliasDeclaration>;
-  isTSTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypeAliasDeclaration>;
+  isTSTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.TSTypeAnnotation>,
-  ): this is NodePath<T & t.TSTypeAnnotation>;
-  isTSTypeAssertion<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypeAnnotation>;
+  isTSTypeAssertion(
+    this: NodePath,
     opts?: Opts<t.TSTypeAssertion>,
-  ): this is NodePath<T & t.TSTypeAssertion>;
-  isTSTypeElement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypeAssertion>;
+  isTSTypeElement(
+    this: NodePath,
     opts?: Opts<t.TSTypeElement>,
-  ): this is NodePath<T & t.TSTypeElement>;
-  isTSTypeLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypeElement>;
+  isTSTypeLiteral(
+    this: NodePath,
     opts?: Opts<t.TSTypeLiteral>,
-  ): this is NodePath<T & t.TSTypeLiteral>;
-  isTSTypeOperator<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypeLiteral>;
+  isTSTypeOperator(
+    this: NodePath,
     opts?: Opts<t.TSTypeOperator>,
-  ): this is NodePath<T & t.TSTypeOperator>;
-  isTSTypeParameter<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypeOperator>;
+  isTSTypeParameter(
+    this: NodePath,
     opts?: Opts<t.TSTypeParameter>,
-  ): this is NodePath<T & t.TSTypeParameter>;
-  isTSTypeParameterDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypeParameter>;
+  isTSTypeParameterDeclaration(
+    this: NodePath,
     opts?: Opts<t.TSTypeParameterDeclaration>,
-  ): this is NodePath<T & t.TSTypeParameterDeclaration>;
-  isTSTypeParameterInstantiation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypeParameterDeclaration>;
+  isTSTypeParameterInstantiation(
+    this: NodePath,
     opts?: Opts<t.TSTypeParameterInstantiation>,
-  ): this is NodePath<T & t.TSTypeParameterInstantiation>;
-  isTSTypePredicate<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypeParameterInstantiation>;
+  isTSTypePredicate(
+    this: NodePath,
     opts?: Opts<t.TSTypePredicate>,
-  ): this is NodePath<T & t.TSTypePredicate>;
-  isTSTypeQuery<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypePredicate>;
+  isTSTypeQuery(
+    this: NodePath,
     opts?: Opts<t.TSTypeQuery>,
-  ): this is NodePath<T & t.TSTypeQuery>;
-  isTSTypeReference<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypeQuery>;
+  isTSTypeReference(
+    this: NodePath,
     opts?: Opts<t.TSTypeReference>,
-  ): this is NodePath<T & t.TSTypeReference>;
-  isTSUndefinedKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSTypeReference>;
+  isTSUndefinedKeyword(
+    this: NodePath,
     opts?: Opts<t.TSUndefinedKeyword>,
-  ): this is NodePath<T & t.TSUndefinedKeyword>;
-  isTSUnionType<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSUndefinedKeyword>;
+  isTSUnionType(
+    this: NodePath,
     opts?: Opts<t.TSUnionType>,
-  ): this is NodePath<T & t.TSUnionType>;
-  isTSUnknownKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSUnionType>;
+  isTSUnknownKeyword(
+    this: NodePath,
     opts?: Opts<t.TSUnknownKeyword>,
-  ): this is NodePath<T & t.TSUnknownKeyword>;
-  isTSVoidKeyword<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSUnknownKeyword>;
+  isTSVoidKeyword(
+    this: NodePath,
     opts?: Opts<t.TSVoidKeyword>,
-  ): this is NodePath<T & t.TSVoidKeyword>;
-  isTaggedTemplateExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TSVoidKeyword>;
+  isTaggedTemplateExpression(
+    this: NodePath,
     opts?: Opts<t.TaggedTemplateExpression>,
-  ): this is NodePath<T & t.TaggedTemplateExpression>;
-  isTemplateElement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TaggedTemplateExpression>;
+  isTemplateElement(
+    this: NodePath,
     opts?: Opts<t.TemplateElement>,
-  ): this is NodePath<T & t.TemplateElement>;
-  isTemplateLiteral<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TemplateElement>;
+  isTemplateLiteral(
+    this: NodePath,
     opts?: Opts<t.TemplateLiteral>,
-  ): this is NodePath<T & t.TemplateLiteral>;
-  isTerminatorless<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TemplateLiteral>;
+  isTerminatorless(
+    this: NodePath,
     opts?: Opts<t.Terminatorless>,
-  ): this is NodePath<T & t.Terminatorless>;
-  isThisExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Terminatorless>;
+  isThisExpression(
+    this: NodePath,
     opts?: Opts<t.ThisExpression>,
-  ): this is NodePath<T & t.ThisExpression>;
-  isThisTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ThisExpression>;
+  isThisTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.ThisTypeAnnotation>,
-  ): this is NodePath<T & t.ThisTypeAnnotation>;
-  isThrowStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ThisTypeAnnotation>;
+  isThrowStatement(
+    this: NodePath,
     opts?: Opts<t.ThrowStatement>,
-  ): this is NodePath<T & t.ThrowStatement>;
-  isTopicReference<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.ThrowStatement>;
+  isTopicReference(
+    this: NodePath,
     opts?: Opts<t.TopicReference>,
-  ): this is NodePath<T & t.TopicReference>;
-  isTryStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TopicReference>;
+  isTryStatement(
+    this: NodePath,
     opts?: Opts<t.TryStatement>,
-  ): this is NodePath<T & t.TryStatement>;
-  isTupleExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TryStatement>;
+  isTupleExpression(
+    this: NodePath,
     opts?: Opts<t.TupleExpression>,
-  ): this is NodePath<T & t.TupleExpression>;
-  isTupleTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TupleExpression>;
+  isTupleTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.TupleTypeAnnotation>,
-  ): this is NodePath<T & t.TupleTypeAnnotation>;
-  isTypeAlias<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TupleTypeAnnotation>;
+  isTypeAlias(
+    this: NodePath,
     opts?: Opts<t.TypeAlias>,
-  ): this is NodePath<T & t.TypeAlias>;
-  isTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TypeAlias>;
+  isTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.TypeAnnotation>,
-  ): this is NodePath<T & t.TypeAnnotation>;
-  isTypeCastExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TypeAnnotation>;
+  isTypeCastExpression(
+    this: NodePath,
     opts?: Opts<t.TypeCastExpression>,
-  ): this is NodePath<T & t.TypeCastExpression>;
-  isTypeParameter<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TypeCastExpression>;
+  isTypeParameter(
+    this: NodePath,
     opts?: Opts<t.TypeParameter>,
-  ): this is NodePath<T & t.TypeParameter>;
-  isTypeParameterDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TypeParameter>;
+  isTypeParameterDeclaration(
+    this: NodePath,
     opts?: Opts<t.TypeParameterDeclaration>,
-  ): this is NodePath<T & t.TypeParameterDeclaration>;
-  isTypeParameterInstantiation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TypeParameterDeclaration>;
+  isTypeParameterInstantiation(
+    this: NodePath,
     opts?: Opts<t.TypeParameterInstantiation>,
-  ): this is NodePath<T & t.TypeParameterInstantiation>;
-  isTypeScript<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TypeParameterInstantiation>;
+  isTypeScript(
+    this: NodePath,
     opts?: Opts<t.TypeScript>,
-  ): this is NodePath<T & t.TypeScript>;
-  isTypeofTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TypeScript>;
+  isTypeofTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.TypeofTypeAnnotation>,
-  ): this is NodePath<T & t.TypeofTypeAnnotation>;
-  isUnaryExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.TypeofTypeAnnotation>;
+  isUnaryExpression(
+    this: NodePath,
     opts?: Opts<t.UnaryExpression>,
-  ): this is NodePath<T & t.UnaryExpression>;
-  isUnaryLike<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.UnaryExpression>;
+  isUnaryLike(
+    this: NodePath,
     opts?: Opts<t.UnaryLike>,
-  ): this is NodePath<T & t.UnaryLike>;
-  isUnionTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.UnaryLike>;
+  isUnionTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.UnionTypeAnnotation>,
-  ): this is NodePath<T & t.UnionTypeAnnotation>;
-  isUpdateExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.UnionTypeAnnotation>;
+  isUpdateExpression(
+    this: NodePath,
     opts?: Opts<t.UpdateExpression>,
-  ): this is NodePath<T & t.UpdateExpression>;
-  isUserWhitespacable<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.UpdateExpression>;
+  isUserWhitespacable(
+    this: NodePath,
     opts?: Opts<t.UserWhitespacable>,
-  ): this is NodePath<T & t.UserWhitespacable>;
-  isV8IntrinsicIdentifier<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.UserWhitespacable>;
+  isV8IntrinsicIdentifier(
+    this: NodePath,
     opts?: Opts<t.V8IntrinsicIdentifier>,
-  ): this is NodePath<T & t.V8IntrinsicIdentifier>;
-  isVariableDeclaration<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.V8IntrinsicIdentifier>;
+  isVariableDeclaration(
+    this: NodePath,
     opts?: Opts<t.VariableDeclaration>,
-  ): this is NodePath<T & t.VariableDeclaration>;
-  isVariableDeclarator<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.VariableDeclaration>;
+  isVariableDeclarator(
+    this: NodePath,
     opts?: Opts<t.VariableDeclarator>,
-  ): this is NodePath<T & t.VariableDeclarator>;
-  isVariance<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.VariableDeclarator>;
+  isVariance(
+    this: NodePath,
     opts?: Opts<t.Variance>,
-  ): this is NodePath<T & t.Variance>;
-  isVoidTypeAnnotation<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Variance>;
+  isVoidTypeAnnotation(
+    this: NodePath,
     opts?: Opts<t.VoidTypeAnnotation>,
-  ): this is NodePath<T & t.VoidTypeAnnotation>;
-  isWhile<T extends t.Node>(
-    this: NodePath<T>,
-    opts?: Opts<t.While>,
-  ): this is NodePath<T & t.While>;
-  isWhileStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.VoidTypeAnnotation>;
+  isWhile(this: NodePath, opts?: Opts<t.While>): this is NodePath<t.While>;
+  isWhileStatement(
+    this: NodePath,
     opts?: Opts<t.WhileStatement>,
-  ): this is NodePath<T & t.WhileStatement>;
-  isWithStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.WhileStatement>;
+  isWithStatement(
+    this: NodePath,
     opts?: Opts<t.WithStatement>,
-  ): this is NodePath<T & t.WithStatement>;
-  isYieldExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.WithStatement>;
+  isYieldExpression(
+    this: NodePath,
     opts?: Opts<t.YieldExpression>,
-  ): this is NodePath<T & t.YieldExpression>;
+  ): this is NodePath<t.YieldExpression>;
 }
 
 export interface NodePathValidators

--- a/packages/babel-traverse/src/path/introspection.ts
+++ b/packages/babel-traverse/src/path/introspection.ts
@@ -38,7 +38,7 @@ export function has<N extends t.Node>(
   this: NodePath<N>,
   key: keyof N,
 ): boolean {
-  const val = this.node && this.node[key];
+  const val = (this.node as N)?.[key];
   if (val && Array.isArray(val)) {
     return !!val.length;
   } else {
@@ -80,7 +80,7 @@ export function equals<N extends t.Node>(
   key: keyof N,
   value: any,
 ): boolean {
-  return this.node[key] === value;
+  return (this.node as N)[key] === value;
 }
 
 /**
@@ -694,6 +694,9 @@ export function isInStrictMode(this: NodePath) {
     if (path.isFunction()) {
       body = path.node.body as t.BlockStatement;
     } else if (path.isProgram()) {
+      // @ts-expect-error TODO: TS thinks that `path` here cannot be
+      // Program due to the `isProgram()` check at the beginning of
+      // the function
       body = path.node;
     } else {
       return false;

--- a/packages/babel-traverse/src/path/lib/hoister.ts
+++ b/packages/babel-traverse/src/path/lib/hoister.ts
@@ -260,6 +260,8 @@ export default class PathHoister<T extends t.Node = t.Node> {
 
     this.path.replaceWith(cloneNode(uid));
 
+    // @ts-expect-error TS cannot refine the type of `attached`
+    // TODO: Should we use `attached.isVariableDeclaration()`?
     return attachTo.isVariableDeclarator()
       ? attached.get("init")
       : attached.get("declarations.0.init");

--- a/packages/babel-traverse/src/path/lib/virtual-types-validator.ts
+++ b/packages/babel-traverse/src/path/lib/virtual-types-validator.ts
@@ -35,30 +35,30 @@ type Opts<Obj> = Partial<{
 }>;
 
 export interface VirtualTypeNodePathValidators {
-  isBindingIdentifier<T extends t.Node>(
-    this: NodePath<T>,
+  isBindingIdentifier(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["BindingIdentifier"]>,
-  ): this is NodePath<T & VirtualTypeAliases["BindingIdentifier"]>;
+  ): this is NodePath<VirtualTypeAliases["BindingIdentifier"]>;
   isBlockScoped(opts?: Opts<VirtualTypeAliases["BlockScoped"]>): boolean;
   /**
    * @deprecated
    */
-  isExistentialTypeParam<T extends t.Node>(
-    this: NodePath<T>,
+  isExistentialTypeParam(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["ExistentialTypeParam"]>,
-  ): this is NodePath<T & VirtualTypeAliases["ExistentialTypeParam"]>;
-  isExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<VirtualTypeAliases["ExistentialTypeParam"]>;
+  isExpression(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["Expression"]>,
-  ): this is NodePath<T & t.Expression>;
-  isFlow<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Expression>;
+  isFlow(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["Flow"]>,
-  ): this is NodePath<T & t.Flow>;
-  isForAwaitStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.Flow>;
+  isForAwaitStatement(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["ForAwaitStatement"]>,
-  ): this is NodePath<T & VirtualTypeAliases["ForAwaitStatement"]>;
+  ): this is NodePath<VirtualTypeAliases["ForAwaitStatement"]>;
   isGenerated(opts?: VirtualTypeAliases["Generated"]): boolean;
   /**
    * @deprecated
@@ -68,35 +68,35 @@ export interface VirtualTypeNodePathValidators {
   ): void;
   isPure(opts?: VirtualTypeAliases["Pure"]): boolean;
   isReferenced(opts?: VirtualTypeAliases["Referenced"]): boolean;
-  isReferencedIdentifier<T extends t.Node>(
-    this: NodePath<T>,
+  isReferencedIdentifier(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["ReferencedIdentifier"]>,
-  ): this is NodePath<T & VirtualTypeAliases["ReferencedIdentifier"]>;
-  isReferencedMemberExpression<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<VirtualTypeAliases["ReferencedIdentifier"]>;
+  isReferencedMemberExpression(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["ReferencedMemberExpression"]>,
-  ): this is NodePath<T & VirtualTypeAliases["ReferencedMemberExpression"]>;
-  isRestProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<VirtualTypeAliases["ReferencedMemberExpression"]>;
+  isRestProperty(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["RestProperty"]>,
-  ): this is NodePath<T & t.RestProperty>;
-  isScope<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.RestProperty>;
+  isScope(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["Scope"]>,
-  ): this is NodePath<T & VirtualTypeAliases["Scope"]>;
-  isSpreadProperty<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<VirtualTypeAliases["Scope"]>;
+  isSpreadProperty(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["SpreadProperty"]>,
-  ): this is NodePath<T & t.SpreadProperty>;
-  isStatement<T extends t.Node>(
-    this: NodePath<T>,
+  ): this is NodePath<t.SpreadProperty>;
+  isStatement(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["Statement"]>,
-  ): this is NodePath<T & t.Statement>;
+  ): this is NodePath<t.Statement>;
   isUser(opts?: VirtualTypeAliases["User"]): boolean;
-  isVar<T extends t.Node>(
-    this: NodePath<T>,
+  isVar(
+    this: NodePath,
     opts?: Opts<VirtualTypeAliases["Var"]>,
-  ): this is NodePath<T & VirtualTypeAliases["Var"]>;
+  ): this is NodePath<VirtualTypeAliases["Var"]>;
 }
 
 export function isReferencedIdentifier(this: NodePath, opts?: any): boolean {
@@ -192,19 +192,11 @@ export function isFlow(this: NodePath): boolean {
 
 // TODO: 7.0 Backwards Compat
 export function isRestProperty(this: NodePath): boolean {
-  return (
-    nodeIsRestElement(this.node) &&
-    this.parentPath &&
-    this.parentPath.isObjectPattern()
-  );
+  return nodeIsRestElement(this.node) && this.parentPath?.isObjectPattern();
 }
 
 export function isSpreadProperty(this: NodePath): boolean {
-  return (
-    nodeIsRestElement(this.node) &&
-    this.parentPath &&
-    this.parentPath.isObjectExpression()
-  );
+  return nodeIsRestElement(this.node) && this.parentPath?.isObjectExpression();
 }
 
 export function isForAwaitStatement(this: NodePath): boolean {

--- a/packages/babel-traverse/src/path/replacement.ts
+++ b/packages/babel-traverse/src/path/replacement.ts
@@ -110,11 +110,18 @@ export function replaceWithSourceString(this: NodePath, replacement: string) {
 /**
  * Replace the current node with another.
  */
-
 export function replaceWith<R extends t.Node>(
   this: NodePath,
-  replacementPath: R | NodePath<R>,
-): [NodePath<R>] {
+  replacementPath: R,
+): [NodePath<R>];
+export function replaceWith<R extends NodePath>(
+  this: NodePath,
+  replacementPath: R,
+): [R];
+export function replaceWith(
+  this: NodePath,
+  replacementPath: t.Node | NodePath,
+): [NodePath] {
   this.resync();
 
   if (this.removed) {
@@ -133,7 +140,7 @@ export function replaceWith<R extends t.Node>(
   }
 
   if (this.node === replacement) {
-    return [this as NodePath<R>];
+    return [this];
   }
 
   if (this.isProgram() && !isProgram(replacement)) {
@@ -174,9 +181,7 @@ export function replaceWith<R extends t.Node>(
       !this.canSwapBetweenExpressionAndStatement(replacement)
     ) {
       // replacing an expression with a statement so let's explode it
-      return this.replaceExpressionWithStatements([replacement]) as [
-        NodePath<R>,
-      ];
+      return this.replaceExpressionWithStatements([replacement]) as [NodePath];
     }
   }
 
@@ -196,9 +201,7 @@ export function replaceWith<R extends t.Node>(
   // requeue for visiting
   this.requeue();
 
-  return [
-    nodePath ? (this.get(nodePath) as NodePath<R>) : (this as NodePath<R>),
-  ];
+  return [nodePath ? this.get(nodePath) : this];
 }
 
 /**

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -1112,9 +1112,7 @@ export default class Scope {
     }
 
     if (path.isLoop() || path.isCatchClause() || path.isFunction()) {
-      // @ts-expect-error TS can not infer NodePath<Loop> | NodePath<CatchClause> as NodePath<Loop | CatchClause>
       path.ensureBlock();
-      // @ts-expect-error todo(flow->ts): improve types
       path = path.get("body");
     }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This pull request makes it so that the types `NodePath<t.Identifier | t.StringLiteral>` and `NodePath<t.Identifier> | NodePath<t.StringLiteral>` are equivalent. This makes our `path.is*` able to better perform type narrowing:
```js
if (path.isIdentifier()) {
  // path is NodePath<t.Identifier> -- this already worked
} else {
  // path is NodePath<t.StringLiteral> -- this works thanks to this PR
}
```

It also makes https://github.com/babel/babel/pull/16430 slightly faster, because it reduces the number of possible `NodePath<...>` types (because `NodePath<t.Identifier> | NodePath<t.StringLiteral>` and `NodePath<t.Identifier | t.StringLiteral>` are now the same type).

Unfortunately it makes it more common for `.ensureBlock()` to not work, since `asserts` return types do not work on unions (https://github.com/microsoft/TypeScript/issues/44212). I consider this acceptable, since `path.is*` are much more common. 