### PR TITLE
Fix test262-parser-tests update workflow

### DIFF
--- a/.github/workflows/update-parser-tests.yml
+++ b/.github/workflows/update-parser-tests.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Build babel parser
         run: |
           yarn install --immutable --mode=skip-build
+          yarn node ./scripts/set-module-type.js module
           yarn gulp build-rollup
       - name: Update test262 allow list
         run: |


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/actions/runs/9310770695/job/25635209697
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The test262 parser tests update workflow has been broken since https://github.com/babel/babel/pull/16535, as we still built babel-parser into cjs while its package type is marked as module. In this PR we always build the ESM version.

The revised workflow [works for my fork](https://github.com/JLHwung/babel/actions/runs/9326391308/job/25674856055): It stops at the pull request step as it is lack of proper token.