### PR TITLE
fix: cannot read properties of undefined (reading 'line')

### DIFF
--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -1110,7 +1110,7 @@ class Printer {
     const nodeLoc = node.loc;
     const len = comments.length;
     let hasLoc = !!nodeLoc;
-    const nodeStartLine = hasLoc ? nodeLoc.start.line : 0;
+    const nodeStartLine = hasLoc ? (nodeLoc?.start?.line ? nodeLoc.start.line : 0) : 0;
     const nodeEndLine = hasLoc ? nodeLoc.end.line : 0;
     let lastLine = 0;
     let leadingCommentNewline = 0;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Hey there, I'm using @babel/generator and this error appeared for me:

![image](https://github.com/babel/babel/assets/43671640/98ee2224-829e-4d31-8331-08ebefa26d9d)

@babel\generator\lib\printer.js:599
     const nodeStartLine = hasLoc ? nodeLoc.start.line : 0;
TypeError: Cannot read properties of undefined (reading 'line')


So I went straight to this node_module file and added this line of code:
`const nodeStartLine = hasLoc ? (nodeLoc?.start?.line ? nodeLoc.start.line : 0) : 0;`

Giving more context:

I'm using:
node: v20.11.1
npm: v20.2.4

I used the parser with the object { sourceType: 'module' },
to generate the AST and then I performed some functions with traverse, then when running the generator the above error occurs with the file below:
```
/* eslint-disable vars-on-top */
/* eslint-disable no-var */
/* eslint-disable no-param-reassign */
/* eslint-disable no-bitwise */
// eslint-disable-next-line import/prefer-default-export

export function lightenHexColor(col, amt) {
   let usePound = false;

   if (col && col[0] === '#') {
     col = col.slice(1);
     usePound = true;
   }

   const num = parseInt(col, 16);
   let r = (num >> 16) + amt;

   if (r > 255) r = 255;
   else if (r < 0) r = 0;

   let b = ((num >> 8) & 0x00FF) + amt;

   if (b > 255) b = 255;
   else if (b < 0) b = 0;

   let g = (num & 0x0000FF) + amt;

   if (g > 255) g = 255;
   else if (g < 0) g = 0;

   return (usePound ? '#' : '') + (g | (b << 8) | (r << 16)).toString(16);
}

export function getHexColorFromRoot(options) {
   const {
     type,
     isBackground,
     lighten,
   } = options;
   let colorFromRoot = '';

   const definedColor = isBackground
     // eslint-disable-next-line prefer-template
     ? '--background-' + type + '-type'
     // eslint-disable-next-line prefer-template
     : '--' + type + '-type';

   const rootColor = getComputedStyle(document.documentElement)
     .getPropertyValue(definedColor)
     .trim();

   const isStandardColor = /^#[0-9a-f]{3,6}$/i;

   if (rootColor.match(isStandardColor)) {
     const color = lightenHexColor(rootColor, lighten);

     colorFromRoot = color;
   } else {
     var split = rootColor.split(' ');

     split[1] = lightenHexColor(split[1], lighten);
     split[3] = lightenHexColor(split[3], lighten);

     colorFromRoot = split.join(' ');
   }

   return colorFromRoot;
}

export function getSolidColor(type) {
   let newType = type;

   const typesWithMoreColors = [
     {
       type: 'flying',
       changeFor: 'water',
     },
     {
       type: 'ground',
       changeFor: 'electric',
     },
     {
       type: 'dragon',
       changeFor: 'ice',
     },
   ];

   const isMoreThenOneColor = typesWithMoreColors
     .filter((elem) => elem.type === type).shift();

   if (isMoreThenOneColor) {
     newType = isMoreThenOneColor.changeFor;
   }

   return newType;
}

export function getCardBackgroundColor(type) {
   if (type) {
     const color = getHexColorFromRoot({
       type: getSolidColor(type),
       isBackground: true,
       Lighten: 32,
     });

     // eslint-disable-next-line prefer-template
     return 'background: ' + color;
   }
   return 'background: var(--card-white);';
}

```

I thought about this solution, because I noticed that sometimes AST doesn't put either start, or start.line.