### PR TITLE
fix: do not add `.value: undefined` to regexp literals

### DIFF
--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -1730,13 +1730,12 @@ export default abstract class ExpressionParser extends LValParser {
     pattern: string;
     flags: N.RegExpLiteral["flags"];
   }) {
-    const node = this.parseLiteral<N.RegExpLiteral>(
-      value.value,
-      "RegExpLiteral",
-    );
+    const node = this.startNode<N.RegExpLiteral>();
+    this.addExtra(node, "raw", this.input.slice(node.start, this.state.end));
     node.pattern = value.pattern;
     node.flags = value.flags;
-    return node;
+    this.next();
+    return this.finishNode(node, "RegExpLiteral");
   }
 
   parseBooleanLiteral(value: boolean) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16419 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I tried representing `undefined` as `null` in `output.json`, but that would cause changes for 5000+ tests.