### PR TITLE
Simplify the printing logic for `(` before ambiguous tokens

### DIFF
--- a/packages/babel-generator/src/generators/expressions.ts
+++ b/packages/babel-generator/src/generators/expressions.ts
@@ -6,6 +6,7 @@ import {
   isNewExpression,
 } from "@babel/types";
 import type * as t from "@babel/types";
+import { TokenContext } from "../node/index.ts";
 
 export function UnaryExpression(this: Printer, node: t.UnaryExpression) {
   const { operator } = node;
@@ -237,6 +238,7 @@ export function ExpressionStatement(
   this: Printer,
   node: t.ExpressionStatement,
 ) {
+  this.tokenContext |= TokenContext.expressionStatement;
   this.print(node.expression, node);
   this.semicolon();
 }

--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -2,6 +2,7 @@ import type Printer from "../printer.ts";
 import { isDeclareExportDeclaration, isStatement } from "@babel/types";
 import type * as t from "@babel/types";
 import { ExportAllDeclaration } from "./modules.ts";
+import { TokenContext } from "../node/index.ts";
 
 export function AnyTypeAnnotation(this: Printer) {
   this.word("any");
@@ -521,11 +522,21 @@ export function TypeAlias(
   this.semicolon();
 }
 
-export function TypeAnnotation(this: Printer, node: t.TypeAnnotation) {
+export function TypeAnnotation(
+  this: Printer,
+  node: t.TypeAnnotation,
+  parent: t.Node,
+) {
   this.token(":");
   this.space();
-  // @ts-expect-error todo(flow->ts) can this be removed? `.optional` looks to be not existing property
-  if (node.optional) this.token("?");
+  if (parent.type === "ArrowFunctionExpression") {
+    this.tokenContext |= TokenContext.arrowFlowReturnType;
+  } else if (
+    // @ts-expect-error todo(flow->ts) can this be removed? `.optional` looks to be not existing property
+    node.optional
+  ) {
+    this.token("?");
+  }
   this.print(node.typeAnnotation, node);
 }
 

--- a/packages/babel-generator/src/generators/methods.ts
+++ b/packages/babel-generator/src/generators/methods.ts
@@ -1,6 +1,7 @@
 import type Printer from "../printer.ts";
 import type * as t from "@babel/types";
 import { isIdentifier, type ParentMaps } from "@babel/types";
+import { TokenContext } from "../node/index.ts";
 
 type ParentsOf<T extends t.Node> = ParentMaps[T["type"]];
 
@@ -223,6 +224,7 @@ export function ArrowFunctionExpression(
 
   this.space();
 
+  this.tokenContext |= TokenContext.arrowBody;
   this.print(node.body, node);
 }
 

--- a/packages/babel-generator/src/generators/modules.ts
+++ b/packages/babel-generator/src/generators/modules.ts
@@ -8,6 +8,7 @@ import {
   isStatement,
 } from "@babel/types";
 import type * as t from "@babel/types";
+import { TokenContext } from "../node/index.ts";
 
 export function ImportSpecifier(this: Printer, node: t.ImportSpecifier) {
   if (node.importKind === "type" || node.importKind === "typeof") {
@@ -230,6 +231,7 @@ export function ExportDefaultDeclaration(
   this.space();
   this.word("default");
   this.space();
+  this.tokenContext |= TokenContext.exportDefault;
   const declar = node.declaration;
   this.print(declar, node);
   if (!isStatement(declar)) this.semicolon();

--- a/packages/babel-generator/src/generators/statements.ts
+++ b/packages/babel-generator/src/generators/statements.ts
@@ -10,6 +10,7 @@ import type * as t from "@babel/types";
 // We inline this package
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
+import { TokenContext } from "../node/index.ts";
 
 export function WithStatement(this: Printer, node: t.WithStatement) {
   this.word("with");
@@ -70,6 +71,7 @@ export function ForStatement(this: Printer, node: t.ForStatement) {
 
   {
     const exit = this.enterForStatementInit(true);
+    this.tokenContext |= TokenContext.forHead;
     this.print(node.init, node);
     exit();
   }
@@ -112,6 +114,9 @@ function ForXStatement(this: Printer, node: t.ForXStatement) {
   this.token("(");
   {
     const exit = isForOf ? null : this.enterForStatementInit(true);
+    this.tokenContext |= isForOf
+      ? TokenContext.forOfHead
+      : TokenContext.forInHead;
     this.print(node.left, node);
     exit?.();
   }

--- a/packages/babel-generator/src/node/index.ts
+++ b/packages/babel-generator/src/node/index.ts
@@ -13,6 +13,16 @@ import type * as t from "@babel/types";
 
 import type { WhitespaceFlag } from "./whitespace.ts";
 
+export const enum TokenContext {
+  expressionStatement = 1 << 0,
+  arrowBody = 1 << 1,
+  exportDefault = 1 << 2,
+  forHead = 1 << 3,
+  forInHead = 1 << 4,
+  forOfHead = 1 << 5,
+  arrowFlowReturnType = 1 << 6,
+}
+
 type NodeHandler<R> = (
   node: t.Node,
   // todo:
@@ -20,7 +30,7 @@ type NodeHandler<R> = (
   //   ? Extract<typeof t[K], { type: "string" }>
   //   : t.Node,
   parent: t.Node,
-  stack?: t.Node[],
+  tokenContext?: number,
   inForStatementInit?: boolean,
 ) => R;
 
@@ -104,7 +114,7 @@ export function needsWhitespaceAfter(node: t.Node, parent: t.Node) {
 export function needsParens(
   node: t.Node,
   parent: t.Node,
-  printStack?: t.Node[],
+  tokenContext?: number,
   inForInit?: boolean,
 ) {
   if (!parent) return false;
@@ -121,7 +131,7 @@ export function needsParens(
     );
   }
 
-  return expandedParens.get(node.type)?.(node, parent, printStack, inForInit);
+  return expandedParens.get(node.type)?.(node, parent, tokenContext, inForInit);
 }
 
 function isDecoratorMemberExpression(node: t.Node): boolean {

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1329,7 +1329,7 @@ describe("programmatic generation", function () {
         t.sequenceExpression([t.objectExpression([]), t.numericLiteral(1)]),
       );
       const output = generate(arrowFunctionExpression).code;
-      expect(output).toBe("() => (({}), 1)");
+      expect(output).toBe("() => ({}, 1)");
     });
   });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

See https://github.com/babel/babel/pull/16648. With this change we don't need to manually list cases where `(` is needed anymore, and we do not need to walk up in the tree.