### PR TITLE
Avoid unnecessary parens around `async` in `for await`

### DIFF
--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -473,11 +473,6 @@ export function Identifier(
   // ECMAScript specifically forbids a for-of loop from starting with the
   // token sequence `for (async of`, because it would be ambiguous with
   // `for (async of => {};;)`, so we need to add extra parentheses.
-  //
-  // If the parent is a for-await-of loop (i.e. parent.await === true), the
-  // parentheses aren't strictly needed, but we add them anyway because
-  // some tools (including earlier Babel versions) can't parse
-  // `for await (async of [])` without them.
   return (
     node.name === "async" &&
     isForOfStatement(parent) &&

--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -475,9 +475,7 @@ export function Identifier(
   // `for (async of => {};;)`, so we need to add extra parentheses.
   return (
     node.name === "async" &&
-    isForOfStatement(parent) &&
-    node === parent.left &&
-    !parent.await
+    isForOfStatement(parent, { left: node, await: false })
   );
 }
 

--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -479,7 +479,10 @@ export function Identifier(
   // some tools (including earlier Babel versions) can't parse
   // `for await (async of [])` without them.
   return (
-    node.name === "async" && isForOfStatement(parent) && node === parent.left
+    node.name === "async" &&
+    isForOfStatement(parent) &&
+    node === parent.left &&
+    !parent.await
   );
 }
 

--- a/packages/babel-generator/test/fixtures/edgecase/for-await-async-of/output.js
+++ b/packages/babel-generator/test/fixtures/edgecase/for-await-async-of/output.js
@@ -1,7 +1,7 @@
 async function f() {
-  for await ((async) of []);
-  for await ((async) of async) async;
-  for await ((async) of []);
+  for await (async of []);
+  for await (async of async) async;
+  for await (async of []);
   for await (async.x of []);
-  for await ((async) of []);
+  for await (async of []);
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The parentheses are only required in the sync case, since `for (async of` could either start a `for (async of => x; y ; z) {}` or a `for (async of x) {}`. With `for await` there is no ambiguity.