### PR TITLE
Use `type: module` in all `package.json`s

### DIFF
--- a/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
+++ b/codemods/babel-plugin-codemod-object-assign-to-object-spread/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/codemods/babel-plugin-codemod-object-assign-to-object-spread/test/package.json
+++ b/codemods/babel-plugin-codemod-object-assign-to-object-spread/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/codemods/babel-plugin-codemod-optional-catch-binding/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/codemods/babel-plugin-codemod-optional-catch-binding/test/package.json
+++ b/codemods/babel-plugin-codemod-optional-catch-binding/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/eslint/babel-eslint-config-internal/package.json
+++ b/eslint/babel-eslint-config-internal/package.json
@@ -4,7 +4,7 @@
   "description": "The Babel Team's ESLint configuration. Since it's internal, it might not respect semver.",
   "private": true,
   "main": "./index.js",
-  "type": "module",
+  "type": "commonjs",
   "exports": {
     ".": "./index.js",
     "./package.json": "./package.json"

--- a/eslint/babel-eslint-config-internal/package.json
+++ b/eslint/babel-eslint-config-internal/package.json
@@ -4,7 +4,7 @@
   "description": "The Babel Team's ESLint configuration. Since it's internal, it might not respect semver.",
   "private": true,
   "main": "./index.js",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": "./index.js",
     "./package.json": "./package.json"

--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -20,7 +20,7 @@
     "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
   },
   "main": "./lib/index.cjs",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": "./lib/index.cjs",
     "./experimental-worker": "./lib/experimental-worker.cjs",

--- a/eslint/babel-eslint-parser/test/package.json
+++ b/eslint/babel-eslint-parser/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/eslint/babel-eslint-plugin-development-internal/package.json
+++ b/eslint/babel-eslint-plugin-development-internal/package.json
@@ -22,5 +22,5 @@
   "devDependencies": {
     "eslint": "^8.22.0"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/eslint/babel-eslint-plugin-development-internal/test/rules/package.json
+++ b/eslint/babel-eslint-plugin-development-internal/test/rules/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/eslint/babel-eslint-plugin-development/package.json
+++ b/eslint/babel-eslint-plugin-development/package.json
@@ -9,7 +9,7 @@
   ],
   "author": "The Babel Team (https://babel.dev/team)",
   "main": "./lib/index.cjs",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": "./lib/index.cjs",
     "./package.json": "./package.json"

--- a/eslint/babel-eslint-plugin-development/test/rules/package.json
+++ b/eslint/babel-eslint-plugin-development/test/rules/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/eslint/babel-eslint-plugin/package.json
+++ b/eslint/babel-eslint-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "7.24.6",
   "description": "Companion rules for @babel/eslint-parser",
   "main": "./lib/index.cjs",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": "./lib/index.cjs",
     "./package.json": "./package.json"

--- a/eslint/babel-eslint-plugin/test/rules/package.json
+++ b/eslint/babel-eslint-plugin/test/rules/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/eslint/babel-eslint-shared-fixtures/package.json
+++ b/eslint/babel-eslint-shared-fixtures/package.json
@@ -18,5 +18,5 @@
     "@babel/preset-react": "workspace:^",
     "eslint": "^8.22.0"
   },
-  "type": "module"
+  "type": "commonjs"
 }

--- a/eslint/babel-eslint-shared-fixtures/package.json
+++ b/eslint/babel-eslint-shared-fixtures/package.json
@@ -18,5 +18,5 @@
     "@babel/preset-react": "workspace:^",
     "eslint": "^8.22.0"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/eslint/babel-eslint-tests/package.json
+++ b/eslint/babel-eslint-tests/package.json
@@ -12,5 +12,5 @@
     "eslint-plugin-import": "^2.25.4",
     "npm-babel-parser": "npm:@babel/parser@^7.14.0"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/eslint/babel-eslint-tests/test/package.json
