### PR TITLE
Support undecorated static accessor in anonymous classes

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1141,6 +1141,10 @@ function transformClass(
         setterKey = t.cloneNode(key);
       }
 
+      if (!path.node.id) {
+        path.node.id = path.scope.generateUidIdentifier("Class");
+      }
+
       addProxyAccessorsFor(
         path.node.id,
         newPath,
@@ -1454,6 +1458,9 @@ function transformClass(
 
             locals = [newFieldInitId, getId, setId];
           } else {
+            if (!path.node.id) {
+              path.node.id = path.scope.generateUidIdentifier("Class");
+            }
             addProxyAccessorsFor(
               path.node.id,
               newPath,

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1010,6 +1010,20 @@ function checkPrivateMethodUpdateError(
   });
 }
 
+/**
+ * Apply decorator and accessor transform
+ * @param path The class path.
+ * @param state The plugin pass.
+ * @param constantSuper The constantSuper compiler assumption.
+ * @param ignoreFunctionLength The ignoreFunctionLength compiler assumption.
+ * @param className The class name.
+ * - If className is a `string`, it will be a valid identifier name that can safely serve as a class id
+ * - If className is an Identifier, it is the reference to the name derived from NamedEvaluation
+ * - If className is a StringLiteral, it is derived from NamedEvaluation on literal computed keys
+ * @param propertyVisitor The visitor that should be applied on property prior to the transform.
+ * @param version The decorator version.
+ * @returns The transformed class path or undefined if there are no decorators.
+ */
 function transformClass(
   path: NodePath<t.Class>,
   state: PluginPass,
@@ -1018,7 +1032,7 @@ function transformClass(
   className: string | t.Identifier | t.StringLiteral | undefined,
   propertyVisitor: Visitor<PluginPass>,
   version: DecoratorVersionKind,
-): NodePath {
+): NodePath | undefined {
   const body = path.get("body.body");
 
   const classDecorators = path.node.decorators;

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-private/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-private/input.js
@@ -4,3 +4,9 @@ class Foo {
 
   static accessor #b = 123;
 }
+
+Foo = class {
+  static accessor #a;
+
+  static accessor #b = 123;
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-private/input.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-private/input.mjs
@@ -10,3 +10,9 @@ Foo = class {
 
   static accessor #b = 123;
 }
+
+export default class {
+  static accessor #a;
+
+  static accessor #b = 123;
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-private/output.js
@@ -15,3 +15,19 @@ class Foo {
     Foo.#B = v;
   }
 }
+Foo = class _Class {
+  static #A;
+  static get #a() {
+    return _Class.#A;
+  }
+  static set #a(v) {
+    _Class.#A = v;
+  }
+  static #B = 123;
+  static get #b() {
+    return _Class.#B;
+  }
+  static set #b(v) {
+    _Class.#B = v;
+  }
+};

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-private/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-private/output.js
@@ -15,19 +15,19 @@ class Foo {
     Foo.#B = v;
   }
 }
-Foo = class _Class {
+Foo = class Foo {
   static #A;
   static get #a() {
-    return _Class.#A;
+    return Foo.#A;
   }
   static set #a(v) {
-    _Class.#A = v;
+    Foo.#A = v;
   }
   static #B = 123;
   static get #b() {
-    return _Class.#B;
+    return Foo.#B;
   }
   static set #b(v) {
-    _Class.#B = v;
+    Foo.#B = v;
   }
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-private/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-private/output.mjs
@@ -31,3 +31,19 @@ Foo = class Foo {
     Foo.#B = v;
   }
 };
+export default class _Class {
+  static #A;
+  static get #a() {
+    return _Class.#A;
+  }
+  static set #a(v) {
+    _Class.#A = v;
+  }
+  static #B = 123;
+  static get #b() {
+    return _Class.#B;
+  }
+  static set #b(v) {
+    _Class.#B = v;
+  }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-public/input.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-public/input.js
@@ -6,3 +6,11 @@ class Foo {
 
   static accessor ['c'] = 456;
 }
+
+Foo = class {
+  static accessor a;
+
+  static accessor b = 123;
+
+  static accessor ['c'] = 456;
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-public/input.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-public/input.mjs
@@ -14,3 +14,11 @@ Foo = class {
 
   static accessor ['c'] = 456;
 }
+
+export default class {
+  static accessor a;
+
+  static accessor b = 123;
+
+  static accessor ['c'] = 456;
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-public/output.js
@@ -22,3 +22,26 @@ class Foo {
     Foo.#C = v;
   }
 }
+Foo = class _Class {
+  static #A;
+  static get a() {
+    return _Class.#A;
+  }
+  static set a(v) {
+    _Class.#A = v;
+  }
+  static #B = 123;
+  static get b() {
+    return _Class.#B;
+  }
+  static set b(v) {
+    _Class.#B = v;
+  }
+  static #C = 456;
+  static get ['c']() {
+    return _Class.#C;
+  }
+  static set ['c'](v) {
+    _Class.#C = v;
+  }
+};

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-public/output.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-public/output.js
@@ -22,26 +22,26 @@ class Foo {
     Foo.#C = v;
   }
 }
