### PR TITLE
fix: remove one prettier e2e patch

### DIFF
--- a/scripts/integration-tests/e2e-prettier.sh
+++ b/scripts/integration-tests/e2e-prettier.sh
@@ -25,7 +25,6 @@ if [ "$BABEL_8_BREAKING" = true ] ; then
   # Based on https://github.com/prettier/prettier/pull/15157
   sed -i 's/const getChalk = () => chalk/default (code) => code/' scripts/build/shims/babel-highlight.js
   sed -i 's/const generate = babelGenerator.default/const generate = babelGenerator/' scripts/build/transform/index.js
-  sed -i 's/,"updateContext":null//g' tests/integration/__tests__/__snapshots__/debug-print-ast.js.snap
   rm tests/unit/__snapshots__/visitor-keys.js.snap
   # Update recordAndTuple usage
   sed -i 's/\["recordAndTuple", { syntaxType: "hash" }\]/"recordAndTuple"/' src/language-js/parse/babel.js


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fix failing prettier Babel 8 e2e tests
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The upstream prettier test was just updated in https://github.com/prettier/prettier/pull/16518. Based on the new test, we can safely remove the Babel 8 patch now.