### PR TITLE
[Babel 8] Remove `extra.shorthand`

### DIFF
--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -2093,9 +2093,11 @@ export default abstract class ExpressionParser extends LValParser {
         this.raise(Errors.InvalidRecordProperty, prop);
       }
 
-      // @ts-expect-error shorthand may not index prop
-      if (prop.shorthand) {
-        this.addExtra(prop, "shorthand", true);
+      if (!process.env.BABEL_8_BREAKING) {
+        // @ts-expect-error shorthand may not index prop
+        if (prop.shorthand) {
+          this.addExtra(prop, "shorthand", true);
+        }
       }
 
       // @ts-expect-error Fixme: refine typings

--- a/packages/babel-parser/test/fixtures/annex-b/disabled/3.4-var-redeclaration-catch-binding/output.json
+++ b/packages/babel-parser/test/fixtures/annex-b/disabled/3.4-var-redeclaration-catch-binding/output.json
@@ -86,9 +86,6 @@
                   "type": "Identifier",
                   "start":44,"end":45,"loc":{"start":{"line":2,"column":16,"index":44},"end":{"line":2,"column":17,"index":45},"identifierName":"f"},
                   "name": "f"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/annex-b/enabled/3.4-var-redeclaration-catch-binding/output.json
+++ b/packages/babel-parser/test/fixtures/annex-b/enabled/3.4-var-redeclaration-catch-binding/output.json
@@ -85,9 +85,6 @@
                   "type": "Identifier",
                   "start":44,"end":45,"loc":{"start":{"line":2,"column":16,"index":44},"end":{"line":2,"column":17,"index":45},"identifierName":"f"},
                   "name": "f"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/comments/basic/call-expression-trailing-comma-object-shorthand/output.json
+++ b/packages/babel-parser/test/fixtures/comments/basic/call-expression-trailing-comma-object-shorthand/output.json
@@ -46,9 +46,6 @@
                     "type": "Identifier",
                     "start":8,"end":9,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":9,"index":9},"identifierName":"b"},
                     "name": "b"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/comments/basic/object-expression-trailing-comma/output.json
+++ b/packages/babel-parser/test/fixtures/comments/basic/object-expression-trailing-comma/output.json
@@ -34,9 +34,6 @@
                     "start":22,"end":23,"loc":{"start":{"line":3,"column":2,"index":22},"end":{"line":3,"column":3,"index":23},"identifierName":"x"},
                     "name": "x"
                   },
-                  "extra": {
-                    "shorthand": true
-                  },
                   "trailingComments": [
                     {
                       "type": "CommentBlock",

--- a/packages/babel-parser/test/fixtures/comments/interpreter-directive/interpreter-directive-object/output.json
+++ b/packages/babel-parser/test/fixtures/comments/interpreter-directive/interpreter-directive-object/output.json
@@ -37,9 +37,6 @@
                     "type": "Identifier",
                     "start":33,"end":38,"loc":{"start":{"line":3,"column":6,"index":33},"end":{"line":3,"column":11,"index":38},"identifierName":"spawn"},
                     "name": "spawn"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/core/create-parenthesized-expressions/invalid-parenthesized-assignment-pattern/output.json
+++ b/packages/babel-parser/test/fixtures/core/create-parenthesized-expressions/invalid-parenthesized-assignment-pattern/output.json
@@ -39,9 +39,6 @@
                     "type": "Identifier",
                     "start":2,"end":3,"loc":{"start":{"line":1,"column":2,"index":2},"end":{"line":1,"column":3,"index":3},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/core/escape-keyword/invalid/output.json
+++ b/packages/babel-parser/test/fixtures/core/escape-keyword/invalid/output.json
@@ -41,9 +41,6 @@
                     "type": "Identifier",
                     "start":12,"end":22,"loc":{"start":{"line":2,"column":2,"index":12},"end":{"line":2,"column":12,"index":22},"identifierName":"break"},
                     "name": "break"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/core/object/member-expression-after-property-initializer-1/output.json
+++ b/packages/babel-parser/test/fixtures/core/object/member-expression-after-property-initializer-1/output.json
@@ -46,9 +46,6 @@
                     },
                     "value": 42
                   }
-                },
-                "extra": {
-                  "shorthand": true
                 }
               },
               {

--- a/packages/babel-parser/test/fixtures/core/object/member-expression-after-property-initializer-2/output.json
+++ b/packages/babel-parser/test/fixtures/core/object/member-expression-after-property-initializer-2/output.json
@@ -46,9 +46,6 @@
                     },
                     "value": 42
                   }
-                },
-                "extra": {
-                  "shorthand": true
                 }
               },
               {

--- a/packages/babel-parser/test/fixtures/core/object/valid-property-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/core/object/valid-property-initializer/output.json
@@ -55,9 +55,6 @@
                         },
                         "value": 123
                       }
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   },
                   {

--- a/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-var-obj-destr/output.json
+++ b/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-var-obj-destr/output.json
@@ -41,9 +41,6 @@
                   "type": "Identifier",
                   "start":17,"end":20,"loc":{"start":{"line":2,"column":11,"index":17},"end":{"line":2,"column":14,"index":20},"identifierName":"foo"},
                   "name": "foo"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/core/uncategorised/544/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/544/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":22,"end":28,"loc":{"start":{"line":2,"column":8,"index":22},"end":{"line":2,"column":14,"index":28},"identifierName":"public"},
                     "name": "public"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/core/uncategorised/545/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/545/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":8,"end":14,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":14,"index":14},"identifierName":"public"},
                     "name": "public"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/core/uncategorised/546/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/546/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":8,"end":14,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":14,"index":14},"identifierName":"public"},
                     "name": "public"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/core/uncategorised/549/output.json
+++ b/packages/babel-parser/test/fixtures/core/uncategorised/549/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":8,"end":17,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":17,"index":17},"identifierName":"arguments"},
                     "name": "arguments"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/array-rest-spread/with-object/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/array-rest-spread/with-object/output.json
@@ -40,9 +40,6 @@
                           "type": "Identifier",
                           "start":9,"end":15,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":15,"index":15},"identifierName":"length"},
                           "name": "length"
-                        },
-                        "extra": {
-                          "shorthand": true
                         }
                       }
                     ]

--- a/packages/babel-parser/test/fixtures/es2015/arrow-functions/object-rest-spread/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/arrow-functions/object-rest-spread/output.json
@@ -45,9 +45,6 @@
                         "type": "Identifier",
                         "start":14,"end":19,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":19,"index":19},"identifierName":"title"},
                         "name": "title"
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     },
                     {

--- a/packages/babel-parser/test/fixtures/es2015/destructuring/binding-arguments-module/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/destructuring/binding-arguments-module/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":8,"end":17,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":17,"index":17},"identifierName":"arguments"},
                     "name": "arguments"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/destructuring/binding-arguments-strict/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/destructuring/binding-arguments-strict/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":22,"end":31,"loc":{"start":{"line":2,"column":8,"index":22},"end":{"line":2,"column":17,"index":31},"identifierName":"arguments"},
                     "name": "arguments"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/destructuring/binding-eval/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/destructuring/binding-eval/output.json
@@ -45,9 +45,6 @@
                     "start":23,"end":31,"loc":{"start":{"line":1,"column":23,"index":23},"end":{"line":1,"column":31,"index":31},"identifierName":"defValue"},
                     "name": "defValue"
                   }
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/destructuring/binding-this/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/destructuring/binding-this/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":6,"end":10,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":10,"index":10},"identifierName":"this"},
                     "name": "this"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/destructuring/parenthesized-lhs-object/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/destructuring/parenthesized-lhs-object/output.json
