### PR TITLE
[Babel 8] Use more native fs methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
     "@types/jest": "^29.5.11",
-    "@types/node": "^20.11.5",
+    "@types/node": "^20.12.7",
     "@yarnpkg/types": "^4.0.0",
     "babel-plugin-transform-charcodes": "^0.2.0",
     "c8": "^8.0.1",

--- a/packages/babel-cli/src/babel/dir.ts
+++ b/packages/babel-cli/src/babel/dir.ts
@@ -119,9 +119,7 @@ export default async function ({
 
       const files = util.readdir(dirname, cliOptions.includeDotfiles);
       for (const filename of files) {
-        const src = path.join(dirname, filename);
-
-        const written = await handleFile(src, dirname);
+        const written = await handleFile(filename, dirname);
         if (written) count += 1;
       }
 

--- a/packages/babel-cli/src/babel/file.ts
+++ b/packages/babel-cli/src/babel/file.ts
@@ -158,17 +158,13 @@ export default async function ({
 
       const stat = fs.statSync(filename);
       if (stat.isDirectory()) {
-        const dirname = filename;
-
-        util
-          .readdirForCompilable(
+        _filenames.push(
+          ...util.readdirForCompilable(
             filename,
             cliOptions.includeDotfiles,
             cliOptions.extensions,
-          )
-          .forEach(function (filename) {
-            _filenames.push(path.join(dirname, filename));
-          });
+          ),
+        );
       } else {
         _filenames.push(filename);
       }

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import commander from "commander";
 import { version, DEFAULT_EXTENSIONS } from "@babel/core";
 import * as glob from "glob";
+import { alphasort } from "./util.ts";
 
 import type { InputOptions } from "@babel/core";
 
@@ -216,9 +217,7 @@ export default function parseArgv(args: Array<string>): CmdOptions | null {
     let files = process.env.BABEL_8_BREAKING
       ? // glob 9+ no longer sorts the result, here we maintain the glob 7 behaviour
         // https://github.com/isaacs/node-glob/blob/c3cd57ae128faa0e9190492acc743bb779ac4054/common.js#L151
-        glob.sync(input, { dotRelative: true }).sort(function alphasort(a, b) {
-          return a.localeCompare(b, "en");
-        })
+        glob.sync(input, { dotRelative: true }).sort(alphasort)
       : // @ts-expect-error When USE_ESM is true and BABEL_8_BREAKING is off,
         // the glob package is an ESM wrapper of the CJS glob 7
         (USE_ESM ? glob.default.sync : glob.sync)(input);

--- a/packages/babel-cli/src/babel/util.ts
+++ b/packages/babel-cli/src/babel/util.ts
@@ -15,6 +15,10 @@ export function chmod(src: string, dest: string): void {
   }
 }
 
+export function alphasort(a: string, b: string) {
+  return a.localeCompare(b, "en");
+}
+
 type ReaddirFilter = (filename: string) => boolean;
 
 export function readdir(
@@ -22,15 +26,43 @@ export function readdir(
   includeDotfiles: boolean,
   filter?: ReaddirFilter,
 ): Array<string> {
-  return readdirRecursive(dirname, (filename, index, currentDirectory) => {
-    const stat = fs.statSync(path.join(currentDirectory, filename));
-
-    if (stat.isDirectory()) return true;
-
+  if (process.env.BABEL_8_BREAKING) {
     return (
-      (includeDotfiles || filename[0] !== ".") && (!filter || filter(filename))
+      fs
+        .readdirSync(dirname, { recursive: true, withFileTypes: true })
+        .filter(dirent => {
+          // exclude directory entries from readdir results
+          if (dirent.isDirectory()) return false;
+          const filename = dirent.name;
+          return (
+            (includeDotfiles || filename[0] !== ".") &&
+            (!filter || filter(filename))
+          );
+        })
+        .map(dirent => path.join(dirent.path, dirent.name))
+        // readdirSyncRecursive conducts BFS, sort the entries so we can match the DFS behaviour of fs-readdir-recursive
+        // https://github.com/nodejs/node/blob/d6b12f5b77e35c58a611d614cf0aac674ec2c3ed/lib/fs.js#L1421
+        .sort(alphasort)
     );
-  });
+  } else {
+    return readdirRecursive(
+      "",
+      (filename, index, currentDirectory) => {
+        const stat = fs.statSync(path.join(currentDirectory, filename));
+
+        // ensure we recurse into .* folders
+        if (stat.isDirectory()) return true;
+
+        return (
+          (includeDotfiles || filename[0] !== ".") &&
+          (!filter || filter(filename))
+        );
+      },
+      // @ts-expect-error improve @types/fs-readdir-recursive typings
+      [],
+      dirname,
+    );
+  }
 }
 
 export function readdirForCompilable(

--- a/packages/babel-cli/src/babel/util.ts
+++ b/packages/babel-cli/src/babel/util.ts
@@ -109,19 +109,7 @@ export async function compile(filename: string, opts: InputOptions) {
 }
 
 export function deleteDir(path: string): void {
-  if (fs.existsSync(path)) {
-    fs.readdirSync(path).forEach(function (file) {
-      const curPath = path + "/" + file;
-      if (fs.lstatSync(curPath).isDirectory()) {
-        // recurse
-        deleteDir(curPath);
-      } else {
-        // delete file
-        fs.unlinkSync(curPath);
-      }
-    });
-    fs.rmdirSync(path);
-  }
+  fs.rmSync(path, { force: true, recursive: true });
 }
 
 process.on("uncaughtException", function (err) {

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -679,19 +679,7 @@ const outputFileSync = function (filePath: string, data: string) {
 };
 
 function deleteDir(path: string): void {
-  if (fs.existsSync(path)) {
-    fs.readdirSync(path).forEach(function (file) {
-      const curPath = path + "/" + file;
-      if (fs.lstatSync(curPath).isDirectory()) {
-        // recurse
-        deleteDir(curPath);
-      } else {
-        // delete file
-        fs.unlinkSync(curPath);
-      }
-    });
-    fs.rmdirSync(path);
-  }
+  fs.rmSync(path, { force: true, recursive: true });
 }
 
 const fileFilter = function (x: string) {

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -26,7 +26,6 @@ import { diff } from "jest-diff";
 import type { ChildProcess } from "child_process";
 import { spawn } from "child_process";
 import os from "os";
-import { sync as makeDir } from "make-dir";
 import readdir from "fs-readdir-recursive";
 
 import { createRequire } from "module";
@@ -675,7 +674,7 @@ const readDir = function (loc: string, filter: Parameters<typeof readdir>[1]) {
 };
 
 const outputFileSync = function (filePath: string, data: string) {
-  makeDir(path.dirname(filePath));
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, data);
 };
 
@@ -903,7 +902,7 @@ export function buildProcessTests(
             createHash("sha1").update(testLoc).digest("hex"),
           );
           deleteDir(tmpLoc);
-          makeDir(tmpLoc);
+          fs.mkdirSync(tmpLoc, { recursive: true });
 
           const { inFiles } = opts;
           for (const filename of Object.keys(inFiles)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5496,12 +5496,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^20.11.5":
-  version: 20.11.5
-  resolution: "@types/node@npm:20.11.5"
+"@types/node@npm:*, @types/node@npm:^20.12.7":
+  version: 20.12.7
+  resolution: "@types/node@npm:20.12.7"
   dependencies:
     undici-types: "npm:~5.26.4"
-  checksum: 10/9f31c471047d7b3e240ce7b77ff29b0d15e83be7e3feafb3d0b0d0931122b438b1eefa302a5a2e1e9849914ff3fd76aafbd8ccb372efb1331ba048da63bce6f8
+  checksum: 10/b4a28a3b593a9bdca5650880b6a9acef46911d58cf7cfa57268f048e9a7157a7c3196421b96cea576850ddb732e3b54bc982c8eb5e1e5ef0635d4424c2fce801
   languageName: node
   linkType: hard
 
@@ -7145,7 +7145,7 @@ __metadata:
     "@rollup/plugin-replace": "npm:^5.0.5"
     "@rollup/plugin-terser": "npm:^0.4.4"
     "@types/jest": "npm:^29.5.11"
-    "@types/node": "npm:^20.11.5"
+    "@types/node": "npm:^20.12.7"
     "@yarnpkg/types": "npm:^4.0.0"
     babel-plugin-transform-charcodes: "npm:^0.2.0"
     c8: "npm:^8.0.1"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we use the following fs native methods available on Node.js 18+ for Babel 8. 
- `fs.mkdirSync(_, { recursive: true })`. The polyfill is already available, in this PR we replaced more `make-dir` usage
- `fs.rmSync(_, { force: true, recursive: true })`, a polyfill is also added.
- `fs.readdirSync(_, { recursive: true, withFileTypes: true })`

