### PR TITLE
Allow using custom config in `babel-node --eval`

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -738,7 +738,6 @@ const assertTest = function (
       throw new Error("stdout:\n" + stdout);
     }
   } catch (e) {
-    console.log(JSON.stringify(opts.stdout), JSON.stringify(stdout));
     if (!process.env.OVERWRITE) throw e;
     console.log(`Updated test file: ${opts.stdoutPath}`);
     outputFileSync(opts.stdoutPath, stdout + "\n");

--- a/packages/babel-node/src/_babel-node.ts
+++ b/packages/babel-node/src/_babel-node.ts
@@ -151,8 +151,8 @@ const _eval = function (code: string, filename: string) {
 
   code = babel.transformSync(code, {
     filename: filename,
-    presets: opts.presets,
-    plugins: (opts.plugins || []).concat([replPlugin]),
+    ...babelOptions,
+    plugins: (opts.babelOptions || []).concat([replPlugin]),
   }).code;
 
   return vm.runInThisContext(code, {

--- a/packages/babel-node/src/_babel-node.ts
+++ b/packages/babel-node/src/_babel-node.ts
@@ -144,7 +144,7 @@ const _eval = function (code: string, filename: string) {
   code = babel.transformSync(code, {
     filename: filename,
     ...babelOptions,
-    plugins: (opts.babelOptions || []).concat([replPlugin]),
+    plugins: (opts.plugins || []).concat([replPlugin]),
   }).code;
 
   return vm.runInThisContext(code, {

--- a/packages/babel-node/src/_babel-node.ts
+++ b/packages/babel-node/src/_babel-node.ts
@@ -111,14 +111,6 @@ register(babelOptions);
 
 const replPlugin = ({ types: t }: PluginAPI): PluginObject => ({
   visitor: {
-    VariableDeclaration(path) {
-      if (path.node.kind !== "var") {
-        throw path.buildCodeFrameError(
-          "Only `var` variables are supported in the REPL",
-        );
-      }
-    },
-
     Program(path) {
       let hasExpressionStatement: boolean;
       for (const bodyPath of path.get("body")) {

--- a/packages/babel-node/test/fixtures/cli/--eval_--config-file/in-files/configFile.js
+++ b/packages/babel-node/test/fixtures/cli/--eval_--config-file/in-files/configFile.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache.forever();
+
+  console.log("Config was loaded, so --config-file was used.");
+
+  return {};
+};

--- a/packages/babel-node/test/fixtures/cli/--eval_--config-file/in-files/configFile.js
+++ b/packages/babel-node/test/fixtures/cli/--eval_--config-file/in-files/configFile.js
@@ -1,7 +1,15 @@
 module.exports = function (api) {
   api.cache.forever();
 
-  console.log("Config was loaded, so --config-file was used.");
-
-  return {};
+  return {
+    plugins: [
+      () => ({
+        visitor: {
+          BinaryExpression(path) {
+            path.node.operator = "+";
+          },
+        },
+      }),
+    ],
+  };
 };

--- a/packages/babel-node/test/fixtures/cli/--eval_--config-file/in-files/configFile.js
+++ b/packages/babel-node/test/fixtures/cli/--eval_--config-file/in-files/configFile.js
@@ -6,6 +6,7 @@ module.exports = function (api) {
       () => ({
         visitor: {
           BinaryExpression(path) {
+            console.log("Plugin applied");
             path.node.operator = "+";
           },
         },

--- a/packages/babel-node/test/fixtures/cli/--eval_--config-file/options.json
+++ b/packages/babel-node/test/fixtures/cli/--eval_--config-file/options.json
@@ -1,0 +1,8 @@
+{
+  "args": [
+    "--config-file",
+    "./configFile.js",
+    "--eval",
+    "console.log([1, 2, 3].map(x => x * x));"
+  ]
+}

--- a/packages/babel-node/test/fixtures/cli/--eval_--config-file/stdout.txt
+++ b/packages/babel-node/test/fixtures/cli/--eval_--config-file/stdout.txt
@@ -1,2 +1,1 @@
-Config was loaded, so --config-file was used.
-[ 1, 4, 9 ]
+[ 2, 4, 6 ]

--- a/packages/babel-node/test/fixtures/cli/--eval_--config-file/stdout.txt
+++ b/packages/babel-node/test/fixtures/cli/--eval_--config-file/stdout.txt
@@ -1,1 +1,2 @@
+Plugin applied
 [ 2, 4, 6 ]

--- a/packages/babel-node/test/fixtures/cli/--eval_--config-file/stdout.txt
+++ b/packages/babel-node/test/fixtures/cli/--eval_--config-file/stdout.txt
@@ -1,0 +1,2 @@
+Config was loaded, so --config-file was used.
+[ 1, 4, 9 ]

--- a/packages/babel-node/test/fixtures/cli/--eval_default-config-file/in-files/babel.config.js
+++ b/packages/babel-node/test/fixtures/cli/--eval_default-config-file/in-files/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache.forever();
+
+  console.log("Config was loaded, so --config-file was used.");
+
+  return {};
+};

--- a/packages/babel-node/test/fixtures/cli/--eval_default-config-file/in-files/babel.config.js
+++ b/packages/babel-node/test/fixtures/cli/--eval_default-config-file/in-files/babel.config.js
@@ -1,7 +1,15 @@
 module.exports = function (api) {
   api.cache.forever();
 
-  console.log("Config was loaded, so --config-file was used.");
-
-  return {};
+  return {
+    plugins: [
+      () => ({
+        visitor: {
+          BinaryExpression(path) {
+            path.node.operator = "+";
+          },
+        },
+      }),
+    ],
+  };
 };

--- a/packages/babel-node/test/fixtures/cli/--eval_default-config-file/in-files/babel.config.js
+++ b/packages/babel-node/test/fixtures/cli/--eval_default-config-file/in-files/babel.config.js
@@ -6,6 +6,7 @@ module.exports = function (api) {
       () => ({
         visitor: {
           BinaryExpression(path) {
+            console.log("Plugin applied");
             path.node.operator = "+";
           },
         },

--- a/packages/babel-node/test/fixtures/cli/--eval_default-config-file/options.json
+++ b/packages/babel-node/test/fixtures/cli/--eval_default-config-file/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--eval", "console.log([1, 2, 3].map(x => x * x));"]
+}

--- a/packages/babel-node/test/fixtures/cli/--eval_default-config-file/stdout.txt
+++ b/packages/babel-node/test/fixtures/cli/--eval_default-config-file/stdout.txt
@@ -1,2 +1,1 @@
-Config was loaded, so --config-file was used.
-[ 1, 4, 9 ]
+[ 2, 4, 6 ]

--- a/packages/babel-node/test/fixtures/cli/--eval_default-config-file/stdout.txt
+++ b/packages/babel-node/test/fixtures/cli/--eval_default-config-file/stdout.txt
@@ -1,1 +1,2 @@
+Plugin applied
 [ 2, 4, 6 ]

--- a/packages/babel-node/test/fixtures/cli/--eval_default-config-file/stdout.txt
+++ b/packages/babel-node/test/fixtures/cli/--eval_default-config-file/stdout.txt
@@ -1,0 +1,2 @@
+Config was loaded, so --config-file was used.
+[ 1, 4, 9 ]


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #11877, fixes #16675
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Transform code for `babel-node` eval does not use the options that were passed in the cli flags. Also, `replPlugin`, which is used for code transformation, only allows `var` variables, although modern versions of node repl support `let` and `const`.

Based on the history of this file, it appears that this code was written in 2017 when node did not support any variables other than var, but there is no need for this check now. If anyone needs to use babel-node with node < 6.0.0, they can pass their configuration file through --config-file.