@@ -36,9 +36,6 @@
                   "type": "Identifier",
                   "start":2,"end":3,"loc":{"start":{"line":1,"column":2,"index":2},"end":{"line":1,"column":3,"index":3},"identifierName":"a"},
                   "name": "a"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ],

--- a/packages/babel-parser/test/fixtures/es2015/for-in/var-objectbindingpattern-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/for-in/var-objectbindingpattern-initializer/output.json
@@ -39,9 +39,6 @@
                       "type": "Identifier",
                       "start":10,"end":11,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":11,"index":11},"identifierName":"a"},
                       "name": "a"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/for-of/brackets-const/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/for-of/brackets-const/output.json
@@ -37,9 +37,6 @@
                       "type": "Identifier",
                       "start":12,"end":13,"loc":{"start":{"line":1,"column":12,"index":12},"end":{"line":1,"column":13,"index":13},"identifierName":"a"},
                       "name": "a"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/for-of/brackets-let/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/for-of/brackets-let/output.json
@@ -37,9 +37,6 @@
                       "type": "Identifier",
                       "start":10,"end":11,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":11,"index":11},"identifierName":"a"},
                       "name": "a"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/for-of/brackets-var/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/for-of/brackets-var/output.json
@@ -37,9 +37,6 @@
                       "type": "Identifier",
                       "start":10,"end":11,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":11,"index":11},"identifierName":"a"},
                       "name": "a"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-1/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-1/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":6,"end":9,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":9,"index":9},"identifierName":"let"},
                     "name": "let"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-2/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-2/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":8,"end":11,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":11,"index":11},"identifierName":"let"},
                     "name": "let"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-7/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-7/output.json
@@ -49,9 +49,6 @@
                       },
                       "value": 10
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-8/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-at-binding-list-fail-8/output.json
@@ -49,9 +49,6 @@
                       },
                       "value": 10
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/let/let-with-linebreak-obj-dstrk/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/let/let-with-linebreak-obj-dstrk/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":10,"end":11,"loc":{"start":{"line":2,"column":6,"index":10},"end":{"line":2,"column":7,"index":11},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring-assignment/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring-assignment/output.json
@@ -76,9 +76,6 @@
                         },
                         "value": 1
                       }
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring/output.json
@@ -38,9 +38,6 @@
                       "type": "Identifier",
                       "start":15,"end":18,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":18,"index":18},"identifierName":"foo"},
                       "name": "foo"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]
@@ -146,9 +143,6 @@
                             "type": "Identifier",
                             "start":84,"end":87,"loc":{"start":{"line":3,"column":22,"index":84},"end":{"line":3,"column":25,"index":87},"identifierName":"baz"},
                             "name": "baz"
-                          },
-                          "extra": {
-                            "shorthand": true
                           }
                         }
                       ]
@@ -227,9 +221,6 @@
                                   "type": "Identifier",
                                   "start":129,"end":132,"loc":{"start":{"line":4,"column":30,"index":129},"end":{"line":4,"column":33,"index":132},"identifierName":"qux"},
                                   "name": "qux"
-                                },
-                                "extra": {
-                                  "shorthand": true
                                 }
                               }
                             ]
@@ -311,9 +302,6 @@
                                   "type": "Identifier",
                                   "start":176,"end":180,"loc":{"start":{"line":5,"column":30,"index":176},"end":{"line":5,"column":34,"index":180},"identifierName":"qux2"},
                                   "name": "qux2"
-                                },
-                                "extra": {
-                                  "shorthand": true
                                 }
                               }
                             ]
@@ -337,9 +325,6 @@
                       "type": "Identifier",
                       "start":186,"end":190,"loc":{"start":{"line":5,"column":40,"index":186},"end":{"line":5,"column":44,"index":190},"identifierName":"foo3"},
                       "name": "foo3"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]
@@ -573,9 +558,6 @@
                                   "type": "Identifier",
                                   "start":341,"end":345,"loc":{"start":{"line":9,"column":29,"index":341},"end":{"line":9,"column":33,"index":345},"identifierName":"qux3"},
                                   "name": "qux3"
-                                },
-                                "extra": {
-                                  "shorthand": true
                                 }
                               }
                             ]
@@ -698,9 +680,6 @@
                                   "type": "Identifier",
                                   "start":411,"end":415,"loc":{"start":{"line":10,"column":29,"index":411},"end":{"line":10,"column":33,"index":415},"identifierName":"qux5"},
                                   "name": "qux5"
-                                },
-                                "extra": {
-                                  "shorthand": true
                                 }
                               }
                             ]
@@ -758,9 +737,6 @@
                                       "type": "Identifier",
                                       "start":437,"end":441,"loc":{"start":{"line":10,"column":55,"index":437},"end":{"line":10,"column":59,"index":441},"identifierName":"qux6"},
                                       "name": "qux6"
-                                    },
-                                    "extra": {
-                                      "shorthand": true
                                     }
                                   }
                                 ]
@@ -814,9 +790,6 @@
                       "type": "Identifier",
                       "start":469,"end":472,"loc":{"start":{"line":11,"column":15,"index":469},"end":{"line":11,"column":18,"index":472},"identifierName":"Foo"},
                       "name": "Foo"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring10/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring10/output.json
@@ -89,9 +89,6 @@
                                 "type": "Identifier",
                                 "start":46,"end":49,"loc":{"start":{"line":2,"column":20,"index":46},"end":{"line":2,"column":23,"index":49},"identifierName":"foo"},
                                 "name": "foo"
-                              },
-                              "extra": {
-                                "shorthand": true
                               }
                             }
                           ]

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring11/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring11/output.json
@@ -93,9 +93,6 @@
                                     "type": "Identifier",
                                     "start":49,"end":52,"loc":{"start":{"line":2,"column":22,"index":49},"end":{"line":2,"column":25,"index":52},"identifierName":"foo"},
                                     "name": "foo"
-                                  },
-                                  "extra": {
-                                    "shorthand": true
                                   }
                                 }
                               ]

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring12/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring12/output.json
@@ -89,9 +89,6 @@
                                 "type": "Identifier",
                                 "start":48,"end":51,"loc":{"start":{"line":2,"column":21,"index":48},"end":{"line":2,"column":24,"index":51},"identifierName":"foo"},
                                 "name": "foo"
