### PR TITLE
Correctly print parens around `in` in `for` heads

### DIFF
--- a/packages/babel-generator/src/generators/base.ts
+++ b/packages/babel-generator/src/generators/base.ts
@@ -46,7 +46,9 @@ export function BlockStatement(this: Printer, node: t.BlockStatement) {
     }
   }
 
+  const exit = this.enterForStatementInit(false);
   this.printSequence(node.body, node, { indent: true });
+  exit();
 
   this.rightBrace(node);
 }

--- a/packages/babel-generator/src/generators/classes.ts
+++ b/packages/babel-generator/src/generators/classes.ts
@@ -75,7 +75,9 @@ export function ClassBody(this: Printer, node: t.ClassBody) {
   } else {
     this.newline();
 
+    const exit = this.enterForStatementInit(false);
     this.printSequence(node.body, node, { indent: true });
+    exit();
 
     if (!this.endsWith(charCodes.lineFeed)) this.newline();
 

--- a/packages/babel-generator/src/generators/expressions.ts
+++ b/packages/babel-generator/src/generators/expressions.ts
@@ -6,7 +6,6 @@ import {
   isNewExpression,
 } from "@babel/types";
 import type * as t from "@babel/types";
-import * as n from "../node/index.ts";
 
 export function UnaryExpression(this: Printer, node: t.UnaryExpression) {
   const { operator } = node;
@@ -97,7 +96,9 @@ export function NewExpression(
     this.token("?.");
   }
   this.token("(");
+  const exit = this.enterForStatementInit(false);
   this.printList(node.arguments, node);
+  exit();
   this.rightParens(node);
 }
 
@@ -179,7 +180,9 @@ export function OptionalCallExpression(
   this.print(node.typeArguments, node); // Flow
 
   this.token("(");
+  const exit = this.enterForStatementInit(false);
   this.printList(node.arguments, node);
+  exit();
   this.rightParens(node);
 }
 
@@ -189,7 +192,9 @@ export function CallExpression(this: Printer, node: t.CallExpression) {
   this.print(node.typeArguments, node); // Flow
   this.print(node.typeParameters, node); // TS
   this.token("(");
+  const exit = this.enterForStatementInit(false);
   this.printList(node.arguments, node);
+  exit();
   this.rightParens(node);
 }
 
@@ -251,19 +256,7 @@ export function AssignmentPattern(this: Printer, node: t.AssignmentPattern) {
 export function AssignmentExpression(
   this: Printer,
   node: t.AssignmentExpression,
-  parent: t.Node,
 ) {
-  // Somewhere inside a for statement `init` node but doesn't usually
-  // needs a paren except for `in` expressions: `for (a in b ? a : b;;)`
-  const parens =
-    this.inForStatementInitCounter &&
-    node.operator === "in" &&
-    !n.needsParens(node, parent);
-
-  if (parens) {
-    this.token("(");
-  }
-
   this.print(node.left, node);
 
   this.space();
@@ -275,10 +268,6 @@ export function AssignmentExpression(
   this.space();
 
   this.print(node.right, node);
-
-  if (parens) {
-    this.token(")");
-  }
 }
 
 export function BindExpression(this: Printer, node: t.BindExpression) {
@@ -306,9 +295,11 @@ export function MemberExpression(this: Printer, node: t.MemberExpression) {
   }
 
   if (computed) {
+    const exit = this.enterForStatementInit(false);
     this.token("[");
     this.print(node.property, node);
     this.token("]");
+    exit();
   } else {
     this.token(".");
     this.print(node.property, node);

--- a/packages/babel-generator/src/generators/methods.ts
+++ b/packages/babel-generator/src/generators/methods.ts
@@ -38,6 +38,8 @@ export function _parameters(
     | t.TSFunctionType
     | t.TSConstructorType,
 ) {
+  const exit = this.enterForStatementInit(false);
+
   const paramLength = parameters.length;
   for (let i = 0; i < paramLength; i++) {
     this._param(parameters[i], parent);
@@ -47,6 +49,8 @@ export function _parameters(
       this.space();
     }
   }
+
+  exit();
 }
 
 export function _param(

--- a/packages/babel-generator/src/generators/statements.ts
+++ b/packages/babel-generator/src/generators/statements.ts
@@ -68,9 +68,12 @@ export function ForStatement(this: Printer, node: t.ForStatement) {
   this.space();
   this.token("(");
 
-  this.inForStatementInitCounter++;
-  this.print(node.init, node);
-  this.inForStatementInitCounter--;
+  {
+    const exit = this.enterForStatementInit(true);
+    this.print(node.init, node);
+    exit();
+  }
+
   this.token(";");
 
   if (node.test) {
@@ -107,7 +110,11 @@ function ForXStatement(this: Printer, node: t.ForXStatement) {
   }
   this.noIndentInnerCommentsHere();
   this.token("(");
-  this.print(node.left, node);
+  {
+    const exit = isForOf ? null : this.enterForStatementInit(true);
+    this.print(node.left, node);
+    exit?.();
+  }
   this.space();
   this.word(isForOf ? "of" : "in");
   this.space();

--- a/packages/babel-generator/src/generators/types.ts
+++ b/packages/babel-generator/src/generators/types.ts
@@ -25,9 +25,11 @@ export function ObjectExpression(this: Printer, node: t.ObjectExpression) {
   this.token("{");
 
   if (props.length) {
+    const exit = this.enterForStatementInit(false);
     this.space();
     this.printList(props, node, { indent: true, statement: true });
     this.space();
+    exit();
   }
 
   this.sourceWithOffset("end", node.loc, -1);
@@ -87,6 +89,8 @@ export function ArrayExpression(this: Printer, node: t.ArrayExpression) {
 
   this.token("[");
 
+  const exit = this.enterForStatementInit(false);
+
   for (let i = 0; i < elems.length; i++) {
     const elem = elems[i];
     if (elem) {
@@ -102,6 +106,8 @@ export function ArrayExpression(this: Printer, node: t.ArrayExpression) {
       this.token(",");
     }
   }
+
+  exit();
 
   this.token("]");
 }

--- a/packages/babel-generator/src/node/index.ts
+++ b/packages/babel-generator/src/node/index.ts
@@ -21,6 +21,7 @@ type NodeHandler<R> = (
   //   : t.Node,
   parent: t.Node,
   stack?: t.Node[],
+  inForStatementInit?: boolean,
 ) => R;
 
 export type NodeHandlers<R> = {
@@ -35,8 +36,11 @@ function expandAliases<R>(obj: NodeHandlers<R>) {
     map.set(
       type,
       fn
-        ? function (node, parent, stack) {
-            return fn(node, parent, stack) ?? func(node, parent, stack);
+        ? function (node, parent, stack, inForInit) {
+            return (
+              fn(node, parent, stack, inForInit) ??
+              func(node, parent, stack, inForInit)
+            );
           }
         : func,
     );
@@ -101,6 +105,7 @@ export function needsParens(
   node: t.Node,
   parent: t.Node,
   printStack?: t.Node[],
+  inForInit?: boolean,
 ) {
   if (!parent) return false;
 
@@ -116,7 +121,7 @@ export function needsParens(
     );
   }
 
-  return expandedParens.get(node.type)?.(node, parent, printStack);
+  return expandedParens.get(node.type)?.(node, parent, printStack, inForInit);
 }
 
 function isDecoratorMemberExpression(node: t.Node): boolean {

--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -252,19 +252,12 @@ export function TSInstantiationExpression(
 export function BinaryExpression(
   node: t.BinaryExpression,
   parent: t.Node,
+  stack: unknown,
+  inForStatementInit: boolean,
 ): boolean {
-  // let i = (1 in []);
   // for ((1 in []);;);
-  if (node.operator === "in") {
-    const parentType = parent.type;
-    return (
-      parentType === "VariableDeclarator" ||
-      parentType === "ForStatement" ||
-      parentType === "ForInStatement" ||
-      parentType === "ForOfStatement"
-    );
-  }
-  return false;
+  // for (var x = (1 in []) in 2);
+  return node.operator === "in" && inForStatementInit;
 }
 
 export function SequenceExpression(

--- a/packages/babel-generator/test/fixtures/parentheses/in-inside-for/input.js
+++ b/packages/babel-generator/test/fixtures/parentheses/in-inside-for/input.js
@@ -1,0 +1,47 @@
+for (var a = (b in c) in {});
+for (var a = 1 || (b in c) in {});
+for (var a = 1 + (2 || (b in c)) in {});
+for (var a = (() => b in c) in {});
+for (var a = 1 || (() => b in c) in {});
+for (var a = (() => { b in c; }) in {});
+for (var a = [b in c] in {});
+for (var a = {b: b in c} in {});
+for (var a = (x = b in c) => {} in {});
+for (var a = class extends (b in c) {} in {});
+for (var a = function (x = b in c) {} in {});
+
+for (var a = (b in c);;);
+for (var a = 1 || (b in c);;);
+for (var a = 1 + (2 || (b in c));;);
+for (var a = (() => b in c);;);
+for (var a = 1 || (() => b in c);;);
+for (var a = (() => { b in c; });;);
+for (var a = [b in c];;);
+for (var a = {b: b in c};;);
+for (var a = (x = b in c) => {};;);
+for (var a = class extends (b in c) {};;);
+for (var a = function (x = b in c) {};;);
+
+for (var a in (b in c));
+for (var a in 1 || (b in c));
+for (var a in 1 + (2 || (b in c)));
+for (var a in (() => b in c));
+for (var a in 1 || (() => b in c));
+for (var a in (() => { b in c; }));
+for (var a in [b in c]);
+for (var a in {b: b in c});
+for (var a in (x = b in c) => {});
+for (var a in class extends (b in c) {});
+for (var a in function (x = b in c) {});
+
+for (;a = (b in c););
+for (;a = 1 || (b in c););
+for (;a = 1 + (2 || (b in c)););
+for (;a = (() => b in c););
+for (;a = 1 || (() => b in c););
+for (;a = (() => { b in c; }););
+for (;a = [b in c];);
+for (;a = {b: b in c};);
+for (;a = (x = b in c) => {};);
+for (;a = class extends (b in c) {};);
+for (;a = function (x = b in c) {};);

--- a/packages/babel-generator/test/fixtures/parentheses/in-inside-for/options.json
+++ b/packages/babel-generator/test/fixtures/parentheses/in-inside-for/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "script",
+  "strictMode": false
+}

--- a/packages/babel-generator/test/fixtures/parentheses/in-inside-for/output.js
+++ b/packages/babel-generator/test/fixtures/parentheses/in-inside-for/output.js
@@ -1,0 +1,60 @@
+for (var a = (b in c) in {});
+for (var a = 1 || (b in c) in {});
+for (var a = 1 + (2 || b in c) in {});
+for (var a = () => (b in c) in {});
+for (var a = 1 || (() => b in c) in {});
+for (var a = () => {
+  b in c;
+} in {});
+for (var a = [b in c] in {});
+for (var a = {
+  b: b in c
+} in {});
+for (var a = (x = b in c) => {} in {});
+for (var a = class extends (b in c) {} in {});
+for (var a = function (x = b in c) {} in {});
+for (var a = (b in c);;);
+for (var a = 1 || (b in c);;);
+for (var a = 1 + (2 || b in c);;);
+for (var a = () => (b in c);;);
+for (var a = 1 || (() => b in c);;);
+for (var a = () => {
+  b in c;
+};;);
+for (var a = [b in c];;);
+for (var a = {
+  b: b in c
+};;);
+for (var a = (x = b in c) => {};;);
+for (var a = class extends (b in c) {};;);
+for (var a = function (x = b in c) {};;);
+for (var a in b in c);
+for (var a in 1 || b in c);
+for (var a in 1 + (2 || b in c));
+for (var a in () => b in c);
+for (var a in 1 || (() => b in c));
+for (var a in () => {
+  b in c;
+});
+for (var a in [b in c]);
+for (var a in {
+  b: b in c
+});
+for (var a in (x = b in c) => {});
+for (var a in class extends (b in c) {});
+for (var a in function (x = b in c) {});
+for (; a = b in c;);
+for (; a = 1 || b in c;);
+for (; a = 1 + (2 || b in c););
+for (; a = () => b in c;);
+for (; a = 1 || (() => b in c););
+for (; a = () => {
+  b in c;
+};);
+for (; a = [b in c];);
+for (; a = {
+  b: b in c
+};);
+for (; a = (x = b in c) => {};);
+for (; a = class extends (b in c) {};);
+for (; a = function (x = b in c) {};);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16628
| Patch: Bug Fix?          | y
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I really wanted to use `using`, but we would need an assumption to avoid the try/catch when we know it's not necessary.