### PR TITLE
Bump glob to 10.3.12

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -311,6 +311,11 @@ module.exports = function (api) {
         ].map(normalize),
         plugins: [pluginImportMetaUrl],
       },
+      !convertESM &&
+        !bool(process.env.BABEL_8_BREAKING) && {
+          include: ["./packages/babel-cli/src/babel/options.ts"],
+          plugins: [pluginReplaceGlobImport],
+        },
       {
         test: sources.map(source => normalize(source.replace("/src", "/test"))),
         plugins: [
@@ -1043,6 +1048,50 @@ function pluginGeneratorOptimization({ types: t }) {
             }
           }
         },
+      },
+    },
+  };
+}
+
+/**
+ * Replace
+ *   `import { sync as globSync } from "glob"`
+ * by
+ *   `import * as glob from "glob";const globSync = glob.default.sync`
+ *
+ * When USE_ESM is true and BABEL_8_BREAKING is false, the proxy package inserted
+ * by yarn-plugin-condition becomes an ESM wrapper for the glob 7 authored in CJS,
+ * so we have to replace the glob imports following this ESM wrapper interface.
+ * @param {import("@babel/core")} pluginAPI
+ * @returns {import("@babel/core").PluginObj}
+ */
+function pluginReplaceGlobImport({ types: t }) {
+  return {
+    visitor: {
+      ImportDeclaration(path) {
+        if (
+          path.node.source.value === "glob" &&
+          path.node.specifiers[0].type === "ImportSpecifier"
+        ) {
+          path.replaceWithMultiple([
+            t.importDeclaration(
+              [t.importNamespaceSpecifier(t.identifier("glob"))],
+              path.node.source
+            ),
+            t.variableDeclaration("const", [
+              t.variableDeclarator(
+                t.identifier("globSync"),
+                t.memberExpression(
+                  t.memberExpression(
+                    t.identifier("glob"),
+                    t.identifier("default")
+                  ),
+                  t.identifier("sync")
+                )
+              ),
+            ]),
+          ]);
+        }
       },
     },
   };

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -28,7 +28,7 @@
     "commander": "^4.0.1",
     "convert-source-map": "^2.0.0",
     "fs-readdir-recursive": "^1.1.0",
-    "glob": "^7.2.0",
+    "glob": "condition:BABEL_8_BREAKING ? ^9.3.5 : ^7.2.0",
     "make-dir": "condition:BABEL_8_BREAKING ? : ^2.1.0",
     "slash": "condition:BABEL_8_BREAKING ? ^3.0.0 : ^2.0.0"
   },

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -28,7 +28,7 @@
     "commander": "^4.0.1",
     "convert-source-map": "^2.0.0",
     "fs-readdir-recursive": "^1.1.0",
-    "glob": "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync)",
+    "glob": "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync|default)",
     "make-dir": "condition:BABEL_8_BREAKING ? : ^2.1.0",
     "slash": "condition:BABEL_8_BREAKING ? ^3.0.0 : ^2.0.0"
   },

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -28,7 +28,7 @@
     "commander": "^4.0.1",
     "convert-source-map": "^2.0.0",
     "fs-readdir-recursive": "^1.1.0",
-    "glob": "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0",
+    "glob": "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync)",
     "make-dir": "condition:BABEL_8_BREAKING ? : ^2.1.0",
     "slash": "condition:BABEL_8_BREAKING ? ^3.0.0 : ^2.0.0"
   },

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -28,7 +28,7 @@
     "commander": "^4.0.1",
     "convert-source-map": "^2.0.0",
     "fs-readdir-recursive": "^1.1.0",