-                              },
-                              "extra": {
-                                "shorthand": true
                               }
                             }
                           ]

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring13/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring13/output.json
@@ -111,9 +111,6 @@
                       "type": "Identifier",
                       "start":62,"end":63,"loc":{"start":{"line":2,"column":35,"index":62},"end":{"line":2,"column":36,"index":63},"identifierName":"b"},
                       "name": "b"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   },
                   {

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring2/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring2/output.json
@@ -70,9 +70,6 @@
                       "type": "Identifier",
                       "start":41,"end":44,"loc":{"start":{"line":2,"column":15,"index":41},"end":{"line":2,"column":18,"index":44},"identifierName":"foo"},
                       "name": "foo"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring3/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring3/output.json
@@ -42,9 +42,6 @@
                       "type": "Identifier",
                       "start":15,"end":18,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":18,"index":18},"identifierName":"foo"},
                       "name": "foo"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring6/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring6/output.json
@@ -42,9 +42,6 @@
                       "type": "Identifier",
                       "start":15,"end":18,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":18,"index":18},"identifierName":"foo"},
                       "name": "foo"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring7/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring7/output.json
@@ -75,9 +75,6 @@
                       "type": "Identifier",
                       "start":41,"end":44,"loc":{"start":{"line":2,"column":15,"index":41},"end":{"line":2,"column":18,"index":44},"identifierName":"foo"},
                       "name": "foo"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring8/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/modules/duplicate-named-export-destructuring8/output.json
@@ -67,9 +67,6 @@
                       "type": "Identifier",
                       "start":36,"end":39,"loc":{"start":{"line":2,"column":15,"index":36},"end":{"line":2,"column":18,"index":39},"identifierName":"Foo"},
                       "name": "Foo"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/object/invalid-property-initializer-1/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/object/invalid-property-initializer-1/output.json
@@ -85,9 +85,6 @@
                       },
                       "value": 123
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/object/invalid-property-initializer-in-call/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/object/invalid-property-initializer-in-call/output.json
@@ -54,9 +54,6 @@
                       },
                       "value": 0
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/object/invalid-property-initializer-in-rhs/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/object/invalid-property-initializer-in-rhs/output.json
@@ -54,9 +54,6 @@
                     },
                     "value": 0
                   }
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/object/invalid-property-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/object/invalid-property-initializer/output.json
@@ -54,9 +54,6 @@
                       },
                       "value": 123
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {

--- a/packages/babel-parser/test/fixtures/es2015/regression/186/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/regression/186/output.json
@@ -38,9 +38,6 @@
                     "type": "Identifier",
                     "start":11,"end":16,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":16,"index":16},"identifierName":"async"},
                     "name": "async"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -58,9 +55,6 @@
                     "type": "Identifier",
                     "start":18,"end":21,"loc":{"start":{"line":1,"column":18,"index":18},"end":{"line":1,"column":21,"index":21},"identifierName":"bar"},
                     "name": "bar"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/shorthand/get-eval-arguments/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/shorthand/get-eval-arguments/output.json
@@ -38,9 +38,6 @@
                     "type": "Identifier",
                     "start":11,"end":14,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":14,"index":14},"identifierName":"get"},
                     "name": "get"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -58,9 +55,6 @@
                     "type": "Identifier",
                     "start":16,"end":20,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":20,"index":20},"identifierName":"eval"},
                     "name": "eval"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -78,9 +72,6 @@
                     "type": "Identifier",
                     "start":22,"end":31,"loc":{"start":{"line":1,"column":22,"index":22},"end":{"line":1,"column":31,"index":31},"identifierName":"arguments"},
                     "name": "arguments"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/es2015/shorthand/reserved-word-strict/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/shorthand/reserved-word-strict/output.json
@@ -43,9 +43,6 @@
                     "type": "Identifier",
                     "start":25,"end":35,"loc":{"start":{"line":2,"column":11,"index":25},"end":{"line":2,"column":21,"index":35},"identifierName":"implements"},
                     "name": "implements"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -63,9 +60,6 @@
                     "type": "Identifier",
                     "start":37,"end":46,"loc":{"start":{"line":2,"column":23,"index":37},"end":{"line":2,"column":32,"index":46},"identifierName":"interface"},
                     "name": "interface"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -83,9 +77,6 @@
                     "type": "Identifier",
                     "start":48,"end":55,"loc":{"start":{"line":2,"column":34,"index":48},"end":{"line":2,"column":41,"index":55},"identifierName":"package"},
                     "name": "package"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/es2015/shorthand/reserved-word/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/shorthand/reserved-word/output.json
@@ -43,9 +43,6 @@
                     "type": "Identifier",
                     "start":11,"end":16,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":16,"index":16},"identifierName":"const"},
                     "name": "const"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -63,9 +60,6 @@
                     "type": "Identifier",
                     "start":18,"end":20,"loc":{"start":{"line":1,"column":18,"index":18},"end":{"line":1,"column":20,"index":20},"identifierName":"if"},
                     "name": "if"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -83,9 +77,6 @@
                     "type": "Identifier",
                     "start":22,"end":26,"loc":{"start":{"line":1,"column":22,"index":22},"end":{"line":1,"column":26,"index":26},"identifierName":"this"},
                     "name": "this"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/147/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/147/output.json
@@ -56,9 +56,6 @@
                     "type": "Identifier",
                     "start":16,"end":17,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":17,"index":17},"identifierName":"y"},
                     "name": "y"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/153/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/153/output.json
@@ -40,9 +40,6 @@
                     "type": "Identifier",
                     "start":12,"end":13,"loc":{"start":{"line":1,"column":12,"index":12},"end":{"line":1,"column":13,"index":13},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/154/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/154/output.json
@@ -48,9 +48,6 @@
                         "type": "Identifier",
                         "start":14,"end":15,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":15,"index":15},"identifierName":"x"},
                         "name": "x"
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/155/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/155/output.json
@@ -54,9 +54,6 @@
                             "type": "Identifier",
                             "start":15,"end":16,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":16,"index":16},"identifierName":"x"},
                             "name": "x"
-                          },
-                          "extra": {
-                            "shorthand": true
                           }
                         }
                       ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/156/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/156/output.json
@@ -51,9 +51,6 @@
                           "type": "Identifier",
                           "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"x"},
                           "name": "x"
-                        },
-                        "extra": {
-                          "shorthand": true
                         }
                       }
                     ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/157/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/157/output.json
@@ -56,9 +56,6 @@
                             "type": "Identifier",
                             "start":11,"end":12,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":12,"index":12},"identifierName":"x"},
                             "name": "x"
-                          },
-                          "extra": {
-                            "shorthand": true
                           }
                         }
                       ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/158/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/158/output.json
@@ -39,9 +39,6 @@
                       "type": "Identifier",
                       "start":3,"end":4,"loc":{"start":{"line":1,"column":3,"index":3},"end":{"line":1,"column":4,"index":4},"identifierName":"x"},
                       "name": "x"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/165/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/165/output.json
@@ -37,9 +37,6 @@
                   "type": "Identifier",
                   "start":13,"end":14,"loc":{"start":{"line":1,"column":13,"index":13},"end":{"line":1,"column":14,"index":14},"identifierName":"a"},
                   "name": "a"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               },
               {
@@ -57,9 +54,6 @@
                   "type": "Identifier",
                   "start":16,"end":17,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":17,"index":17},"identifierName":"b"},
                   "name": "b"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/166/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/166/output.json
@@ -45,9 +45,6 @@
                   "type": "Identifier",
                   "start":16,"end":17,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":17,"index":17},"identifierName":"a"},
                   "name": "a"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/168/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/168/output.json
@@ -52,9 +52,6 @@
                         "type": "Identifier",
                         "start":18,"end":19,"loc":{"start":{"line":1,"column":18,"index":18},"end":{"line":1,"column":19,"index":19},"identifierName":"w"},
                         "name": "w"
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     },
                     {
@@ -72,9 +69,6 @@
                         "type": "Identifier",
                         "start":21,"end":22,"loc":{"start":{"line":1,"column":21,"index":21},"end":{"line":1,"column":22,"index":22},"identifierName":"x"},
                         "name": "x"
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/170/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/170/output.json
@@ -40,9 +40,6 @@
                     "type": "Identifier",
                     "start":14,"end":15,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":15,"index":15},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -60,9 +57,6 @@
                     "type": "Identifier",
                     "start":17,"end":18,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":1,"column":18,"index":18},"identifierName":"b"},
                     "name": "b"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/172/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/172/output.json
@@ -55,9 +55,6 @@
                           "type": "Identifier",
                           "start":19,"end":20,"loc":{"start":{"line":1,"column":19,"index":19},"end":{"line":1,"column":20,"index":20},"identifierName":"w"},
                           "name": "w"
-                        },
-                        "extra": {
-                          "shorthand": true
                         }
                       },
                       {
@@ -75,9 +72,6 @@
                           "type": "Identifier",
                           "start":22,"end":23,"loc":{"start":{"line":1,"column":22,"index":22},"end":{"line":1,"column":23,"index":23},"identifierName":"x"},
                           "name": "x"
-                        },
-                        "extra": {
-                          "shorthand": true
                         }
                       }
                     ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/175/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/175/output.json
