### PR TITLE
fix: provide legacy typings for TS < 4.1

### DIFF
--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -17,7 +17,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index-legacy.d.ts",
   "typesVersions": {
-    ">=3.7": {
+    ">=4.1": {
       "lib/index-legacy.d.ts": [
         "lib/index.d.ts"
       ]
@@ -56,7 +56,7 @@
   },
   "exports": {
     ".": {
-      "types@>=3.7": "./lib/index.d.ts",
+      "types@>=4.1": "./lib/index.d.ts",
       "types": "./lib/index-legacy.d.ts",
       "default": "./lib/index.js"
     },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16637 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In #16570 we improved the typings for `getBindingIdentifiers` via [Key Remapping in Mapped Types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#key-remapping-in-mapped-types), which is a TypeScript 4.1 feature. Note that TypeScript 4.1 was released in November 2020 (almost 4 years ago).

As we already provide legacy typings for TS < 3.7, here we bump the legacy typing condition to TS < 4.1. Hopefully this should address the @babel/types type check errors on TS < 4.1.