### PR TITLE
Test: Improve available-plugins compat-data check

### DIFF
--- a/packages/babel-preset-env/src/available-plugins.ts
+++ b/packages/babel-preset-env/src/available-plugins.ts
@@ -234,9 +234,10 @@ if (!process.env.BABEL_8_BREAKING) {
   // syntax enabled by default, we can safely skip enabling it.
   if (!USE_ESM) {
     // @ts-expect-error unknown key
-    legacyBabel7SyntaxPluginsLoaders["unicode-sets-regex"] = IS_STANDALONE
-      ? e()
-      : () => require("@babel/plugin-syntax-unicode-sets-regex");
+    legacyBabel7SyntaxPluginsLoaders["syntax-unicode-sets-regex"] =
+      IS_STANDALONE
+        ? e()
+        : () => require("@babel/plugin-syntax-unicode-sets-regex");
   }
 
   Object.assign(availablePlugins, legacyBabel7SyntaxPluginsLoaders);

--- a/packages/babel-preset-env/test/index.skip-bundled.js
+++ b/packages/babel-preset-env/test/index.skip-bundled.js
@@ -1,5 +1,7 @@
 // eslint-disable-next-line import/extensions
 import compatData from "@babel/compat-data/plugins";
+// eslint-disable-next-line import/extensions
+import bugfixesData from "@babel/compat-data/plugin-bugfixes";
 import * as babel from "@babel/core";
 
 import { USE_ESM, itBabel7, itBabel8, describeBabel7NoESM } from "$repo-utils";
@@ -312,13 +314,27 @@ describe("babel-preset-env", () => {
   });
 
   it("available-plugins is in sync with @babel/compat-data", () => {
-    const arrAvailablePlugins = Object.keys(availablePlugins).sort();
-    const arrCompatData = Object.keys(compatData)
-      // TODO(Babel 8): Remove this .map
-      .map(name => name.replace("proposal-", "transform-"))
+    const arrAvailablePlugins = Object.keys(availablePlugins)
+      .filter(
+        name =>
+          // 1. The syntax plugins are always enabled, they don't have compat-data entries
+          // 2. The modules transforms are for non-ES module systems, they don't have compat-data entries
+          // 3. The dynamic import transform is controlled by the modules option and the API caller support
+          !(
+            name.startsWith("syntax-") ||
+            name.startsWith("transform-modules-") ||
+            name === "transform-dynamic-import"
+          ),
+      )
       .sort();
+    const arrCompatData = [
+      ...Object.keys(compatData),
+      ...Object.keys(bugfixesData),
+    ].sort();
 
-    expect(arrAvailablePlugins).toEqual(expect.arrayContaining(arrCompatData));
+    for (const plugin of arrAvailablePlugins) {
+      expect(arrCompatData).toContain(plugin);
+    }
   });
 
   describe("debug", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Improve the sync test between preset-env/available-plugins and compat-data as it suddens starts failing on https://github.com/babel/babel/pull/16692. The new test happens to catch a bug where we did not properly declare syntax plugin entry for old `@babel/core` versions.