-Foo = class _Class {
+Foo = class Foo {
   static #A;
   static get a() {
-    return _Class.#A;
+    return Foo.#A;
   }
   static set a(v) {
-    _Class.#A = v;
+    Foo.#A = v;
   }
   static #B = 123;
   static get b() {
-    return _Class.#B;
+    return Foo.#B;
   }
   static set b(v) {
-    _Class.#B = v;
+    Foo.#B = v;
   }
   static #C = 456;
   static get ['c']() {
-    return _Class.#C;
+    return Foo.#C;
   }
   static set ['c'](v) {
-    _Class.#C = v;
+    Foo.#C = v;
   }
 };

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-public/output.mjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors/undecorated-static-public/output.mjs
@@ -45,3 +45,26 @@ Foo = class Foo {
     Foo.#C = v;
   }
 };
+export default class _Class {
+  static #A;
+  static get a() {
+    return _Class.#A;
+  }
+  static set a(v) {
+    _Class.#A = v;
+  }
+  static #B = 123;
+  static get b() {
+    return _Class.#B;
+  }
+  static set b(v) {
+    _Class.#B = v;
+  }
+  static #C = 456;
+  static get ['c']() {
+    return _Class.#C;
+  }
+  static set ['c'](v) {
+    _Class.#C = v;
+  }
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/expressions-named-evaluation/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/expressions-named-evaluation/exec.js
@@ -157,6 +157,34 @@ const noop = () => {}
 
 {
   const logs = [];
+  const dec = () => {
+    return {
+      init(v) {
+        logs.push(v.name);
+        return v;
+      }
+    }
+  };
+  const f = () => { logs.push("computing f"); return 8. }
+
+  class C {
+    @dec static accessor A0 = class { static accessor q; };
+    @dec static accessor "1" = class { accessor q; };
+    @dec static accessor 2 = class extends class {} { static accessor p; };
+    @dec static accessor 3n = class extends class {} { accessor #q; };
+    @dec static accessor ["4"] = class { static accessor p; };
+    @dec static accessor [5] = class { static accessor #p; };
+    @dec static accessor [6n] = class { accessor p; };
+    @dec static accessor [f()] = class { @dec static accessor 7 = class { static accessor p }; };
+    @dec static accessor [{ [Symbol.toPrimitive]: () => (logs.push("computing symbol"), Symbol(9)) }] = class { static accessor p; };
+    @dec static accessor #_10 = class { static accessor #p; };
+  }
+
+  expect(logs).toEqual(["computing f", "computing symbol", "A0", "1", "2", "3", "4", "5", "6", "7", "8", "[9]", "#_10"]);
+}
+
+{
+  const logs = [];
   const dec = decFactory(logs);
   // __proto__ setter should not name anonymous class
   ({

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/expressions-named-evaluation/exec.js
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-classes/expressions-named-evaluation/exec.js
@@ -13,6 +13,8 @@ export const atypical = @dec class {}
 
 expect(logs).toEqual(["default", "atypical"]);
 
+const noop = () => {}
+
 {
   const logs = [];
   const dec = decFactory(logs);
@@ -126,6 +128,27 @@ expect(logs).toEqual(["default", "atypical"]);
     static accessor [6n] = @dec class { p; };
     static accessor [f()] = @dec class { @dec static 7() {} };
     static accessor [{ [Symbol.toPrimitive]: () => (logs.push("computing symbol"), Symbol(9)) }] = @dec class { p; };
+    static accessor #_10 = @dec class {};
+  }
+
+  expect(logs).toEqual(["computing f", "computing symbol", "A0", "1", "2", "3", "4", "5", "6", "7", "8", "[9]", "#_10"]);
+}
+
+{
+  const logs = [];
+  const dec = decFactory(logs);
+  const f = () => { logs.push("computing f"); return 8. }
+
+  class C {
+    static accessor A0 = @dec class {};
+    static accessor "1" = @dec class { static {} };
+    static accessor 2 = @dec class extends class {} {};
+    static accessor 3n = @dec class extends class {} { static {} };
+    static accessor ["4"] = @dec class { static accessor p; };
+    static accessor [5] = @dec class { @noop static accessor #p; };
+    static accessor [6n] = @dec class { accessor p; };
+    static accessor [f()] = @dec class { @dec static 7() {} };
+    static accessor [{ [Symbol.toPrimitive]: () => (logs.push("computing symbol"), Symbol(9)) }] = @dec class { @noop accessor p; };
     static accessor #_10 = @dec class {};
   }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/16473
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Ensures that the class is named when Babel transforms an undecorated static accessor. The named evaluation is still preserved because Babel generates specific `setFunctionName` calls for those will-be-transformed classes.