### PR TITLE
Add NodePath#getAssignmentIdentifiers

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/validation.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/validation.ts
@@ -177,7 +177,9 @@ function injectTDZChecks(binding: Scope.Binding, state: PluginPass) {
       }
     } else if (path.isAssignmentExpression()) {
       const nodes = [];
-      const ids = path.getBindingIdentifiers();
+      const ids = process.env.BABEL_8_BREAKING
+        ? path.getAssignmentIdentifiers()
+        : path.getBindingIdentifiers();
 
       for (const name of Object.keys(ids)) {
         const replacement = getTDZReplacement(path, state, ids[name]);

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -3,6 +3,7 @@
 import type TraversalContext from "../context.ts";
 import NodePath from "./index.ts";
 import {
+  getAssignmentIdentifiers as _getAssignmentIdentifiers,
   getBindingIdentifiers as _getBindingIdentifiers,
   getOuterBindingIdentifiers as _getOuterBindingIdentifiers,
   numericLiteral,
@@ -451,6 +452,10 @@ export function _getPattern(
     }
   }
   return path;
+}
+
+export function getAssignmentIdentifiers(this: NodePath) {
+  return _getAssignmentIdentifiers(this.node);
 }
 
 function getBindingIdentifiers(

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -307,6 +307,7 @@ const methods = {
   get: NodePath_family.get,
   _getKey: NodePath_family._getKey,
   _getPattern: NodePath_family._getPattern,
+  getAssignmentIdentifiers: NodePath_family.getAssignmentIdentifiers,
   getBindingIdentifiers: NodePath_family.getBindingIdentifiers,
   getOuterBindingIdentifiers: NodePath_family.getOuterBindingIdentifiers,
   getBindingIdentifierPaths: NodePath_family.getBindingIdentifierPaths,

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -793,7 +793,7 @@ class Scope {
   }
 
   registerConstantViolation(path: NodePath) {
-    const ids = path.getBindingIdentifiers();
+    const ids = path.getAssignmentIdentifiers();
     for (const name of Object.keys(ids)) {
       this.getBinding(name)?.reassign(path);
     }
@@ -1045,7 +1045,7 @@ class Scope {
     // register assignments
     for (const path of state.assignments) {
       // register undeclared bindings as globals
-      const ids = path.getBindingIdentifiers();
+      const ids = path.getAssignmentIdentifiers();
       for (const name of Object.keys(ids)) {
         if (path.scope.getBinding(name)) continue;
         programParent.addGlobal(ids[name]);

--- a/packages/babel-traverse/src/scope/lib/renamer.ts
+++ b/packages/babel-traverse/src/scope/lib/renamer.ts
@@ -48,11 +48,15 @@ const renameVisitor: Visitor<Renamer> = {
   },
 
   "AssignmentExpression|Declaration|VariableDeclarator"(
-    path: NodePath<t.AssignmentPattern | t.Declaration | t.VariableDeclarator>,
+    path: NodePath<
+      t.AssignmentExpression | t.Declaration | t.VariableDeclarator
+    >,
     state,
   ) {
     if (path.isVariableDeclaration()) return;
-    const ids = path.getOuterBindingIdentifiers();
+    const ids = path.isAssignmentExpression()
+      ? path.getAssignmentIdentifiers()
+      : path.getOuterBindingIdentifiers();
 
     for (const name in ids) {
       if (name === state.oldName) ids[name].name = state.newName;

--- a/packages/babel-types/src/index.ts
+++ b/packages/babel-types/src/index.ts
@@ -62,6 +62,7 @@ export { default as removePropertiesDeep } from "./modifications/removePropertie
 export { default as removeTypeDuplicates } from "./modifications/flow/removeTypeDuplicates.ts";
 
 // retrievers
+export { default as getAssignmentIdentifiers } from "./retrievers/getAssignmentIdentifiers.ts";
 export { default as getBindingIdentifiers } from "./retrievers/getBindingIdentifiers.ts";
 export { default as getOuterBindingIdentifiers } from "./retrievers/getOuterBindingIdentifiers.ts";
 

--- a/packages/babel-types/src/retrievers/getAssignmentIdentifiers.ts
+++ b/packages/babel-types/src/retrievers/getAssignmentIdentifiers.ts
@@ -1,0 +1,62 @@
+import type * as t from "../index.ts";
+
+/**
+ * For the given node, generate a map from assignment id names to the identifier node.
+ * Unlike getBindingIdentifiers, this function does not handle declarations and imports.
+ * @param node the assignment expression or forXstatement
+ * @returns an object map
+ * @see getBindingIdentifiers
+ */
+export default function getAssignmentIdentifiers(
+  node: t.Node | t.Node[],
+): Record<string, t.Identifier> {
+  // null represents holes in an array pattern
+  const search: (t.Node | null)[] = [].concat(node);
+  const ids = Object.create(null);
+
+  while (search.length) {
+    const id = search.pop();
+    if (!id) continue;
+
+    switch (id.type) {
+      case "ArrayPattern":
+        search.push(...id.elements);
+        break;
+
+      case "AssignmentExpression":
+      case "AssignmentPattern":
+      case "ForInStatement":
+      case "ForOfStatement":
+        search.push(id.left);
+        break;
+
+      case "ObjectPattern":
+        search.push(...id.properties);
+        break;
+
+      case "ObjectProperty":
+        search.push(id.value);
+        break;
+
+      case "RestElement":
+      case "UpdateExpression":
+        search.push(id.argument);
+        break;
+
+      case "UnaryExpression":
+        if (id.operator === "delete") {
+          search.push(id.argument);
+        }
+        break;
+
+      case "Identifier":
+        ids[id.name] = id;
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  return ids;
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we introduce a new `getAssignmentIdentifiers` method to extract identifiers allowed in the left hand side. Currently this method is a subset of the `getBindingIdentifiers`, however in Babel 8 we will remove the assignment LHS support for `getBindingIdentifiers`, as those are not binding identifiers per spec. 

In Babel 8, `getBindingIdentifiers` will only return identifiers that will introduce new bindings, while `getAssignmentIdentifiers` only returns identifiers that is reassigned.