### PR TITLE
Ensure enum members syntactically determinable to be strings do not get reverse mappings

### DIFF
--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -20,6 +20,7 @@
     "@babel/helper-annotate-as-pure": "workspace:^",
     "@babel/helper-create-class-features-plugin": "workspace:^",
     "@babel/helper-plugin-utils": "workspace:^",
+    "@babel/helper-skip-transparent-expression-wrappers": "workspace:^",
     "@babel/plugin-syntax-typescript": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-typescript/src/enum.ts
+++ b/packages/babel-plugin-transform-typescript/src/enum.ts
@@ -120,6 +120,7 @@ function enumFill(path: NodePath<t.TSEnumDeclaration>, t: t, id: t.Identifier) {
 }
 
 export function isSyntacticallyString(expr: t.Expression): boolean {
+  // @ts-ignore(Babel 7 vs Babel 8) Type 'Expression | Super' is not assignable to type 'Expression' in Babel 8
   expr = skipTransparentExprWrapperNodes(expr);
   switch (expr.type) {
     case "BinaryExpression": {

--- a/packages/babel-plugin-transform-typescript/test/fixtures/enum/reverse-mappings-syntactically-determinable/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/enum/reverse-mappings-syntactically-determinable/input.ts
@@ -1,0 +1,9 @@
+const BAR = 2..toFixed(0);
+
+enum Foo {
+    A = `${BAR}`,
+    B = "2" + BAR,
+    C = (`${BAR}`),
+    D = (`${BAR}}`) as string,
+    E = `${BAR}`!,
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/enum/reverse-mappings-syntactically-determinable/output.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/enum/reverse-mappings-syntactically-determinable/output.js
@@ -1,0 +1,9 @@
+const BAR = 2..toFixed(0);
+var Foo = function (Foo) {
+  Foo["A"] = `${BAR}`;
+  Foo["B"] = "2" + BAR;
+  Foo["C"] = `${BAR}`;
+  Foo["D"] = `${BAR}}`;
+  Foo["E"] = `${BAR}`;
+  return Foo;
+}(Foo || {});

--- a/packages/babel-plugin-transform-typescript/tsconfig.json
+++ b/packages/babel-plugin-transform-typescript/tsconfig.json
@@ -20,6 +20,9 @@
       "path": "../../packages/babel-helper-create-class-features-plugin"
     },
     {
+      "path": "../../packages/babel-helper-skip-transparent-expression-wrappers"
+    },
+    {
       "path": "../../packages/babel-plugin-syntax-typescript"
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3807,6 +3807,7 @@ __metadata:
     "@babel/helper-create-class-features-plugin": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
+    "@babel/helper-skip-transparent-expression-wrappers": "workspace:^"
     "@babel/plugin-syntax-typescript": "workspace:^"
     "@babel/traverse": "workspace:^"
     "@babel/types": "workspace:^"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Ref: https://github.com/microsoft/TypeScript/pull/57686 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
