### PR TITLE
fix typescript code generation for yield expression inside type expre…

### DIFF
--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -307,7 +307,8 @@ export function YieldExpression(
     hasPostfixPart(node, parent) ||
     (parentType === "AwaitExpression" && isYieldExpression(node)) ||
     (parentType === "ConditionalExpression" && node === parent.test) ||
-    isClassExtendsClause(node, parent)
+    isClassExtendsClause(node, parent) ||
+    isTSTypeExpression(parentType)
   );
 }
 

--- a/packages/babel-generator/test/fixtures/typescript/yield-expression-inside-type-expression/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/yield-expression-inside-type-expression/input.js
@@ -1,0 +1,5 @@
+function* generator() {
+    const one = (yield "one") as number;
+    const two = <number>(yield "two");
+    const three = (yield "three") satisfies number;
+}

--- a/packages/babel-generator/test/fixtures/typescript/yield-expression-inside-type-expression/options.json
+++ b/packages/babel-generator/test/fixtures/typescript/yield-expression-inside-type-expression/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["typescript"]
+}

--- a/packages/babel-generator/test/fixtures/typescript/yield-expression-inside-type-expression/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/yield-expression-inside-type-expression/output.js
@@ -1,0 +1,5 @@
+function* generator() {
+  const one = ((yield "one") as number);
+  const two = (<number> (yield "two"));
+  const three = ((yield "three") satisfies number);
+}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16590 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | No
| License                  | MIT

add parentheses around yield expressions if its parent is of type `TSAsExpression`, `TSSatisfiesExpression` or `TSTypeAssertion`

this fixes issue where 

```js
const one = (yield "one") as number;
```

after parsing and generation becomes

```js
const one = (yield "one" as number);
```

as you can see, the meaning of the expression changes and causes type errors too. 

this PR solves the issue by wrapping the yield expressions inside parentheses

```js
const one = ((yield "one") as number);
```

(the same can be observed for await expressions and this solution fixes that too)