@@ -63,9 +63,6 @@
                               "type": "Identifier",
                               "start":12,"end":13,"loc":{"start":{"line":1,"column":12,"index":12},"end":{"line":1,"column":13,"index":13},"identifierName":"w"},
                               "name": "w"
-                            },
-                            "extra": {
-                              "shorthand": true
                             }
                           },
                           {
@@ -83,9 +80,6 @@
                               "type": "Identifier",
                               "start":15,"end":16,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":16,"index":16},"identifierName":"x"},
                               "name": "x"
-                            },
-                            "extra": {
-                              "shorthand": true
                             }
                           }
                         ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/178/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/178/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":3,"end":4,"loc":{"start":{"line":1,"column":3,"index":3},"end":{"line":1,"column":4,"index":4},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/179/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/179/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":3,"end":4,"loc":{"start":{"line":1,"column":3,"index":3},"end":{"line":1,"column":4,"index":4},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/183/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/183/output.json
@@ -53,9 +53,6 @@
                     "type": "Identifier",
                     "start":9,"end":10,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":10,"index":10},"identifierName":"c"},
                     "name": "c"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/186/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/186/output.json
@@ -37,9 +37,6 @@
                       "type": "Identifier",
                       "start":3,"end":4,"loc":{"start":{"line":1,"column":3,"index":3},"end":{"line":1,"column":4,"index":4},"identifierName":"a"},
                       "name": "a"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   },
                   {
@@ -57,9 +54,6 @@
                       "type": "Identifier",
                       "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"b"},
                       "name": "b"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/190/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/190/output.json
@@ -37,9 +37,6 @@
                         "type": "Identifier",
                         "start":7,"end":8,"loc":{"start":{"line":1,"column":7,"index":7},"end":{"line":1,"column":8,"index":8},"identifierName":"a"},
                         "name": "a"
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     },
                     {
@@ -57,9 +54,6 @@
                         "type": "Identifier",
                         "start":10,"end":11,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":11,"index":11},"identifierName":"b"},
                         "name": "b"
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/279/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/279/output.json
@@ -40,9 +40,6 @@
                     "type": "Identifier",
                     "start":16,"end":17,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":17,"index":17},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/280/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/280/output.json
@@ -45,9 +45,6 @@
                   "type": "Identifier",
                   "start":30,"end":31,"loc":{"start":{"line":1,"column":30,"index":30},"end":{"line":1,"column":31,"index":31},"identifierName":"a"},
                   "name": "a"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/281/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/281/output.json
@@ -55,9 +55,6 @@
                         "type": "Identifier",
                         "start":32,"end":33,"loc":{"start":{"line":1,"column":32,"index":32},"end":{"line":1,"column":33,"index":33},"identifierName":"a"},
                         "name": "a"
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]
@@ -103,9 +100,6 @@
                             "type": "Identifier",
                             "start":47,"end":48,"loc":{"start":{"line":1,"column":47,"index":47},"end":{"line":1,"column":48,"index":48},"identifierName":"a"},
                             "name": "a"
-                          },
-                          "extra": {
-                            "shorthand": true
                           }
                         }
                       ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/287/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/287/output.json
@@ -40,9 +40,6 @@
                         "type": "Identifier",
                         "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"a"},
                         "name": "a"
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/303/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/303/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":5,"end":8,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":8,"index":8},"identifierName":"get"},
                     "name": "get"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/305/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/305/output.json
@@ -42,9 +42,6 @@
                       "start":16,"end":28,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":28,"index":28},"identifierName":"defaultValue"},
                       "name": "defaultValue"
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/307/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/307/output.json
@@ -46,9 +46,6 @@
                     },
                     "value": 0
                   }
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/308/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/308/output.json
@@ -49,9 +49,6 @@
                       },
                       "value": 0
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/309/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/309/output.json
@@ -70,9 +70,6 @@
                               },
                               "value": 1
                             }
-                          },
-                          "extra": {
-                            "shorthand": true
                           }
                         }
                       ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/310/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/310/output.json
@@ -42,9 +42,6 @@
                   },
                   "value": 0
                 }
-              },
-              "extra": {
-                "shorthand": true
               }
             }
           ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/313/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/313/output.json
@@ -38,9 +38,6 @@
                   "type": "Identifier",
                   "start":15,"end":22,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":22,"index":22},"identifierName":"message"},
                   "name": "message"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/321/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/321/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/335/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/335/output.json
@@ -40,9 +40,6 @@
                   "type": "Identifier",
                   "start":13,"end":18,"loc":{"start":{"line":1,"column":13,"index":13},"end":{"line":1,"column":18,"index":18},"identifierName":"yield"},
                   "name": "yield"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/355/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/355/output.json
@@ -45,9 +45,6 @@
                     "type": "NullLiteral",
                     "start":19,"end":23,"loc":{"start":{"line":1,"column":19,"index":19},"end":{"line":1,"column":23,"index":23}}
                   }
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/360/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/360/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":8,"end":13,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":13,"index":13},"identifierName":"await"},
                     "name": "await"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/361/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/361/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":8,"end":13,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":13,"index":13},"identifierName":"await"},
                     "name": "await"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/362/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/362/output.json
@@ -37,9 +37,6 @@
                   "type": "Identifier",
                   "start":15,"end":20,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":20,"index":20},"identifierName":"await"},
                   "name": "await"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/363/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/363/output.json
@@ -40,9 +40,6 @@
                   "type": "Identifier",
                   "start":15,"end":20,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":20,"index":20},"identifierName":"await"},
                   "name": "await"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/372/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/372/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":8,"end":12,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":12,"index":12},"identifierName":"enum"},
                     "name": "enum"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/373/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/373/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":8,"end":12,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":12,"index":12},"identifierName":"enum"},
                     "name": "enum"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/374/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/374/output.json
@@ -40,9 +40,6 @@
                   "type": "Identifier",
                   "start":15,"end":19,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":19,"index":19},"identifierName":"enum"},
                   "name": "enum"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/375/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/375/output.json
@@ -40,9 +40,6 @@
                   "type": "Identifier",
                   "start":15,"end":19,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":19,"index":19},"identifierName":"enum"},
                   "name": "enum"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/393/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/393/output.json
