### PR TITLE
Add `uncheckedRequire` option for JSON imports to CJS

### DIFF
--- a/packages/babel-helper-import-to-platform-api/src/index.ts
+++ b/packages/babel-helper-import-to-platform-api/src/index.ts
@@ -194,8 +194,21 @@ export function importToPlatformApi(
     }
   };
 
+  let buildFetch = buildFetchSync;
+  if (!buildFetchSync) {
+    if (toCommonJS) {
+      buildFetch = (specifier, path) => {
+        throw path.buildCodeFrameError(
+          "Cannot compile to CommonJS, since it would require top-level await.",
+        );
+      };
+    } else {
+      buildFetch = buildFetchAsync;
+    }
+  }
+
   return {
-    buildFetch: buildFetchSync || buildFetchAsync,
+    buildFetch,
     buildFetchAsync: buildFetchAsyncWrapped,
     needsAwait: !buildFetchSync,
   };

--- a/packages/babel-plugin-proposal-json-modules/src/index.ts
+++ b/packages/babel-plugin-proposal-json-modules/src/index.ts
@@ -110,6 +110,7 @@ export default declare(api => {
           data.push({ id, fetch });
           decl.remove();
         }
+        if (data.length === 0) return;
 
         const decl = buildParallelStaticImports(data, helper.needsAwait);
         if (decl) path.unshiftContainer("body", decl);

--- a/packages/babel-plugin-proposal-json-modules/src/index.ts
+++ b/packages/babel-plugin-proposal-json-modules/src/index.ts
@@ -8,7 +8,11 @@ import {
   type Builders,
 } from "@babel/helper-import-to-platform-api";
 
-export default declare(api => {
+export interface Options {
+  uncheckedRequire: boolean;
+}
+
+export default declare((api, options: Options) => {
   const { types: t, template } = api;
   api.assertVersion(REQUIRED_VERSION("^7.22.0"));
 
@@ -18,6 +22,10 @@ export default declare(api => {
   let helperCJS: Builders;
 
   const transformers: Pieces = {
+    commonJS: options.uncheckedRequire
+      ? (require: t.Expression, specifier: t.Expression) =>
+          t.callExpression(require, [specifier])
+      : null,
     webFetch: (fetch: t.Expression) =>
       template.expression.ast`${fetch}.then(r => r.json())`,
     nodeFsSync: (read: t.Expression) =>

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration-multiple/input.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration-multiple/input.js
@@ -1,0 +1,3 @@
+import j from "./x.json" with { type: "json" };
+someBody;
+import j2 from "./x2.json" with { type: "json" };

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration-multiple/options.json
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration-multiple/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Cannot compile to CommonJS, since it would require top-level await."
+}

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration-namespace/input.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration-namespace/input.js
@@ -1,0 +1,1 @@
+import * as ns from "./x.json" with { type: "json" };

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration-namespace/options.json
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration-namespace/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Cannot compile to CommonJS, since it would require top-level await."
+}

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration/input.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration/input.js
@@ -1,0 +1,1 @@
+import j from "./x.json" with { type: "json" };

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration/options.json
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-declaration/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Cannot compile to CommonJS, since it would require top-level await."
+}

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-expression/input.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-expression/input.js
@@ -1,0 +1,2 @@
+// TODO: Not supported yet
+let promise = import("./x.json", { with: { type: "json" } });

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-expression/output.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-expression/output.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// TODO: Not supported yet
+let promise = import("./x.json", {
+  with: {
+    type: "json"
+  }
+});

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-meta-resolve-fallback/input.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-meta-resolve-fallback/input.js
@@ -1,0 +1,1 @@
+import j from "./x.json" with { type: "json" };

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-meta-resolve-fallback/options.json
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/import-meta-resolve-fallback/options.json
@@ -1,0 +1,4 @@
+{
+  "targets": { "firefox": "90" },
+  "throws": "Cannot compile to CommonJS, since it would require top-level await."
+}

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/options.json
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/browser-cjs/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "targets": { "firefox": "110" },
+  "plugins": ["proposal-json-modules", "transform-modules-commonjs"]
+}

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-cjs/input.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-cjs/input.js
@@ -1,0 +1,1 @@
+import x from "./x.json" with { type: "json" };

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-cjs/options.json
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-cjs/options.json
@@ -1,0 +1,8 @@
+{
+  "sourceType": "module",
+  "targets": { "firefox": "110", "node": "16" },
+  "plugins": [
+    ["proposal-json-modules", { "uncheckedRequire": true }],
+    "transform-modules-commonjs"
+  ]
+}

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-cjs/output.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-cjs/output.js
@@ -1,0 +1,3 @@
+"use strict";
+
+const x = require("./x.json");

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-esm/input.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-esm/input.js
@@ -1,0 +1,1 @@
+import x from "./x.json" with { type: "json" };

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-esm/options.json
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-esm/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "targets": { "firefox": "110", "node": "16" },
+  "plugins": [["proposal-json-modules", { "uncheckedRequire": true }]]
+}

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-esm/output.mjs
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-and-node-esm/output.mjs
@@ -1,0 +1,1 @@
+const x = await (typeof process === "object" && process.versions?.node ? import("module").then(module => module.createRequire(import.meta.url)("./x.json")) : fetch(import.meta.resolve("./x.json")).then(r => r.json()));

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-cjs/input.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-cjs/input.js
@@ -1,0 +1,1 @@
+import x from "./x.json" with { type: "json" };

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-cjs/options.json
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-cjs/options.json
@@ -1,0 +1,8 @@
+{
+  "sourceType": "module",
+  "targets": { "firefox": "110" },
+  "plugins": [
+    ["proposal-json-modules", { "uncheckedRequire": true }],
+    "transform-modules-commonjs"
+  ]
+}

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-cjs/output.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-cjs/output.js
@@ -1,0 +1,3 @@
+"use strict";
+
+const x = require("./x.json");

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-esm/input.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-esm/input.js
@@ -1,0 +1,1 @@
+import x from "./x.json" with { type: "json" };

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-esm/options.json
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-esm/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "targets": { "firefox": "110" },
+  "plugins": [["proposal-json-modules", { "uncheckedRequire": true }]]
+}

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-esm/output.mjs
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/browser-esm/output.mjs
@@ -1,0 +1,1 @@
+const x = await fetch(import.meta.resolve("./x.json")).then(r => r.json());

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-cjs/input.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-cjs/input.js
@@ -1,0 +1,1 @@
+import x from "./x.json" with { type: "json" };

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-cjs/options.json
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-cjs/options.json
@@ -1,0 +1,8 @@
+{
+  "sourceType": "module",
+  "targets": { "node": "16" },
+  "plugins": [
+    ["proposal-json-modules", { "uncheckedRequire": true }],
+    "transform-modules-commonjs"
+  ]
+}

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-cjs/output.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-cjs/output.js
@@ -1,0 +1,3 @@
+"use strict";
+
+const x = require("./x.json");

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-esm/input.js
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-esm/input.js
@@ -1,0 +1,1 @@
+import x from "./x.json" with { type: "json" };

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-esm/options.json
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-esm/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "targets": { "node": "16" },
+  "plugins": [["proposal-json-modules", { "uncheckedRequire": true }]]
+}

--- a/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-esm/output.mjs
+++ b/packages/babel-plugin-proposal-json-modules/test/fixtures/uncheckedRequire/node-esm/output.mjs
@@ -1,0 +1,2 @@
+import { createRequire as _createRequire } from "module";
+const x = _createRequire(import.meta.url)("./x.json");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16534
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

As #16534 shows, sometimes it is impossible to properly compile `with { type: "json" }` (specifically, when targeting CJS + browsers).

This PR makes that case an error, providing a workaround to compile `import "x.json" with { type: "json" }` to simply `require("x.json")`. Technically this is unsound, because there could be a `x.json.js` file what gets executed without asserting that it's actually JSON, but if you are using CJS you are not loading files from the network anyway.