+++ b/eslint/babel-eslint-tests/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -66,13 +66,14 @@
     ],
     "USE_ESM": [
       {
-        "type": "module",
         "bin": {
           "babel": "./bin/babel.mjs",
           "babel-external-helpers": "./bin/babel-external-helpers.mjs"
         }
       },
-      null
+      {
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -82,5 +83,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-cli/test/package.json
+++ b/packages/babel-cli/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -38,10 +38,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -51,5 +51,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-code-frame/test/package.json
+++ b/packages/babel-code-frame/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-compat-data/package.json
+++ b/packages/babel-compat-data/package.json
@@ -52,5 +52,5 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "module"
+  "type": "commonjs"
 }

--- a/packages/babel-compat-data/package.json
+++ b/packages/babel-compat-data/package.json
@@ -52,5 +52,5 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -99,7 +99,6 @@
     ],
     "USE_ESM": [
       {
-        "type": "module",
         "exports": {
           ".": {
             "types": "./lib/index.d.ts",
@@ -109,7 +108,9 @@
           "./package.json": "./package.json"
         }
       },
-      null
+      {
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -120,5 +121,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-core/test/package.json
+++ b/packages/babel-core/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -46,10 +46,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -59,5 +59,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-generator/test/package.json
+++ b/packages/babel-generator/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-annotate-as-pure/package.json
+++ b/packages/babel-helper-annotate-as-pure/package.json
@@ -35,10 +35,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -48,5 +48,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-annotate-as-pure/test/package.json
+++ b/packages/babel-helper-annotate-as-pure/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
+++ b/packages/babel-helper-builder-binary-assignment-operator-visitor/package.json
@@ -35,10 +35,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -48,5 +48,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-builder-react-jsx/package.json
+++ b/packages/babel-helper-builder-react-jsx/package.json
@@ -37,10 +37,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -50,5 +50,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-builder-react-jsx/test/package.json
+++ b/packages/babel-helper-builder-react-jsx/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-check-duplicate-nodes/package.json
+++ b/packages/babel-helper-check-duplicate-nodes/package.json
@@ -36,13 +36,13 @@
   "devDependencies": {
     "@babel/core": "workspace:^"
   },
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-helper-check-duplicate-nodes/test/package.json
+++ b/packages/babel-helper-check-duplicate-nodes/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -39,13 +39,13 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-helper-compilation-targets/test/package.json
+++ b/packages/babel-helper-compilation-targets/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -53,10 +53,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -66,5 +66,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-create-class-features-plugin/test/package.json
+++ b/packages/babel-helper-create-class-features-plugin/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -44,10 +44,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -57,5 +57,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-create-regexp-features-plugin/test/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-environment-visitor/package.json
+++ b/packages/babel-helper-environment-visitor/package.json
@@ -28,13 +28,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -37,10 +37,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -50,5 +50,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-function-name/package.json
+++ b/packages/babel-helper-function-name/package.json
@@ -36,10 +36,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -49,5 +49,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-hoist-variables/package.json
+++ b/packages/babel-helper-hoist-variables/package.json
@@ -36,10 +36,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -49,5 +49,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-import-to-platform-api/package.json
+++ b/packages/babel-helper-import-to-platform-api/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-member-expression-to-functions/package.json
+++ b/packages/babel-helper-member-expression-to-functions/package.json
@@ -35,10 +35,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -48,5 +48,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -36,10 +36,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -49,5 +49,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-module-imports/test/package.json
+++ b/packages/babel-helper-module-imports/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-optimise-call-expression/package.json
+++ b/packages/babel-helper-optimise-call-expression/package.json
@@ -36,10 +36,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -49,5 +49,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-optimise-call-expression/test/package.json
+++ b/packages/babel-helper-optimise-call-expression/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-plugin-test-runner/package.json
+++ b/packages/babel-helper-plugin-test-runner/package.json
@@ -55,11 +55,11 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-plugin-utils/package.json
+++ b/packages/babel-helper-plugin-utils/package.json
@@ -32,10 +32,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -45,5 +45,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-remap-async-to-generator/package.json
+++ b/packages/babel-helper-remap-async-to-generator/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-replace-supers/package.json
+++ b/packages/babel-helper-replace-supers/package.json
@@ -40,10 +40,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -53,5 +53,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-simple-access/package.json
+++ b/packages/babel-helper-simple-access/package.json
@@ -36,10 +36,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -49,5 +49,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-simple-access/test/package.json
+++ b/packages/babel-helper-simple-access/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-skip-transparent-expression-wrappers/package.json
+++ b/packages/babel-helper-skip-transparent-expression-wrappers/package.json
@@ -29,13 +29,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-helper-split-export-declaration/package.json
+++ b/packages/babel-helper-split-export-declaration/package.json
@@ -35,10 +35,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -48,5 +48,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-string-parser/package.json
+++ b/packages/babel-helper-string-parser/package.json
@@ -22,10 +22,10 @@
   "author": "The Babel Team (https://babel.dev/team)",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {
@@ -43,5 +43,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helper-transform-fixture-test-runner/test/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-validator-identifier/package.json
+++ b/packages/babel-helper-validator-identifier/package.json
@@ -27,13 +27,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-helper-validator-identifier/test/package.json
+++ b/packages/babel-helper-validator-identifier/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-validator-option/package.json
+++ b/packages/babel-helper-validator-option/package.json
@@ -23,13 +23,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-helper-validator-option/test/package.json
+++ b/packages/babel-helper-validator-option/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helper-wrap-function/package.json
+++ b/packages/babel-helper-wrap-function/package.json
@@ -37,10 +37,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -50,5 +50,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -39,10 +39,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -52,5 +52,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-helpers/scripts/package.json
+++ b/packages/babel-helpers/scripts/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-helpers/test/package.json
+++ b/packages/babel-helpers/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-highlight/package.json
+++ b/packages/babel-highlight/package.json
@@ -38,10 +38,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -51,5 +51,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-highlight/test/package.json
+++ b/packages/babel-highlight/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -58,10 +58,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -71,5 +71,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-node/test/package.json
+++ b/packages/babel-node/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -56,7 +56,6 @@
     ],
     "USE_ESM": [
       {
-        "type": "module",
         "exports": {
           ".": {
             "require": "./lib/index.cjs",
@@ -65,7 +64,9 @@
           "./package.json": "./package.json"
         }
       },
-      null
+      {
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -75,5 +76,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-parser/test/package.json
+++ b/packages/babel-parser/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/package.json
+++ b/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/package.json
@@ -42,10 +42,10 @@
   "author": "The Babel Team (https://babel.dev/team)",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {
@@ -56,5 +56,5 @@
       {}
     ]
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/test/package.json
+++ b/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/package.json
+++ b/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/package.json
@@ -40,13 +40,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/test/package.json
+++ b/packages/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/package.json
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/package.json
@@ -41,13 +41,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/package.json
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/package.json
+++ b/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/package.json
@@ -42,10 +42,10 @@
   "author": "The Babel Team (https://babel.dev/team)",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {
@@ -56,5 +56,5 @@
       {}
     ]
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/test/package.json
+++ b/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-external-helpers/package.json
+++ b/packages/babel-plugin-external-helpers/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-external-helpers/test/package.json
+++ b/packages/babel-plugin-external-helpers/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-async-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-async-do-expressions/package.json
@@ -41,13 +41,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-proposal-async-do-expressions/test/package.json
+++ b/packages/babel-plugin-proposal-async-do-expressions/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -50,10 +50,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -63,5 +63,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-decorators/test/package.json
+++ b/packages/babel-plugin-proposal-decorators/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-destructuring-private/package.json
+++ b/packages/babel-plugin-proposal-destructuring-private/package.json
@@ -42,13 +42,13 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-proposal-destructuring-private/test/package.json
+++ b/packages/babel-plugin-proposal-destructuring-private/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-do-expressions/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-do-expressions/test/package.json
+++ b/packages/babel-plugin-proposal-do-expressions/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-duplicate-named-capturing-groups-regex/package.json
+++ b/packages/babel-plugin-proposal-duplicate-named-capturing-groups-regex/package.json
@@ -38,10 +38,10 @@
   "author": "The Babel Team (https://babel.dev/team)",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {
@@ -59,5 +59,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-duplicate-named-capturing-groups-regex/test/package.json
+++ b/packages/babel-plugin-proposal-duplicate-named-capturing-groups-regex/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-explicit-resource-management/package.json
+++ b/packages/babel-plugin-proposal-explicit-resource-management/package.json
@@ -33,10 +33,10 @@
   "author": "The Babel Team (https://babel.dev/team)",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/package.json
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-export-default-from/package.json
+++ b/packages/babel-plugin-proposal-export-default-from/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-export-default-from/test/package.json
+++ b/packages/babel-plugin-proposal-export-default-from/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-function-bind/package.json
+++ b/packages/babel-plugin-proposal-function-bind/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-function-bind/test/package.json
+++ b/packages/babel-plugin-proposal-function-bind/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-function-sent/package.json
+++ b/packages/babel-plugin-proposal-function-sent/package.json
@@ -44,10 +44,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -57,5 +57,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-function-sent/test/package.json
+++ b/packages/babel-plugin-proposal-function-sent/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/package.json
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/package.json
@@ -43,13 +43,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/test/package.json
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-import-defer/package.json
+++ b/packages/babel-plugin-proposal-import-defer/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-import-defer/test/package.json
+++ b/packages/babel-plugin-proposal-import-defer/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-import-wasm-source/package.json
+++ b/packages/babel-plugin-proposal-import-wasm-source/package.json
@@ -47,13 +47,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-proposal-import-wasm-source/test/package.json
+++ b/packages/babel-plugin-proposal-import-wasm-source/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-json-modules/package.json
+++ b/packages/babel-plugin-proposal-json-modules/package.json
@@ -48,13 +48,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-proposal-json-modules/test/package.json
+++ b/packages/babel-plugin-proposal-json-modules/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-optional-chaining-assign/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining-assign/package.json
@@ -43,10 +43,10 @@
       {}
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-optional-chaining-assign/test/package.json
+++ b/packages/babel-plugin-proposal-optional-chaining-assign/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-partial-application/package.json
+++ b/packages/babel-plugin-proposal-partial-application/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-partial-application/test/package.json
+++ b/packages/babel-plugin-proposal-partial-application/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-pipeline-operator/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-pipeline-operator/test/package.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-record-and-tuple/package.json
+++ b/packages/babel-plugin-proposal-record-and-tuple/package.json
@@ -39,13 +39,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-proposal-record-and-tuple/test/package.json
+++ b/packages/babel-plugin-proposal-record-and-tuple/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-regexp-modifiers/package.json
+++ b/packages/babel-plugin-proposal-regexp-modifiers/package.json
@@ -36,10 +36,10 @@
   "author": "The Babel Team (https://babel.dev/team)",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {
@@ -57,5 +57,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-regexp-modifiers/test/package.json
+++ b/packages/babel-plugin-proposal-regexp-modifiers/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-proposal-throw-expressions/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-proposal-throw-expressions/test/package.json
+++ b/packages/babel-plugin-proposal-throw-expressions/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-syntax-async-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-async-do-expressions/package.json
@@ -36,13 +36,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-syntax-decimal/package.json
+++ b/packages/babel-plugin-syntax-decimal/package.json
@@ -32,13 +32,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-syntax-decorators/package.json
+++ b/packages/babel-plugin-syntax-decorators/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-decorators/test/package.json
+++ b/packages/babel-plugin-syntax-decorators/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-syntax-destructuring-private/package.json
+++ b/packages/babel-plugin-syntax-destructuring-private/package.json
@@ -38,10 +38,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -51,7 +51,7 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs",
+  "type": "module",
   "devDependencies": {
     "@babel/core": "workspace:^"
   }

--- a/packages/babel-plugin-syntax-do-expressions/package.json
+++ b/packages/babel-plugin-syntax-do-expressions/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-explicit-resource-management/package.json
+++ b/packages/babel-plugin-syntax-explicit-resource-management/package.json
@@ -40,10 +40,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -53,5 +53,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-export-default-from/package.json
+++ b/packages/babel-plugin-syntax-export-default-from/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-flow/package.json
+++ b/packages/babel-plugin-syntax-flow/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-function-bind/package.json
+++ b/packages/babel-plugin-syntax-function-bind/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-function-sent/package.json
+++ b/packages/babel-plugin-syntax-function-sent/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-import-assertions/package.json
+++ b/packages/babel-plugin-syntax-import-assertions/package.json
@@ -40,10 +40,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -53,5 +53,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-import-attributes/package.json
+++ b/packages/babel-plugin-syntax-import-attributes/package.json
@@ -30,10 +30,10 @@
   "author": "The Babel Team (https://babel.dev/team)",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {
@@ -51,5 +51,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-import-defer/package.json
+++ b/packages/babel-plugin-syntax-import-defer/package.json
@@ -40,10 +40,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -53,5 +53,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-import-reflection/package.json
+++ b/packages/babel-plugin-syntax-import-reflection/package.json
@@ -40,10 +40,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -53,5 +53,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-import-source/package.json
+++ b/packages/babel-plugin-syntax-import-source/package.json
@@ -30,10 +30,10 @@
   "author": "The Babel Team (https://babel.dev/team)",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {
@@ -51,5 +51,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-module-blocks/package.json
+++ b/packages/babel-plugin-syntax-module-blocks/package.json
@@ -32,13 +32,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-syntax-optional-chaining-assign/package.json
+++ b/packages/babel-plugin-syntax-optional-chaining-assign/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-partial-application/package.json
+++ b/packages/babel-plugin-syntax-partial-application/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-pipeline-operator/package.json
+++ b/packages/babel-plugin-syntax-pipeline-operator/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-record-and-tuple/package.json
+++ b/packages/babel-plugin-syntax-record-and-tuple/package.json
@@ -40,10 +40,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -53,5 +53,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-throw-expressions/package.json
+++ b/packages/babel-plugin-syntax-throw-expressions/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-syntax-typescript/test/package.json
+++ b/packages/babel-plugin-syntax-typescript/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-arrow-functions/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/package.json
@@ -44,10 +44,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -57,5 +57,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-arrow-functions/test/package.json
+++ b/packages/babel-plugin-transform-arrow-functions/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-async-generator-functions/package.json
+++ b/packages/babel-plugin-transform-async-generator-functions/package.json
@@ -47,10 +47,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -60,5 +60,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-async-generator-functions/test/package.json
+++ b/packages/babel-plugin-transform-async-generator-functions/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-async-to-generator/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/package.json
@@ -44,10 +44,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -57,5 +57,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-async-to-generator/test/package.json
+++ b/packages/babel-plugin-transform-async-to-generator/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-block-scoped-functions/test/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-block-scoping/package.json
+++ b/packages/babel-plugin-transform-block-scoping/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-block-scoping/test/package.json
+++ b/packages/babel-plugin-transform-block-scoping/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-class-properties/package.json
+++ b/packages/babel-plugin-transform-class-properties/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-class-properties/test/package.json
+++ b/packages/babel-plugin-transform-class-properties/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-class-static-block/package.json
+++ b/packages/babel-plugin-transform-class-static-block/package.json
@@ -42,13 +42,13 @@
     "node": ">=6.9.0"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-transform-class-static-block/test/package.json
+++ b/packages/babel-plugin-transform-class-static-block/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-classes/package.json
+++ b/packages/babel-plugin-transform-classes/package.json
@@ -50,10 +50,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -63,5 +63,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-classes/test/package.json
+++ b/packages/babel-plugin-transform-classes/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-computed-properties/package.json
+++ b/packages/babel-plugin-transform-computed-properties/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-computed-properties/test/package.json
+++ b/packages/babel-plugin-transform-computed-properties/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-destructuring/test/package.json
+++ b/packages/babel-plugin-transform-destructuring/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-dotall-regex/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/package.json
@@ -48,10 +48,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -61,5 +61,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-dotall-regex/test/package.json
+++ b/packages/babel-plugin-transform-dotall-regex/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-duplicate-keys/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-duplicate-keys/test/package.json
+++ b/packages/babel-plugin-transform-duplicate-keys/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-dynamic-import/package.json
+++ b/packages/babel-plugin-transform-dynamic-import/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-dynamic-import/test/package.json
+++ b/packages/babel-plugin-transform-dynamic-import/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-exponentiation-operator/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-exponentiation-operator/test/package.json
+++ b/packages/babel-plugin-transform-exponentiation-operator/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-export-namespace-from/package.json
+++ b/packages/babel-plugin-transform-export-namespace-from/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-export-namespace-from/test/package.json
+++ b/packages/babel-plugin-transform-export-namespace-from/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-flow-comments/package.json
+++ b/packages/babel-plugin-transform-flow-comments/package.json
@@ -44,10 +44,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -57,5 +57,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-flow-comments/test/package.json
+++ b/packages/babel-plugin-transform-flow-comments/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-flow-strip-types/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-flow-strip-types/test/package.json
+++ b/packages/babel-plugin-transform-flow-strip-types/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-for-of/package.json
+++ b/packages/babel-plugin-transform-for-of/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-for-of/test/package.json
+++ b/packages/babel-plugin-transform-for-of/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-function-name/package.json
+++ b/packages/babel-plugin-transform-function-name/package.json
@@ -44,10 +44,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -57,5 +57,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-function-name/test/package.json
+++ b/packages/babel-plugin-transform-function-name/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-instanceof/package.json
+++ b/packages/babel-plugin-transform-instanceof/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-instanceof/test/package.json
+++ b/packages/babel-plugin-transform-instanceof/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-jscript/package.json
+++ b/packages/babel-plugin-transform-jscript/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-jscript/test/package.json
+++ b/packages/babel-plugin-transform-jscript/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-json-strings/package.json
+++ b/packages/babel-plugin-transform-json-strings/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-json-strings/test/package.json
+++ b/packages/babel-plugin-transform-json-strings/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-literals/package.json
+++ b/packages/babel-plugin-transform-literals/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-logical-assignment-operators/package.json
+++ b/packages/babel-plugin-transform-logical-assignment-operators/package.json
@@ -44,10 +44,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -57,5 +57,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-logical-assignment-operators/test/package.json
+++ b/packages/babel-plugin-transform-logical-assignment-operators/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-member-expression-literals/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-member-expression-literals/test/package.json
+++ b/packages/babel-plugin-transform-member-expression-literals/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -44,10 +44,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -57,5 +57,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-modules-amd/test/package.json
+++ b/packages/babel-plugin-transform-modules-amd/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -45,10 +45,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -58,5 +58,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-modules-commonjs/test/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -47,10 +47,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -60,5 +60,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-modules-systemjs/test/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -44,10 +44,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -57,5 +57,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-modules-umd/test/package.json
+++ b/packages/babel-plugin-transform-modules-umd/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/package.json
@@ -48,10 +48,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -61,5 +61,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-named-capturing-groups-regex/test/package.json
+++ b/packages/babel-plugin-transform-named-capturing-groups-regex/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-new-target/package.json
+++ b/packages/babel-plugin-transform-new-target/package.json
@@ -44,10 +44,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -57,5 +57,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-new-target/test/package.json
+++ b/packages/babel-plugin-transform-new-target/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/package.json
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/test/package.json
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-numeric-separator/package.json
+++ b/packages/babel-plugin-transform-numeric-separator/package.json
@@ -45,10 +45,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -58,5 +58,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-numeric-separator/test/package.json
+++ b/packages/babel-plugin-transform-numeric-separator/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-object-assign/package.json
+++ b/packages/babel-plugin-transform-object-assign/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-object-rest-spread/package.json
+++ b/packages/babel-plugin-transform-object-rest-spread/package.json
@@ -46,10 +46,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -59,5 +59,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-object-rest-spread/test/package.json
+++ b/packages/babel-plugin-transform-object-rest-spread/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-object-super/package.json
+++ b/packages/babel-plugin-transform-object-super/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-object-super/test/package.json
+++ b/packages/babel-plugin-transform-object-super/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-optional-catch-binding/package.json
+++ b/packages/babel-plugin-transform-optional-catch-binding/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-optional-catch-binding/test/package.json
+++ b/packages/babel-plugin-transform-optional-catch-binding/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-optional-chaining/package.json
+++ b/packages/babel-plugin-transform-optional-chaining/package.json
@@ -46,10 +46,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -59,5 +59,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-optional-chaining/test/package.json
+++ b/packages/babel-plugin-transform-optional-chaining/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-parameters/package.json
+++ b/packages/babel-plugin-transform-parameters/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-parameters/test/package.json
+++ b/packages/babel-plugin-transform-parameters/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-private-methods/package.json
+++ b/packages/babel-plugin-transform-private-methods/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-private-methods/test/package.json
+++ b/packages/babel-plugin-transform-private-methods/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-private-property-in-object/package.json
+++ b/packages/babel-plugin-transform-private-property-in-object/package.json
@@ -45,10 +45,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -58,5 +58,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-private-property-in-object/test/package.json
+++ b/packages/babel-plugin-transform-private-property-in-object/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-property-literals/package.json
+++ b/packages/babel-plugin-transform-property-literals/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-property-literals/test/package.json
+++ b/packages/babel-plugin-transform-property-literals/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-property-mutators/package.json
+++ b/packages/babel-plugin-transform-property-mutators/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-property-mutators/test/package.json
+++ b/packages/babel-plugin-transform-property-mutators/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-proto-to-assign/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-proto-to-assign/test/package.json
+++ b/packages/babel-plugin-transform-proto-to-assign/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-react-constant-elements/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/package.json
+++ b/packages/babel-plugin-transform-react-constant-elements/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-react-display-name/package.json
+++ b/packages/babel-plugin-transform-react-display-name/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-react-display-name/test/package.json
+++ b/packages/babel-plugin-transform-react-display-name/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-react-inline-elements/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-react-inline-elements/test/package.json
+++ b/packages/babel-plugin-transform-react-inline-elements/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-react-jsx-compat/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-react-jsx-compat/test/package.json
+++ b/packages/babel-plugin-transform-react-jsx-compat/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-react-jsx-development/package.json
+++ b/packages/babel-plugin-transform-react-jsx-development/package.json
@@ -41,10 +41,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -54,5 +54,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-react-jsx-development/test/package.json
+++ b/packages/babel-plugin-transform-react-jsx-development/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-react-jsx-self/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-react-jsx-self/test/package.json
+++ b/packages/babel-plugin-transform-react-jsx-self/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-react-jsx-source/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-react-jsx-source/test/package.json
+++ b/packages/babel-plugin-transform-react-jsx-source/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-react-jsx/package.json
+++ b/packages/babel-plugin-transform-react-jsx/package.json
@@ -47,10 +47,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -64,5 +64,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-react-jsx/test/package.json
+++ b/packages/babel-plugin-transform-react-jsx/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-react-pure-annotations/package.json
+++ b/packages/babel-plugin-transform-react-pure-annotations/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-react-pure-annotations/test/package.json
+++ b/packages/babel-plugin-transform-react-pure-annotations/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -40,10 +40,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -53,5 +53,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-regenerator/test/package.json
+++ b/packages/babel-plugin-transform-regenerator/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-reserved-words/package.json
+++ b/packages/babel-plugin-transform-reserved-words/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-reserved-words/test/package.json
+++ b/packages/babel-plugin-transform-reserved-words/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-runtime/package.json
+++ b/packages/babel-plugin-transform-runtime/package.json
@@ -57,10 +57,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -70,5 +70,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-runtime/scripts/package.json
+++ b/packages/babel-plugin-transform-runtime/scripts/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-runtime/test/package.json
+++ b/packages/babel-plugin-transform-runtime/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-shorthand-properties/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-shorthand-properties/test/package.json
+++ b/packages/babel-plugin-transform-shorthand-properties/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-spread/package.json
+++ b/packages/babel-plugin-transform-spread/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-spread/test/package.json
+++ b/packages/babel-plugin-transform-spread/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-sticky-regex/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-sticky-regex/test/package.json
+++ b/packages/babel-plugin-transform-sticky-regex/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-strict-mode/package.json
+++ b/packages/babel-plugin-transform-strict-mode/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-strict-mode/test/package.json
+++ b/packages/babel-plugin-transform-strict-mode/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-template-literals/package.json
+++ b/packages/babel-plugin-transform-template-literals/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-template-literals/test/package.json
+++ b/packages/babel-plugin-transform-template-literals/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-typeof-symbol/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/package.json
@@ -45,10 +45,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -58,5 +58,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-typeof-symbol/test/package.json
+++ b/packages/babel-plugin-transform-typeof-symbol/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -48,10 +48,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -61,5 +61,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-typescript/test/package.json
+++ b/packages/babel-plugin-transform-typescript/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-unicode-escapes/package.json
+++ b/packages/babel-plugin-transform-unicode-escapes/package.json
@@ -42,10 +42,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -55,5 +55,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-unicode-escapes/test/package.json
+++ b/packages/babel-plugin-transform-unicode-escapes/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-unicode-property-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-property-regex/package.json
@@ -49,10 +49,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -62,5 +62,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-unicode-property-regex/test/package.json
+++ b/packages/babel-plugin-transform-unicode-property-regex/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-unicode-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/package.json
@@ -43,10 +43,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -56,5 +56,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-plugin-transform-unicode-regex/test/package.json
+++ b/packages/babel-plugin-transform-unicode-regex/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-plugin-transform-unicode-sets-regex/package.json
+++ b/packages/babel-plugin-transform-unicode-sets-regex/package.json
@@ -48,13 +48,13 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-plugin-transform-unicode-sets-regex/test/package.json
+++ b/packages/babel-plugin-transform-unicode-sets-regex/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -122,10 +122,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -135,5 +135,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-preset-env/test/package.json
+++ b/packages/babel-preset-env/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-preset-flow/package.json
+++ b/packages/babel-preset-flow/package.json
@@ -49,10 +49,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -62,5 +62,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-preset-flow/test/package.json
+++ b/packages/babel-preset-flow/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-preset-react/package.json
+++ b/packages/babel-preset-react/package.json
@@ -45,10 +45,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -58,5 +58,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-preset-react/test/package.json
+++ b/packages/babel-preset-react/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -48,10 +48,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -61,5 +61,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-preset-typescript/test/package.json
+++ b/packages/babel-preset-typescript/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/babel-register"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "commonjs",
+  "type": "module",
   "main": "./lib/index.js",
   "dependencies": {
     "@cspotcode/source-map-support": "condition:BABEL_8_BREAKING ? ^0.8.1 :",
@@ -49,6 +49,12 @@
       },
       {
         "exports": null
+      }
+    ],
+    "USE_ESM": [
+      null,
+      {
+        "type": "commonjs"
       }
     ]
   },

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/babel-register"
   },
   "author": "The Babel Team (https://babel.dev/team)",
-  "type": "module",
+  "type": "commonjs",
   "main": "./lib/index.js",
   "dependencies": {
     "@cspotcode/source-map-support": "condition:BABEL_8_BREAKING ? ^0.8.1 :",
@@ -49,12 +49,6 @@
       },
       {
         "exports": null
-      }
-    ],
-    "USE_ESM": [
-      null,
-      {
-        "type": "commonjs"
       }
     ]
   },

--- a/packages/babel-register/test/package.json
+++ b/packages/babel-register/test/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/packages/babel-register/test/package.json
+++ b/packages/babel-register/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -1139,13 +1139,13 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -1139,14 +1139,8 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "module",
+  "type": "commonjs",
   "conditions": {
-    "USE_ESM": [
-      null,
-      {
-        "type": "commonjs"
-      }
-    ],
     "BABEL_8_BREAKING": [
       {
         "private": true

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -1351,14 +1351,8 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "module",
+  "type": "commonjs",
   "conditions": {
-    "USE_ESM": [
-      null,
-      {
-        "type": "commonjs"
-      }
-    ],
     "BABEL_8_BREAKING": [
       {
         "engines": {

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -1351,13 +1351,13 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-runtime-corejs3/test/package.json
+++ b/packages/babel-runtime-corejs3/test/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/packages/babel-runtime-corejs3/test/package.json
+++ b/packages/babel-runtime-corejs3/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -1043,14 +1043,8 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "module",
+  "type": "commonjs",
   "conditions": {
-    "USE_ESM": [
-      null,
-      {
-        "type": "commonjs"
-      }
-    ],
     "BABEL_8_BREAKING": [
       {
         "engines": {

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -1043,13 +1043,13 @@
   "engines": {
     "node": ">=6.9.0"
   },
-  "type": "commonjs",
+  "type": "module",
   "conditions": {
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ],
     "BABEL_8_BREAKING": [
       {

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -160,10 +160,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -172,5 +172,5 @@
     "./babel.min.js": "./babel.min.js",
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-standalone/package.json
+++ b/packages/babel-standalone/package.json
@@ -158,12 +158,6 @@
       {
         "exports": null
       }
-    ],
-    "USE_ESM": [
-      null,
-      {
-        "type": "commonjs"
-      }
     ]
   },
   "exports": {
@@ -172,5 +166,5 @@
     "./babel.min.js": "./babel.min.js",
     "./package.json": "./package.json"
   },
-  "type": "module"
+  "type": "commonjs"
 }

--- a/packages/babel-standalone/test/package.json
+++ b/packages/babel-standalone/test/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/packages/babel-standalone/test/package.json
+++ b/packages/babel-standalone/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-template/package.json
+++ b/packages/babel-template/package.json
@@ -35,10 +35,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -48,5 +48,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-template/test/package.json
+++ b/packages/babel-template/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-traverse/package.json
+++ b/packages/babel-traverse/package.json
@@ -46,10 +46,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -59,5 +59,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-traverse/scripts/package.json
+++ b/packages/babel-traverse/scripts/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-traverse/test/package.json
+++ b/packages/babel-traverse/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -48,10 +48,10 @@
       }
     ],
     "USE_ESM": [
+      null,
       {
-        "type": "module"
-      },
-      null
+        "type": "commonjs"
+      }
     ]
   },
   "exports": {
@@ -62,5 +62,5 @@
     },
     "./package.json": "./package.json"
   },
-  "type": "commonjs"
+  "type": "module"
 }

--- a/packages/babel-types/scripts/package.json
+++ b/packages/babel-types/scripts/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/packages/babel-types/test/package.json
+++ b/packages/babel-types/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -233,12 +233,14 @@ function enforceConditions({ Yarn }) {
     if (workspace.manifest.private) continue;
     if (workspace.manifest.main === "./lib/index.cjs") continue;
     if (workspace.ident === "@babel/compat-data") continue;
-    if (!workspace.manifest.conditions) {
-      workspace.set("conditions", { USE_ESM: [null, { type: "commonjs" }] });
-    } else if (!workspace.manifest.conditions.USE_ESM) {
-      workspace.set("conditions.USE_ESM", [null, { type: "commonjs" }]);
-    } else {
-      workspace.set("conditions.USE_ESM.1", { type: "commonjs" });
+    if (workspace.manifest.type !== "commonjs") {
+      if (!workspace.manifest.conditions) {
+        workspace.set("conditions", { USE_ESM: [null, { type: "commonjs" }] });
+      } else if (!workspace.manifest.conditions.USE_ESM) {
+        workspace.set("conditions.USE_ESM", [null, { type: "commonjs" }]);
+      } else {
+        workspace.set("conditions.USE_ESM.1", { type: "commonjs" });
+      }
     }
   }
 }

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -164,9 +164,8 @@ gen_enforced_field(WorkspaceCwd, 'type', 'commonjs') :-
  */
 function enforceType({ Yarn }) {
   for (const workspace of Yarn.workspaces()) {
-    const { type } = workspace.manifest;
-    if (type !== "module") {
-      workspace.set("type", "commonjs");
+    if (!workspace.manifest.private && workspace.manifest.type !== "commonjs") {
+      workspace.set("type", "module");
     }
   }
 }
@@ -235,7 +234,11 @@ function enforceConditions({ Yarn }) {
     if (workspace.manifest.main === "./lib/index.cjs") continue;
     if (workspace.ident === "@babel/compat-data") continue;
     if (!workspace.manifest.conditions) {
-      workspace.set("conditions", { USE_ESM: [{ type: "module" }, null] });
+      workspace.set("conditions", { USE_ESM: [null, { type: "commonjs" }] });
+    } else if (!workspace.manifest.conditions.USE_ESM) {
+      workspace.set("conditions.USE_ESM", [null, { type: "commonjs" }]);
+    } else {
+      workspace.set("conditions.USE_ESM.1", { type: "commonjs" });
     }
   }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

TypeScript 5.5 reads `type` from `package.json`, and bans ESM syntax in `.ts` files that have `type: commonjs` (https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#respecting-file-extensions-and-packagejson-in-other-module-modes).

Currently we:
- have `type: commonjs`
- write ESM in the `.ts` files in `src/`
- replace with with `type: module` when publishing Babel 8

With this PR we:
- have `type: module`
- write ESM in the `.ts` files in `src/`
- replace with with `type: commonjs` when publishing Babel 7

This is needed to update to TS5.5, but I'm opening it as its own PR for ease of review.