### PR TITLE
Statically generate boilerplate for bitfield accessors

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -197,6 +197,7 @@ module.exports = function (api) {
         plugins: [
           "babel-plugin-transform-charcodes",
           pluginBabelParserTokenType,
+          pluginBabelParserBitField,
         ],
         assumptions: parserAssumptions,
       },
@@ -1002,6 +1003,120 @@ function pluginBabelParserTokenType({
             );
           }
           path.replaceWith(numericLiteral(tokenType));
+        }
+      },
+    },
+  };
+}
+
+/** @param {{ types: import("@babel/types") }} api */
+function pluginBabelParserBitField({ types: t, template }) {
+  const bodyTemplate = template.statement({ allowReturnOutsideFunction: true });
+
+  return {
+    manipulateOptions({ parserOpts }) {
+      parserOpts.plugins.push("decorators", "decoratorAutoAccessors");
+    },
+    visitor: {
+      Class(path) {
+        let storageName;
+        let initial = 0;
+        let nextMask = 1;
+        for (const element of path.get("body.body")) {
+          if (
+            element.isClassAccessorProperty() &&
+            element.node.decorators?.some(dec =>
+              t.isIdentifier(dec.expression, { name: "bit" })
+            )
+          ) {
+            if (element.node.static || t.isPrivateName(element.node.key)) {
+              throw element.buildCodeFrameError(
+                "@bit cannot be used on static or private fields"
+              );
+            }
+            if (element.node.decorators.length > 1) {
+              throw element.buildCodeFrameError(
+                "@bit cannot be used with other decorators"
+              );
+            }
+            if (!t.isBooleanLiteral(element.node.value)) {
+              throw element.buildCodeFrameError(
+                "@bit fields must be initialized to a boolean literal"
+              );
+            }
+            if (nextMask === 0) {
+              // overflow
+              throw path.buildCodeFrameError(
+                "A class can contain at most 32 @bit decorators"
+              );
+            }
+
+            storageName ??= t.privateName(
+              path.scope.generateUidIdentifier("flags")
+            );
+
+            if (element.node.value.value) {
+              initial |= nextMask;
+            }
+
+            element.replaceWithMultiple([
+              t.classMethod(
+                "get",
+                element.node.key,
+                [],
+                bodyTemplate.ast`{
+                  return (
+                    this.${t.cloneNode(storageName)} & ${t.numericLiteral(nextMask)}
+                  ) > 0;
+                }`
+              ),
+              t.classMethod(
+                "set",
+                element.node.key,
+                [t.identifier("v")],
+                bodyTemplate.ast`{
+                  if (v) this.${t.cloneNode(storageName)} |= ${t.numericLiteral(nextMask)};
+                  else this.${t.cloneNode(storageName)} &= ${t.valueToNode(~nextMask)};
+                }`
+              ),
+            ]);
+
+            nextMask <<= 1;
+          }
+        }
+
+        if (storageName) {
+          path
+            .get("body")
+            .unshiftContainer(
+              "body",
+              t.classPrivateProperty(storageName, t.numericLiteral(initial))
+            );
+
+          path.traverse({
+            CallExpression(path) {
+              if (path.get("callee").isIdentifier({ name: "cloneBits" })) {
+                if (path.node.arguments.length !== 2) {
+                  throw path.buildCodeFrameError(
+                    "cloneBits expects two arguments"
+                  );
+                }
+                path.replaceWith(
+                  t.assignmentExpression(
+                    "=",
+                    t.memberExpression(
+                      path.node.arguments[0],
+                      t.cloneNode(storageName)
+                    ),
+                    t.memberExpression(
+                      path.node.arguments[1],
+                      t.cloneNode(storageName)
+                    )
+                  )
+                );
+              }
+            },
+          });
         }
       },
     },

--- a/packages/babel-parser/src/tokenizer/state.ts
+++ b/packages/babel-parser/src/tokenizer/state.ts
@@ -28,26 +28,11 @@ export const enum LoopLabelKind {
   Switch = 2,
 }
 
-// This is observably a no-op, but we use it to statically pack
-// multiple booleans into a single bitfield.
-declare function bit(
-  target: ClassAccessorDecoratorTarget<State, boolean>,
-  context: ClassAccessorDecoratorContext<State, boolean> & {
-    private: false;
-    static: false;
-  },
-): void; /*{
-  ((context.metadata.bits as any[]) ??= []).push(context.name);
-} */
-// This function copies all properties marked with the `bit` decorator from
-// `from` to `to`.
-declare function cloneBits<T>(to: T, from: T): void; /* {
-  from.constructor[Symbol.metadata].bits?.forEach((name) => {
-    to[name] = from[name];
-  });
-} */
+declare const bit: import("../../../../scripts/babel-plugin-bit-decorator/types.d.ts").BitDecorator<State>;
 
 export default class State {
+  @bit.storage #flags: number;
+
   @bit accessor strict = false;
 
   curLine: number;
@@ -180,7 +165,7 @@ export default class State {
 
   clone(): State {
     const state = new State();
-    cloneBits(state, this);
+    state.#flags = this.#flags;
     state.curLine = this.curLine;
     state.lineStart = this.lineStart;
     state.startLoc = this.startLoc;

--- a/packages/babel-parser/src/tokenizer/state.ts
+++ b/packages/babel-parser/src/tokenizer/state.ts
@@ -31,7 +31,7 @@ export const enum LoopLabelKind {
 declare const bit: import("../../../../scripts/babel-plugin-bit-decorator/types.d.ts").BitDecorator<State>;
 
 export default class State {
-  @bit.storage #flags: number;
+  @bit.storage flags: number;
 
   @bit accessor strict = false;
 
@@ -165,7 +165,7 @@ export default class State {
 
   clone(): State {
     const state = new State();
-    state.#flags = this.#flags;
+    state.flags = this.flags;
     state.curLine = this.curLine;
     state.lineStart = this.lineStart;
     state.startLoc = this.startLoc;

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -33,6 +33,8 @@ export const REMOVED = 1 << 0;
 export const SHOULD_STOP = 1 << 1;
 export const SHOULD_SKIP = 1 << 2;
 
+declare const bit: import("../../../../scripts/babel-plugin-bit-decorator/types.d.ts").BitDecorator<any>;
+
 const NodePath_Final = class NodePath {
   constructor(hub: HubInterface, parent: t.Node | null) {
     this.parent = parent;
@@ -53,8 +55,12 @@ const NodePath_Final = class NodePath {
   contexts: Array<TraversalContext> = [];
   state: any = null;
   opts: ExplodedTraverseOptions | null = null;
-  // this.shouldSkip = false; this.shouldStop = false; this.removed = false;
-  _traverseFlags: number = 0;
+
+  @bit.storage _traverseFlags: number;
+  @bit(REMOVED) accessor removed = false;
+  @bit(SHOULD_STOP) accessor shouldStop = false;
+  @bit(SHOULD_SKIP) accessor shouldSkip = false;
+
   skipKeys: Record<string, boolean> | null = null;
   parentPath: NodePath_Final | null = null;
   container: t.Node | Array<t.Node> | null = null;
@@ -179,41 +185,6 @@ const NodePath_Final = class NodePath {
 
   get parentKey(): string {
     return (this.listKey || this.key) as string;
-  }
-
-  get shouldSkip() {
-    return !!(this._traverseFlags & SHOULD_SKIP);
-  }
-
-  set shouldSkip(v) {
-    if (v) {
-      this._traverseFlags |= SHOULD_SKIP;
-    } else {
-      this._traverseFlags &= ~SHOULD_SKIP;
-    }
-  }
-
-  get shouldStop() {
-    return !!(this._traverseFlags & SHOULD_STOP);
-  }
-
-  set shouldStop(v) {
-    if (v) {
-      this._traverseFlags |= SHOULD_STOP;
-    } else {
-      this._traverseFlags &= ~SHOULD_STOP;
-    }
-  }
-
-  get removed() {
-    return !!(this._traverseFlags & REMOVED);
-  }
-  set removed(v) {
-    if (v) {
-      this._traverseFlags |= REMOVED;
-    } else {
-      this._traverseFlags &= ~REMOVED;
-    }
   }
 };
 

--- a/scripts/babel-plugin-bit-decorator/plugin.cjs
+++ b/scripts/babel-plugin-bit-decorator/plugin.cjs
@@ -1,0 +1,123 @@
+module.exports = pluginBabelBitDecorator;
+
+/** @param {{ types: import("@babel/types") }} api */
+function pluginBabelBitDecorator({ types: t, template }) {
+  const bodyTemplate = template.statement({ allowReturnOutsideFunction: true });
+
+  return {
+    manipulateOptions({ parserOpts }) {
+      parserOpts.plugins.push("decorators", "decoratorAutoAccessors");
+    },
+    visitor: {
+      Class(path) {
+        let storageField;
+        let storageName;
+
+        for (const element of path.get("body.body")) {
+          if (
+            (element.isClassProperty() || element.isClassPrivateProperty()) &&
+            element.node.decorators?.some(dec =>
+              t.matchesPattern(dec.expression, "bit.storage")
+            )
+          ) {
+            element.node.decorators = element.node.decorators.filter(
+              dec => !t.matchesPattern(dec.expression, "bit.storage")
+            );
+            storageField = element;
+            storageName = element.node.key;
+            break;
+          }
+        }
+
+        let initial = 0;
+        let nextMask = 1;
+
+        for (const element of path.get("body.body")) {
+          let dec;
+          if (
+            element.isClassAccessorProperty() &&
+            (dec = element
+              .get("decorators")
+              ?.find(
+                ({ node: dec }) =>
+                  t.isIdentifier(dec.expression, { name: "bit" }) ||
+                  (t.isCallExpression(dec.expression) &&
+                    t.isIdentifier(dec.expression.callee, { name: "bit" }))
+              ))
+          ) {
+            if (element.node.static || t.isPrivateName(element.node.key)) {
+              throw element.buildCodeFrameError(
+                "@bit cannot be used on static or private fields"
+              );
+            }
+            if (element.node.decorators.length > 1) {
+              throw element.buildCodeFrameError(
+                "@bit cannot be used with other decorators"
+              );
+            }
+            if (!t.isBooleanLiteral(element.node.value)) {
+              throw element.buildCodeFrameError(
+                "@bit fields must be initialized to a boolean literal"
+              );
+            }
+            if (!storageName) {
+              throw path.buildCodeFrameError(
+                "Cannot use @bit withuot also declaring a @bit.storage field"
+              );
+            }
+            if (nextMask === 0) {
+              // overflow
+              throw path.buildCodeFrameError(
+                "A class can contain at most 32 @bit decorators"
+              );
+            }
+
+            let val;
+            if (
+              t.isCallExpression(dec.node.expression) &&
+              dec.node.expression.arguments.length > 0 &&
+              (val = dec.get("expression.arguments.0").evaluate().value) !==
+                nextMask
+            ) {
+              throw dec.buildCodeFrameError(
+                `Bit mask is ${nextMask.toString(2)}, but found ${val?.toString(2)} (or couldn't evaluate)`
+              );
+            }
+
+            if (element.node.value.value) {
+              initial |= nextMask;
+            }
+
+            element.replaceWithMultiple([
+              t.classMethod(
+                "get",
+                element.node.key,
+                [],
+                bodyTemplate.ast`{
+                  return (
+                    this.${t.cloneNode(storageName)} & ${t.numericLiteral(nextMask)}
+                  ) > 0;
+                }`
+              ),
+              t.classMethod(
+                "set",
+                element.node.key,
+                [t.identifier("v")],
+                bodyTemplate.ast`{
+                  if (v) this.${t.cloneNode(storageName)} |= ${t.numericLiteral(nextMask)};
+                  else this.${t.cloneNode(storageName)} &= ${t.valueToNode(~nextMask)};
+                }`
+              ),
+            ]);
+
+            nextMask <<= 1;
+          }
+        }
+
+        if (storageField) {
+          storageField.node.value = t.numericLiteral(initial);
+        }
+      },
+    },
+  };
+}

--- a/scripts/babel-plugin-bit-decorator/plugin.cjs
+++ b/scripts/babel-plugin-bit-decorator/plugin.cjs
@@ -16,7 +16,8 @@ function pluginBabelBitDecorator({ types: t, template }) {
         for (const element of path.get("body.body")) {
           if (
             (element.isClassProperty() || element.isClassPrivateProperty()) &&
-            element.node.decorators?.some(dec =>
+            element.node.decorators &&
+            element.node.decorators.some(dec =>
               t.matchesPattern(dec.expression, "bit.storage")
             )
           ) {
@@ -36,14 +37,16 @@ function pluginBabelBitDecorator({ types: t, template }) {
           let dec;
           if (
             element.isClassAccessorProperty() &&
-            (dec = element
-              .get("decorators")
-              ?.find(
-                ({ node: dec }) =>
-                  t.isIdentifier(dec.expression, { name: "bit" }) ||
-                  (t.isCallExpression(dec.expression) &&
-                    t.isIdentifier(dec.expression.callee, { name: "bit" }))
-              ))
+            (dec =
+              element.node.decorators &&
+              element
+                .get("decorators")
+                .find(
+                  ({ node: dec }) =>
+                    t.isIdentifier(dec.expression, { name: "bit" }) ||
+                    (t.isCallExpression(dec.expression) &&
+                      t.isIdentifier(dec.expression.callee, { name: "bit" }))
+                ))
           ) {
             if (element.node.static || t.isPrivateName(element.node.key)) {
               throw element.buildCodeFrameError(
@@ -80,7 +83,7 @@ function pluginBabelBitDecorator({ types: t, template }) {
                 nextMask
             ) {
               throw dec.buildCodeFrameError(
-                `Bit mask is ${nextMask.toString(2)}, but found ${val?.toString(2)} (or couldn't evaluate)`
+                `Bit mask is ${nextMask.toString(2)}, but found ${val.toString(2)} (or couldn't evaluate)`
               );
             }
 

--- a/scripts/babel-plugin-bit-decorator/types.d.ts
+++ b/scripts/babel-plugin-bit-decorator/types.d.ts
@@ -1,0 +1,37 @@
+type BitDecoratorCall<T> = (
+  target: ClassAccessorDecoratorTarget<T, boolean>,
+  context: ClassAccessorDecoratorContext<T, boolean> & {
+    private: false;
+    static: false;
+  }
+) => ClassAccessorDecoratorTarget<T, boolean>; /*{
+  const bitMask = (context.metadata.nextBitMask ??= 1);
+  context.metadata.nextBitMask <<= 1;
+  return {
+    init() {
+      return 0;
+    },
+    get() {
+      return (context.metadata.bitsStorage.get(this) & bitMask) > 0;
+    },
+    set(v) {
+      context.metadata.bitsStorage.set(
+        this,
+        v
+          ? context.metadata.bitsStorage.get(this) | bitMask
+          : context.metadata.bitsStorage.get(this) & ~bitMask,
+      );
+    },
+  };
+}*/
+
+export type BitDecorator<T> = BitDecoratorCall<T> & {
+  (assertMask: number): BitDecoratorCall<T>;
+
+  storage(
+    value: unknown,
+    context: ClassFieldDecoratorContext<T, number>
+  ): void /*{
+    context.metadata.bitsStorage = context.access;
+  }*/;
+};


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

There is a lot of duplicated code in how we pack parser state bits -- we can replace all of it with a decorator (that we actually transpile away to not regress on performance).