@@ -45,9 +45,6 @@
                       "start":8,"end":10,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":10,"index":10}},
                       "properties": []
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/61/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/61/output.json
@@ -38,9 +38,6 @@
                   "type": "Identifier",
                   "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"y"},
                   "name": "y"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               },
               {
@@ -58,9 +55,6 @@
                   "type": "Identifier",
                   "start":9,"end":10,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":10,"index":10},"identifierName":"z"},
                   "name": "z"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/63/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/63/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":7,"end":8,"loc":{"start":{"line":1,"column":7,"index":7},"end":{"line":1,"column":8,"index":8},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/65/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/65/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2015/uncategorised/67/output.json
+++ b/packages/babel-parser/test/fixtures/es2015/uncategorised/67/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2016/simple-parameter-list/object-pattern-default/output.json
+++ b/packages/babel-parser/test/fixtures/es2016/simple-parameter-list/object-pattern-default/output.json
@@ -43,9 +43,6 @@
                     "type": "Identifier",
                     "start":13,"end":20,"loc":{"start":{"line":1,"column":13,"index":13},"end":{"line":1,"column":20,"index":20},"identifierName":"option1"},
                     "name": "option1"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -63,9 +60,6 @@
                     "type": "Identifier",
                     "start":22,"end":29,"loc":{"start":{"line":1,"column":22,"index":22},"end":{"line":1,"column":29,"index":29},"identifierName":"option2"},
                     "name": "option2"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2016/simple-parameter-list/object-pattern/output.json
+++ b/packages/babel-parser/test/fixtures/es2016/simple-parameter-list/object-pattern/output.json
@@ -40,9 +40,6 @@
                   "type": "Identifier",
                   "start":13,"end":20,"loc":{"start":{"line":1,"column":13,"index":13},"end":{"line":1,"column":20,"index":20},"identifierName":"option1"},
                   "name": "option1"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               },
               {
@@ -60,9 +57,6 @@
                   "type": "Identifier",
                   "start":22,"end":29,"loc":{"start":{"line":1,"column":22,"index":22},"end":{"line":1,"column":29,"index":29},"identifierName":"option2"},
                   "name": "option2"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/es2017/async-call/parenthesized-argument-object-with-assignment/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-call/parenthesized-argument-object-with-assignment/output.json
@@ -54,9 +54,6 @@
                       },
                       "value": 1
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/27/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/27/output.json
@@ -54,9 +54,6 @@
                           "start":23,"end":27,"loc":{"start":{"line":1,"column":23,"index":23},"end":{"line":1,"column":27,"index":27}},
                           "value": true
                         }
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/29/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/29/output.json
@@ -54,9 +54,6 @@
                           "start":31,"end":35,"loc":{"start":{"line":1,"column":31,"index":31},"end":{"line":1,"column":35,"index":35}},
                           "value": true
                         }
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/32/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/32/output.json
@@ -54,9 +54,6 @@
                           "start":29,"end":32,"loc":{"start":{"line":1,"column":29,"index":29},"end":{"line":1,"column":32,"index":32},"identifierName":"bar"},
                           "name": "bar"
                         }
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/34/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/34/output.json
@@ -54,9 +54,6 @@
                           "start":37,"end":40,"loc":{"start":{"line":1,"column":37,"index":37},"end":{"line":1,"column":40,"index":40},"identifierName":"bar"},
                           "name": "bar"
                         }
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/35/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/35/output.json
@@ -50,9 +50,6 @@
                       "start":22,"end":26,"loc":{"start":{"line":1,"column":22,"index":22},"end":{"line":1,"column":26,"index":26}},
                       "value": true
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/36/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/36/output.json
@@ -50,9 +50,6 @@
                       "start":23,"end":27,"loc":{"start":{"line":1,"column":23,"index":23},"end":{"line":1,"column":27,"index":27}},
                       "value": true
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/37/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/37/output.json
@@ -42,9 +42,6 @@
                       "start":16,"end":20,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":20,"index":20}},
                       "value": true
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/7/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/7/output.json
@@ -38,9 +38,6 @@
                     "type": "Identifier",
                     "start":6,"end":11,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":11,"index":11},"identifierName":"async"},
                     "name": "async"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/8/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/8/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":7,"end":12,"loc":{"start":{"line":1,"column":7,"index":7},"end":{"line":1,"column":12,"index":12},"identifierName":"async"},
                     "name": "async"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/await-binding-inside-arrow-params-inside-async-arrow-params/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/await-binding-inside-arrow-params-inside-async-arrow-params/output.json
@@ -54,9 +54,6 @@
                           "type": "Identifier",
                           "start":14,"end":19,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":19,"index":19},"identifierName":"await"},
                           "name": "await"
-                        },
-                        "extra": {
-                          "shorthand": true
                         }
                       }
                     ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-await-with-object-exp-in-function/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-await-with-object-exp-in-function/output.json
@@ -50,9 +50,6 @@
                         "type": "Identifier",
                         "start":27,"end":30,"loc":{"start":{"line":2,"column":10,"index":27},"end":{"line":2,"column":13,"index":30},"identifierName":"foo"},
                         "name": "foo"
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/multiple-await-in-async-arrow-params/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/multiple-await-in-async-arrow-params/output.json
@@ -55,9 +55,6 @@
                         }
                       ]
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -98,16 +95,10 @@
                             "type": "Identifier",
                             "start":30,"end":35,"loc":{"start":{"line":1,"column":30,"index":30},"end":{"line":1,"column":35,"index":35},"identifierName":"await"},
                             "name": "await"
-                          },
-                          "extra": {
-                            "shorthand": true
                           }
                         }
                       ]
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2017/async-functions/object-default-params/output.json
+++ b/packages/babel-parser/test/fixtures/es2017/async-functions/object-default-params/output.json
@@ -58,9 +58,6 @@
                           },
                           "value": "bar"
                         }
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/10/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/10/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -53,9 +50,6 @@
                     "type": "Identifier",
                     "start":9,"end":10,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":10,"index":10},"identifierName":"y"},
                     "name": "y"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/11/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/11/output.json
