### PR TITLE
Simplify `helper-function-name` logic

### DIFF
--- a/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/output.js
+++ b/packages/babel-plugin-transform-arrow-functions/test/fixtures/arrow-functions/self-referential/output.js
@@ -1,13 +1,13 @@
 var fooCalls = [];
-var jumpTable = function jumpTable(name, arg) {
-  if (jumpTable[name]) {
-    jumpTable[name](arg);
+var _jumpTable = function jumpTable(name, arg) {
+  if (_jumpTable[name]) {
+    _jumpTable[name](arg);
   }
 };
-Object.assign(jumpTable, {
+Object.assign(_jumpTable, {
   foo(arg) {
     fooCalls.push(arg);
   }
 });
-jumpTable('foo', 'bar');
+_jumpTable('foo', 'bar');
 expect(fooCalls[0]).toBe('bar');

--- a/packages/babel-plugin-transform-function-name/src/index.ts
+++ b/packages/babel-plugin-transform-function-name/src/index.ts
@@ -28,7 +28,7 @@ export default declare(api => {
           const newNode = nameFunction(
             // @ts-expect-error Fixme: should check ArrowFunctionExpression
             value,
-            false,
+            undefined,
             supportUnicodeId,
           );
           if (newNode) value.replaceWith(newNode);

--- a/packages/babel-plugin-transform-function-name/test/fixtures/function-name/with-arrow-functions-transform/output.js
+++ b/packages/babel-plugin-transform-function-name/test/fixtures/function-name/with-arrow-functions-transform/output.js
@@ -1,11 +1,11 @@
-const x = function x() {
-  return x;
+const _x = function x() {
+  return _x;
 };
 const y = function y(x) {
   return x();
 };
 const z = {
   z: function z() {
-    return y(x);
+    return y(_x);
   }
 }.z;

--- a/packages/babel-preset-env/test/fixtures/plugins-integration/issue-15170/output.js
+++ b/packages/babel-preset-env/test/fixtures/plugins-integration/issue-15170/output.js
@@ -1,34 +1,22 @@
 var _this = this;
 x = /*#__PURE__*/function () {
   var _ref = function (_x) {
-    var _marked = /*#__PURE__*/babelHelpers.regeneratorRuntime().mark(x);
     function x(_x2) {
-      var _args = arguments;
-      return babelHelpers.regeneratorRuntime().wrap(function x$(_context) {
-        while (1) switch (_context.prev = _context.next) {
-          case 0:
-            return _context.delegateYield(_x.apply(this, _args), "t0", 1);
-          case 1:
-            return _context.abrupt("return", _context.t0);
-          case 2:
-          case "end":
-            return _context.stop();
-        }
-      }, _marked, this);
+      return _x.apply(this, arguments);
     }
     x.toString = function () {
       return _x.toString();
     };
     return x;
   }( /*#__PURE__*/babelHelpers.regeneratorRuntime().mark(function _callee(x) {
-    return babelHelpers.regeneratorRuntime().wrap(function _callee$(_context2) {
-      while (1) switch (_context2.prev = _context2.next) {
+    return babelHelpers.regeneratorRuntime().wrap(function _callee$(_context) {
+      while (1) switch (_context.prev = _context.next) {
         case 0:
           babelHelpers.newArrowCheck(this, _this);
-          return _context2.abrupt("return", 0);
+          return _context.abrupt("return", 0);
         case 2:
         case "end":
-          return _context2.stop();
+          return _context.stop();
       }
     }, _callee, this);
   }));

--- a/packages/babel-traverse/src/path/conversion.ts
+++ b/packages/babel-traverse/src/path/conversion.ts
@@ -217,7 +217,7 @@ export function arrowFunctionToExpression(
       callExpression(
         memberExpression(
           // @ts-expect-error TS can't infer nameFunction returns CallExpression | ArrowFunctionExpression here
-          nameFunction(this, true) || fn.node,
+          nameFunction(this) || fn.node,
           identifier("bind"),
         ),
         [checkBinding ? identifier(checkBinding.name) : thisExpression()],


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

- We had some logic to avoid variable renames when injecting a new ID with the same name that in practice refers to the same variable. Remove that logic, as
  1. it's not actually necessary
  2. it's based on specific knowledge of our arrow functions transform, and might not apply to other callers of the helper
- We were assigning a `newId[NOT_LOCAL_BINDING] = true`, but that's not needed anymore