### PR TITLE
Only import types from declared dependencies

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -640,7 +640,7 @@ function buildRollupDts(packages) {
     build(
       "packages/babel-parser/typings/babel-parser.source.d.ts",
       "packages/babel-parser/typings/babel-parser.d.ts",
-      "// This file is auto-generated! Do not modify it directly.\n/* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/consistent-type-imports, prettier/prettier */",
+      "// This file is auto-generated! Do not modify it directly.\n/* eslint-disable @typescript-eslint/consistent-type-imports, prettier/prettier */",
       "packages/babel-parser"
     )
   );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -175,6 +175,15 @@ module.exports = [
       "guard-for-in": "error",
       "import/extensions": ["error", "ignorePackages"],
       "import/no-unresolved": "error",
+    },
+  },
+  {
+    files: sourceFiles("js,ts,cjs,mjs"),
+    ignores: [
+      // This is bundled
+      "packages/babel-parser/**/*.{js,ts}",
+    ],
+    rules: {
       "import/no-extraneous-dependencies": [
         "error",
         { includeTypes: true, devDependencies: false },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -180,8 +180,9 @@ module.exports = [
   {
     files: sourceFiles("js,ts,cjs,mjs"),
     ignores: [
-      // This is bundled
+      // These are bundled
       "packages/babel-parser/**/*.{js,ts}",
+      "packages/babel-standalone/**/*.{js,ts}",
     ],
     rules: {
       "import/no-extraneous-dependencies": [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -175,6 +175,10 @@ module.exports = [
       "guard-for-in": "error",
       "import/extensions": ["error", "ignorePackages"],
       "import/no-unresolved": "error",
+      "import/no-extraneous-dependencies": [
+        "error",
+        { includeTypes: true, devDependencies: false },
+      ],
     },
   },
   ...compat.extends("plugin:jest/recommended").map(config => {

--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -197,6 +197,7 @@ const loadMjsDefault = endHiddenCallStack(async function loadMjsDefault(
 
 function getTSPreset(filepath: string) {
   try {
+    // eslint-disable-next-line import/no-extraneous-dependencies
     return require("@babel/preset-typescript");
   } catch (error) {
     if (error.code !== "MODULE_NOT_FOUND") throw error;

--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -119,6 +119,8 @@ function loadCtsDefault(filepath: string) {
           );
         } catch (error) {
           if (!hasTsSupport) {
+            // TODO(Babel 8): Add this as an optional peer dependency
+            // eslint-disable-next-line import/no-extraneous-dependencies
             const packageJson = require("@babel/preset-typescript/package.json");
             if (semver.lt(packageJson.version, "7.21.4")) {
               console.error(

--- a/packages/babel-generator/src/buffer.ts
+++ b/packages/babel-generator/src/buffer.ts
@@ -1,4 +1,7 @@
 import type SourceMap from "./source-map.ts";
+
+// We inline this package
+// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charcodes from "charcodes";
 
 export type Pos = {

--- a/packages/babel-generator/src/generators/classes.ts
+++ b/packages/babel-generator/src/generators/classes.ts
@@ -4,6 +4,9 @@ import {
   isExportNamedDeclaration,
 } from "@babel/types";
 import type * as t from "@babel/types";
+
+// We inline this package
+// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 
 export function ClassDeclaration(

--- a/packages/babel-generator/src/generators/methods.ts
+++ b/packages/babel-generator/src/generators/methods.ts
@@ -1,15 +1,14 @@
 import type Printer from "../printer.ts";
 import type * as t from "@babel/types";
-import { isIdentifier } from "@babel/types";
-import type { NodePath } from "@babel/traverse";
+import { isIdentifier, type ParentMaps } from "@babel/types";
+
+type ParentsOf<T extends t.Node> = ParentMaps[T["type"]];
 
 export function _params(
   this: Printer,
   node: t.Function | t.TSDeclareMethod | t.TSDeclareFunction,
   idNode: t.Expression | t.PrivateName,
-  parentNode: NodePath<
-    t.Function | t.TSDeclareMethod | t.TSDeclareFunction
-  >["parent"],
+  parentNode: ParentsOf<typeof node>,
 ) {
   this.print(node.typeParameters, node);
 
@@ -144,9 +143,7 @@ export function _predicate(
 export function _functionHead(
   this: Printer,
   node: t.FunctionDeclaration | t.FunctionExpression | t.TSDeclareFunction,
-  parent: NodePath<
-    t.FunctionDeclaration | t.FunctionExpression | t.TSDeclareFunction
-  >["parent"],
+  parent: ParentsOf<typeof node>,
 ) {
   if (node.async) {
     this.word("async");
@@ -179,7 +176,7 @@ export function _functionHead(
 export function FunctionExpression(
   this: Printer,
   node: t.FunctionExpression,
-  parent: NodePath<t.FunctionExpression>["parent"],
+  parent: ParentsOf<typeof node>,
 ) {
   this._functionHead(node, parent);
   this.space();
@@ -191,7 +188,7 @@ export { FunctionExpression as FunctionDeclaration };
 export function ArrowFunctionExpression(
   this: Printer,
   node: t.ArrowFunctionExpression,
-  parent: NodePath<t.ArrowFunctionExpression>["parent"],
+  parent: ParentsOf<typeof node>,
 ) {
   if (node.async) {
     this.word("async", true);
@@ -244,9 +241,7 @@ function hasTypesOrComments(
 function _getFuncIdName(
   this: Printer,
   idNode: t.Expression | t.PrivateName,
-  parent: NodePath<
-    t.Function | t.TSDeclareMethod | t.TSDeclareFunction
-  >["parent"],
+  parent: ParentsOf<t.Function | t.TSDeclareMethod | t.TSDeclareFunction>,
 ) {
   let id: t.Expression | t.PrivateName | t.LVal = idNode;
 

--- a/packages/babel-generator/src/generators/statements.ts
+++ b/packages/babel-generator/src/generators/statements.ts
@@ -6,6 +6,9 @@ import {
   isStatement,
 } from "@babel/types";
 import type * as t from "@babel/types";
+
+// We inline this package
+// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 
 export function WithStatement(this: Printer, node: t.WithStatement) {

--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -1,6 +1,5 @@
 import type Printer from "../printer.ts";
 import type * as t from "@babel/types";
-import type { NodePath } from "@babel/traverse";
 
 export function TSTypeAnnotation(this: Printer, node: t.TSTypeAnnotation) {
   this.token(":");
@@ -77,7 +76,7 @@ export function TSParameterProperty(
 export function TSDeclareFunction(
   this: Printer,
   node: t.TSDeclareFunction,
-  parent: NodePath<t.TSDeclareFunction>["parent"],
+  parent: t.ParentMaps["TSDeclareFunction"],
 ) {
   if (node.declare) {
     this.word("declare");

--- a/packages/babel-generator/src/index.ts
+++ b/packages/babel-generator/src/index.ts
@@ -4,10 +4,6 @@ import type * as t from "@babel/types";
 import type { Opts as jsescOptions } from "jsesc";
 import type { Format } from "./printer.ts";
 import type {
-  RecordAndTuplePluginOptions,
-  PipelineOperatorPluginOptions,
-} from "@babel/parser";
-import type {
   EncodedSourceMap,
   DecodedSourceMap,
   Mapping,
@@ -192,13 +188,13 @@ export interface GeneratorOptions {
    * For use with the recordAndTuple token.
    * @deprecated It will be removed in Babel 8.
    */
-  recordAndTupleSyntaxType?: RecordAndTuplePluginOptions["syntaxType"];
+  recordAndTupleSyntaxType?: "bar" | "hash";
 
   /**
    * For use with the Hack-style pipe operator.
    * Changes what token is used for pipe bodies’ topic references.
    */
-  topicToken?: PipelineOperatorPluginOptions["topicToken"];
+  topicToken?: "%" | "#" | "@@" | "^^" | "^";
 
   /**
    * The import attributes syntax style:

--- a/packages/babel-generator/src/node/whitespace.ts
+++ b/packages/babel-generator/src/node/whitespace.ts
@@ -14,6 +14,9 @@ import {
   isOptionalMemberExpression,
   isStringLiteral,
 } from "@babel/types";
+
+// We inline this package
+// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 
 import type { NodeHandlers } from "./index.ts";

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -9,16 +9,16 @@ import {
   isTSInterfaceBody,
   isTSEnumDeclaration,
 } from "@babel/types";
-import type {
-  RecordAndTuplePluginOptions,
-  PipelineOperatorPluginOptions,
-} from "@babel/parser";
 import type { Opts as jsescOptions } from "jsesc";
 
+import type { GeneratorOptions } from "./index.ts";
 import * as generatorFunctions from "./generators/index.ts";
 import type SourceMap from "./source-map.ts";
-import * as charCodes from "charcodes";
 import type { TraceMap } from "@jridgewell/trace-mapping";
+
+// We inline this package
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as charCodes from "charcodes";
 
 const SCIENTIFIC_NOTATION = /e/i;
 const ZERO_DECIMAL_INTEGER = /\.0+$/;
@@ -63,7 +63,7 @@ export type Format = {
   /**
    * @deprecated Removed in Babel 8, syntax type is always 'hash'
    */
-  recordAndTupleSyntaxType?: RecordAndTuplePluginOptions["syntaxType"];
+  recordAndTupleSyntaxType?: GeneratorOptions["recordAndTupleSyntaxType"];
   jsescOption: jsescOptions;
   /**
    * @deprecated Removed in Babel 8, use `jsescOption` instead
@@ -73,7 +73,7 @@ export type Format = {
    * For use with the Hack-style pipe operator.
    * Changes what token is used for pipe bodies’ topic references.
    */
-  topicToken?: PipelineOperatorPluginOptions["topicToken"];
+  topicToken?: GeneratorOptions["topicToken"];
   /**
    * @deprecated Removed in Babel 8
    */

--- a/packages/babel-helper-annotate-as-pure/src/index.ts
+++ b/packages/babel-helper-annotate-as-pure/src/index.ts
@@ -1,5 +1,4 @@
 import { addComment, type Node } from "@babel/types";
-import type { NodePath } from "@babel/traverse";
 
 const PURE_ANNOTATION = "#__PURE__";
 
@@ -7,7 +6,9 @@ const isPureAnnotated = ({ leadingComments }: Node): boolean =>
   !!leadingComments &&
   leadingComments.some(comment => /[@#]__PURE__/.test(comment.value));
 
-export default function annotateAsPure(pathOrNode: Node | NodePath): void {
+export default function annotateAsPure(
+  pathOrNode: Node | { node: Node },
+): void {
   const node =
     // @ts-expect-error Node will not have `node` property
     (pathOrNode["node"] || pathOrNode) as Node;

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -14,10 +14,8 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
+    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
-  },
-  "devDependencies": {
-    "@babel/traverse": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -21,6 +21,9 @@
     "@babel/core": "workspace:^",
     "@babel/traverse": "workspace:^"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "engines": {
     "node": ">=6.9.0"
   },
@@ -33,7 +36,8 @@
         }
       },
       {
-        "exports": null
+        "exports": null,
+        "peerDependencies": null
       }
     ],
     "USE_ESM": [

--- a/packages/babel-helper-builder-react-jsx/src/index.ts
+++ b/packages/babel-helper-builder-react-jsx/src/index.ts
@@ -23,9 +23,7 @@ import {
   thisExpression,
 } from "@babel/types";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
-import type { NodePath, Visitor } from "@babel/traverse";
-import type { PluginPass } from "@babel/core";
-import type * as t from "@babel/types";
+import type { PluginPass, NodePath, Visitor, types as t } from "@babel/core";
 
 type ElementState = {
   tagExpr: t.Expression; // tag node,

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -2,7 +2,6 @@ import type { NodePath, Scope, Visitor } from "@babel/core";
 import { types as t, template } from "@babel/core";
 import ReplaceSupers from "@babel/helper-replace-supers";
 import splitExportDeclaration from "@babel/helper-split-export-declaration";
-import * as charCodes from "charcodes";
 import type { PluginAPI, PluginObject, PluginPass } from "@babel/core";
 import { skipTransparentExprWrappers } from "@babel/helper-skip-transparent-expression-wrappers";
 import {
@@ -11,6 +10,9 @@ import {
 } from "./fields.ts";
 import { memoiseComputedKey } from "./misc.ts";
 
+// We inline this package
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as charCodes from "charcodes";
 interface Options {
   /** @deprecated use `constantSuper` assumption instead. Only supported in 2021-12 version. */
   loose?: boolean;

--- a/packages/babel-helper-create-class-features-plugin/src/typescript.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/typescript.ts
@@ -1,5 +1,4 @@
-import type { NodePath } from "@babel/core";
-import type * as t from "@babel/types";
+import type { NodePath, types as t } from "@babel/core";
 
 export function assertFieldTransformed(
   path: NodePath<t.ClassProperty | t.ClassDeclaration>,

--- a/packages/babel-helper-create-regexp-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-regexp-features-plugin/src/index.ts
@@ -1,6 +1,5 @@
 import rewritePattern from "regexpu-core";
-import type { NodePath } from "@babel/traverse";
-import { types as t, type PluginObject } from "@babel/core";
+import { types as t, type PluginObject, type NodePath } from "@babel/core";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 
 import semver from "semver";

--- a/packages/babel-helper-environment-visitor/package.json
+++ b/packages/babel-helper-environment-visitor/package.json
@@ -21,8 +21,10 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
+  },
+  "devDependencies": {
+    "@babel/traverse": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-environment-visitor/package.json
+++ b/packages/babel-helper-environment-visitor/package.json
@@ -20,7 +20,7 @@
     },
     "./package.json": "./package.json"
   },
-  "devDependencies": {
+  "dependencies": {
     "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
   },

--- a/packages/babel-helper-environment-visitor/src/index.ts
+++ b/packages/babel-helper-environment-visitor/src/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies -- TODO: Avoid cycle
 import type { NodePath, Visitor } from "@babel/traverse";
 import type * as t from "@babel/types";
 

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -15,12 +15,15 @@
   "homepage": "https://babel.dev/docs/en/next/babel-helper-fixtures",
   "main": "./lib/index.js",
   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.5",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.1"
   },
   "devDependencies": {
     "@babel/core": "workspace:^",
-    "@jridgewell/gen-mapping": "^0.3.5",
     "@types/semver": "^7.3.4"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">=6.9.0"
@@ -33,7 +36,8 @@
         }
       },
       {
-        "exports": null
+        "exports": null,
+        "peerDependencies": null
       }
     ],
     "USE_ESM": [

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -15,8 +15,10 @@
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/template": "workspace:^",
-    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
+  },
+  "devDependencies": {
+    "@babel/traverse": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -15,10 +15,8 @@
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/template": "workspace:^",
+    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
-  },
-  "devDependencies": {
-    "@babel/traverse": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-function-name/src/index.ts
+++ b/packages/babel-helper-function-name/src/index.ts
@@ -18,6 +18,7 @@ import {
   toBindingIdentifierName,
 } from "@babel/types";
 import type * as t from "@babel/types";
+// eslint-disable-next-line import/no-extraneous-dependencies -- TODO: Avoid cycle
 import type { NodePath, Scope, Visitor } from "@babel/traverse";
 
 function getFunctionArity(node: t.Function): number {

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -14,11 +14,8 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
+    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
-  },
-  "TODO": "The @babel/traverse dependency is only needed for the NodePath TS type. We can consider exporting it from @babel/core.",
-  "devDependencies": {
-    "@babel/traverse": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -14,8 +14,10 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
+  },
+  "devDependencies": {
+    "@babel/traverse": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-hoist-variables/src/index.ts
+++ b/packages/babel-helper-hoist-variables/src/index.ts
@@ -4,6 +4,7 @@ import {
   identifier,
 } from "@babel/types";
 import type * as t from "@babel/types";
+// eslint-disable-next-line import/no-extraneous-dependencies -- TODO: Avoid cycle
 import type { NodePath, Visitor } from "@babel/traverse";
 
 export type EmitFunction = (

--- a/packages/babel-helper-import-to-platform-api/src/index.ts
+++ b/packages/babel-helper-import-to-platform-api/src/index.ts
@@ -1,5 +1,4 @@
-import { types as t, template } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, template, type NodePath } from "@babel/core";
 import type { Targets } from "@babel/helper-compilation-targets";
 import { addNamed } from "@babel/helper-module-imports";
 

--- a/packages/babel-helper-member-expression-to-functions/package.json
+++ b/packages/babel-helper-member-expression-to-functions/package.json
@@ -15,10 +15,8 @@
   "main": "./lib/index.js",
   "author": "The Babel Team (https://babel.dev/team)",
   "dependencies": {
+    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
-  },
-  "devDependencies": {
-    "@babel/traverse": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -18,6 +18,9 @@
     "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
   },
+  "devDependencies": {
+    "@babel/core": "workspace:^"
+  },
   "engines": {
     "node": ">=6.9.0"
   },

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -15,11 +15,8 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
+    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
-  },
-  "devDependencies": {
-    "@babel/core": "workspace:^",
-    "@babel/traverse": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-module-imports/src/import-builder.ts
+++ b/packages/babel-helper-module-imports/src/import-builder.ts
@@ -14,8 +14,7 @@ import {
   variableDeclarator,
 } from "@babel/types";
 import type * as t from "@babel/types";
-import type { Scope } from "@babel/traverse";
-import type { File } from "@babel/core";
+import type { Scope, HubInterface } from "@babel/traverse";
 
 /**
  * A class to track and accumulate mutations to the AST that will eventually
@@ -26,10 +25,10 @@ export default class ImportBuilder {
   private _resultName: t.Identifier | t.MemberExpression = null;
 
   declare _scope: Scope;
-  declare _hub: File["hub"];
+  declare _hub: HubInterface;
   private _importedSource: string;
 
-  constructor(importedSource: string, scope: Scope, hub: File["hub"]) {
+  constructor(importedSource: string, scope: Scope, hub: HubInterface) {
     this._scope = scope;
     this._hub = hub;
     this._importedSource = importedSource;

--- a/packages/babel-helper-module-imports/src/import-injector.ts
+++ b/packages/babel-helper-module-imports/src/import-injector.ts
@@ -7,8 +7,7 @@ import {
   isImportDeclaration,
 } from "@babel/types";
 import type * as t from "@babel/types";
-import type { NodePath, Scope } from "@babel/traverse";
-import type { File } from "@babel/core";
+import type { NodePath, Scope, HubInterface } from "@babel/traverse";
 
 import ImportBuilder from "./import-builder.ts";
 import isModule from "./is-module.ts";
@@ -121,7 +120,7 @@ export default class ImportInjector {
   /**
    * The file used to inject helpers and resolve paths.
    */
-  declare _hub: File["hub"];
+  declare _hub: HubInterface;
 
   /**
    * The default options to use with this instance when imports are added.
@@ -145,7 +144,7 @@ export default class ImportInjector {
 
     this._programPath = programPath;
     this._programScope = programPath.scope;
-    this._hub = programPath.hub as File["hub"];
+    this._hub = programPath.hub;
 
     this._defaultOpts = this._applyDefaults(importedSource, opts, true);
   }

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -22,8 +22,7 @@
     "@babel/helper-validator-identifier": "workspace:^"
   },
   "devDependencies": {
-    "@babel/core": "workspace:^",
-    "@babel/traverse": "workspace:^"
+    "@babel/core": "workspace:^"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0"

--- a/packages/babel-helper-module-transforms/src/index.ts
+++ b/packages/babel-helper-module-transforms/src/index.ts
@@ -17,7 +17,7 @@ import type {
   SourceModuleMetadata,
 } from "./normalize-and-load-metadata.ts";
 import * as Lazy from "./lazy-modules.ts";
-import type { NodePath } from "@babel/traverse";
+import type { NodePath } from "@babel/core";
 
 const {
   booleanLiteral,

--- a/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-live-references.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { template, types as t } from "@babel/core";
-import type { NodePath, Visitor, Scope } from "@babel/traverse";
+import type { NodePath, Visitor, Scope } from "@babel/core";
 import simplifyAccess from "@babel/helper-simple-access";
 
 import type { ModuleMetadata } from "./normalize-and-load-metadata.ts";

--- a/packages/babel-helper-module-transforms/src/rewrite-this.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-this.ts
@@ -2,7 +2,7 @@ import environmentVisitor from "@babel/helper-environment-visitor";
 import { traverse, types as t } from "@babel/core";
 const { numericLiteral, unaryExpression } = t;
 
-import type { NodePath, Visitor } from "@babel/traverse";
+import type { NodePath, Visitor } from "@babel/core";
 
 /**
  * A visitor to walk the tree, rewriting all `this` references in the top-level scope to be

--- a/packages/babel-helper-plugin-utils/package.json
+++ b/packages/babel-helper-plugin-utils/package.json
@@ -20,6 +20,9 @@
   "devDependencies": {
     "@babel/core": "workspace:^"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "conditions": {
     "BABEL_8_BREAKING": [
       {
@@ -28,7 +31,8 @@
         }
       },
       {
-        "exports": null
+        "exports": null,
+        "peerDependencies": null
       }
     ],
     "USE_ESM": [

--- a/packages/babel-helper-remap-async-to-generator/src/index.ts
+++ b/packages/babel-helper-remap-async-to-generator/src/index.ts
@@ -1,6 +1,6 @@
 /* @noflow */
 
-import type { NodePath } from "@babel/traverse";
+import type { NodePath } from "@babel/core";
 import wrapFunction from "@babel/helper-wrap-function";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 import environmentVisitor from "@babel/helper-environment-visitor";

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -15,11 +15,11 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
+    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
   },
   "devDependencies": {
-    "@babel/core": "workspace:^",
-    "@babel/traverse": "workspace:^"
+    "@babel/core": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-skip-transparent-expression-wrappers/package.json
+++ b/packages/babel-helper-skip-transparent-expression-wrappers/package.json
@@ -20,10 +20,8 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
+    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
-  },
-  "devDependencies": {
-    "@babel/traverse": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-split-export-declaration/package.json
+++ b/packages/babel-helper-split-export-declaration/package.json
@@ -14,10 +14,8 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
+    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
-  },
-  "devDependencies": {
-    "@babel/traverse": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-split-export-declaration/package.json
+++ b/packages/babel-helper-split-export-declaration/package.json
@@ -14,8 +14,10 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
+  },
+  "devDependencies": {
+    "@babel/traverse": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-split-export-declaration/src/index.ts
+++ b/packages/babel-helper-split-export-declaration/src/index.ts
@@ -7,6 +7,7 @@ import {
   variableDeclarator,
 } from "@babel/types";
 import type * as t from "@babel/types";
+// eslint-disable-next-line import/no-extraneous-dependencies -- TODO: Avoid cycle
 import type { NodePath } from "@babel/traverse";
 
 export default function splitExportDeclaration(

--- a/packages/babel-helper-string-parser/src/index.ts
+++ b/packages/babel-helper-string-parser/src/index.ts
@@ -1,3 +1,5 @@
+// We inline this package
+// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 
 // The following character codes are forbidden from being

--- a/packages/babel-helper-validator-identifier/src/identifier.ts
+++ b/packages/babel-helper-validator-identifier/src/identifier.ts
@@ -1,3 +1,5 @@
+// We inline this package
+// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 
 // ## Character categories

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -16,13 +16,11 @@
   "dependencies": {
     "@babel/helper-function-name": "workspace:^",
     "@babel/template": "workspace:^",
+    "@babel/traverse": "workspace:^",
     "@babel/types": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"
-  },
-  "devDependencies": {
-    "@babel/traverse": "workspace:^"
   },
   "author": "The Babel Team (https://babel.dev/team)",
   "conditions": {

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated! Do not modify it directly.
-/* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/consistent-type-imports, prettier/prettier */
+/* eslint-disable @typescript-eslint/consistent-type-imports, prettier/prettier */
 import * as _babel_types from '@babel/types';
 
 type Plugin =

--- a/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/src/index.ts
+++ b/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/src/index.ts
@@ -1,5 +1,4 @@
-import type { NodePath, Visitor } from "@babel/traverse";
-import type { types as t } from "@babel/core";
+import type { types as t, NodePath, Visitor } from "@babel/core";
 import { declare } from "@babel/helper-plugin-utils";
 import environmentVisitor from "@babel/helper-environment-visitor";
 

--- a/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/src/util.ts
+++ b/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/src/util.ts
@@ -1,5 +1,4 @@
-import type { FunctionExpression } from "@babel/types";
-import type { NodePath } from "@babel/traverse";
+import type { NodePath, types as t } from "@babel/core";
 
 /**
  * Check whether a function expression can be affected by
@@ -8,7 +7,7 @@ import type { NodePath } from "@babel/traverse";
  * @returns the name of function id if it should be transformed, otherwise returns false
  */
 export function shouldTransform(
-  path: NodePath<FunctionExpression>,
+  path: NodePath<t.FunctionExpression>,
 ): string | false {
   const { node } = path;
   const functionId = node.id;

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/src/index.ts
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/src/index.ts
@@ -1,8 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { transform } from "@babel/plugin-transform-optional-chaining";
 import { shouldTransform } from "./util.ts";
-import type { NodePath } from "@babel/traverse";
-import type * as t from "@babel/types";
+import type { NodePath, types as t } from "@babel/core";
 
 export default declare(api => {
   api.assertVersion(REQUIRED_VERSION(7));

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/src/util.ts
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/src/util.ts
@@ -1,6 +1,5 @@
 import { skipTransparentExprWrappers } from "@babel/helper-skip-transparent-expression-wrappers";
-import type { NodePath } from "@babel/traverse";
-import { types as t } from "@babel/core";
+import { types as t, type NodePath } from "@babel/core";
 // https://crbug.com/v8/11558
 
 // check if there is a spread element followed by another argument.

--- a/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/src/index.ts
+++ b/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/src/index.ts
@@ -1,5 +1,5 @@
-import type { NodePath, Scope } from "@babel/traverse";
-import { types as t, type PluginPass, type File } from "@babel/core";
+import type { NodePath, Scope, PluginPass, File } from "@babel/core";
+import { types as t } from "@babel/core";
 import { declare } from "@babel/helper-plugin-utils";
 
 import {

--- a/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/src/util.ts
+++ b/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/src/util.ts
@@ -1,5 +1,4 @@
-import type { NodePath, Visitor } from "@babel/traverse";
-import { types as t } from "@babel/core";
+import { types as t, type NodePath, type Visitor } from "@babel/core";
 import { requeueComputedKeyAndDecorators } from "@babel/helper-environment-visitor";
 
 function isNameOrLength(key: t.Node): boolean {

--- a/packages/babel-plugin-proposal-async-do-expressions/src/index.ts
+++ b/packages/babel-plugin-proposal-async-do-expressions/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxAsyncDoExpressions from "@babel/plugin-syntax-async-do-expressions";
 import hoistVariables from "@babel/helper-hoist-variables";
-import type * as t from "@babel/types";
+import type { types as t } from "@babel/core";
 
 export default declare(({ types: t, assertVersion }) => {
   assertVersion(REQUIRED_VERSION("^7.13.0"));

--- a/packages/babel-plugin-proposal-decorators/src/transformer-legacy.ts
+++ b/packages/babel-plugin-proposal-decorators/src/transformer-legacy.ts
@@ -1,7 +1,7 @@
 // Fork of https://github.com/loganfsmyth/babel-plugin-proposal-decorators-legacy
 
-import { template, types as t, type PluginPass } from "@babel/core";
-import type { NodePath, Visitor } from "@babel/traverse";
+import { template, types as t } from "@babel/core";
+import type { NodePath, Visitor, PluginPass } from "@babel/core";
 
 const buildClassDecorator = template.statement(`
   DECORATOR(CLASS_REF = INNER) || CLASS_REF;

--- a/packages/babel-plugin-proposal-destructuring-private/src/index.ts
+++ b/packages/babel-plugin-proposal-destructuring-private/src/index.ts
@@ -9,9 +9,7 @@ import {
 import { convertFunctionParams } from "@babel/plugin-transform-parameters";
 import { unshiftForXStatementBody } from "@babel/plugin-transform-destructuring";
 
-import type { PluginPass } from "@babel/core";
-import type { NodePath, Visitor } from "@babel/traverse";
-import type * as t from "@babel/types";
+import type { PluginPass, NodePath, Visitor, types as t } from "@babel/core";
 
 export default declare(function ({ assertVersion, assumption, types: t }) {
   assertVersion(REQUIRED_VERSION("^7.17.0"));

--- a/packages/babel-plugin-proposal-destructuring-private/src/util.ts
+++ b/packages/babel-plugin-proposal-destructuring-private/src/util.ts
@@ -1,7 +1,5 @@
-import type * as t from "@babel/types";
-import type { Scope } from "@babel/traverse";
-import { types } from "@babel/core";
-import type { File } from "@babel/core";
+import { types as t } from "@babel/core";
+import type { File, Scope } from "@babel/core";
 import { buildObjectExcludingKeys } from "@babel/plugin-transform-destructuring";
 const {
   assignmentExpression,
@@ -17,7 +15,7 @@ const {
   variableDeclarator,
   variableDeclaration,
   unaryExpression,
-} = types;
+} = t;
 
 function buildUndefinedNode() {
   return unaryExpression("void", numericLiteral(0));

--- a/packages/babel-plugin-proposal-explicit-resource-management/src/index.ts
+++ b/packages/babel-plugin-proposal-explicit-resource-management/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxExplicitResourceManagement from "@babel/plugin-syntax-explicit-resource-management";
-import { types as t, template, traverse, type PluginPass } from "@babel/core";
-import type { NodePath, Visitor } from "@babel/traverse";
+import { types as t, template, traverse } from "@babel/core";
+import type { NodePath, Visitor, PluginPass } from "@babel/core";
 
 const enum USING_KIND {
   NORMAL,

--- a/packages/babel-plugin-proposal-function-bind/src/index.ts
+++ b/packages/babel-plugin-proposal-function-bind/src/index.ts
@@ -1,7 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxFunctionBind from "@babel/plugin-syntax-function-bind";
-import { types as t } from "@babel/core";
-import type { Scope } from "@babel/traverse";
+import { types as t, type Scope } from "@babel/core";
 
 export default declare(api => {
   api.assertVersion(REQUIRED_VERSION(7));

--- a/packages/babel-plugin-proposal-function-sent/src/index.ts
+++ b/packages/babel-plugin-proposal-function-sent/src/index.ts
@@ -1,8 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxFunctionSent from "@babel/plugin-syntax-function-sent";
 import wrapFunction from "@babel/helper-wrap-function";
-import { types as t } from "@babel/core";
-import type { Visitor } from "@babel/traverse";
+import { types as t, type Visitor } from "@babel/core";
 
 export default declare(api => {
   api.assertVersion(REQUIRED_VERSION(7));

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/src/index.ts
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/src/index.ts
@@ -1,6 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import type { NodePath } from "@babel/traverse";
-import type * as t from "@babel/types";
+import type { types as t, NodePath } from "@babel/core";
 import syntaxImportAttributes from "@babel/plugin-syntax-import-attributes";
 
 export default declare(api => {

--- a/packages/babel-plugin-proposal-import-defer/src/index.ts
+++ b/packages/babel-plugin-proposal-import-defer/src/index.ts
@@ -1,6 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import type { types as t } from "@babel/core";
-import type { Scope } from "@babel/traverse";
+import type { types as t, Scope } from "@babel/core";
 import { defineCommonJSHook } from "@babel/plugin-transform-modules-commonjs";
 
 import syntaxImportDefer from "@babel/plugin-syntax-import-defer";

--- a/packages/babel-plugin-proposal-optional-chaining-assign/src/index.ts
+++ b/packages/babel-plugin-proposal-optional-chaining-assign/src/index.ts
@@ -1,7 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxOptionalChainingAssign from "@babel/plugin-syntax-optional-chaining-assign";
-import type { NodePath } from "@babel/traverse";
-import type * as t from "@babel/types";
+import type { NodePath, types as t } from "@babel/core";
 import { skipTransparentExprWrappers } from "@babel/helper-skip-transparent-expression-wrappers";
 import { transformOptionalChain } from "@babel/plugin-transform-optional-chaining";
 

--- a/packages/babel-plugin-proposal-partial-application/src/index.ts
+++ b/packages/babel-plugin-proposal-partial-application/src/index.ts
@@ -1,7 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxPartialApplication from "@babel/plugin-syntax-partial-application";
-import { types as t } from "@babel/core";
-import type { Scope } from "@babel/traverse";
+import { types as t, type Scope } from "@babel/core";
 
 export default declare(api => {
   api.assertVersion(REQUIRED_VERSION(7));

--- a/packages/babel-plugin-proposal-pipeline-operator/src/buildOptimizedSequenceExpression.ts
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/buildOptimizedSequenceExpression.ts
@@ -1,5 +1,4 @@
-import { types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, type NodePath } from "@babel/core";
 
 // tries to optimize sequence expressions in the format
 //   (a = b, (c => c + e)(a))

--- a/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.ts
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.ts
@@ -1,5 +1,4 @@
-import { types as t, type PluginObject } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, type PluginObject, type NodePath } from "@babel/core";
 import buildOptimizedSequenceExpression from "./buildOptimizedSequenceExpression.ts";
 
 const fsharpVisitor: PluginObject["visitor"] = {

--- a/packages/babel-plugin-proposal-pipeline-operator/src/hackVisitor.ts
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/hackVisitor.ts
@@ -1,6 +1,5 @@
 import { types as t } from "@babel/core";
-import type { NodePath, Visitor } from "@babel/traverse";
-import type { PluginPass } from "@babel/core";
+import type { PluginPass, NodePath, Visitor } from "@babel/core";
 
 type State = {
   topicReferences: NodePath<t.TopicReference>[];

--- a/packages/babel-plugin-proposal-pipeline-operator/src/minimalVisitor.ts
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/minimalVisitor.ts
@@ -1,5 +1,5 @@
-import { types as t, type PluginPass } from "@babel/core";
-import type { NodePath, Visitor } from "@babel/traverse";
+import { types as t } from "@babel/core";
+import type { PluginPass, NodePath, Visitor } from "@babel/core";
 import buildOptimizedSequenceExpression from "./buildOptimizedSequenceExpression.ts";
 
 const minimalVisitor: Visitor<PluginPass> = {

--- a/packages/babel-plugin-proposal-pipeline-operator/src/smartVisitor.ts
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/smartVisitor.ts
@@ -1,6 +1,5 @@
 import { types as t } from "@babel/core";
-import type { PluginPass } from "@babel/core";
-import type { Visitor } from "@babel/traverse";
+import type { PluginPass, Visitor } from "@babel/core";
 
 const updateTopicReferenceVisitor: Visitor<{ topicId: t.Identifier }> = {
   PipelinePrimaryTopicReference(path) {

--- a/packages/babel-plugin-syntax-flow/src/index.ts
+++ b/packages/babel-plugin-syntax-flow/src/index.ts
@@ -1,7 +1,11 @@
 import { declare } from "@babel/helper-plugin-utils";
-import type { FlowPluginOptions } from "@babel/parser";
 
-export default declare((api, options: FlowPluginOptions) => {
+export interface Options {
+  all?: boolean;
+  enums?: boolean;
+}
+
+export default declare((api, options: Options) => {
   api.assertVersion(REQUIRED_VERSION(7));
 
   // When enabled and plugins includes flow, all files should be parsed as if

--- a/packages/babel-plugin-transform-async-generator-functions/src/for-await.ts
+++ b/packages/babel-plugin-transform-async-generator-functions/src/for-await.ts
@@ -1,5 +1,4 @@
-import { types as t, template } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, template, type NodePath } from "@babel/core";
 
 const buildForAwait = template(`
   async function wrapper() {

--- a/packages/babel-plugin-transform-async-generator-functions/src/index.ts
+++ b/packages/babel-plugin-transform-async-generator-functions/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import remapAsyncToGenerator from "@babel/helper-remap-async-to-generator";
-import type { NodePath, Visitor } from "@babel/traverse";
-import { traverse, types as t, type PluginPass } from "@babel/core";
+import type { NodePath, Visitor, PluginPass } from "@babel/core";
+import { traverse, types as t } from "@babel/core";
 import rewriteForAwait from "./for-await.ts";
 import environmentVisitor from "@babel/helper-environment-visitor";
 

--- a/packages/babel-plugin-transform-block-scoped-functions/src/index.ts
+++ b/packages/babel-plugin-transform-block-scoped-functions/src/index.ts
@@ -1,6 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import { types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, type NodePath } from "@babel/core";
 
 export default declare(api => {
   api.assertVersion(REQUIRED_VERSION(7));

--- a/packages/babel-plugin-transform-block-scoping/src/annex-B_3_3.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/annex-B_3_3.ts
@@ -1,5 +1,5 @@
 import { types as t } from "@babel/core";
-import type { NodePath, Visitor, Scope } from "@babel/traverse";
+import type { NodePath, Visitor, Scope } from "@babel/core";
 
 // Whenever a function declaration in a nested block scope
 // doesn't conflict with a block-scoped binding from an outer

--- a/packages/babel-plugin-transform-block-scoping/src/index.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/index.ts
@@ -1,6 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
-import type { NodePath, Scope, Visitor } from "@babel/traverse";
-import { type PluginPass, types as t, traverse } from "@babel/core";
+import type { NodePath, Scope, Visitor, PluginPass } from "@babel/core";
+import { types as t, traverse } from "@babel/core";
 
 import {
   getLoopBodyBindings,

--- a/packages/babel-plugin-transform-block-scoping/src/loop.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/loop.ts
@@ -1,8 +1,8 @@
 import { template, types as t } from "@babel/core";
-import type { NodePath, Visitor, Binding } from "@babel/traverse";
+import type { NodePath, Visitor, Scope } from "@babel/core";
 
 interface LoopBodyBindingsState {
-  blockScoped: Binding[];
+  blockScoped: Scope.Binding[];
 }
 
 const collectLoopBodyBindingsVisitor: Visitor<LoopBodyBindingsState> = {
@@ -32,7 +32,10 @@ export function getLoopBodyBindings(loopPath: NodePath<t.Loop>) {
   return state.blockScoped;
 }
 
-export function getUsageInBody(binding: Binding, loopPath: NodePath<t.Loop>) {
+export function getUsageInBody(
+  binding: Scope.Binding,
+  loopPath: NodePath<t.Loop>,
+) {
   // UpdateExpressions are counted both as a reference and a mutation,
   // so we need to de-duplicate them.
   const seen = new WeakSet<t.Node>();

--- a/packages/babel-plugin-transform-block-scoping/src/validation.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/validation.ts
@@ -1,5 +1,5 @@
-import { types as t, type PluginPass } from "@babel/core";
-import type { Binding, NodePath } from "@babel/traverse";
+import { types as t } from "@babel/core";
+import type { Scope, NodePath, PluginPass } from "@babel/core";
 
 export function validateUsage(
   path: NodePath<t.VariableDeclaration>,
@@ -25,7 +25,7 @@ export function validateUsage(
 
 function disallowConstantViolations(
   name: string,
-  binding: Binding,
+  binding: Scope.Binding,
   state: PluginPass,
 ) {
   for (const violation of binding.constantViolations) {
@@ -151,7 +151,7 @@ function getTDZReplacement(
   return { status, node: buildTDZAssert(status, id, state) };
 }
 
-function injectTDZChecks(binding: Binding, state: PluginPass) {
+function injectTDZChecks(binding: Scope.Binding, state: PluginPass) {
   const allUsages = new Set(binding.referencePaths);
   binding.constantViolations.forEach(allUsages.add, allUsages);
 

--- a/packages/babel-plugin-transform-class-static-block/src/index.ts
+++ b/packages/babel-plugin-transform-class-static-block/src/index.ts
@@ -1,5 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import type { Scope } from "@babel/traverse";
+import type { Scope } from "@babel/core";
 
 import {
   enableFeature,

--- a/packages/babel-plugin-transform-classes/src/transformClass.ts
+++ b/packages/babel-plugin-transform-classes/src/transformClass.ts
@@ -1,8 +1,8 @@
-import type { NodePath, Scope, Visitor } from "@babel/traverse";
+import type { NodePath, Scope, Visitor, File } from "@babel/core";
 import nameFunction from "@babel/helper-function-name";
 import ReplaceSupers from "@babel/helper-replace-supers";
 import environmentVisitor from "@babel/helper-environment-visitor";
-import { traverse, template, types as t, type File } from "@babel/core";
+import { traverse, template, types as t } from "@babel/core";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 
 import addCallSuperHelper from "./inline-callSuper-helpers.ts";

--- a/packages/babel-plugin-transform-computed-properties/src/index.ts
+++ b/packages/babel-plugin-transform-computed-properties/src/index.ts
@@ -1,8 +1,7 @@
 import { types as t } from "@babel/core";
-import type { PluginPass } from "@babel/core";
+import type { PluginPass, Scope } from "@babel/core";
 import { declare } from "@babel/helper-plugin-utils";
 import template from "@babel/template";
-import type { Scope } from "@babel/traverse";
 
 export interface Options {
   loose?: boolean;

--- a/packages/babel-plugin-transform-destructuring/src/index.ts
+++ b/packages/babel-plugin-transform-destructuring/src/index.ts
@@ -1,5 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import { types as t } from "@babel/core";
+import { types as t, type NodePath } from "@babel/core";
 import {
   DestructuringTransformer,
   convertVariableDeclaration,
@@ -8,7 +8,6 @@ import {
   type DestructuringTransformerNode,
 } from "./util.ts";
 export { buildObjectExcludingKeys, unshiftForXStatementBody } from "./util.ts";
-import type { NodePath } from "@babel/traverse";
 
 /**
  * Test if a VariableDeclaration's declarations contains any Patterns.

--- a/packages/babel-plugin-transform-destructuring/src/util.ts
+++ b/packages/babel-plugin-transform-destructuring/src/util.ts
@@ -1,7 +1,5 @@
 import { types as t } from "@babel/core";
-import type { File } from "@babel/core";
-import type { Scope, NodePath } from "@babel/traverse";
-import type { TraversalAncestors } from "@babel/types";
+import type { File, Scope, NodePath } from "@babel/core";
 
 function isPureVoid(node: t.Node) {
   return (
@@ -61,7 +59,7 @@ interface ArrayUnpackVisitorState {
 // NOTE: This visitor is meant to be used via t.traverse
 const arrayUnpackVisitor = (
   node: t.Node,
-  ancestors: TraversalAncestors,
+  ancestors: t.TraversalAncestors,
   state: ArrayUnpackVisitorState,
 ) => {
   if (!ancestors.length) {

--- a/packages/babel-plugin-transform-flow-comments/src/index.ts
+++ b/packages/babel-plugin-transform-flow-comments/src/index.ts
@@ -1,8 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxFlow from "@babel/plugin-syntax-flow";
-import { types as t } from "@babel/core";
+import { types as t, type NodePath } from "@babel/core";
 import generateCode from "@babel/generator";
-import type { NodePath } from "@babel/traverse";
 
 export default declare(api => {
   api.assertVersion(REQUIRED_VERSION(7));

--- a/packages/babel-plugin-transform-flow-strip-types/src/index.ts
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.ts
@@ -1,7 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxFlow from "@babel/plugin-syntax-flow";
-import { types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, type NodePath } from "@babel/core";
 
 export interface Options {
   requireDirective?: boolean;

--- a/packages/babel-plugin-transform-for-of/src/index.ts
+++ b/packages/babel-plugin-transform-for-of/src/index.ts
@@ -1,6 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import { template, types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { template, types as t, type NodePath } from "@babel/core";
 
 import transformWithoutHelper from "./no-helper-implementation.ts";
 import { skipTransparentExprWrapperNodes } from "@babel/helper-skip-transparent-expression-wrappers";

--- a/packages/babel-plugin-transform-for-of/src/no-helper-implementation.ts
+++ b/packages/babel-plugin-transform-for-of/src/no-helper-implementation.ts
@@ -1,5 +1,5 @@
-import { type PluginPass, template, types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { template, types as t } from "@babel/core";
+import type { PluginPass, NodePath } from "@babel/core";
 
 // This is the legacy implementation, which inlines all the code.
 // It must be kept for compatibility reasons.

--- a/packages/babel-plugin-transform-json-strings/src/index.ts
+++ b/packages/babel-plugin-transform-json-strings/src/index.ts
@@ -1,6 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import type * as t from "@babel/types";
-import type { NodePath } from "@babel/traverse";
+import type { NodePath, types as t } from "@babel/core";
 
 export default declare(api => {
   api.assertVersion(REQUIRED_VERSION(7));

--- a/packages/babel-plugin-transform-modules-amd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-amd/src/index.ts
@@ -11,9 +11,9 @@ import {
   wrapInterop,
   getModuleName,
 } from "@babel/helper-module-transforms";
-import { template, types as t, type PluginPass } from "@babel/core";
+import { template, types as t } from "@babel/core";
 import type { PluginOptions } from "@babel/helper-module-transforms";
-import type { NodePath } from "@babel/traverse";
+import type { NodePath, PluginPass } from "@babel/core";
 
 const buildWrapper = template.statement(`
   define(MODULE_NAME, AMD_ARGUMENTS, function(IMPORT_NAMES) {

--- a/packages/babel-plugin-transform-modules-commonjs/src/dynamic-import.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/dynamic-import.ts
@@ -1,8 +1,8 @@
 // Heavily inspired by
 // https://github.com/airbnb/babel-plugin-dynamic-import-node/blob/master/src/utils.js
 
-import type { NodePath } from "@babel/traverse";
-import { types as t, template, type File } from "@babel/core";
+import type { File, NodePath } from "@babel/core";
+import { types as t, template } from "@babel/core";
 import { buildDynamicImport } from "@babel/helper-module-transforms";
 
 const requireNoInterop = (source: t.Expression) =>

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.ts
@@ -10,9 +10,9 @@ import {
   getModuleName,
 } from "@babel/helper-module-transforms";
 import simplifyAccess from "@babel/helper-simple-access";
-import { template, types as t, type PluginPass } from "@babel/core";
+import { template, types as t } from "@babel/core";
+import type { PluginPass, Visitor, Scope, NodePath } from "@babel/core";
 import type { PluginOptions } from "@babel/helper-module-transforms";
-import type { Visitor, Scope, NodePath } from "@babel/traverse";
 
 import { transformDynamicImport } from "./dynamic-import.ts";
 import { lazyImportsHook } from "./lazy.ts";

--- a/packages/babel-plugin-transform-modules-systemjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.ts
@@ -1,6 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import hoistVariables from "@babel/helper-hoist-variables";
-import { template, types as t, type PluginPass } from "@babel/core";
+import { template, types as t } from "@babel/core";
+import type { PluginPass, NodePath, Scope, Visitor } from "@babel/core";
 import {
   buildDynamicImport,
   getModuleName,
@@ -8,7 +9,6 @@ import {
 } from "@babel/helper-module-transforms";
 import type { PluginOptions } from "@babel/helper-module-transforms";
 import { isIdentifierName } from "@babel/helper-validator-identifier";
-import type { NodePath, Scope, Visitor } from "@babel/traverse";
 
 const buildTemplate = template.statement(`
   SYSTEM_REGISTER(MODULE_NAME, SOURCES, function (EXPORT_IDENTIFIER, CONTEXT_IDENTIFIER) {

--- a/packages/babel-plugin-transform-modules-umd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-umd/src/index.ts
@@ -12,8 +12,7 @@ import {
   getModuleName,
 } from "@babel/helper-module-transforms";
 import type { PluginOptions } from "@babel/helper-module-transforms";
-import { types as t, template } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, template, type NodePath } from "@babel/core";
 
 const buildPrerequisiteAssignment = template(`
   GLOBAL_REFERENCE = GLOBAL_REFERENCE || {}

--- a/packages/babel-plugin-transform-new-target/src/index.ts
+++ b/packages/babel-plugin-transform-new-target/src/index.ts
@@ -1,6 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import { types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, type NodePath } from "@babel/core";
 
 export default declare(api => {
   api.assertVersion(REQUIRED_VERSION(7));

--- a/packages/babel-plugin-transform-numeric-separator/src/index.ts
+++ b/packages/babel-plugin-transform-numeric-separator/src/index.ts
@@ -1,6 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import type { NodePath } from "@babel/traverse";
-import type * as t from "@babel/types";
+import type { NodePath, types as t } from "@babel/core";
 
 /**
  * Given a bigIntLiteral or NumericLiteral, remove numeric

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.ts
@@ -1,7 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
-import type { PluginPass } from "@babel/core";
-import type { NodePath, Scope } from "@babel/traverse";
+import type { PluginPass, NodePath, Scope } from "@babel/core";
 import { convertFunctionParams } from "@babel/plugin-transform-parameters";
 import { isRequired } from "@babel/helper-compilation-targets";
 import shouldStoreRHSInTemporaryVariable from "./shouldStoreRHSInTemporaryVariable.ts";

--- a/packages/babel-plugin-transform-object-super/src/index.ts
+++ b/packages/babel-plugin-transform-object-super/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import ReplaceSupers from "@babel/helper-replace-supers";
-import { types as t, type File } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t } from "@babel/core";
+import type { File, NodePath } from "@babel/core";
 
 function replacePropertySuper(
   path: NodePath<t.ObjectMethod>,

--- a/packages/babel-plugin-transform-optional-chaining/src/index.ts
+++ b/packages/babel-plugin-transform-optional-chaining/src/index.ts
@@ -1,7 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { transform, transformOptionalChain } from "./transform.ts";
-import type { NodePath } from "@babel/traverse";
-import type * as t from "@babel/types";
+import type { NodePath, types as t } from "@babel/core";
 
 export interface Options {
   loose?: boolean;

--- a/packages/babel-plugin-transform-optional-chaining/src/transform.ts
+++ b/packages/babel-plugin-transform-optional-chaining/src/transform.ts
@@ -1,5 +1,4 @@
-import { types as t, template } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, template, type NodePath } from "@babel/core";
 import {
   skipTransparentExprWrapperNodes,
   skipTransparentExprWrappers,

--- a/packages/babel-plugin-transform-optional-chaining/src/util.ts
+++ b/packages/babel-plugin-transform-optional-chaining/src/util.ts
@@ -1,4 +1,4 @@
-import type { NodePath } from "@babel/traverse";
+import type { NodePath } from "@babel/core";
 import { isTransparentExprWrapper } from "@babel/helper-skip-transparent-expression-wrappers";
 /**
  * Test if a NodePath will be cast to boolean when evaluated.

--- a/packages/babel-plugin-transform-parameters/src/rest.ts
+++ b/packages/babel-plugin-transform-parameters/src/rest.ts
@@ -1,5 +1,5 @@
 import { template, types as t } from "@babel/core";
-import type { NodePath, Visitor } from "@babel/traverse";
+import type { NodePath, Visitor } from "@babel/core";
 
 import {
   iifeVisitor,

--- a/packages/babel-plugin-transform-parameters/src/shadow-utils.ts
+++ b/packages/babel-plugin-transform-parameters/src/shadow-utils.ts
@@ -1,5 +1,5 @@
 import { types as t } from "@babel/core";
-import type { NodePath, Scope, Visitor } from "@babel/traverse";
+import type { NodePath, Scope, Visitor } from "@babel/core";
 
 type State = {
   needsOuterBinding: boolean;

--- a/packages/babel-plugin-transform-private-property-in-object/src/index.ts
+++ b/packages/babel-plugin-transform-private-property-in-object/src/index.ts
@@ -6,8 +6,7 @@ import {
   buildCheckInRHS,
 } from "@babel/helper-create-class-features-plugin";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
-import type * as t from "@babel/types";
-import type { NodePath, Scope } from "@babel/traverse";
+import type { NodePath, Scope, types as t } from "@babel/core";
 
 export interface Options {
   loose?: boolean;

--- a/packages/babel-plugin-transform-react-constant-elements/src/index.ts
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.ts
@@ -1,6 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { types as t, template } from "@babel/core";
-import type { Visitor, Scope, NodePath } from "@babel/traverse";
+import type { Visitor, Scope, NodePath } from "@babel/core";
 
 export interface Options {
   allowMutablePropsOnTags?: null | string[];

--- a/packages/babel-plugin-transform-react-jsx-self/src/index.ts
+++ b/packages/babel-plugin-transform-react-jsx-self/src/index.ts
@@ -14,7 +14,7 @@
  */
 import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
-import type { Visitor, NodePath } from "@babel/traverse";
+import type { Visitor, NodePath } from "@babel/core";
 
 const TRACE_ID = "__self";
 

--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
@@ -1,8 +1,7 @@
 import jsx from "@babel/plugin-syntax-jsx";
 import { declare } from "@babel/helper-plugin-utils";
 import { template, types as t } from "@babel/core";
-import type { PluginPass } from "@babel/core";
-import type { NodePath, Scope, Visitor } from "@babel/traverse";
+import type { PluginPass, NodePath, Scope, Visitor } from "@babel/core";
 import { addNamed, addNamespace, isModule } from "@babel/helper-module-imports";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 import type {

--- a/packages/babel-plugin-transform-react-pure-annotations/src/index.ts
+++ b/packages/babel-plugin-transform-react-pure-annotations/src/index.ts
@@ -1,7 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
-import { types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, type NodePath } from "@babel/core";
 
 // Mapping of React top-level methods that are pure.
 // This plugin adds a /*#__PURE__#/ annotation to calls to these methods,

--- a/packages/babel-plugin-transform-reserved-words/src/index.ts
+++ b/packages/babel-plugin-transform-reserved-words/src/index.ts
@@ -1,6 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import { types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, type NodePath } from "@babel/core";
 
 export default declare(api => {
   api.assertVersion(REQUIRED_VERSION(7));

--- a/packages/babel-plugin-transform-spread/src/index.ts
+++ b/packages/babel-plugin-transform-spread/src/index.ts
@@ -1,8 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { skipTransparentExprWrappers } from "@babel/helper-skip-transparent-expression-wrappers";
-import type { File } from "@babel/core";
 import { types as t } from "@babel/core";
-import type { NodePath, Scope } from "@babel/traverse";
+import type { File, NodePath, Scope } from "@babel/core";
 
 type ListElement = t.SpreadElement | t.Expression;
 

--- a/packages/babel-plugin-transform-template-literals/src/index.ts
+++ b/packages/babel-plugin-transform-template-literals/src/index.ts
@@ -1,6 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import { template, types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { template, types as t, type NodePath } from "@babel/core";
 
 export interface Options {
   loose?: boolean;

--- a/packages/babel-plugin-transform-typescript/src/const-enum.ts
+++ b/packages/babel-plugin-transform-typescript/src/const-enum.ts
@@ -1,5 +1,4 @@
-import type * as t from "@babel/types";
-import type { NodePath } from "@babel/traverse";
+import type { NodePath, types as t } from "@babel/core";
 
 import { translateEnumValues } from "./enum.ts";
 

--- a/packages/babel-plugin-transform-typescript/src/enum.ts
+++ b/packages/babel-plugin-transform-typescript/src/enum.ts
@@ -1,5 +1,4 @@
-import { template, types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { template, types as t, type NodePath } from "@babel/core";
 import assert from "assert";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 

--- a/packages/babel-plugin-transform-typescript/src/global-types.ts
+++ b/packages/babel-plugin-transform-typescript/src/global-types.ts
@@ -1,4 +1,4 @@
-import type { NodePath, Scope } from "@babel/traverse";
+import type { NodePath, Scope } from "@babel/core";
 
 export const GLOBAL_TYPES = new WeakMap<Scope, Set<string>>();
 

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -1,8 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 import syntaxTypeScript from "@babel/plugin-syntax-typescript";
-import type { PluginPass, types as t } from "@babel/core";
+import type { PluginPass, types as t, Scope, NodePath } from "@babel/core";
 import { injectInitialization } from "@babel/helper-create-class-features-plugin";
-import type { Binding, NodePath } from "@babel/traverse";
 import type { Options as SyntaxOptions } from "@babel/plugin-syntax-typescript";
 
 import transpileConstEnum from "./const-enum.ts";
@@ -724,7 +723,7 @@ export default declare((api, opts: Options) => {
     pragmaImportName,
     pragmaFragImportName,
   }: {
-    binding: Binding;
+    binding: Scope.Binding;
     programPath: NodePath<t.Program>;
     pragmaImportName: string;
     pragmaFragImportName: string;

--- a/packages/babel-plugin-transform-typescript/src/namespace.ts
+++ b/packages/babel-plugin-transform-typescript/src/namespace.ts
@@ -1,5 +1,4 @@
-import { template, types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { template, types as t, type NodePath } from "@babel/core";
 
 import { registerGlobalType } from "./global-types.ts";
 

--- a/packages/babel-plugin-transform-unicode-escapes/src/index.ts
+++ b/packages/babel-plugin-transform-unicode-escapes/src/index.ts
@@ -1,6 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import { types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import { types as t, type NodePath } from "@babel/core";
 
 export default declare(api => {
   api.assertVersion(REQUIRED_VERSION(7));

--- a/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
+++ b/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
@@ -1,6 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
-import type { types as t } from "@babel/core";
-import type { NodePath } from "@babel/traverse";
+import type { types as t, NodePath } from "@babel/core";
 
 export default declare(function ({ types: t }) {
   return {

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -253,9 +253,13 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, null, 'dependencies') :-
 function enforceBabelHelperBabelDeps({ Yarn }) {
   for (const workspace of Yarn.workspaces()) {
     if (workspace.ident?.startsWith("@babel/helper-")) {
-      workspace.unset("dependencies['@babel/traverse']");
-
-      if (workspace.pkg.peerDependencies.has("@babel/core")) {
+      if (
+        workspace.pkg.peerDependencies.has("@babel/core") &&
+        // In some cases, we remove peerDependencies for Babel 7
+        workspace.manifest.conditions?.BABEL_8_BREAKING?.[1]
+          ?.peerDependencies !== null
+      ) {
+        workspace.unset("dependencies['@babel/traverse']");
         workspace.unset("dependencies['@babel/template']");
         workspace.unset("dependencies['@babel/types']");
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,6 +571,8 @@ __metadata:
     "@babel/helper-annotate-as-pure": "workspace:^"
     "@babel/traverse": "workspace:^"
     "@babel/types": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -726,6 +728,8 @@ __metadata:
     "@jridgewell/gen-mapping": "npm:^0.3.5"
     "@types/semver": "npm:^7.3.4"
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -851,7 +855,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-module-imports@workspace:packages/babel-helper-module-imports"
   dependencies:
-    "@babel/core": "workspace:^"
     "@babel/traverse": "workspace:^"
     "@babel/types": "workspace:^"
   languageName: unknown
@@ -897,7 +900,6 @@ __metadata:
     "@babel/helper-simple-access": "workspace:^"
     "@babel/helper-split-export-declaration": "workspace:^"
     "@babel/helper-validator-identifier": "workspace:^"
-    "@babel/traverse": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0
   languageName: unknown
@@ -949,6 +951,8 @@ __metadata:
   resolution: "@babel/helper-plugin-utils@workspace:packages/babel-helper-plugin-utils"
   dependencies:
     "@babel/core": "workspace:^"
+  peerDependencies:
+    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,6 +855,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/helper-module-imports@workspace:packages/babel-helper-module-imports"
   dependencies:
+    "@babel/core": "workspace:^"
     "@babel/traverse": "workspace:^"
     "@babel/types": "workspace:^"
   languageName: unknown


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR makes sure that all our `import type`s only reference packages that are listed in `dependencies`/`peerDependencies`. This is done mainly in two ways:
1. plugins all peerDepend on `@babel/core`, so they can import `NodePath`/`Visitor`/`Scope`/`types` from there rather than from `@babel/traverse`/`@babel/types`
2. helpers can depend on `@babel/traverse`/`@babel/types`: if a helper expects a `NodePath` as a parameter, you already have to have `@babel/traverse`/`@babel/types` in your dependencies so this is not causing extra deps.

To (2) there are some exceptions:
- `babel-helper-builder-react-jsx` and `babel-helper-plugin-utils` only make sense when using with a full plugin (and not directly with parser+traverse), so I added `@babel/core` as a peer dependency (but only for Babel 8)
- `babel-helper-fixtures` is also only needed when testing plugins, so I added `@babel/core` as a peer dep

This PR doesn't lint `@babel/standalone` and `@babel/parser` since those are bundled, but we should probably add `@babel/types` as a dependency of `@babel/parser`. I don't really like doing it since it's perfectly reasonable to use `@babel/parser` without also using `@babel/types`, but on the other hand if the dependency is only used in `import type` it won't actually affect anything at runtime (it won't be loaded) so adding it is not too bad.

~~There is one remaining lint error fixed by https://github.com/babel/babel/pull/16493.~~