@@ -73,9 +73,6 @@
                       "type": "Identifier",
                       "start":37,"end":40,"loc":{"start":{"line":2,"column":15,"index":37},"end":{"line":2,"column":18,"index":40},"identifierName":"bar"},
                       "name": "bar"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   },
                   {

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/12/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/12/output.json
@@ -42,9 +42,6 @@
                       "type": "Identifier",
                       "start":15,"end":18,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":18,"index":18},"identifierName":"foo"},
                       "name": "foo"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   },
                   {

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/13/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/13/output.json
@@ -88,9 +88,6 @@
                             "type": "Identifier",
                             "start":44,"end":47,"loc":{"start":{"line":2,"column":22,"index":44},"end":{"line":2,"column":25,"index":47},"identifierName":"baz"},
                             "name": "baz"
-                          },
-                          "extra": {
-                            "shorthand": true
                           }
                         },
                         {

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/14/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/14/output.json
@@ -82,9 +82,6 @@
                           "type": "Identifier",
                           "start":43,"end":46,"loc":{"start":{"line":2,"column":21,"index":43},"end":{"line":2,"column":24,"index":46},"identifierName":"baz"},
                           "name": "baz"
-                        },
-                        "extra": {
-                          "shorthand": true
                         }
                       },
                       {

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/15/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/15/output.json
@@ -86,9 +86,6 @@
                               "type": "Identifier",
                               "start":44,"end":47,"loc":{"start":{"line":2,"column":22,"index":44},"end":{"line":2,"column":25,"index":47},"identifierName":"baz"},
                               "name": "baz"
-                            },
-                            "extra": {
-                              "shorthand": true
                             }
                           },
                           {

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/2/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/2/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/3/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/3/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":11,"end":12,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":12,"index":12},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/5/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/5/output.json
@@ -38,9 +38,6 @@
                   "type": "Identifier",
                   "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"x"},
                   "name": "x"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               },
               {

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/6/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/6/output.json
@@ -29,9 +29,6 @@
                 "type": "Identifier",
                 "start":2,"end":3,"loc":{"start":{"line":1,"column":2,"index":2},"end":{"line":1,"column":3,"index":3},"identifierName":"x"},
                 "name": "x"
-              },
-              "extra": {
-                "shorthand": true
               }
             },
             {
@@ -58,9 +55,6 @@
                 "type": "Identifier",
                 "start":11,"end":12,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":12,"index":12},"identifierName":"a"},
                 "name": "a"
-              },
-              "extra": {
-                "shorthand": true
               }
             },
             {
@@ -87,9 +81,6 @@
                 "type": "Identifier",
                 "start":20,"end":21,"loc":{"start":{"line":1,"column":20,"index":20},"end":{"line":1,"column":21,"index":21},"identifierName":"c"},
                 "name": "c"
-              },
-              "extra": {
-                "shorthand": true
               }
             }
           ],

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/7/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/7/output.json
@@ -45,9 +45,6 @@
                     "type": "Identifier",
                     "start":12,"end":13,"loc":{"start":{"line":1,"column":12,"index":12},"end":{"line":1,"column":13,"index":13},"identifierName":"y"},
                     "name": "y"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -65,9 +62,6 @@
                     "type": "Identifier",
                     "start":15,"end":16,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":16,"index":16},"identifierName":"z"},
                     "name": "z"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/8/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/8/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -56,9 +53,6 @@
                     "type": "Identifier",
                     "start":9,"end":10,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":10,"index":10},"identifierName":"y"},
                     "name": "y"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/9/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/9/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {

--- a/packages/babel-parser/test/fixtures/es2018/object-rest-spread/expression-rest-not-last-invalid/output.json
+++ b/packages/babel-parser/test/fixtures/es2018/object-rest-spread/expression-rest-not-last-invalid/output.json
@@ -45,9 +45,6 @@
                   "type": "Identifier",
                   "start":11,"end":12,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":12,"index":12},"identifierName":"b"},
                   "name": "b"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/dupe-param-3/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/dupe-param-3/output.json
@@ -44,9 +44,6 @@
                       "type": "Identifier",
                       "start":27,"end":28,"loc":{"start":{"line":2,"column":13,"index":27},"end":{"line":2,"column":14,"index":28},"identifierName":"a"},
                       "name": "a"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/patterned-catch/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/patterned-catch/output.json
@@ -52,9 +52,6 @@
                       "type": "Identifier",
                       "start":21,"end":22,"loc":{"start":{"line":1,"column":21,"index":21},"end":{"line":1,"column":22,"index":22},"identifierName":"c"},
                       "name": "c"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   },
                   {
@@ -141,9 +138,6 @@
                         "start":42,"end":43,"loc":{"start":{"line":1,"column":42,"index":42},"end":{"line":1,"column":43,"index":43},"identifierName":"i"},
                         "name": "i"
                       }
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/with-object-pattern/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-array-pattern/with-object-pattern/output.json
@@ -37,9 +37,6 @@
                         "type": "Identifier",
                         "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"a"},
                         "name": "a"
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/object-binding-pattern-01/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/object-binding-pattern-01/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":2,"end":3,"loc":{"start":{"line":1,"column":2,"index":2},"end":{"line":1,"column":3,"index":3},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -65,9 +62,6 @@
                       "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"b"},
                       "name": "b"
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {

--- a/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/object-binding-pattern-invalid-rest-in-object-pattern/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/object-binding-pattern-invalid-rest-in-object-pattern/output.json
@@ -36,9 +36,6 @@
                     "type": "Identifier",
                     "start":2,"end":3,"loc":{"start":{"line":1,"column":2,"index":2},"end":{"line":1,"column":3,"index":3},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {

--- a/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/object-binding-pattern-nested-cover-grammar/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/object-binding-pattern-nested-cover-grammar/output.json
@@ -125,9 +125,6 @@
                                                                                                       "start":24,"end":25,"loc":{"start":{"line":1,"column":24,"index":24},"end":{"line":1,"column":25,"index":25},"identifierName":"b"},
                                                                                                       "name": "b"
                                                                                                     }
-                                                                                                  },
-                                                                                                  "extra": {
-                                                                                                    "shorthand": true
                                                                                                   }
                                                                                                 }
                                                                                               ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-destructuring-assignment-array-pattern/nested-cover-grammar/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-destructuring-assignment-array-pattern/nested-cover-grammar/output.json
@@ -46,9 +46,6 @@
                         "start":4,"end":5,"loc":{"start":{"line":1,"column":4,"index":4},"end":{"line":1,"column":5,"index":5},"identifierName":"b"},
                         "name": "b"
                       }
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-destructuring-assignment-object-pattern/nested-cover-grammar/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-destructuring-assignment-object-pattern/nested-cover-grammar/output.json
@@ -136,9 +136,6 @@
                                                                                                       "value": 0
                                                                                                     }
                                                                                                   }
-                                                                                                },
-                                                                                                "extra": {
-                                                                                                  "shorthand": true
                                                                                                 }
                                                                                               }
                                                                                             ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-destructuring-assignment-object-pattern/object-pattern-assignment/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-destructuring-assignment-object-pattern/object-pattern-assignment/output.json
@@ -33,9 +33,6 @@
                   "type": "Identifier",
                   "start":7,"end":8,"loc":{"start":{"line":2,"column":4,"index":7},"end":{"line":2,"column":5,"index":8},"identifierName":"a"},
                   "name": "a"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               },
               {
@@ -111,9 +108,6 @@
                         "type": "Identifier",
                         "start":39,"end":40,"loc":{"start":{"line":5,"column":9,"index":39},"end":{"line":5,"column":10,"index":40},"identifierName":"a"},
                         "name": "a"
-                      },
-                      "extra": {
-                        "shorthand": true
                       }
                     }
                   ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-destructuring-assignment/invalid-cover-grammar/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-destructuring-assignment/invalid-cover-grammar/output.json
@@ -121,9 +121,6 @@
                                                                                                   "start":23,"end":24,"loc":{"start":{"line":1,"column":23,"index":23},"end":{"line":1,"column":24,"index":24},"identifierName":"b"},
                                                                                                   "name": "b"
                                                                                                 }
-                                                                                              },
-                                                                                              "extra": {
-                                                                                                "shorthand": true
                                                                                               }
                                                                                             }
                                                                                           ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-for-of/for-of-object-pattern-const/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-for-of/for-of-object-pattern-const/output.json
@@ -37,9 +37,6 @@
                       "type": "Identifier",
                       "start":12,"end":13,"loc":{"start":{"line":1,"column":12,"index":12},"end":{"line":1,"column":13,"index":13},"identifierName":"x"},
                       "name": "x"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   },
                   {
@@ -57,9 +54,6 @@
                       "type": "Identifier",
                       "start":15,"end":16,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":16,"index":16},"identifierName":"y"},
                       "name": "y"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-for-of/for-of-object-pattern/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-for-of/for-of-object-pattern/output.json
@@ -30,9 +30,6 @@
                 "type": "Identifier",
                 "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"x"},
                 "name": "x"
-              },
-              "extra": {
-                "shorthand": true
               }
             },
             {
@@ -50,9 +47,6 @@
                 "type": "Identifier",
                 "start":9,"end":10,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":10,"index":10},"identifierName":"y"},
                 "name": "y"
-              },
-              "extra": {
-                "shorthand": true
               }
             }
           ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-generator/generator-parameter-binding-property-reserved/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-generator/generator-parameter-binding-property-reserved/output.json
