### PR TITLE
fix: set module type to cjs before generating docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,25 +135,28 @@ jobs:
           # is true. Use the empry string instead.
           BABEL_8_BREAKING: ${{ needs.check-release-type.outputs.is-babel-8 == 'true' || '' }}
 
-      - name: Generate babel-types docs
-        continue-on-error: true
-        run: |
-          mkdir build
-          node ./packages/babel-types/scripts/generators/docs.js > ./build/types.md
-
-      - name: Upload babel-types docs
-        continue-on-error: true
-        uses: actions/upload-artifact@v3
-        with:
-          name: babel-types-docs
-          path: build/types.md
-          retention-days: 3
-
       - name: Publish to npm (Babel 7)
         run: yarn release-tool publish --yes
         if: needs.check-release-type.outputs.is-babel-8 == 'false'
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Generate babel-types docs
+        continue-on-error: true
+        if: needs.check-release-type.outputs.is-babel-8 == 'false'
+        run: |
+          mkdir build
+          node ./scripts/set-module-type.js commonjs
+          node ./packages/babel-types/scripts/generators/docs.js > ./build/types.md
+
+      - name: Upload babel-types docs
+        continue-on-error: true
+        if: needs.check-release-type.outputs.is-babel-8 == 'false'
+        uses: actions/upload-artifact@v3
+        with:
+          name: babel-types-docs
+          path: build/types.md
+          retention-days: 3
 
       - name: Publish to npm (Babel 8)
         # --tag-version-prefix must match the one set in `make new-babel-8-version-create-branch`


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The types docs update workflow is [failing recently](https://github.com/babel/babel/actions/runs/9384667322/job/25840992858#step:7:7)
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The types docs workflow has been broken, very likely since https://github.com/babel/babel/pull/16535. In this PR we move the type update step after the publish step so that the `set-module-type` command will not interfere with the publish process. The update workflow now will run only when we are releasing a Babel 7 release.
