### PR TITLE
Fix decorator bare yield await

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1231,7 +1231,7 @@ function transformClass(
     path.node.decorators = null;
 
     const classDecsUsePrivateName = classDecorators.some(usesPrivateField);
-    const { hasSideEffects, decoratorsThis } =
+    const { hasSideEffects, usesFnContext, decoratorsThis } =
       handleDecorators(classDecorators);
 
     const { haveThis, decs } = generateDecorationList(
@@ -1243,6 +1243,7 @@ function transformClass(
     classDecorations = decs;
 
     if (
+      usesFnContext ||
       (hasSideEffects && willExtractSomeElemDecs) ||
       classDecsUsePrivateName
     ) {

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/decorator-evaluation-new-target/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/decorator-evaluation-new-target/exec.js
@@ -16,6 +16,24 @@
 }
 
 {
+  let receivedNewTarget;
+  function decFactory(target) {
+    receivedNewTarget = target;
+    return x => x;
+  }
+  function B() {
+    @decFactory(new.target)
+    class C {
+       #p;
+    }
+  }
+
+  new B();
+
+  expect(receivedNewTarget).toBe(B);
+}
+
+{
   function noop() {}
   let receivedNewTarget;
   function decFactory(target) {
@@ -51,4 +69,18 @@
   new B();
 
   expect(receivedNewTarget).toBe(B);
+}
+
+{
+  let C;
+  const newC = class {};
+  function B () {
+    C = @(new.target)
+    class {
+       #p;
+    }
+  }
+
+  Reflect.construct(B, [], function () { return newC })
+  expect(C).toBe(newC);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/decorator-evaluation-this/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/decorator-evaluation-this/exec.js
@@ -17,6 +17,25 @@
 }
 
 {
+  let receivedName;
+  function decFactory(name) {
+    receivedName = name;
+    return x => x;
+  }
+  class B {
+    static m() {
+      @decFactory(this.name)
+      class C {
+         #p;
+      }
+    }
+  }
+
+  B.m();
+  expect(receivedName).toBe("B");
+}
+
+{
   let receivedLength;
   function decFactory(length) {
     receivedLength = length;
@@ -58,4 +77,19 @@
 
   B.m();
   expect(receivedLength).toBe(2);
+}
+
+{
+  let C;
+  const newC = class {};
+  const B = () => newC;
+  B.m = function () {
+    C = @(this)
+    class {
+       #p;
+    }
+  }
+
+  B.m();
+  expect(C).toBe(newC);
 }

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/decorator-evaluation-yield/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-misc/decorator-evaluation-yield/exec.js
@@ -100,3 +100,63 @@ const noop = () => {};
   expect([...log].join()).toBe("0,1,2,3,4,5,6,7,8,9,10,11");
   expect(Foo).toHaveProperty("accessor");
 }
+
+{
+  const id = function* (x) {
+    yield x;
+  }
+  const log = {
+    *[Symbol.iterator]() {
+      @(yield 0, noop)
+      @(yield 1, noop)
+      class Foo {
+        method() {}
+        static method() {}
+        field;
+        static field;
+        get getter() {
+          return;
+        }
+        static get getter() {
+          return;
+        }
+        set setter(x) {}
+        static set setter(x) {}
+        accessor accessor;
+        static accessor accessor;
+      }
+    },
+  };
+  expect([...log].join()).toBe("0,1");
+}
+
+{
+  let C;
+  const iter = (function* iterFactory() {
+    C =
+      @(yield)
+      @(yield)
+      class C {
+        method() {}
+        static method() {}
+        field;
+        static field;
+        get getter() {
+          return;
+        }
+        static get getter() {
+          return;
+        }
+        set setter(x) {}
+        static set setter(x) {}
+        accessor accessor;
+        static accessor accessor;
+      };
+  })();
+  const C1 = class {},
+    C2 = class {};
+  iter.next();
+  iter.next(() => C1);
+  iter.next(() => C2);
+  expect(C).toBe(C1);
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16481 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we call the yield await from the decorator node so that it works for the bare yield / await expressions. For class decorators we also plug in the `usesFnContext` to avoid function context variables / yield / await expressions being inlined within the static block.