@@ -39,9 +39,6 @@
                     "type": "Identifier",
                     "start":12,"end":17,"loc":{"start":{"line":1,"column":12,"index":12},"end":{"line":1,"column":17,"index":17},"identifierName":"yield"},
                     "name": "yield"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-object-initialiser/proto-identifier-shorthand/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-object-initialiser/proto-identifier-shorthand/output.json
@@ -45,9 +45,6 @@
                 "type": "Identifier",
                 "start":20,"end":29,"loc":{"start":{"line":1,"column":20,"index":20},"end":{"line":1,"column":29,"index":29},"identifierName":"__proto__"},
                 "name": "__proto__"
-              },
-              "extra": {
-                "shorthand": true
               }
             }
           ],

--- a/packages/babel-parser/test/fixtures/esprima/es2015-object-initialiser/proto-literal-shorthand/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-object-initialiser/proto-literal-shorthand/output.json
@@ -49,9 +49,6 @@
                 "type": "Identifier",
                 "start":22,"end":31,"loc":{"start":{"line":1,"column":22,"index":22},"end":{"line":1,"column":31,"index":31},"identifierName":"__proto__"},
                 "name": "__proto__"
-              },
-              "extra": {
-                "shorthand": true
               }
             }
           ],

--- a/packages/babel-parser/test/fixtures/esprima/es2015-object-initialiser/proto-shorthand-identifier/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-object-initialiser/proto-shorthand-identifier/output.json
@@ -29,9 +29,6 @@
                 "type": "Identifier",
                 "start":3,"end":12,"loc":{"start":{"line":1,"column":3,"index":3},"end":{"line":1,"column":12,"index":12},"identifierName":"__proto__"},
                 "name": "__proto__"
-              },
-              "extra": {
-                "shorthand": true
               }
             },
             {

--- a/packages/babel-parser/test/fixtures/esprima/es2015-object-initialiser/proto-shorthand-literal/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-object-initialiser/proto-shorthand-literal/output.json
@@ -29,9 +29,6 @@
                 "type": "Identifier",
                 "start":3,"end":12,"loc":{"start":{"line":1,"column":3,"index":3},"end":{"line":1,"column":12,"index":12},"identifierName":"__proto__"},
                 "name": "__proto__"
-              },
-              "extra": {
-                "shorthand": true
               }
             },
             {

--- a/packages/babel-parser/test/fixtures/esprima/es2015-object-initialiser/proto-shorthands/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-object-initialiser/proto-shorthands/output.json
@@ -29,9 +29,6 @@
                 "type": "Identifier",
                 "start":3,"end":12,"loc":{"start":{"line":1,"column":3,"index":3},"end":{"line":1,"column":12,"index":12},"identifierName":"__proto__"},
                 "name": "__proto__"
-              },
-              "extra": {
-                "shorthand": true
               }
             },
             {
@@ -49,9 +46,6 @@
                 "type": "Identifier",
                 "start":14,"end":23,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":23,"index":23},"identifierName":"__proto__"},
                 "name": "__proto__"
-              },
-              "extra": {
-                "shorthand": true
               }
             }
           ],

--- a/packages/babel-parser/test/fixtures/esprima/es2015-object-literal-property-value-shorthand/migrated_0000/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-object-literal-property-value-shorthand/migrated_0000/output.json
@@ -38,9 +38,6 @@
                   "type": "Identifier",
                   "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"y"},
                   "name": "y"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               },
               {
@@ -58,9 +55,6 @@
                   "type": "Identifier",
                   "start":9,"end":10,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":10,"index":10},"identifierName":"z"},
                   "name": "z"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ]

--- a/packages/babel-parser/test/fixtures/esprima/es2015-object-pattern/elision/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-object-pattern/elision/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/esprima/es2015-object-pattern/properties/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/es2015-object-pattern/properties/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -66,9 +63,6 @@
                       },
                       "value": 0
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {

--- a/packages/babel-parser/test/fixtures/esprima/rest-parameter/arrow-rest-parameter-object/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/rest-parameter/arrow-rest-parameter-object/output.json
@@ -44,9 +44,6 @@
                       "type": "Identifier",
                       "start":8,"end":9,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":9,"index":9},"identifierName":"b"},
                       "name": "b"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/esprima/rest-parameter/rest-parameter-object/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/rest-parameter/rest-parameter-object/output.json
@@ -40,9 +40,6 @@
                     "type": "Identifier",
                     "start":15,"end":16,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":16,"index":16},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/esprima/statement-iteration/pattern-in-for-in/output.json
+++ b/packages/babel-parser/test/fixtures/esprima/statement-iteration/pattern-in-for-in/output.json
@@ -53,9 +53,6 @@
                     "type": "Identifier",
                     "start":13,"end":14,"loc":{"start":{"line":1,"column":13,"index":13},"end":{"line":1,"column":14,"index":14},"identifierName":"c"},
                     "name": "c"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -82,9 +79,6 @@
                       "start":17,"end":18,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":1,"column":18,"index":18},"identifierName":"e"},
                       "name": "e"
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {

--- a/packages/babel-parser/test/fixtures/experimental/record-and-tuple-babel-7/invalid-property-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/record-and-tuple-babel-7/invalid-property-initializer/output.json
@@ -45,9 +45,6 @@
                   },
                   "value": 1
                 }
-              },
-              "extra": {
-                "shorthand": true
               }
             }
           ]

--- a/packages/babel-parser/test/fixtures/experimental/record-and-tuple-babel-7/trailing-comma-comments/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/record-and-tuple-babel-7/trailing-comma-comments/output.json
@@ -55,9 +55,6 @@
                 "start":17,"end":18,"loc":{"start":{"line":2,"column":3,"index":17},"end":{"line":2,"column":4,"index":18},"identifierName":"a"},
                 "name": "a"
               },
-              "extra": {
-                "shorthand": true
-              },
               "trailingComments": [
                 {
                   "type": "CommentBlock",

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/107/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/107/output.json
@@ -48,9 +48,6 @@
                           "type": "Identifier",
                           "start":11,"end":12,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":12,"index":12},"identifierName":"a"},
                           "name": "a"
-                        },
-                        "extra": {
-                          "shorthand": true
                         }
                       }
                     ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/60/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/60/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/61/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/61/output.json
@@ -33,9 +33,6 @@
                     "type": "Identifier",
                     "start":5,"end":6,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":6,"index":6},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/flow/type-annotations/63/output.json
+++ b/packages/babel-parser/test/fixtures/flow/type-annotations/63/output.json
@@ -37,9 +37,6 @@
                   "type": "Identifier",
                   "start":14,"end":15,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":15,"index":15},"identifierName":"x"},
                   "name": "x"
-                },
-                "extra": {
-                  "shorthand": true
                 }
               }
             ],

--- a/packages/babel-parser/test/fixtures/jsx/regression/3/output.json
+++ b/packages/babel-parser/test/fixtures/jsx/regression/3/output.json
@@ -56,9 +56,6 @@
                       "type": "Identifier",
                       "start":8,"end":9,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":9,"index":9},"identifierName":"a"},
                       "name": "a"
