### PR TITLE
[Babel 8] Bump commander to 12.1.0

### DIFF
--- a/lib/third-party-libs.d.ts
+++ b/lib/third-party-libs.d.ts
@@ -6,6 +6,12 @@ declare module "js-tokens" {
   export * from "js-tokens-BABEL_8_BREAKING-true";
 }
 
+declare module "commander" {
+  import type { Command } from "commander-BABEL_8_BREAKING-true";
+  const _default: { program: Command };
+  export { _default as default };
+}
+
 declare module "@babel/preset-modules/lib/plugins/transform-async-arrows-in-class/index.js" {
   import type { declare } from "@babel/helper-plugin-utils";
   let plugin: ReturnType<typeof declare>;

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@jridgewell/trace-mapping": "^0.3.25",
-    "commander": "^6.2.0",
+    "commander": "condition:BABEL_8_BREAKING ? ^12.0.0 : ^6.2.0",
     "convert-source-map": "^2.0.0",
     "fs-readdir-recursive": "^1.1.0",
     "glob": "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync|default)",

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@jridgewell/trace-mapping": "^0.3.25",
-    "commander": "condition:BABEL_8_BREAKING ? ^12.0.0 : ^6.2.0",
+    "commander": "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0",
     "convert-source-map": "^2.0.0",
     "fs-readdir-recursive": "^1.1.0",
     "glob": "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync|default)",

--- a/packages/babel-cli/src/babel-external-helpers.ts
+++ b/packages/babel-cli/src/babel-external-helpers.ts
@@ -1,7 +1,7 @@
 import * as commander from "commander";
 import { buildExternalHelpers } from "@babel/core";
 
-const program = commander.default.program as commander.Command;
+const program = commander.default.program;
 
 function collect(value: unknown, previousValue: Array<string>): Array<string> {
   // If the user passed the option with no value, like "babel-external-helpers --whitelist", do nothing.

--- a/packages/babel-cli/src/babel-external-helpers.ts
+++ b/packages/babel-cli/src/babel-external-helpers.ts
@@ -1,6 +1,7 @@
 import * as commander from "commander";
 import { buildExternalHelpers } from "@babel/core";
 
+// @ts-expect-error TS2339: Property 'default' does not exist on type 'typeof import("./node_modules/commander-BABEL_8_BREAKING-true/typings/index")'
 const program = commander.default.program as commander.Command;
 
 function collect(value: unknown, previousValue: Array<string>): Array<string> {

--- a/packages/babel-cli/src/babel-external-helpers.ts
+++ b/packages/babel-cli/src/babel-external-helpers.ts
@@ -1,7 +1,6 @@
 import * as commander from "commander";
 import { buildExternalHelpers } from "@babel/core";
 
-// @ts-expect-error TS2339: Property 'default' does not exist on type 'typeof import("./node_modules/commander-BABEL_8_BREAKING-true/typings/index")'
 const program = commander.default.program as commander.Command;
 
 function collect(value: unknown, previousValue: Array<string>): Array<string> {

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -7,6 +7,7 @@ import { alphasort } from "./util.ts";
 
 import type { InputOptions } from "@babel/core";
 
+// @ts-expect-error TS2339: Property 'default' does not exist on type 'typeof import("./node_modules/commander-BABEL_8_BREAKING-true/typings/index")'
 const program = commander.default.program as commander.Command;
 
 // Standard Babel input configs.

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -7,7 +7,6 @@ import { alphasort } from "./util.ts";
 
 import type { InputOptions } from "@babel/core";
 
-// @ts-expect-error TS2339: Property 'default' does not exist on type 'typeof import("./node_modules/commander-BABEL_8_BREAKING-true/typings/index")'
 const program = commander.default.program as commander.Command;
 
 // Standard Babel input configs.

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -1,13 +1,13 @@
 import fs from "fs";
 
-import * as Commander from "commander";
+import * as commander from "commander";
 import { version, DEFAULT_EXTENSIONS } from "@babel/core";
 import * as glob from "glob";
 import { alphasort } from "./util.ts";
 
 import type { InputOptions } from "@babel/core";
 
-const program = Commander.default.program as Commander.Command;
+const program = commander.default.program as commander.Command;
 
 // Standard Babel input configs.
 program.option(

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -7,7 +7,7 @@ import { alphasort } from "./util.ts";
 
 import type { InputOptions } from "@babel/core";
 
-const program = commander.default.program as commander.Command;
+const program = commander.default.program;
 
 // Standard Babel input configs.
 program.option(

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@babel/register": "workspace:^",
-    "commander": "condition:BABEL_8_BREAKING ? ^12.0.0 : ^6.2.0",
+    "commander": "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0",
     "core-js": "^3.30.2",
     "node-environment-flags": "condition:BABEL_8_BREAKING ? : ^1.0.5",
     "regenerator-runtime": "^0.14.0",

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@babel/register": "workspace:^",
-    "commander": "^6.2.0",
+    "commander": "condition:BABEL_8_BREAKING ? ^12.0.0 : ^6.2.0",
     "core-js": "^3.30.2",
     "node-environment-flags": "condition:BABEL_8_BREAKING ? : ^1.0.5",
     "regenerator-runtime": "^0.14.0",

--- a/packages/babel-node/src/_babel-node.ts
+++ b/packages/babel-node/src/_babel-node.ts
@@ -16,6 +16,7 @@ import type { PluginAPI, PluginObject } from "@babel/core";
 
 const require = createRequire(import.meta.url);
 
+// @ts-expect-error TS2339: Property 'default' does not exist on type 'typeof import("./node_modules/commander-BABEL_8_BREAKING-true/typings/index")'
 const program = commander.default.program as commander.Command;
 
 function collect(value: unknown, previousValue: string[]): Array<string> {

--- a/packages/babel-node/src/_babel-node.ts
+++ b/packages/babel-node/src/_babel-node.ts
@@ -16,7 +16,6 @@ import type { PluginAPI, PluginObject } from "@babel/core";
 
 const require = createRequire(import.meta.url);
 
-// @ts-expect-error TS2339: Property 'default' does not exist on type 'typeof import("./node_modules/commander-BABEL_8_BREAKING-true/typings/index")'
 const program = commander.default.program as commander.Command;
 
 function collect(value: unknown, previousValue: string[]): Array<string> {

--- a/packages/babel-node/src/_babel-node.ts
+++ b/packages/babel-node/src/_babel-node.ts
@@ -16,7 +16,7 @@ import type { PluginAPI, PluginObject } from "@babel/core";
 
 const require = createRequire(import.meta.url);
 
-const program = commander.default.program as commander.Command;
+const program = commander.default.program;
 
 function collect(value: unknown, previousValue: string[]): Array<string> {
   // If the user passed the option with no value, like "babel-node file.js --presets", do nothing.

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -265,6 +265,7 @@ fs.writeFileSync(
               "babel-plugin-dynamic-import-node/utils",
               ["./lib/babel-plugin-dynamic-import-node.d.ts"],
             ],
+            ["commander", ["./node_modules/commander-BABEL_8_BREAKING-true"]],
             ["glob", ["./node_modules/glob-BABEL_8_BREAKING-true"]],
             ["globals", ["./node_modules/globals-BABEL_8_BREAKING-true"]],
             ["js-tokens", ["./node_modules/js-tokens-BABEL_8_BREAKING-true"]],

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -265,10 +265,8 @@ fs.writeFileSync(
               "babel-plugin-dynamic-import-node/utils",
               ["./lib/babel-plugin-dynamic-import-node.d.ts"],
             ],
-            ["commander", ["./node_modules/commander-BABEL_8_BREAKING-true"]],
             ["glob", ["./node_modules/glob-BABEL_8_BREAKING-true"]],
             ["globals", ["./node_modules/globals-BABEL_8_BREAKING-true"]],
-            ["js-tokens", ["./node_modules/js-tokens-BABEL_8_BREAKING-true"]],
             ["regexpu-core", ["./lib/regexpu-core.d.ts"]],
             [
               "to-fast-properties",

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -265,8 +265,10 @@ fs.writeFileSync(
               "babel-plugin-dynamic-import-node/utils",
               ["./lib/babel-plugin-dynamic-import-node.d.ts"],
             ],
+            ["commander", ["./lib/third-party-libs.d.ts"]],
             ["glob", ["./node_modules/glob-BABEL_8_BREAKING-true"]],
             ["globals", ["./node_modules/globals-BABEL_8_BREAKING-true"]],
+            ["js-tokens", ["./node_modules/js-tokens-BABEL_8_BREAKING-true"]],
             ["regexpu-core", ["./lib/regexpu-core.d.ts"]],
             [
               "to-fast-properties",

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -602,6 +602,9 @@
       "babel-plugin-dynamic-import-node/utils": [
         "./lib/babel-plugin-dynamic-import-node.d.ts"
       ],
+      "commander": [
+        "./node_modules/commander-BABEL_8_BREAKING-true"
+      ],
       "glob": [
         "./node_modules/glob-BABEL_8_BREAKING-true"
       ],

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -602,11 +602,17 @@
       "babel-plugin-dynamic-import-node/utils": [
         "./lib/babel-plugin-dynamic-import-node.d.ts"
       ],
+      "commander": [
+        "./lib/third-party-libs.d.ts"
+      ],
       "glob": [
         "./node_modules/glob-BABEL_8_BREAKING-true"
       ],
       "globals": [
         "./node_modules/globals-BABEL_8_BREAKING-true"
+      ],
+      "js-tokens": [
+        "./node_modules/js-tokens-BABEL_8_BREAKING-true"
       ],
       "regexpu-core": [
         "./lib/regexpu-core.d.ts"

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -602,17 +602,11 @@
       "babel-plugin-dynamic-import-node/utils": [
         "./lib/babel-plugin-dynamic-import-node.d.ts"
       ],
-      "commander": [
-        "./node_modules/commander-BABEL_8_BREAKING-true"
-      ],
       "glob": [
         "./node_modules/glob-BABEL_8_BREAKING-true"
       ],
       "globals": [
         "./node_modules/globals-BABEL_8_BREAKING-true"
-      ],
-      "js-tokens": [
-        "./node_modules/js-tokens-BABEL_8_BREAKING-true"
       ],
       "regexpu-core": [
         "./lib/regexpu-core.d.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,7 +230,7 @@ __metadata:
     "@types/fs-readdir-recursive": "npm:^1.1.0"
     "@types/glob": "npm:^7.2.0"
     chokidar: "npm:^3.4.0"
-    commander: "npm:^6.2.0"
+    commander: "condition:BABEL_8_BREAKING ? ^12.0.0 : ^6.2.0"
     convert-source-map: "npm:^2.0.0"
     fs-readdir-recursive: "npm:^1.1.0"
     glob: "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync|default)"
@@ -1256,7 +1256,7 @@ __metadata:
     "@babel/register": "workspace:^"
     "@babel/runtime": "workspace:^"
     "@types/v8flags": "npm:^3.1.1"
-    commander: "npm:^6.2.0"
+    commander: "condition:BABEL_8_BREAKING ? ^12.0.0 : ^6.2.0"
     core-js: "npm:^3.30.2"
     node-environment-flags: "condition:BABEL_8_BREAKING ? : ^1.0.5"
     regenerator-runtime: "npm:^0.14.0"
@@ -8116,6 +8116,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander-BABEL_8_BREAKING-false@npm:commander@^6.2.0":
+  version: 6.2.1
+  resolution: "commander@npm:6.2.1"
+  checksum: 10/25b88c2efd0380c84f7844b39cf18510da7bfc5013692d68cdc65f764a1c34e6c8a36ea6d72b6620e3710a930cf8fab2695bdec2bf7107a0f4fa30a3ef3b7d0e
+  languageName: node
+  linkType: hard
+
+"commander-BABEL_8_BREAKING-true@npm:commander@^12.0.0":
+  version: 12.0.0
+  resolution: "commander@npm:12.0.0"
+  checksum: 10/62062e2ffe6abd5aa42a551e62fd5eb9b2620f6ac4299382b2aa9fb02f95cda0242d7e84acb890479bd6491edb805f7f91aecb5b4f5c70dc57df49ed7f02ef14
+  languageName: node
+  linkType: hard
+
+"commander@condition:BABEL_8_BREAKING ? ^12.0.0 : ^6.2.0":
+  version: 0.0.0-condition-3490ed
+  resolution: "commander@condition:BABEL_8_BREAKING?^12.0.0:^6.2.0#3490ed"
+  dependencies:
+    commander-BABEL_8_BREAKING-false: "npm:commander@^6.2.0"
+    commander-BABEL_8_BREAKING-true: "npm:commander@^12.0.0"
+  checksum: 10/0f72a1ef05986d7ce60ddc8a7abc5e167858e8c77dc73e3f26e34127bad695f9051f2f2dc45afd01a88275991da05e21999d810474e77f550f96f14411477fba
+  languageName: node
+  linkType: hard
+
 "commander@npm:11.1.0":
   version: 11.1.0
   resolution: "commander@npm:11.1.0"
@@ -8134,13 +8158,6 @@ __metadata:
   version: 4.0.1
   resolution: "commander@npm:4.0.1"
   checksum: 10/90cf3f01bce830a927cf9759099683a274ce64015ea3d5f1f2215463dbe04e3ef2ffbbe25c5c733f12bf076b1eef592704ac02e31d4da183aa715ef75f662056
-  languageName: node
-  linkType: hard
-
-"commander@npm:^6.2.0":
-  version: 6.2.1
-  resolution: "commander@npm:6.2.1"
-  checksum: 10/25b88c2efd0380c84f7844b39cf18510da7bfc5013692d68cdc65f764a1c34e6c8a36ea6d72b6620e3710a930cf8fab2695bdec2bf7107a0f4fa30a3ef3b7d0e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,7 +230,7 @@ __metadata:
     "@types/fs-readdir-recursive": "npm:^1.1.0"
     "@types/glob": "npm:^7.2.0"
     chokidar: "npm:^3.4.0"
-    commander: "condition:BABEL_8_BREAKING ? ^12.0.0 : ^6.2.0"
+    commander: "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0"
     convert-source-map: "npm:^2.0.0"
     fs-readdir-recursive: "npm:^1.1.0"
     glob: "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync|default)"
@@ -1256,7 +1256,7 @@ __metadata:
     "@babel/register": "workspace:^"
     "@babel/runtime": "workspace:^"
     "@types/v8flags": "npm:^3.1.1"
-    commander: "condition:BABEL_8_BREAKING ? ^12.0.0 : ^6.2.0"
+    commander: "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0"
     core-js: "npm:^3.30.2"
     node-environment-flags: "condition:BABEL_8_BREAKING ? : ^1.0.5"
     regenerator-runtime: "npm:^0.14.0"
@@ -8123,20 +8123,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander-BABEL_8_BREAKING-true@npm:commander@^12.0.0":
-  version: 12.0.0
-  resolution: "commander@npm:12.0.0"
-  checksum: 10/62062e2ffe6abd5aa42a551e62fd5eb9b2620f6ac4299382b2aa9fb02f95cda0242d7e84acb890479bd6491edb805f7f91aecb5b4f5c70dc57df49ed7f02ef14
+"commander-BABEL_8_BREAKING-true@npm:commander@^12.1.0":
+  version: 12.1.0
+  resolution: "commander@npm:12.1.0"
+  checksum: 10/cdaeb672d979816853a4eed7f1310a9319e8b976172485c2a6b437ed0db0a389a44cfb222bfbde772781efa9f215bdd1b936f80d6b249485b465c6cb906e1f93
   languageName: node
   linkType: hard
 
-"commander@condition:BABEL_8_BREAKING ? ^12.0.0 : ^6.2.0":
-  version: 0.0.0-condition-3490ed
-  resolution: "commander@condition:BABEL_8_BREAKING?^12.0.0:^6.2.0#3490ed"
+"commander@condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0":
+  version: 0.0.0-condition-5eb315
+  resolution: "commander@condition:BABEL_8_BREAKING?^12.1.0:^6.2.0#5eb315"
   dependencies:
     commander-BABEL_8_BREAKING-false: "npm:commander@^6.2.0"
-    commander-BABEL_8_BREAKING-true: "npm:commander@^12.0.0"
-  checksum: 10/0f72a1ef05986d7ce60ddc8a7abc5e167858e8c77dc73e3f26e34127bad695f9051f2f2dc45afd01a88275991da05e21999d810474e77f550f96f14411477fba
+    commander-BABEL_8_BREAKING-true: "npm:commander@^12.1.0"
+  checksum: 10/722f3bcc78ac4f7d1ef5c38e0ce058c5959d52ae42e2ac811bd9dd9bc6ad61a12d8d13c702c03dd2de1d2521e56b5f8c98f2ee47d76c3e1547cfbb73d482b3f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Bumped commander to 12.0.0 for babel-node and babel-cli
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Commander 12.1.0 supports Node.js 18 and above, so it is safe to bump it for Babel 8.