### PR TITLE
fix plugin-transform-react-constant-elements transform JSXFrament but not add JSXExpressionContainer

### DIFF
--- a/packages/babel-plugin-transform-react-constant-elements/src/index.ts
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.ts
@@ -244,7 +244,8 @@ export default declare((api, options: Options) => {
         `;
         if (
           path.parentPath.isJSXElement() ||
-          path.parentPath.isJSXAttribute()
+          path.parentPath.isJSXAttribute() ||
+          path.parentPath.isJSXFragment()
         ) {
           replacement = t.jsxExpressionContainer(replacement);
         }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-dynamic-and-constant-in-fragment/input.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-dynamic-and-constant-in-fragment/input.js
@@ -1,0 +1,3 @@
+function F(Component) {
+  return <><div>f</div><Component/></>;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-dynamic-and-constant-in-fragment/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-dynamic-and-constant-in-fragment/output.js
@@ -1,0 +1,4 @@
+var _div;
+function F(Component) {
+  return <>{_div || (_div = <div>f</div>)}<Component /></>;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-dynamic-and-fragment-in-fragment/input.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-dynamic-and-fragment-in-fragment/input.js
@@ -1,0 +1,3 @@
+function F(Component) {
+  return <><>f</><Component/></>;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-dynamic-and-fragment-in-fragment/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-dynamic-and-fragment-in-fragment/output.js
@@ -1,0 +1,4 @@
+var _Fragment;
+function F(Component) {
+  return <>{_Fragment || (_Fragment = <>f</>)}<Component /></>;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-expression-container/input.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-expression-container/input.js
@@ -1,0 +1,3 @@
+function C(x) {
+  return <div x={x}>{<span />}</div>;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-expression-container/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-expression-container/output.js
@@ -1,0 +1,4 @@
+var _span;
+function C(x) {
+  return <div x={x}>{_span || (_span = <span />)}</div>;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-fragment/input.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-fragment/input.js
@@ -1,0 +1,3 @@
+function F() {
+  return <><div>f</div></>;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-fragment/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-fragment/output.js
@@ -1,0 +1,4 @@
+var _div;
+function F() {
+  return <>{_div || (_div = <div>f</div>)}</>;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-fragment/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-fragment/output.js
@@ -1,4 +1,4 @@
-var _div;
+var _Fragment;
 function F() {
-  return <>{_div || (_div = <div>f</div>)}</>;
+  return _Fragment || (_Fragment = <><div>f</div></>);
 }

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-spread-attribute/input.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-spread-attribute/input.js
@@ -1,0 +1,3 @@
+function C(x) {
+  return <div x={x} {...<span />} />;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-spread-attribute/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-spread-attribute/output.js
@@ -1,0 +1,4 @@
+var _span;
+function C(x) {
+  return <div x={x} {..._span || (_span = <span />)} />;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-spread-child/input.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-spread-child/input.js
@@ -1,0 +1,3 @@
+function C(x) {
+  return <div x={x}>{...<span />}</div>;
+}

--- a/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-spread-child/output.js
+++ b/packages/babel-plugin-transform-react-constant-elements/test/fixtures/constant-elements/jsx-in-spread-child/output.js
@@ -1,0 +1,4 @@
+var _span;
+function C(x) {
+  return <div x={x}>{..._span || (_span = <span />)}</div>;
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16449 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

fix #16449，the specific repair content is shown in the following figure

<img width="870" alt="image" src="https://github.com/babel/babel/assets/28672197/8555bd8e-255d-4500-8a6e-10b750be29d8">



