### PR TITLE
Improve `getBindingIdentifiers`

### DIFF
--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -369,7 +369,7 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
       // @ts-expect-error Fixme: document symbol ast properties
       !path.get("id").node[NOT_LOCAL_BINDING]
     ) {
-      path.scope.registerBinding("local", path);
+      path.scope.registerBinding("local", path.get("id"), path);
     }
   },
   TSTypeAnnotation(path) {

--- a/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
+++ b/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
@@ -8,6 +8,7 @@ import {
   isExportAllDeclaration,
   isAssignmentExpression,
   isUnaryExpression,
+  isUpdateExpression,
 } from "../validators/generated/index.ts";
 import type * as t from "../index.ts";
 
@@ -52,12 +53,14 @@ function getBindingIdentifiers(
 
     if (
       newBindingsOnly &&
-      // These two nodes do not introduce _new_ bindings, but they are included
+      // These nodes do not introduce _new_ bindings, but they are included
       // in getBindingIdentifiers.keys for backwards compatibility.
       // TODO(@nicolo-ribaudo): Check if we can remove them from .keys in a
       // backward-compatible way, and if not what we need to do to remove them
       // in Babel 8.
-      (isAssignmentExpression(id) || isUnaryExpression(id))
+      (isAssignmentExpression(id) ||
+        isUnaryExpression(id) ||
+        isUpdateExpression(id))
     ) {
       continue;
     }

--- a/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
+++ b/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
@@ -88,7 +88,10 @@ function getBindingIdentifiers(
         continue;
       }
 
-      if (isFunctionExpression(id) || isClassExpression(id)) {
+      if (
+        isFunctionExpression(id) ||
+        (process.env.BABEL_8_BREAKING && isClassExpression(id))
+      ) {
         continue;
       }
     }

--- a/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
+++ b/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
@@ -112,8 +112,6 @@ function getBindingIdentifiers(
       }
     }
   }
-
-  // $FlowIssue Object.create() seems broken
   return ids;
 }
 

