### PR TITLE
fix Babel 8 commander import

### DIFF
--- a/lib/third-party-libs.d.ts
+++ b/lib/third-party-libs.d.ts
@@ -8,8 +8,10 @@ declare module "js-tokens" {
 
 declare module "commander" {
   import type { Command } from "commander-BABEL_8_BREAKING-true";
+  // TODO(Babel 8): Remove default export typings, they are for Babel 7 CJS only
   const _default: { program: Command };
   export { _default as default };
+  export type * from "commander-BABEL_8_BREAKING-true";
 }
 
 declare module "@babel/preset-modules/lib/plugins/transform-async-arrows-in-class/index.js" {

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@jridgewell/trace-mapping": "^0.3.25",
-    "commander": "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0",
+    "commander": "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0 (esm:program|default)",
     "convert-source-map": "^2.0.0",
     "fs-readdir-recursive": "^1.1.0",
     "glob": "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync|default)",

--- a/packages/babel-cli/src/babel-external-helpers.ts
+++ b/packages/babel-cli/src/babel-external-helpers.ts
@@ -1,7 +1,9 @@
 import * as commander from "commander";
 import { buildExternalHelpers } from "@babel/core";
 
-const program = commander.default.program;
+const program = process.env.BABEL_8_BREAKING
+  ? commander.program
+  : commander.default.program;
 
 function collect(value: unknown, previousValue: Array<string>): Array<string> {
   // If the user passed the option with no value, like "babel-external-helpers --whitelist", do nothing.

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -7,7 +7,9 @@ import { alphasort } from "./util.ts";
 
 import type { InputOptions } from "@babel/core";
 
-const program = commander.default.program;
+const program = process.env.BABEL_8_BREAKING
+  ? commander.program
+  : commander.default.program;
 
 // Standard Babel input configs.
 program.option(

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@babel/register": "workspace:^",
-    "commander": "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0",
+    "commander": "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0 (esm:program|default)",
     "core-js": "^3.30.2",
     "node-environment-flags": "condition:BABEL_8_BREAKING ? : ^1.0.5",
     "regenerator-runtime": "^0.14.0",

--- a/packages/babel-node/src/_babel-node.ts
+++ b/packages/babel-node/src/_babel-node.ts
@@ -16,7 +16,9 @@ import type { PluginAPI, PluginObject } from "@babel/core";
 
 const require = createRequire(import.meta.url);
 
-const program = commander.default.program;
+const program = process.env.BABEL_8_BREAKING
+  ? commander.program
+  : commander.default.program;
 
 function collect(value: unknown, previousValue: string[]): Array<string> {
   // If the user passed the option with no value, like "babel-node file.js --presets", do nothing.

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,7 +230,7 @@ __metadata:
     "@types/fs-readdir-recursive": "npm:^1.1.0"
     "@types/glob": "npm:^7.2.0"
     chokidar: "npm:^3.4.0"
-    commander: "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0"
+    commander: "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0 (esm:program|default)"
     convert-source-map: "npm:^2.0.0"
     fs-readdir-recursive: "npm:^1.1.0"
     glob: "condition:BABEL_8_BREAKING ? ^10.3.12 : ^7.2.0 (esm:sync|default)"
@@ -1259,7 +1259,7 @@ __metadata:
     "@babel/register": "workspace:^"
     "@babel/runtime": "workspace:^"
     "@types/v8flags": "npm:^3.1.1"
-    commander: "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0"
+    commander: "condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0 (esm:program|default)"
     core-js: "npm:^3.30.2"
     node-environment-flags: "condition:BABEL_8_BREAKING ? : ^1.0.5"
     regenerator-runtime: "npm:^0.14.0"
@@ -8132,13 +8132,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0":
-  version: 0.0.0-condition-5eb315
-  resolution: "commander@condition:BABEL_8_BREAKING?^12.1.0:^6.2.0#5eb315"
+"commander@condition:BABEL_8_BREAKING ? ^12.1.0 : ^6.2.0 (esm:program|default)":
+  version: 0.0.0-condition-c20610
+  resolution: "commander@condition:BABEL_8_BREAKING?^12.1.0:^6.2.0(esm:program|default)#c20610"
   dependencies:
     commander-BABEL_8_BREAKING-false: "npm:commander@^6.2.0"
     commander-BABEL_8_BREAKING-true: "npm:commander@^12.1.0"
-  checksum: 10/722f3bcc78ac4f7d1ef5c38e0ce058c5959d52ae42e2ac811bd9dd9bc6ad61a12d8d13c702c03dd2de1d2521e56b5f8c98f2ee47d76c3e1547cfbb73d482b3f1
+  checksum: 10/458a757b162d00d72fe2b0541253a182dcce77378adb4f3c3233bf2c0a1bb2de3ea481ad7525852a603632fbea0d2a09e10ece50c5e975e5770da9d2ef436826
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/16547
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Previously the Babel 8 test in #16517 was passing because we the condition proxy package is marked as CJS only, as we did not specify the esm exports for the `commander` package. The commander v12 is a dual package, so essentially we were importing a CJS wrapper of commander, which breaks Babel 8 since the ESM version should be used.

Idea for the yarn conditional plugin: make the `esm` condition clause required when some of dependents are dual / esm-only packages, otherwise users end up using CJS wrappers of those packages.