### PR TITLE
bump import-meta-resolve to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "gulp-filter": "^7.0.0",
     "gulp-plumber": "^1.2.1",
     "husky": "^8.0.3",
-    "import-meta-resolve": "^4.0.0",
+    "import-meta-resolve": "^4.1.0",
     "is-ci": "^3.0.1",
     "jest": "^30.0.0-alpha.2",
     "jest-light-runner": "^0.6.0",

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -20,7 +20,7 @@
     "picocolors": "^1.0.0"
   },
   "devDependencies": {
-    "import-meta-resolve": "^4.0.0",
+    "import-meta-resolve": "^4.1.0",
     "strip-ansi": "^4.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,7 +284,7 @@ __metadata:
   resolution: "@babel/code-frame@workspace:packages/babel-code-frame"
   dependencies:
     "@babel/highlight": "workspace:^"
-    import-meta-resolve: "npm:^4.0.0"
+    import-meta-resolve: "npm:^4.1.0"
     picocolors: "npm:^1.0.0"
     strip-ansi: "npm:^4.0.0"
   languageName: unknown
@@ -7164,7 +7164,7 @@ __metadata:
     gulp-filter: "npm:^7.0.0"
     gulp-plumber: "npm:^1.2.1"
     husky: "npm:^8.0.3"
-    import-meta-resolve: "npm:^4.0.0"
+    import-meta-resolve: "npm:^4.1.0"
     is-ci: "npm:^3.0.1"
     jest: "npm:^30.0.0-alpha.2"
     jest-light-runner: "npm:^0.6.0"
@@ -11144,10 +11144,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-meta-resolve@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "import-meta-resolve@npm:4.0.0"
-  checksum: 10/73f0f1d68f7280cb4415e3a212a6e5d57fbfe61ab6f467df3dad5361529fbd89ac7d8ea2b694412b74985a4226d218ad3fb22fd8f06f5429beda521dc9f0229c
+"import-meta-resolve@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "import-meta-resolve@npm:4.1.0"
+  checksum: 10/40162f67eb406c8d5d49266206ef12ff07b54f5fad8cfd806db9efe3a055958e9969be51d6efaf82e34b8bea6758113dcc17bb79ff148292a4badcabc3472f22
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Deprecation warning on node v22: https://github.com/babel/babel/actions/runs/8927768039/job/24521888880?pr=16452#step:4:915
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Bump `import-meta-resolve` to 4.1.0
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The deprecation is caused by an upstream issue https://github.com/wooorm/import-meta-resolve/issues/27, which was then fixed in v4.1.0.