### PR TITLE
Bump compat data sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,10 +93,10 @@
     "benchmark"
   ],
   "resolutions": {
-    "browserslist": "npm:4.23.0",
-    "caniuse-lite": "npm:1.0.30001615",
-    "core-js-compat": "npm:3.37.0",
-    "electron-to-chromium": "npm:1.4.755",
+    "browserslist": "npm:4.23.1",
+    "caniuse-lite": "npm:1.0.30001640",
+    "core-js-compat": "npm:3.37.1",
+    "electron-to-chromium": "npm:1.4.816",
     "glob-watcher/chokidar": "npm:^3.4.0",
     "@types/babel__core": "link:./nope",
     "@types/babel__traverse": "link:./nope",

--- a/packages/babel-compat-data/package.json
+++ b/packages/babel-compat-data/package.json
@@ -45,9 +45,9 @@
     "compat-data"
   ],
   "devDependencies": {
-    "@mdn/browser-compat-data": "^5.3.0",
-    "core-js-compat": "^3.31.0",
-    "electron-to-chromium": "^1.4.441"
+    "@mdn/browser-compat-data": "^5.5.36",
+    "core-js-compat": "^3.37.1",
+    "electron-to-chromium": "^1.4.816"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@babel/compat-data": "workspace:^",
     "@babel/helper-validator-option": "workspace:^",
-    "browserslist": "^4.22.2",
+    "browserslist": "^4.23.1",
     "lru-cache": "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.1"
   },

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -95,7 +95,7 @@
     "babel-plugin-polyfill-corejs2": "condition:BABEL_8_BREAKING ? : ^0.4.10 (peer:@babel/core) (esm:default)",
     "babel-plugin-polyfill-corejs3": "^0.10.4",
     "babel-plugin-polyfill-regenerator": "condition:BABEL_8_BREAKING ? : ^0.6.1 (peer:@babel/core) (esm:default)",