-                    },
-                    "extra": {
-                      "shorthand": true
                     }
                   }
                 ]

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/destructuring-with-annotation-newline/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/destructuring-with-annotation-newline/output.json
@@ -49,9 +49,6 @@
                     "type": "Identifier",
                     "start":6,"end":7,"loc":{"start":{"line":2,"column":4,"index":6},"end":{"line":2,"column":5,"index":7},"identifierName":"a"},
                     "name": "a"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -69,9 +66,6 @@
                     "type": "Identifier",
                     "start":9,"end":10,"loc":{"start":{"line":2,"column":7,"index":9},"end":{"line":2,"column":8,"index":10},"identifierName":"b"},
                     "name": "b"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/typescript/arrow-function/destructuring/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/arrow-function/destructuring/output.json
@@ -49,9 +49,6 @@
                       },
                       "value": 0
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/typescript/declare/destructure-new-line/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/destructure-new-line/output.json
@@ -45,9 +45,6 @@
                     "type": "Identifier",
                     "start":16,"end":17,"loc":{"start":{"line":2,"column":8,"index":16},"end":{"line":2,"column":9,"index":17},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -65,9 +62,6 @@
                     "type": "Identifier",
                     "start":19,"end":20,"loc":{"start":{"line":2,"column":11,"index":19},"end":{"line":2,"column":12,"index":20},"identifierName":"y"},
                     "name": "y"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/typescript/declare/destructure/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/destructure/output.json
@@ -10,6 +10,7 @@
       {
         "type": "VariableDeclaration",
         "start":0,"end":49,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":49,"index":49}},
+        "declare": true,
         "declarations": [
           {
             "type": "VariableDeclarator",
@@ -33,9 +34,6 @@
                     "type": "Identifier",
                     "start":16,"end":17,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":17,"index":17},"identifierName":"x"},
                     "name": "x"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 },
                 {
@@ -53,9 +51,6 @@
                     "type": "Identifier",
                     "start":19,"end":20,"loc":{"start":{"line":1,"column":19,"index":19},"end":{"line":1,"column":20,"index":20},"identifierName":"y"},
                     "name": "y"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],
@@ -109,8 +104,7 @@
             "init": null
           }
         ],
-        "kind": "const",
-        "declare": true
+        "kind": "const"
       }
     ],
     "directives": []

--- a/packages/babel-parser/test/fixtures/typescript/regression/destructuring-in-function-type-babel-7/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/destructuring-in-function-type-babel-7/output.json
@@ -38,9 +38,6 @@
                     "type": "Identifier",
                     "start":17,"end":22,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":1,"column":22,"index":22},"identifierName":"theme"},
                     "name": "theme"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/typescript/regression/destructuring-in-function-type/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/regression/destructuring-in-function-type/output.json
@@ -38,9 +38,6 @@
                     "type": "Identifier",
                     "start":17,"end":22,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":1,"column":22,"index":22},"identifierName":"theme"},
                     "name": "theme"
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ],

--- a/packages/babel-parser/test/fixtures/typescript/types-arrow-function-babel-7/object-pattern-with-es-record/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types-arrow-function-babel-7/object-pattern-with-es-record/output.json
@@ -47,9 +47,6 @@
                       "start":16,"end":19,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":19,"index":19}},
                       "properties": []
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/typescript/types-arrow-function-babel-7/object-pattern-with-template/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types-arrow-function-babel-7/object-pattern-with-template/output.json
@@ -81,9 +81,6 @@
                         }
                       ]
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/typescript/types-arrow-function/object-pattern-with-es-record/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types-arrow-function/object-pattern-with-es-record/output.json
@@ -47,9 +47,6 @@
                       "start":16,"end":19,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":19,"index":19}},
                       "properties": []
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/fixtures/typescript/types-arrow-function/object-pattern-with-template/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types-arrow-function/object-pattern-with-template/output.json
@@ -81,9 +81,6 @@
                         }
                       ]
                     }
-                  },
-                  "extra": {
-                    "shorthand": true
                   }
                 }
               ]

--- a/packages/babel-parser/test/helpers/run-fixture-tests.js
+++ b/packages/babel-parser/test/helpers/run-fixture-tests.js
@@ -7,6 +7,8 @@ import FixtureError from "./fixture-error.js";
 import toFuzzedOptions from "./to-fuzzed-options.js";
 import { serialize, deserialize } from "./serialization.js";
 import toContextualSyntaxError from "./to-contextual-syntax-error.js";
+import { traverseFast } from "@babel/types";
+import { IS_BABEL_8 } from "$repo-utils";
 
 const { CI, OVERWRITE } = process.env;
 const { stringify, parse: JSONParse } = JSON;
@@ -196,7 +198,7 @@ function parseWithRecovery(parse, source, filename, options) {
     // Normalize the AST
     //
     // TODO: We should consider doing something more involved here as
-    // we may miss bugs where we put unexpected falsey objects in these
+    // we may miss bugs where we put unexpected falsy objects in these
     // properties.
     if (ast.comments && !ast.comments.length) delete ast.comments;
     if (ast.errors && !ast.errors.length) delete ast.errors;
@@ -204,6 +206,17 @@ function parseWithRecovery(parse, source, filename, options) {
       ast.errors = ast.errors.map(error =>
         toContextualSyntaxError(error, source, filename, options),
       );
+    }
+
+    if (!IS_BABEL_8()) {
+      traverseFast(ast, node => {
+        if (node.shorthand) {
+          delete node.extra.shorthand;
+          if (Object.keys(node.extra).length === 0) {
+            delete node.extra;
+          }
+        }
+      });
     }
 
     return { threw: false, ast };

--- a/packages/babel-traverse/src/scope/lib/renamer.ts
+++ b/packages/babel-traverse/src/scope/lib/renamer.ts
@@ -41,7 +41,9 @@ const renameVisitor: Visitor<Renamer> = {
       scope.getBindingIdentifier(name) === state.binding.identifier
     ) {
       node.shorthand = false;
-      if (node.extra?.shorthand) node.extra.shorthand = false;
+      if (!process.env.BABEL_8_BREAKING) {
+        if (node.extra?.shorthand) node.extra.shorthand = false;
+      }
     }
   },
 

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -1,5 +1,6 @@
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
+import { IS_BABEL_8 } from "$repo-utils";
 
 import _traverse, { NodePath } from "../lib/index.js";
 const traverse = _traverse.default || _traverse;
@@ -1050,7 +1051,12 @@ describe("scope", () => {
       const renamedPropertyMatcher = expect.objectContaining({
         type: "ObjectProperty",
         shorthand: false,
-        extra: expect.objectContaining({ shorthand: false }),
+        ...(IS_BABEL_8()
+          ? {}
+          : {
+              // eslint-disable-next-line jest/no-conditional-expect
+              extra: expect.objectContaining({ shorthand: false }),
+            }),
         key: expect.objectContaining({ name: "a" }),
         value: expect.objectContaining({
           name: expect.not.stringMatching(/^a$/),
@@ -1095,7 +1101,12 @@ describe("scope", () => {
       const originalPropertyMatcher = expect.objectContaining({
         type: "ObjectProperty",
         shorthand: true,
-        extra: expect.objectContaining({ shorthand: true }),
+        ...(IS_BABEL_8()
+          ? {}
+          : {
+              // eslint-disable-next-line jest/no-conditional-expect
+              extra: expect.objectContaining({ shorthand: true }),
+            }),
         key: expect.objectContaining({ name: "b" }),
         value: expect.objectContaining({ name: "b" }),
       });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/2891<!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I changed testing tools to avoid a lot of duplication of tests.