### PR TITLE
Remove unused `withSource` from `@babel/generator`

### DIFF
--- a/packages/babel-generator/src/buffer.ts
+++ b/packages/babel-generator/src/buffer.ts
@@ -475,18 +475,6 @@ export default class Buffer {
     this._normalizePosition(prop, loc, columnOffset);
   }
 
-  /**
-   * Call a callback with a specific source location
-   */
-
-  withSource(prop: "start" | "end", loc: Loc, cb: () => void): void {
-    if (this._map) {
-      this.source(prop, loc);
-    }
-
-    cb();
-  }
-
   _normalizePosition(prop: "start" | "end", loc: Loc, columnOffset: number) {
     const pos = loc[prop];
     const target = this._sourcePosition;

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -386,21 +386,6 @@ class Printer {
     this._buf.sourceWithOffset(prop, loc, columnOffset);
   }
 
-  withSource(
-    prop: "start" | "end",
-    loc: Loc | undefined,
-    cb: () => void,
-  ): void {
-    if (!loc) {
-      cb();
-      return;
-    }
-
-    this._catchUp(prop, loc);
-
-    this._buf.withSource(prop, loc, cb);
-  }
-
   sourceIdentifierName(identifierName: string, pos?: Pos): void {
     if (!this._buf._canMarkIdName) return;
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

While working with @nicolo-ribaudo on a source maps task we noticed that these functions are not hit at all in the codecov report.

`printer.ts` - https://app.codecov.io/github/babel/babel/blob/main/packages%2Fbabel-generator%2Fsrc%2Fprinter.ts#L389
`buffer.ts` - https://app.codecov.io/github/babel/babel/blob/main/packages%2Fbabel-generator%2Fsrc%2Fbuffer.ts#L478