-    "glob": "condition:BABEL_8_BREAKING ? ^9.3.5 : ^7.2.0",
+    "glob": "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0",
     "make-dir": "condition:BABEL_8_BREAKING ? : ^2.1.0",
     "slash": "condition:BABEL_8_BREAKING ? ^3.0.0 : ^2.0.0"
   },

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -213,7 +213,18 @@ export default function parseArgv(args: Array<string>): CmdOptions | null {
   const errors: string[] = [];
 
   let filenames = commander.args.reduce(function (globbed: string[], input) {
-    let files = glob.sync(input);
+    if (process.env.BABEL_8_BREAKING) {
+      // glob 9+ no longer sorts the result, here we maintain the glob 7 behaviour
+      // https://github.com/isaacs/node-glob/blob/c3cd57ae128faa0e9190492acc743bb779ac4054/common.js#L151
+      // eslint-disable-next-line no-var
+      var files = glob
+        .sync(input, { dotRelative: true })
+        .sort(function alphasort(a, b) {
+          return a.localeCompare(b, "en");
+        });
+    } else {
+      files = glob.sync(input);
+    }
     if (!files.length) files = [input];
     globbed.push(...files);
     return globbed;

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 
 import commander from "commander";
 import { version, DEFAULT_EXTENSIONS } from "@babel/core";
-import { sync as globSync } from "glob";
+import * as glob from "glob";
 
 import type { InputOptions } from "@babel/core";
 
@@ -216,10 +216,12 @@ export default function parseArgv(args: Array<string>): CmdOptions | null {
     let files = process.env.BABEL_8_BREAKING
       ? // glob 9+ no longer sorts the result, here we maintain the glob 7 behaviour
         // https://github.com/isaacs/node-glob/blob/c3cd57ae128faa0e9190492acc743bb779ac4054/common.js#L151
-        globSync(input, { dotRelative: true }).sort(function alphasort(a, b) {
+        glob.sync(input, { dotRelative: true }).sort(function alphasort(a, b) {
           return a.localeCompare(b, "en");
         })
-      : globSync(input);
+      : // When USE_ESM is true and BABEL_8_BREAKING is off, the glob package is
+        // an ESM wrapper of the CJS glob 7
+        (USE_ESM ? glob.default.sync : glob.sync)(input);
     if (!files.length) files = [input];
     globbed.push(...files);
     return globbed;

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -219,8 +219,8 @@ export default function parseArgv(args: Array<string>): CmdOptions | null {
         glob.sync(input, { dotRelative: true }).sort(function alphasort(a, b) {
           return a.localeCompare(b, "en");
         })
-      : // When USE_ESM is true and BABEL_8_BREAKING is off, the glob package is
-        // an ESM wrapper of the CJS glob 7
+      : // @ts-expect-error When USE_ESM is true and BABEL_8_BREAKING is off,
+        // the glob package is an ESM wrapper of the CJS glob 7
         (USE_ESM ? glob.default.sync : glob.sync)(input);
     if (!files.length) files = [input];
     globbed.push(...files);

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 
 import commander from "commander";
 import { version, DEFAULT_EXTENSIONS } from "@babel/core";
-import glob from "glob";
+import { sync as globSync } from "glob";
 
 import type { InputOptions } from "@babel/core";
 
@@ -217,13 +217,13 @@ export default function parseArgv(args: Array<string>): CmdOptions | null {
       // glob 9+ no longer sorts the result, here we maintain the glob 7 behaviour
       // https://github.com/isaacs/node-glob/blob/c3cd57ae128faa0e9190492acc743bb779ac4054/common.js#L151
       // eslint-disable-next-line no-var
-      var files = glob
-        .sync(input, { dotRelative: true })
-        .sort(function alphasort(a, b) {
+      var files = globSync(input, { dotRelative: true }).sort(
+        function alphasort(a, b) {
           return a.localeCompare(b, "en");
-        });
+        },
+      );
     } else {
-      files = glob.sync(input);
+      files = globSync(input);
     }
     if (!files.length) files = [input];
     globbed.push(...files);

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -213,18 +213,13 @@ export default function parseArgv(args: Array<string>): CmdOptions | null {
   const errors: string[] = [];
 
   let filenames = commander.args.reduce(function (globbed: string[], input) {
-    if (process.env.BABEL_8_BREAKING) {
-      // glob 9+ no longer sorts the result, here we maintain the glob 7 behaviour
-      // https://github.com/isaacs/node-glob/blob/c3cd57ae128faa0e9190492acc743bb779ac4054/common.js#L151
-      // eslint-disable-next-line no-var
-      var files = globSync(input, { dotRelative: true }).sort(
-        function alphasort(a, b) {
+    let files = process.env.BABEL_8_BREAKING
+      ? // glob 9+ no longer sorts the result, here we maintain the glob 7 behaviour
+        // https://github.com/isaacs/node-glob/blob/c3cd57ae128faa0e9190492acc743bb779ac4054/common.js#L151
+        globSync(input, { dotRelative: true }).sort(function alphasort(a, b) {
           return a.localeCompare(b, "en");
-        },
-      );
-    } else {
-      files = globSync(input);
-    }
+        })
+      : globSync(input);
     if (!files.length) files = [input];
     globbed.push(...files);
     return globbed;

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -268,6 +268,7 @@ fs.writeFileSync(
               "babel-plugin-dynamic-import-node/utils",
               ["./lib/babel-plugin-dynamic-import-node.d.ts"],
             ],
+            ["glob", ["./node_modules/glob-BABEL_8_BREAKING-true"]],
             ["globals", ["./node_modules/globals-BABEL_8_BREAKING-true"]],
             ["js-tokens", ["./node_modules/js-tokens-BABEL_8_BREAKING-true"]],
             ["regexpu-core", ["./lib/regexpu-core.d.ts"]],

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -602,6 +602,9 @@
       "babel-plugin-dynamic-import-node/utils": [
         "./lib/babel-plugin-dynamic-import-node.d.ts"
       ],
+      "glob": [
+        "./node_modules/glob-BABEL_8_BREAKING-true"
+      ],
       "globals": [
         "./node_modules/globals-BABEL_8_BREAKING-true"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,7 +233,7 @@ __metadata:
     commander: "npm:^4.0.1"
     convert-source-map: "npm:^2.0.0"
     fs-readdir-recursive: "npm:^1.1.0"
-    glob: "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0"
+    glob: "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync)"
     make-dir: "condition:BABEL_8_BREAKING ? : ^2.1.0"
     semver: "npm:^6.3.1"
     slash: "condition:BABEL_8_BREAKING ? ^3.0.0 : ^2.0.0"
@@ -10422,13 +10422,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0":
-  version: 0.0.0-condition-0bad83
-  resolution: "glob@condition:BABEL_8_BREAKING?^10.3.12:^7.2.0#0bad83"
+"glob@condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync)":
+  version: 0.0.0-condition-9884bd
+  resolution: "glob@condition:BABEL_8_BREAKING?^10.3.12:^7.2.0(esm:sync)#9884bd"
   dependencies:
     glob-BABEL_8_BREAKING-false: "npm:glob@^7.2.0"
     glob-BABEL_8_BREAKING-true: "npm:glob@^10.3.12"
-  checksum: 10/2887d633e02b13b92c81b3de2eebbd841f454a90f972f23ca45bafab4408fca132873b5486b24b373d9f0366ff55232b67cbddead5e17fd9b6ba0cfd1bde3232
+  checksum: 10/93dba76cd35ecd4de162e84ad76a8d33f9316c5a6856fadb78919ba306c27e24128a0d91bfd58f6c9f1b4971a84d8d755b7aad2dbdf23732d53e940118f0b3a5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,7 +233,7 @@ __metadata:
     commander: "npm:^4.0.1"
     convert-source-map: "npm:^2.0.0"
     fs-readdir-recursive: "npm:^1.1.0"
-    glob: "condition:BABEL_8_BREAKING ? ^9.3.5 : ^7.2.0"
+    glob: "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0"
     make-dir: "condition:BABEL_8_BREAKING ? : ^2.1.0"
     semver: "npm:^6.3.1"
     slash: "condition:BABEL_8_BREAKING ? ^3.0.0 : ^2.0.0"
@@ -10339,15 +10339,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-BABEL_8_BREAKING-true@npm:glob@^9.3.5":
-  version: 9.3.5
-  resolution: "glob@npm:9.3.5"
+"glob-BABEL_8_BREAKING-true@npm:glob@^10.3.12":
+  version: 10.3.12
+  resolution: "glob@npm:10.3.12"
   dependencies:
-    fs.realpath: "npm:^1.0.0"
-    minimatch: "npm:^8.0.2"
-    minipass: "npm:^4.2.4"
-    path-scurry: "npm:^1.6.1"
-  checksum: 10/e5fa8a58adf53525bca42d82a1fad9e6800032b7e4d372209b80cfdca524dd9a7dbe7d01a92d7ed20d89c572457f12c250092bc8817cb4f1c63efefdf9b658c0
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^2.3.6"
+    minimatch: "npm:^9.0.1"
+    minipass: "npm:^7.0.4"
+    path-scurry: "npm:^1.10.2"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10/9e8186abc22dc824b5dd86cefd8e6b5621a72d1be7f68bacc0fd681e8c162ec5546660a6ec0553d6a74757a585e655956c7f8f1a6d24570e8d865c307323d178
   languageName: node
   linkType: hard
 
@@ -10419,13 +10422,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@condition:BABEL_8_BREAKING ? ^9.3.5 : ^7.2.0":
-  version: 0.0.0-condition-99e4f3
-  resolution: "glob@condition:BABEL_8_BREAKING?^9.3.5:^7.2.0#99e4f3"
+"glob@condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0":
+  version: 0.0.0-condition-0bad83
+  resolution: "glob@condition:BABEL_8_BREAKING?^10.3.12:^7.2.0#0bad83"
   dependencies:
     glob-BABEL_8_BREAKING-false: "npm:glob@^7.2.0"
-    glob-BABEL_8_BREAKING-true: "npm:glob@^9.3.5"
-  checksum: 10/9863d5ac03449494b1993f6f2e980006232e618713690e7c2475ada191e84415bff1b68f828e7d24b3fa04781866bc86559d5cd03accf804df7f030dedfdc87c
+    glob-BABEL_8_BREAKING-true: "npm:glob@^10.3.12"
+  checksum: 10/2887d633e02b13b92c81b3de2eebbd841f454a90f972f23ca45bafab4408fca132873b5486b24b373d9f0366ff55232b67cbddead5e17fd9b6ba0cfd1bde3232
   languageName: node
   linkType: hard
 
@@ -11705,7 +11708,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jackspeak@npm:^2.3.5":
+"jackspeak@npm:^2.3.5, jackspeak@npm:^2.3.6":
   version: 2.3.6
   resolution: "jackspeak@npm:2.3.6"
   dependencies:
@@ -13171,15 +13174,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^8.0.2":
-  version: 8.0.4
-  resolution: "minimatch@npm:8.0.4"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/aef05598ee565e1013bc8a10f53410ac681561f901c1a084b8ecfd016c9ed919f58f4bbd5b63e05643189dfb26e8106a84f0e1ff12e4a263aa37e1cae7ce9828
-  languageName: node
-  linkType: hard
-
 "minimist@npm:^1.1.0, minimist@npm:^1.2.0, minimist@npm:^1.2.6":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
@@ -13196,14 +13190,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^4.2.4":
-  version: 4.2.8
-  resolution: "minipass@npm:4.2.8"
-  checksum: 10/e148eb6dcb85c980234cad889139ef8ddf9d5bdac534f4f0268446c8792dd4c74f4502479be48de3c1cce2f6450f6da4d0d4a86405a8a12be04c1c36b339569a
-  languageName: node
-  linkType: hard
-
-"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0":
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.4":
   version: 7.0.4
   resolution: "minipass@npm:7.0.4"
   checksum: 10/e864bd02ceb5e0707696d58f7ce3a0b89233f0d686ef0d447a66db705c0846a8dc6f34865cd85256c1472ff623665f616b90b8ff58058b2ad996c5de747d2d18
@@ -14140,7 +14127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^1.10.1, path-scurry@npm:^1.6.1":
+"path-scurry@npm:^1.10.1, path-scurry@npm:^1.10.2":
   version: 1.10.2
   resolution: "path-scurry@npm:1.10.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,7 +233,7 @@ __metadata:
     commander: "npm:^4.0.1"
     convert-source-map: "npm:^2.0.0"
     fs-readdir-recursive: "npm:^1.1.0"
-    glob: "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync)"
+    glob: "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync|default)"
     make-dir: "condition:BABEL_8_BREAKING ? : ^2.1.0"
     semver: "npm:^6.3.1"
     slash: "condition:BABEL_8_BREAKING ? ^3.0.0 : ^2.0.0"
@@ -10422,13 +10422,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync)":
-  version: 0.0.0-condition-9884bd
-  resolution: "glob@condition:BABEL_8_BREAKING?^10.3.12:^7.2.0(esm:sync)#9884bd"
+"glob@condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync|default)":
+  version: 0.0.0-condition-7d059e
+  resolution: "glob@condition:BABEL_8_BREAKING?^10.3.12:^7.2.0(esm:sync|default)#7d059e"
   dependencies:
     glob-BABEL_8_BREAKING-false: "npm:glob@^7.2.0"
     glob-BABEL_8_BREAKING-true: "npm:glob@^10.3.12"
-  checksum: 10/93dba76cd35ecd4de162e84ad76a8d33f9316c5a6856fadb78919ba306c27e24128a0d91bfd58f6c9f1b4971a84d8d755b7aad2dbdf23732d53e940118f0b3a5
+  checksum: 10/8ac0cc489a0e0e709f98f9ec846e9ba17fa5cffa3c2ca9b29051aebfa5b9924ab8926ccb7f1a1f00d9c64d048ea4d7cb62f3be3e3ab20d6c657c51614664b900
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,7 +233,7 @@ __metadata:
     commander: "npm:^4.0.1"
     convert-source-map: "npm:^2.0.0"
     fs-readdir-recursive: "npm:^1.1.0"
-    glob: "npm:^7.2.0"
+    glob: "condition:BABEL_8_BREAKING ? ^9.3.5 : ^7.2.0"
     make-dir: "condition:BABEL_8_BREAKING ? : ^2.1.0"
     semver: "npm:^6.3.1"
     slash: "condition:BABEL_8_BREAKING ? ^3.0.0 : ^2.0.0"
@@ -10325,6 +10325,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob-BABEL_8_BREAKING-false@npm:glob@^7.2.0, glob@npm:^7.0.0, glob@npm:^7.1.0, glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.2.0":
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.1.1"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
+  checksum: 10/59452a9202c81d4508a43b8af7082ca5c76452b9fcc4a9ab17655822e6ce9b21d4f8fbadabe4fe3faef448294cec249af305e2cd824b7e9aaf689240e5e96a7b
+  languageName: node
+  linkType: hard
+
+"glob-BABEL_8_BREAKING-true@npm:glob@^9.3.5":
+  version: 9.3.5
+  resolution: "glob@npm:9.3.5"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    minimatch: "npm:^8.0.2"
+    minipass: "npm:^4.2.4"
+    path-scurry: "npm:^1.6.1"
+  checksum: 10/e5fa8a58adf53525bca42d82a1fad9e6800032b7e4d372209b80cfdca524dd9a7dbe7d01a92d7ed20d89c572457f12c250092bc8817cb4f1c63efefdf9b658c0
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^3.1.0":
   version: 3.1.0
   resolution: "glob-parent@npm:3.1.0"
@@ -10393,6 +10419,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@condition:BABEL_8_BREAKING ? ^9.3.5 : ^7.2.0":
+  version: 0.0.0-condition-99e4f3
+  resolution: "glob@condition:BABEL_8_BREAKING?^9.3.5:^7.2.0#99e4f3"
+  dependencies:
+    glob-BABEL_8_BREAKING-false: "npm:glob@^7.2.0"
+    glob-BABEL_8_BREAKING-true: "npm:glob@^9.3.5"
+  checksum: 10/9863d5ac03449494b1993f6f2e980006232e618713690e7c2475ada191e84415bff1b68f828e7d24b3fa04781866bc86559d5cd03accf804df7f030dedfdc87c
+  languageName: node
+  linkType: hard
+
 "glob@npm:^10.3.10":
   version: 10.3.10
   resolution: "glob@npm:10.3.10"
@@ -10405,20 +10441,6 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 10/38bdb2c9ce75eb5ed168f309d4ed05b0798f640b637034800a6bf306f39d35409bf278b0eaaffaec07591085d3acb7184a201eae791468f0f617771c2486a6a8
-  languageName: node
-  linkType: hard
-
-"glob@npm:^7.0.0, glob@npm:^7.1.0, glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.2.0":
-  version: 7.2.3
-  resolution: "glob@npm:7.2.3"
-  dependencies:
-    fs.realpath: "npm:^1.0.0"
-    inflight: "npm:^1.0.4"
-    inherits: "npm:2"
-    minimatch: "npm:^3.1.1"
-    once: "npm:^1.3.0"
-    path-is-absolute: "npm:^1.0.0"
-  checksum: 10/59452a9202c81d4508a43b8af7082ca5c76452b9fcc4a9ab17655822e6ce9b21d4f8fbadabe4fe3faef448294cec249af305e2cd824b7e9aaf689240e5e96a7b
   languageName: node
   linkType: hard
 
@@ -12824,6 +12846,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "lru-cache@npm:10.2.0"
+  checksum: 10/502ec42c3309c0eae1ce41afca471f831c278566d45a5273a0c51102dee31e0e250a62fa9029c3370988df33a14188a38e682c16143b794de78668de3643e302
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^4.0.1":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
@@ -12847,13 +12876,6 @@ __metadata:
   version: 7.18.3
   resolution: "lru-cache@npm:7.18.3"
   checksum: 10/6029ca5aba3aacb554e919d7ef804fffd4adfc4c83db00fac8248c7c78811fb6d4b6f70f7fd9d55032b3823446546a007edaa66ad1f2377ae833bd983fac5d98
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^9.1.1 || ^10.0.0":
-  version: 10.1.0
-  resolution: "lru-cache@npm:10.1.0"
-  checksum: 10/207278d6fa711fb1f94a0835d4d4737441d2475302482a14785b10515e4c906a57ebf9f35bf060740c9560e91c7c1ad5a04fd7ed030972a9ba18bce2a228e95b
   languageName: node
   linkType: hard
 
@@ -13149,6 +13171,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^8.0.2":
+  version: 8.0.4
+  resolution: "minimatch@npm:8.0.4"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/aef05598ee565e1013bc8a10f53410ac681561f901c1a084b8ecfd016c9ed919f58f4bbd5b63e05643189dfb26e8106a84f0e1ff12e4a263aa37e1cae7ce9828
+  languageName: node
+  linkType: hard
+
 "minimist@npm:^1.1.0, minimist@npm:^1.2.0, minimist@npm:^1.2.6":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
@@ -13162,6 +13193,13 @@ __metadata:
   dependencies:
     yallist: "npm:^4.0.0"
   checksum: 10/cf2aec122a650006bd2367b97819f7f5f0e84810188829f1891db2fd6f75df838aba0b508f0c476483f9b112a5430b304973012efe1107110dd3491d8aec81e8
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^4.2.4":
+  version: 4.2.8
+  resolution: "minipass@npm:4.2.8"
+  checksum: 10/e148eb6dcb85c980234cad889139ef8ddf9d5bdac534f4f0268446c8792dd4c74f4502479be48de3c1cce2f6450f6da4d0d4a86405a8a12be04c1c36b339569a
   languageName: node
   linkType: hard
 
@@ -14102,13 +14140,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^1.10.1":
-  version: 1.10.1
-  resolution: "path-scurry@npm:1.10.1"
+"path-scurry@npm:^1.10.1, path-scurry@npm:^1.6.1":
+  version: 1.10.2
+  resolution: "path-scurry@npm:1.10.2"
   dependencies:
-    lru-cache: "npm:^9.1.1 || ^10.0.0"
+    lru-cache: "npm:^10.2.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
-  checksum: 10/eebfb8304fef1d4f7e1486df987e4fd77413de4fce16508dea69fcf8eb318c09a6b15a7a2f4c22877cec1cb7ecbd3071d18ca9de79eeece0df874a00f1f0bdc8
+  checksum: 10/a2bbbe8dc284c49dd9be78ca25f3a8b89300e0acc24a77e6c74824d353ef50efbf163e64a69f4330b301afca42d0e2229be0560d6d616ac4e99d48b4062016b1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Bump glob to 10.3.12 for Babel 8
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
New options are added to maintain the glob 7 behaviour. The import is changed so that it works for both glob 7 + CJS and glob 10 + ESM scenario. There should be no behaviour changes for babel-cli users.

We can't ship this PR for Babel 7 as glob 9 dropped Node < 14 support.