### PR TITLE
Avoid checking `Scope.globals` multiple times.

### DIFF
--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -1316,15 +1316,26 @@ class Scope {
     opts?: boolean | { noGlobals?: boolean; noUids?: boolean },
   ) {
     if (!name) return false;
-    if (this.hasOwnBinding(name)) return true;
-    {
-      // TODO: Only accept the object form.
-      if (typeof opts === "boolean") opts = { noGlobals: opts };
+    let scope: Scope = this;
+    do {
+      if (scope.hasOwnBinding(name)) {
+        return true;
+      }
+    } while ((scope = scope.parent));
+
+    // TODO: Only accept the object form.
+    let noGlobals;
+    let noUids;
+    if (typeof opts === "object") {
+      noGlobals = opts.noGlobals;
+      noUids = opts.noUids;
+    } else if (typeof opts === "boolean") {
+      noGlobals = opts;
     }
-    if (this.parentHasBinding(name, opts)) return true;
-    if (!opts?.noUids && this.hasUid(name)) return true;
-    if (!opts?.noGlobals && Scope.globals.includes(name)) return true;
-    if (!opts?.noGlobals && Scope.contextVariables.includes(name)) return true;
+
+    if (!noUids && this.hasUid(name)) return true;
+    if (!noGlobals && Scope.globals.includes(name)) return true;
+    if (!noGlobals && Scope.contextVariables.includes(name)) return true;
     return false;
   }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Previously `hasBinding` was called on each parent scope, which resulted in multiple checks of `Scope.globals` and `Scope.contextVariables`.
This improvement is probably small, and I didn't notice a noticeable improvement in `real-case-preset-env-typescript`.