### PR TITLE
Use `buildUndefinedNode` from types in types

### DIFF
--- a/packages/babel-types/src/converters/gatherSequenceExpressions.ts
+++ b/packages/babel-types/src/converters/gatherSequenceExpressions.ts
@@ -19,9 +19,9 @@ import {
   assignmentExpression,
   conditionalExpression,
 } from "../builders/generated/index.ts";
+import { buildUndefinedNode } from "../builders/productions.ts";
 import cloneNode from "../clone/cloneNode.ts";
 import type * as t from "../index.ts";
-import type { Scope } from "@babel/traverse";
 
 export type DeclarationInfo = {
   kind: t.VariableDeclaration["kind"];
@@ -30,7 +30,6 @@ export type DeclarationInfo = {
 
 export default function gatherSequenceExpressions(
   nodes: ReadonlyArray<t.Node>,
-  scope: Scope,
   declars: Array<DeclarationInfo>,
 ) {
   const exprs: t.Expression[] = [];
@@ -67,16 +66,16 @@ export default function gatherSequenceExpressions(
       ensureLastUndefined = true;
     } else if (isIfStatement(node)) {
       const consequent = node.consequent
-        ? gatherSequenceExpressions([node.consequent], scope, declars)
-        : scope.buildUndefinedNode();
+        ? gatherSequenceExpressions([node.consequent], declars)
+        : buildUndefinedNode();
       const alternate = node.alternate
-        ? gatherSequenceExpressions([node.alternate], scope, declars)
-        : scope.buildUndefinedNode();
+        ? gatherSequenceExpressions([node.alternate], declars)
+        : buildUndefinedNode();
       if (!consequent || !alternate) return; // bailed
 
       exprs.push(conditionalExpression(node.test, consequent, alternate));
     } else if (isBlockStatement(node)) {
-      const body = gatherSequenceExpressions(node.body, scope, declars);
+      const body = gatherSequenceExpressions(node.body, declars);
       if (!body) return; // bailed
 
       exprs.push(body);
@@ -93,7 +92,7 @@ export default function gatherSequenceExpressions(
   }
 
   if (ensureLastUndefined) {
-    exprs.push(scope.buildUndefinedNode());
+    exprs.push(buildUndefinedNode());
   }
 
   if (exprs.length === 1) {

--- a/packages/babel-types/src/converters/toSequenceExpression.ts
+++ b/packages/babel-types/src/converters/toSequenceExpression.ts
@@ -24,7 +24,7 @@ export default function toSequenceExpression(
   if (!nodes?.length) return;
 
   const declars: DeclarationInfo[] = [];
-  const result = gatherSequenceExpressions(nodes, scope, declars);
+  const result = gatherSequenceExpressions(nodes, declars);
   if (!result) return;
 
   for (const declar of declars) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Very minor, but given that now `buildUndefinedNode` is implemented in `@babel/types` we can use the `@babel/types` version inside `@babel/types`.

Note that the modified files will all be removed in Babel 8, and `gatherSequenceExpressions` is not exposed.