-    "core-js-compat": "^3.31.0",
+    "core-js-compat": "^3.37.1",
     "semver": "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.1"
   },
   "peerDependencies": {

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
@@ -2,15 +2,15 @@
 
 Using targets:
 {
-  "android": "123",
+  "android": "125",
   "chrome": "109",
-  "edge": "122",
+  "edge": "124",
   "firefox": "115",
   "ios": "15.6",
-  "opera": "107",
+  "opera": "109",
   "opera_mobile": "80",
-  "safari": "17.3",
-  "samsung": "23"
+  "safari": "17.4",
+  "samsung": "24"
 }
 
 Using modules transform: auto

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
@@ -2,15 +2,15 @@
 
 Using targets:
 {
-  "android": "123",
+  "android": "125",
   "chrome": "109",
-  "edge": "122",
+  "edge": "124",
   "firefox": "115",
   "ios": "15.6",
-  "opera": "107",
+  "opera": "109",
   "opera_mobile": "80",
-  "safari": "17.3",
-  "samsung": "23"
+  "safari": "17.4",
+  "samsung": "24"
 }
 
 Using modules transform: auto

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
@@ -2,15 +2,15 @@
 
 Using targets:
 {
-  "android": "123",
-  "chrome": "123",
-  "edge": "123",
-  "firefox": "124",
-  "ios": "17.3",
-  "opera": "108",
+  "android": "125",
+  "chrome": "125",
+  "edge": "125",
+  "firefox": "126",
+  "ios": "17.4",
+  "opera": "110",
   "opera_mobile": "80",
-  "safari": "17.3",
-  "samsung": "23"
+  "safari": "17.4",
+  "samsung": "24"
 }
 
 Using modules transform: auto

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -2,15 +2,15 @@
 
 Using targets:
 {
-  "android": "123",
+  "android": "125",
   "chrome": "109",
-  "edge": "122",
+  "edge": "124",
   "firefox": "115",
   "ios": "15.6",
-  "opera": "107",
+  "opera": "109",
   "opera_mobile": "80",
-  "safari": "17.3",
-  "samsung": "23"
+  "safari": "17.4",
+  "samsung": "24"
 }
 
 Using modules transform: auto

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -2,15 +2,15 @@
 
 Using targets:
 {
-  "android": "123",
+  "android": "125",
   "chrome": "109",
-  "edge": "122",
+  "edge": "124",
   "firefox": "115",
   "ios": "15.6",
-  "opera": "107",
+  "opera": "109",
   "opera_mobile": "80",
-  "safari": "17.3",
-  "samsung": "23"
+  "safari": "17.4",
+  "samsung": "24"
 }
 
 Using modules transform: auto

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -2,15 +2,15 @@
 
 Using targets:
 {
-  "android": "123",
-  "chrome": "123",
-  "edge": "123",
-  "firefox": "124",
-  "ios": "17.3",
-  "opera": "108",
+  "android": "125",
+  "chrome": "125",
+  "edge": "125",
+  "firefox": "126",
+  "ios": "17.4",
+  "opera": "110",
   "opera_mobile": "80",
-  "safari": "17.3",
-  "samsung": "23"
+  "safari": "17.4",
+  "samsung": "24"
 }
 
 Using modules transform: auto

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,9 +308,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@babel/compat-data@workspace:packages/babel-compat-data"
   dependencies:
-    "@mdn/browser-compat-data": "npm:^5.3.0"
-    core-js-compat: "npm:^3.31.0"
-    electron-to-chromium: "npm:^1.4.441"
+    "@mdn/browser-compat-data": "npm:^5.5.36"
+    core-js-compat: "npm:^3.37.1"
+    electron-to-chromium: "npm:^1.4.816"
   languageName: unknown
   linkType: soft
 
@@ -607,7 +607,7 @@ __metadata:
     "@babel/helper-validator-option": "workspace:^"
     "@types/lru-cache": "npm:^5.1.1"
     "@types/semver": "npm:^5.5.0"
-    browserslist: "npm:^4.22.2"
+    browserslist: "npm:^4.23.1"
     lru-cache: "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1"
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.1"
   languageName: unknown
@@ -4072,7 +4072,7 @@ __metadata:
     babel-plugin-polyfill-corejs2: "condition:BABEL_8_BREAKING ? : ^0.4.10 (peer:@babel/core) (esm:default)"
     babel-plugin-polyfill-corejs3: "npm:^0.10.4"
     babel-plugin-polyfill-regenerator: "condition:BABEL_8_BREAKING ? : ^0.6.1 (peer:@babel/core) (esm:default)"
-    core-js-compat: "npm:^3.31.0"
+    core-js-compat: "npm:^3.37.1"
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
@@ -4974,10 +4974,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdn/browser-compat-data@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "@mdn/browser-compat-data@npm:5.3.0"
-  checksum: 10/8d72c870509f9fb91efca68d29ebc49e2b29ffc357d7aefea3c77d72299a6cc41c05904dedfa05745c1ec3ea0d64929bc34cf7536f0b80773e895bf2554bc7c0
+"@mdn/browser-compat-data@npm:^5.5.36":
+  version: 5.5.36
+  resolution: "@mdn/browser-compat-data@npm:5.5.36"
+  checksum: 10/0e5663d8f942f7e195bf5c74f8ca392afa69f8bc471188977396d0337cb66ec2e5453cd041ed107bff9964dd6c88f837c32d06599f3c11640f8f7ee4e6587bb5
   languageName: node
   linkType: hard
 
@@ -7524,17 +7524,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:4.23.0":
-  version: 4.23.0
-  resolution: "browserslist@npm:4.23.0"
+"browserslist@npm:4.23.1":
+  version: 4.23.1
+  resolution: "browserslist@npm:4.23.1"
   dependencies:
-    caniuse-lite: "npm:^1.0.30001587"
-    electron-to-chromium: "npm:^1.4.668"
+    caniuse-lite: "npm:^1.0.30001629"
+    electron-to-chromium: "npm:^1.4.796"
     node-releases: "npm:^2.0.14"
-    update-browserslist-db: "npm:^1.0.13"
+    update-browserslist-db: "npm:^1.0.16"
   bin:
     browserslist: cli.js
-  checksum: 10/496c3862df74565dd942b4ae65f502c575cbeba1fa4a3894dad7aa3b16130dc3033bc502d8848147f7b625154a284708253d9598bcdbef5a1e34cf11dc7bad8e
+  checksum: 10/91da59f70a8e01ece97133670f9857d6d7e96be78e1b7ffa54b869f97d01d01c237612471b595cee41c1ab212e26e536ce0b6716ad1d6c4368a40c222698cac1
   languageName: node
   linkType: hard
 
@@ -7727,10 +7727,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:1.0.30001615":
-  version: 1.0.30001615
-  resolution: "caniuse-lite@npm:1.0.30001615"
-  checksum: 10/3dfb48e9b8fbf4d550cf204075b170ef4a5bcbc7faf9e14b03dc7456ac1aec2da1405d4fca808bc72b47a2ca0818d6d138aa62769548472440ff605ad1313719
+"caniuse-lite@npm:1.0.30001640":
+  version: 1.0.30001640
+  resolution: "caniuse-lite@npm:1.0.30001640"
+  checksum: 10/14f04379452d4302185400db14b286115d25ce96fd09536590233a09908273990deeb1c081a7ea8bc091d86cb4d1665260de8f150e84dc240e17bf7d6af0aca7
   languageName: node
   linkType: hard
 
@@ -8299,12 +8299,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:3.37.0":
-  version: 3.37.0
-  resolution: "core-js-compat@npm:3.37.0"
+"core-js-compat@npm:3.37.1":
+  version: 3.37.1
+  resolution: "core-js-compat@npm:3.37.1"
   dependencies:
     browserslist: "npm:^4.23.0"
-  checksum: 10/5f33d7ba45acc9ceb45544d844090edfd14e46a64c2424df24084347405182c1156588cc3a877fc580c005a0b13b8a1af26bb6c73fe73f22eede89b5483b482d
+  checksum: 10/30c6fdbd9ff179cc53951814689b8aabec106e5de6cddfa7a7feacc96b66d415b8eebcf5ec8f7c68ef35c552fe7d39edb8b15b1ce0f27379a272295b6e937061
   languageName: node
   linkType: hard
 
@@ -8845,10 +8845,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:1.4.755":
-  version: 1.4.755
-  resolution: "electron-to-chromium@npm:1.4.755"
-  checksum: 10/763bd447c987087f5b8bcf884815d6634170fe9257ddd0ee9328379dd927fbbcf1528f6d5d43fb81756d9d1227660580bd43557584daeef3bc7f6019aca625b0
+"electron-to-chromium@npm:1.4.816":
+  version: 1.4.816
+  resolution: "electron-to-chromium@npm:1.4.816"
+  checksum: 10/c44da0ca6eb40b92cc025a9ab157d465708601b4c226b7a41ab3fbb42825094f62b25d6260bb4399dd9a4be308611f22711412eb61a13cecc544d95fab8eafab
   languageName: node
   linkType: hard
 
@@ -9173,10 +9173,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "escalade@npm:3.1.1"
-  checksum: 10/afa618e73362576b63f6ca83c975456621095a1ed42ff068174e3f5cea48afc422814dda548c96e6ebb5333e7265140c7292abcc81bbd6ccb1757d50d3a4e182
+"escalade@npm:^3.1.1, escalade@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "escalade@npm:3.1.2"
+  checksum: 10/a1e07fea2f15663c30e40b9193d658397846ffe28ce0a3e4da0d8e485fedfeca228ab846aee101a05015829adf39f9934ff45b2a3fca47bed37a29646bd05cd3
   languageName: node
   linkType: hard
 
@@ -14336,10 +14336,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "picocolors@npm:1.0.0"
-  checksum: 10/a2e8092dd86c8396bdba9f2b5481032848525b3dc295ce9b57896f931e63fc16f79805144321f72976383fc249584672a75cc18d6777c6b757603f372f745981
+"picocolors@npm:^1.0.0, picocolors@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "picocolors@npm:1.0.1"
+  checksum: 10/fa68166d1f56009fc02a34cdfd112b0dd3cf1ef57667ac57281f714065558c01828cdf4f18600ad6851cbe0093952ed0660b1e0156bddf2184b6aaf5817553a5
   languageName: node
   linkType: hard
 
@@ -17102,17 +17102,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.0.13":
-  version: 1.0.13
-  resolution: "update-browserslist-db@npm:1.0.13"
+"update-browserslist-db@npm:^1.0.16":
+  version: 1.1.0
+  resolution: "update-browserslist-db@npm:1.1.0"
   dependencies:
-    escalade: "npm:^3.1.1"
-    picocolors: "npm:^1.0.0"
+    escalade: "npm:^3.1.2"
+    picocolors: "npm:^1.0.1"
   peerDependencies:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: 10/9074b4ef34d2ed931f27d390aafdd391ee7c45ad83c508e8fed6aaae1eb68f81999a768ed8525c6f88d4001a4fbf1b8c0268f099d0e8e72088ec5945ac796acf
+  checksum: 10/d70b9efeaf4601aadb1a4f6456a7a5d9118e0063d995866b8e0c5e0cf559482671dab6ce7b079f9536b06758a344fbd83f974b965211e1c6e8d1958540b0c24c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Bumped `browserslist`, `caniuse-lite`, `core-js-compat`, `electron-to-chromium` and `@mdn/browser-compat-data`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