--- a/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
+++ b/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
@@ -1,6 +1,7 @@
 import {
   isExportDeclaration,
   isIdentifier,
+  isClassExpression,
   isDeclaration,
   isFunctionDeclaration,
   isFunctionExpression,
@@ -61,10 +62,6 @@ function getBindingIdentifiers(
       continue;
     }
 
-    const keys =
-      // @ts-expect-error getBindingIdentifiers.keys do not cover all AST types
-      getBindingIdentifiers.keys[id.type];
-
     if (isIdentifier(id)) {
       if (duplicates) {
         const _ids = (ids[id.name] = ids[id.name] || []);
@@ -88,10 +85,14 @@ function getBindingIdentifiers(
         continue;
       }
 
-      if (isFunctionExpression(id)) {
+      if (isFunctionExpression(id) || isClassExpression(id)) {
         continue;
       }
     }
+
+    const keys =
+      // @ts-expect-error getBindingIdentifiers.keys do not cover all AST types
+      getBindingIdentifiers.keys[id.type];
 
     if (keys) {
       for (let i = 0; i < keys.length; i++) {

--- a/packages/babel-types/test/retrievers.js
+++ b/packages/babel-types/test/retrievers.js
@@ -1,3 +1,7 @@
+import {
+  describeBabel7,
+  describeBabel8,
+} from "../../../scripts/repo-utils/index.cjs";
 import * as t from "../lib/index.js";
 import { parse } from "@babel/parser";
 
@@ -158,11 +162,6 @@ describe("retrievers", function () {
       ],
       ["class declarations", getBody("class C { a(b) { let c } }")[0], ["C"]],
       [
-        "class expressions",
-        getBody("(class C { a(b) { let c } })")[0].expression,
-        [],
-      ],
-      [
         "object methods",
         getBody("({ a(b) { let c } })")[0].expression.properties[0],
         ["b"],
@@ -233,6 +232,30 @@ describe("retrievers", function () {
       ["unary expression", getBody("void x")[0].expression, ["x"]],
       ["update expression", getBody("++x")[0].expression, ["x"]],
       ["assignment expression", getBody("x ??= 1")[0].expression, ["x"]],
+    ])("%s", (_, program, bindingNames) => {
+      const ids = t.getOuterBindingIdentifiers(program);
+      expect(Object.keys(ids)).toEqual(bindingNames);
+    });
+  });
+  describeBabel7("getOuterBindingIdentifiers - Babel 7", function () {
+    it.each([
+      [
+        "class expressions",
+        getBody("(class C { a(b) { let c } })")[0].expression,
+        ["C"],
+      ],
+    ])("%s", (_, program, bindingNames) => {
+      const ids = t.getOuterBindingIdentifiers(program);
+      expect(Object.keys(ids)).toEqual(bindingNames);
+    });
+  });
+  describeBabel8("getOuterBindingIdentifiers - Babel 8", function () {
+    it.each([
+      [
+        "class expressions",
+        getBody("(class C { a(b) { let c } })")[0].expression,
+        [],
+      ],
     ])("%s", (_, program, bindingNames) => {
       const ids = t.getOuterBindingIdentifiers(program);
       expect(Object.keys(ids)).toEqual(bindingNames);

--- a/packages/babel-types/test/retrievers.js
+++ b/packages/babel-types/test/retrievers.js
@@ -159,7 +159,7 @@ describe("retrievers", function () {
       [
         "class expressions",
         getBody("(class C { a(b) { let c } })")[0].expression,
-        ["C"],
+        [],
       ],
       [
         "object methods",

--- a/packages/babel-types/test/retrievers.js
+++ b/packages/babel-types/test/retrievers.js
@@ -15,8 +15,28 @@ describe("retrievers", function () {
       ],
       [
         "function declarations",
-        getBody("var foo = 1; function bar() { var baz = 2; }"),
-        ["bar", "foo"],
+        getBody("function bar() { var baz = 2; }"),
+        ["bar"],
+      ],
+      [
+        "function declarations with parameters",
+        getBody(
+          "function f(a, { b }, c = 1, [{ _: [ d ], ...e }]) { var baz = 2; }",
+        ),
+        ["f", "a", "c", "b", "e", "d"],
+      ],
+      [
+        "function expressions with parameters",
+        getBody(
+          "(function f(a, { b }, c = 1, [{ _: [ d ], ...e }]) { var baz = 2; })",
+        )[0].expression,
+        ["f", "a", "c", "b", "e", "d"],
+      ],
+      ["class declarations", getBody("class C { a(b) { let c } }")[0], ["C"]],
+      [
+        "class expressions",
+        getBody("(class C { a(b) { let c } })")[0].expression,
+        ["C"],
       ],
       [
         "object methods",
@@ -34,8 +54,25 @@ describe("retrievers", function () {
         ["b"],
       ],
       [
+        "for-in statement",
+        getBody("for ([{ _: [ d ], ...e }] in rhs);"),
+        ["e", "d"],
+      ],
+      [
+        "for-of statement",
+        getBody("for ([{ _: [ d ], ...e }] of rhs);"),
+        ["e", "d"],
+      ],
+      ["catch clause", getBody("try { } catch (e) {}")[0].handler, ["e"]],
+      ["labeled statement", getBody("label: x"), ["label"]],
+      [
         "export named declarations",
         getBody("export const foo = 'foo';"),
+        ["foo"],
+      ],
+      [
+        "export function declarations",
+        getBody("export function foo() {}"),
         ["foo"],
       ],
       [
@@ -73,6 +110,129 @@ describe("retrievers", function () {
       ["assignment expression", getBody("x ??= 1")[0].expression, ["x"]],
     ])("%s", (_, program, bindingNames) => {
       const ids = t.getBindingIdentifiers(program);
+      expect(Object.keys(ids)).toEqual(bindingNames);
+    });
+  });
+  describe("getBindingIdentifiers(%, /* duplicates */ true)", function () {
+    it.each([
+      ["variable declarations", getBody("var a = 1, a = 2"), { a: 2 }],
+      [
+        "function declarations with parameters",
+        getBody("function f(f) { var f = 1; }"),
+        { f: 2 },
+      ],
+    ])("%s", (_, program, expected) => {
+      const ids = t.getBindingIdentifiers(program, true);
+      for (const name of Object.keys(ids)) {
+        ids[name] = Array.isArray(ids[name]) ? ids[name].length : 1;
+      }
+      expect(ids).toEqual(expected);
+    });
+  });
+  describe("getOuterBindingIdentifiers", function () {
+    it.each([
+      [
+        "variable declarations",
+        getBody("var a = 1; let b = 2; const c = 3;"),
+        ["a", "b", "c"],
+      ],
+      [
+        "function declarations",
+        getBody("function bar() { var baz = 2; }"),
+        ["bar"],
+      ],
+      [
+        "function declarations with parameters",
+        getBody(
+          "function f(a, { b }, c = 1, [{ _: [ d ], ...e }]) { var baz = 2; }",
+        ),
+        ["f"],
+      ],
+      [
+        "function expressions with parameters",
+        getBody(
+          "(function f(a, { b }, c = 1, [{ _: [ d ], ...e }]) { var baz = 2; })",
+        )[0].expression,
+        [],
+      ],
+      ["class declarations", getBody("class C { a(b) { let c } }")[0], ["C"]],
+      [
+        "class expressions",
+        getBody("(class C { a(b) { let c } })")[0].expression,
+        ["C"],
+      ],
+      [
+        "object methods",
+        getBody("({ a(b) { let c } })")[0].expression.properties[0],
+        ["b"],
+      ],
+      [
+        "class methods",
+        getBody("(class { a(b) { let c } })")[0].expression.body.body,
+        ["b"],
+      ],
+      [
+        "class private methods",
+        getBody("(class { #a(b) { let c } })")[0].expression.body.body,
+        ["b"],
+      ],
+      [
+        "for-in statement",
+        getBody("for ([{ _: [ d ], ...e }] in rhs);"),
+        ["e", "d"],
+      ],
+      [
+        "for-of statement",
+        getBody("for ([{ _: [ d ], ...e }] of rhs);"),
+        ["e", "d"],
+      ],
+      ["catch clause", getBody("try { } catch (e) {}")[0].handler, ["e"]],
+      ["labeled statement", getBody("label: x"), ["label"]],
+      [
+        "export named declarations",
+        getBody("export const foo = 'foo';"),
+        ["foo"],
+      ],
+      [
+        "export function declarations",
+        getBody("export function foo() {}"),
+        ["foo"],
+      ],
+      [
+        "export default class declarations",
+        getBody("export default class foo {}"),
+        ["foo"],
+      ],
+      [
+        "export default referenced identifiers",
+        getBody("export default foo"),
+        [],
+      ],
+      ["export all declarations", getBody("export * from 'x'"), []],
+      [
+        "export all as namespace declarations",
+        getBody("export * as ns from 'x'"),
+        [], // exported bindings are not associated with declarations
+      ],
+      [
+        "export namespace specifiers",
+        getBody("export * as ns from 'x'")[0].specifiers,
+        ["ns"],
+      ],
+      [
+        "object patterns",
+        getBody("const { a, b: { ...c } = { d } } = {}"),
+        ["a", "c"],
+      ],
+      [
+        "array patterns",
+        getBody("var [ a, ...{ b, ...c } ] = {}"),
+        ["a", "b", "c"],
+      ],
+      ["update expression", getBody("++x")[0].expression, ["x"]],
+      ["assignment expression", getBody("x ??= 1")[0].expression, ["x"]],
+    ])("%s", (_, program, bindingNames) => {
+      const ids = t.getOuterBindingIdentifiers(program);
       expect(Object.keys(ids)).toEqual(bindingNames);
     });
   });

--- a/packages/babel-types/test/retrievers.js
+++ b/packages/babel-types/test/retrievers.js
@@ -106,6 +106,7 @@ describe("retrievers", function () {
         getBody("var [ a, ...{ b, ...c } ] = {}"),
         ["a", "b", "c"],
       ],
+      ["unary expression", getBody("void x")[0].expression, ["x"]],
       ["update expression", getBody("++x")[0].expression, ["x"]],
       ["assignment expression", getBody("x ??= 1")[0].expression, ["x"]],
     ])("%s", (_, program, bindingNames) => {
@@ -229,10 +230,21 @@ describe("retrievers", function () {
         getBody("var [ a, ...{ b, ...c } ] = {}"),
         ["a", "b", "c"],
       ],
+      ["unary expression", getBody("void x")[0].expression, ["x"]],
       ["update expression", getBody("++x")[0].expression, ["x"]],
       ["assignment expression", getBody("x ??= 1")[0].expression, ["x"]],
     ])("%s", (_, program, bindingNames) => {
       const ids = t.getOuterBindingIdentifiers(program);
+      expect(Object.keys(ids)).toEqual(bindingNames);
+    });
+  });
+  describe("getBindingIdentifiers(%, false, false, /* newBindingsOnly */ true)", function () {
+    it.each([
+      ["unary expression", getBody("void x")[0].expression, []],
+      ["update expression", getBody("++x")[0].expression, []],
+      ["assignment expression", getBody("x ??= 1")[0].expression, []],
+    ])("%s", (_, program, bindingNames) => {
+      const ids = t.getBindingIdentifiers(program, false, false, true);
       expect(Object.keys(ids)).toEqual(bindingNames);
     });
   });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `getOuterBindingIdentifiers` should not return the class id for class expressions
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
When `newBindingOnly` is `true`, `getBindingIdentifiers` will not consider an `UpdateExpression` as a binding path. 

More tests are also provided.