### PR TITLE
Add `@babel/types` as a dependency of `@babel/parser`

### DIFF
--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -33,13 +33,16 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "# dependencies": "This package doesn't actually have runtime dependencies. @babel/types is only needed for type definitions.",
+  "dependencies": {
+    "@babel/types": "workspace:^"
+  },
   "devDependencies": {
     "@babel/code-frame": "workspace:^",
     "@babel/helper-check-duplicate-nodes": "workspace:^",
     "@babel/helper-fixtures": "workspace:^",
     "@babel/helper-string-parser": "workspace:^",
     "@babel/helper-validator-identifier": "workspace:^",
-    "@babel/types": "workspace:^",
     "charcodes": "^0.2.0"
   },
   "bin": "./bin/babel-parser.js",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Closes https://github.com/babel/babel/pull/15042, closes https://github.com/babel/babel/pull/11118, closes https://github.com/babel/babel/pull/9924

I still dislike the idea of adding a dependency that is only needed for type-checking and not at runtime, but:
- TS is so popular that at this point a "type dependency" can be considered the same as a runtime dependency
- We are publishing .d.ts for `@babel/parser` already in v7, but it's broken because of the missing dep
- We are going to make TS first-class in Babel 8

So here we are.