### PR TITLE
Reduce redundant `assertThisInitialized`

### DIFF
--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-property-optional-chain/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/accessing-super-property-optional-chain/output.js
@@ -5,8 +5,8 @@ var Test = /*#__PURE__*/function (_Foo) {
     var _babelHelpers$superPr, _babelHelpers$superPr2;
     var _this;
     babelHelpers.classCallCheck(this, Test);
-    (_babelHelpers$superPr = babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Test), "foo", babelHelpers.assertThisInitialized(_this), 1)) === null || _babelHelpers$superPr === void 0 || _babelHelpers$superPr.bar;
-    (_babelHelpers$superPr2 = babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Test), "foo", babelHelpers.assertThisInitialized(_this), 3)) === null || _babelHelpers$superPr2 === void 0 || _babelHelpers$superPr2([]);
+    (_babelHelpers$superPr = babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Test), "foo", _this, 1)) === null || _babelHelpers$superPr === void 0 || _babelHelpers$superPr.bar;
+    (_babelHelpers$superPr2 = babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Test), "foo", _this, 3)) === null || _babelHelpers$superPr2 === void 0 || _babelHelpers$superPr2([]);
     return babelHelpers.assertThisInitialized(_this);
   }
   babelHelpers.inherits(Test, _Foo);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super-inline/output.js
@@ -4,7 +4,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
   function Foo() {
     var _this;
     babelHelpers.classCallCheck(this, Foo);
-    babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "foo", babelHelpers.assertThisInitialized(_this), 3)([_this = babelHelpers.callSuper(this, Foo)]);
+    babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "foo", _this, 3)([_this = babelHelpers.callSuper(this, Foo)]);
     return _this;
   }
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-bare-super/output.js
@@ -4,7 +4,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
   function Foo() {
     var _this;
     babelHelpers.classCallCheck(this, Foo);
-    babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "foo", babelHelpers.assertThisInitialized(_this), 3)([]);
+    babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "foo", _this, 3)([]);
     return _this = babelHelpers.callSuper(this, Foo);
   }
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-2/output.js
@@ -4,8 +4,8 @@ var Foo = /*#__PURE__*/function (_Bar) {
   function Foo() {
     var _this;
     babelHelpers.classCallCheck(this, Foo);
-    var t = () => babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "test", babelHelpers.assertThisInitialized(_this), 3)([]);
-    babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "foo", babelHelpers.assertThisInitialized(_this), 3)([]);
+    var t = () => babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "test", _this, 3)([]);
+    babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "foo", _this, 3)([]);
     return _this = babelHelpers.callSuper(this, Foo);
   }
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda-3/output.js
@@ -4,7 +4,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
   function Foo() {
     var _this;
     babelHelpers.classCallCheck(this, Foo);
-    var t = () => babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "test", babelHelpers.assertThisInitialized(_this), 3)([]);
+    var t = () => babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "test", _this, 3)([]);
     _this = babelHelpers.callSuper(this, Foo);
     t();
     return _this;

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-before-in-lambda/output.js
@@ -4,7 +4,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
   function Foo() {
     var _this;
     babelHelpers.classCallCheck(this, Foo);
-    var t = () => babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "test", babelHelpers.assertThisInitialized(_this), 3)([]);
+    var t = () => babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), "test", _this, 3)([]);
     return _this = babelHelpers.callSuper(this, Foo);
   }
   babelHelpers.inherits(Foo, _Bar);

--- a/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/spec/super-reference-in-prop-exression/output.js
@@ -4,7 +4,7 @@ var Foo = /*#__PURE__*/function (_Bar) {
   function Foo() {
     var _this;
     babelHelpers.classCallCheck(this, Foo);
-    babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), (_this = babelHelpers.callSuper(this, Foo)).method, babelHelpers.assertThisInitialized(_this), 3)([]);
+    babelHelpers.superPropGet((babelHelpers.assertThisInitialized(_this), Foo), (_this = babelHelpers.callSuper(this, Foo)).method, _this, 3)([]);
     return _this;
   }
   babelHelpers.inherits(Foo, _Bar);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
