### PR TITLE
Add `tstyche` and expose some types in Babel 8

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -65,6 +65,8 @@ export default [
       "test/runtime-integration/*/output-absolute.js",
       "Makefile.js",
       ...(process.env.IS_PUBLISH ? testFiles : []),
+      "packages/*/test/*.tst.ts",
+      "eslint/*/test/*.tst.ts",
     ],
   },
   {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "test262-stream": "^1.4.0",
     "tstyche": "^2.1.1",
     "typescript": "5.5.4",
-    "typescript-eslint": "8.0.0-alpha.58"
+    "typescript-eslint": "8.0.0-alpha.39"
   },
   "workspaces": [
     "codemods/*",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,9 @@
     "semver": "^6.3.1",
     "shelljs": "^0.8.5",
     "test262-stream": "^1.4.0",
-    "typescript": "5.5.3",
-    "typescript-eslint": "8.0.0-alpha.39"
+    "tstyche": "^2.1.1",
+    "typescript": "5.5.4",
+    "typescript-eslint": "8.0.0-alpha.58"
   },
   "workspaces": [
     "codemods/*",

--- a/packages/babel-helpers/src/helpers/tsconfig.json
+++ b/packages/babel-helpers/src/helpers/tsconfig.json
@@ -13,5 +13,5 @@
     "strict": true
   },
   "include": ["./*.ts"],
-  "exclude": ["./applyDecs2305.ts", "./construct.ts", "./usingCtx.ts"]
+  "exclude": ["./applyDecs2305.ts"]
 }

--- a/packages/babel-helpers/src/helpers/usingCtx.ts
+++ b/packages/babel-helpers/src/helpers/usingCtx.ts
@@ -78,9 +78,11 @@ export default function _usingCtx(): UsingCtxReturn {
       if (typeof dispose !== "function") {
         throw new TypeError("Object is not disposable.");
       }
+      // @ts-expect-error use before assignment
       if (inner) {
         dispose = function () {
           try {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             inner.call(value);
           } catch (e) {
             // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
@@ -144,6 +146,7 @@ export default function _usingCtx(): UsingCtxReturn {
           }
         }
 
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
         if (error !== empty) throw error;
       }
 

--- a/packages/babel-preset-env/test/index.tst.ts
+++ b/packages/babel-preset-env/test/index.tst.ts
@@ -1,0 +1,4 @@
+import type { Options } from "@babel/preset-env";
+import { expect } from "tstyche";
+
+expect<Options>().type.not.toBe<undefined>();

--- a/packages/babel-preset-flow/src/index.ts
+++ b/packages/babel-preset-flow/src/index.ts
@@ -2,6 +2,8 @@ import { declarePreset } from "@babel/helper-plugin-utils";
 import transformFlowStripTypes from "@babel/plugin-transform-flow-strip-types";
 import normalizeOptions from "./normalize-options.ts";
 
+export type { Options } from "./normalize-options.ts";
+
 export default declarePreset((api, opts) => {
   api.assertVersion(REQUIRED_VERSION(7));
   const {

--- a/packages/babel-preset-flow/src/normalize-options.ts
+++ b/packages/babel-preset-flow/src/normalize-options.ts
@@ -1,8 +1,15 @@
 import { OptionValidator } from "@babel/helper-validator-option";
 const v = new OptionValidator("@babel/preset-flow");
 
-export default function normalizeOptions(options: any = {}) {
+export type Options = {
+  all?: boolean;
+  ignoreExtensions?: boolean;
+  experimental_useHermesParser?: boolean;
+};
+
+export default function normalizeOptions(options: Options = {}) {
   let { all, ignoreExtensions, experimental_useHermesParser } = options;
+  // @ts-expect-error Babel 7 only
   const { allowDeclareFields } = options;
 
   if (process.env.BABEL_8_BREAKING) {

--- a/packages/babel-preset-flow/test/index.tst.ts
+++ b/packages/babel-preset-flow/test/index.tst.ts
@@ -1,0 +1,4 @@
+import type { Options } from "@babel/preset-flow";
+import { expect } from "tstyche";
+
+expect<Options>().type.not.toBe<undefined>();

--- a/packages/babel-preset-react/test/index.tst.ts
+++ b/packages/babel-preset-react/test/index.tst.ts
@@ -1,0 +1,4 @@
+import type { Options } from "@babel/preset-react";
+import { expect } from "tstyche";
+
+expect<Options>().type.not.toBe<undefined>();

--- a/packages/babel-preset-typescript/src/index.ts
+++ b/packages/babel-preset-typescript/src/index.ts
@@ -6,14 +6,18 @@ import normalizeOptions from "./normalize-options.ts";
 import type { Options } from "./normalize-options.ts";
 import pluginRewriteTSImports from "./plugin-rewrite-ts-imports.ts";
 
+export type { Options };
+
 export default declarePreset((api, opts: Options) => {
   api.assertVersion(REQUIRED_VERSION(7));
 
   const {
+    // @ts-expect-error Babel 7 only
     allExtensions,
     ignoreExtensions,
     allowNamespaces,
     disallowAmbiguousJSXLike,
+    // @ts-expect-error Babel 7 only
     isTSX,
     jsxPragma,
     jsxPragmaFrag,

--- a/packages/babel-preset-typescript/src/normalize-options.ts
+++ b/packages/babel-preset-typescript/src/normalize-options.ts
@@ -11,10 +11,6 @@ export interface Options {
   onlyRemoveTypeImports?: boolean;
   optimizeConstEnums?: boolean;
   rewriteImportExtensions?: boolean;
-
-  // TODO: Remove in Babel 8
-  allExtensions?: boolean;
-  isTSX?: boolean;
 }
 
 export default function normalizeOptions(options: Options = {}) {
@@ -33,6 +29,7 @@ export default function normalizeOptions(options: Options = {}) {
     rewriteImportExtensions: "rewriteImportExtensions",
 
     // TODO: Remove in Babel 8
+    // @ts-expect-error Babel 7 only
     allExtensions: "allExtensions",
     isTSX: "isTSX",
   };
@@ -78,14 +75,18 @@ export default function normalizeOptions(options: Options = {}) {
   if (!process.env.BABEL_8_BREAKING) {
     // eslint-disable-next-line no-var
     var allExtensions = v.validateBooleanOption(
+      // @ts-expect-error Babel 7 only
       TopLevelOptions.allExtensions,
+      // @ts-expect-error Babel 7 only
       options.allExtensions,
       false,
     );
 
     // eslint-disable-next-line no-var
     var isTSX = v.validateBooleanOption(
+      // @ts-expect-error Babel 7 only
       TopLevelOptions.isTSX,
+      // @ts-expect-error Babel 7 only
       options.isTSX,
       false,
     );
@@ -142,7 +143,9 @@ export default function normalizeOptions(options: Options = {}) {
     rewriteImportExtensions,
   };
   if (!process.env.BABEL_8_BREAKING) {
+    // @ts-expect-error Babel 7 only
     normalized.allExtensions = allExtensions;
+    // @ts-expect-error Babel 7 only
     normalized.isTSX = isTSX;
   }
   return normalized;

--- a/packages/babel-preset-typescript/test/index.tst.ts
+++ b/packages/babel-preset-typescript/test/index.tst.ts
@@ -1,0 +1,4 @@
+import type { Options } from "@babel/preset-typescript";
+import { expect } from "tstyche";
+
+expect<Options>().type.not.toBe<undefined>();

--- a/packages/babel-traverse/test/index.tst.ts
+++ b/packages/babel-traverse/test/index.tst.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "tstyche";
+import traverse, { NodePath, Visitor } from "@babel/traverse";
+import * as t from "@babel/types";
+
+test("Visitor", () => {
+  const visitor: Visitor = {
+    VariableDeclarator(path) {
+      expect(path).type.toBe<NodePath<t.VariableDeclarator>>();
+      expect(path.parent).type.toBe<t.VariableDeclaration>();
+      expect(path.parentPath).type.toBe<NodePath<t.VariableDeclaration>>();
+
+      const left = path.get("id");
+      if (left.isIdentifier()) {
+        expect(left).type.toBe<NodePath<t.Identifier>>();
+      }
+    },
+    "UnaryExpression|BinaryExpression"(path) {
+      expect
+        .skip(path)
+        .type.toBe<
+          NodePath<t.UnaryExpression> | NodePath<t.BinaryExpression>
+        >();
+    },
+  };
+});
+
+test("traverse", () => {
+  traverse(null, {
+    AssignmentExpression(path) {
+      path.traverse({
+        Identifier(path) {},
+        // @ts-expect-error Discuss whether to support this type
+        noScope: true,
+      });
+    },
+    noScope: true,
+  });
+});

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -305,7 +305,9 @@ fs.writeFileSync(
           "./lib/libdom-minimal.d.ts",
           "packages/babel-parser/typings/*.d.ts",
           "dts/**/*.d.ts",
+          "packages/*/test/*.tst.ts",
         ],
+        exclude: ["dts/**/test/*.tst.d.ts"],
         references: Array.from(new Set(projectsFolders.values()))
           .sort()
           .map(path => ({ path })),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,11 @@
   "include": [
     "./lib/libdom-minimal.d.ts",
     "packages/babel-parser/typings/*.d.ts",
-    "dts/**/*.d.ts"
+    "dts/**/*.d.ts",
+    "packages/*/test/*.tst.ts"
+  ],
+  "exclude": [
+    "dts/**/test/*.tst.d.ts"
   ],
   "references": [
     {

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://tstyche.org/schemas/config.json",
+  "testFileMatch": ["packages/*/test/*.tst.ts", "eslint/*/test/*.tst.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,15 +5668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.39":
-  version: 8.0.0-alpha.39
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.39"
+"@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.58":
+  version: 8.0.0-alpha.58
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.58"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/type-utils": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/utils": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/type-utils": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/utils": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -5687,25 +5687,25 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/86f93123c1fada9225d940305780bbec038c217712df7ace61730103817bc14306935c1860e7bc63a332ac8622bbf43e7463d738286f8dbf1fe25ed9590a278f
+  checksum: 10/5b25c6b18dcecc2cc7bf42ec2d4debe95ec22c6b9c7c2691ab07cb17e23d10d30e6e49d956d50972d8d942e1a76dc26b831606790eaf086fb0f528a396c57836
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.0.0-alpha.39":
-  version: 8.0.0-alpha.39
-  resolution: "@typescript-eslint/parser@npm:8.0.0-alpha.39"
+"@typescript-eslint/parser@npm:8.0.0-alpha.58":
+  version: 8.0.0-alpha.58
+  resolution: "@typescript-eslint/parser@npm:8.0.0-alpha.58"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/types": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/39a7f5d945e72ba34b4960bf735fbafd9bb79a1d3cd569a24abf1b6108cc85b0ab765b191ba131f965bd211a08eeed736a5dde312f4d2e44c03de86c04e808e5
+  checksum: 10/0b93c998ae404330d1058c6962d638a51fbb8dc1a006e0003bcbf3fd1e8629c41d5f478d0efdffe93f02cf0b78132d92c41522e670f7e50bc159dc9897faca50
   languageName: node
   linkType: hard
 
@@ -5719,13 +5719,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.0.0-alpha.39":
-  version: 8.0.0-alpha.39
-  resolution: "@typescript-eslint/scope-manager@npm:8.0.0-alpha.39"
+"@typescript-eslint/scope-manager@npm:8.0.0-alpha.58":
+  version: 8.0.0-alpha.58
+  resolution: "@typescript-eslint/scope-manager@npm:8.0.0-alpha.58"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.39"
-  checksum: 10/b76fb422695725e9ac07320b7096116c5d86cd3be25246b9e5bac41ba63bee783cb07aff365aabbdb743a0e72d1d78958d8b361a485495128bcc197c9b458e0d
+    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
+  checksum: 10/afc55667b056f9e4f39500436693c1cad06fe8428a92e1ea77e3d6e16b583fa110fb2cff8fc8013db335f58c9dee92b6d01b1322a4db0db1cc2d5aeecac728d6
   languageName: node
   linkType: hard
 
@@ -5739,18 +5739,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.0.0-alpha.39":
-  version: 8.0.0-alpha.39
-  resolution: "@typescript-eslint/type-utils@npm:8.0.0-alpha.39"
+"@typescript-eslint/type-utils@npm:8.0.0-alpha.58":
+  version: 8.0.0-alpha.58
+  resolution: "@typescript-eslint/type-utils@npm:8.0.0-alpha.58"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/utils": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/utils": "npm:8.0.0-alpha.58"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^1.3.0"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/c23d050c82a6261ea5399682333678c65e946bae2e221d3efab4215b61dad27a45a2efa09b3582a608c912385c34797768872819676372a62c26650bb2f00593
+  checksum: 10/a8faff6d431e92c277efe3b097412e93ca49f388945ec85cc297f9ac2c9b5a80c976e4df8bc93352624adf3ad85a719bb633762dfd940f69ed22b518b93081f5
   languageName: node
   linkType: hard
 
@@ -5768,10 +5768,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.0.0-alpha.39":
-  version: 8.0.0-alpha.39
-  resolution: "@typescript-eslint/types@npm:8.0.0-alpha.39"
-  checksum: 10/8b37ba62b65655dee320869546de5c883f7a4d4308880b33eb1c22929cca28cc1a03c3d19fc0af6aa2cc79518bb8edc7aa5d4c21635083fb5a62105ae3d727aa
+"@typescript-eslint/types@npm:8.0.0-alpha.58":
+  version: 8.0.0-alpha.58
+  resolution: "@typescript-eslint/types@npm:8.0.0-alpha.58"
+  checksum: 10/01ed99d2c670b2078d68e414a7408186d2e92b6df88b7b0d7b2c80b52229b5f70b7a72b990eaf9a32dbd4947a4158e05136b16e011c8e94cccb7725898734f8f
   languageName: node
   linkType: hard
 
@@ -5793,12 +5793,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.0.0-alpha.39":
-  version: 8.0.0-alpha.39
-  resolution: "@typescript-eslint/typescript-estree@npm:8.0.0-alpha.39"
+"@typescript-eslint/typescript-estree@npm:8.0.0-alpha.58":
+  version: 8.0.0-alpha.58
+  resolution: "@typescript-eslint/typescript-estree@npm:8.0.0-alpha.58"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
     debug: "npm:^4.3.4"
     globby: "npm:^11.1.0"
     is-glob: "npm:^4.0.3"
@@ -5808,21 +5808,21 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/e5fa11a11eeba8bf836d33effec42df613c7c6fc4612a513c191a57324e77bdeb1ae406836e8850b1c18f2c720d85ebe066e78d75d06eec9402dc649ba027311
+  checksum: 10/fbb6729f993db3e2b3230f579fd705067f56310d73611f8583ab7994cf08c4061134d719820f0a4544f5be62fefbce46a626e9c9df3a4199e6c1804097c9fe10
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.0.0-alpha.39":
-  version: 8.0.0-alpha.39
-  resolution: "@typescript-eslint/utils@npm:8.0.0-alpha.39"
+"@typescript-eslint/utils@npm:8.0.0-alpha.58":
+  version: 8.0.0-alpha.58
+  resolution: "@typescript-eslint/utils@npm:8.0.0-alpha.58"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/types": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.58"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10/5b7d6833395b1f939564795c99f6696428a0c086f8c165fc16710780d82d3312a1141be88d2182f7ed953efd2a76f20199f2d75e3b856f2a8a0045a04af7d029
+  checksum: 10/08f794d6e0f645f5809cc17bc5fbd6846ce9208b6f0ef1c08cd2d0977fe8adda57c3693f01562af87a395033f9697931d2f6e10fcdde168828020a0f8120b8c2
   languageName: node
   linkType: hard
 
@@ -5864,13 +5864,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.0.0-alpha.39":
-  version: 8.0.0-alpha.39
-  resolution: "@typescript-eslint/visitor-keys@npm:8.0.0-alpha.39"
+"@typescript-eslint/visitor-keys@npm:8.0.0-alpha.58":
+  version: 8.0.0-alpha.58
+  resolution: "@typescript-eslint/visitor-keys@npm:8.0.0-alpha.58"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
     eslint-visitor-keys: "npm:^3.4.3"
-  checksum: 10/a73a14f1cfd04091a9127fcec68b933b251a24a3a02351015a11a44a71de6e10abfb21a9d4c004a9a08b4eb3debd1606f7b19e8c51400c00f28de3a461ddbeb5
+  checksum: 10/ff4b4f680ea374ad8148078e1cc9c730da2fbc0479792dfdb6d8641dffa391a633812ade929013d2b153f68a0c84ef4b92789dfc6b7a2aad18f0003c57b597b8
   languageName: node
   linkType: hard
 
@@ -7189,8 +7189,9 @@ __metadata:
     semver: "npm:^6.3.1"
     shelljs: "npm:^0.8.5"
     test262-stream: "npm:^1.4.0"
-    typescript: "npm:5.5.3"
-    typescript-eslint: "npm:8.0.0-alpha.39"
+    tstyche: "npm:^2.1.1"
+    typescript: "npm:5.5.4"
+    typescript-eslint: "npm:8.0.0-alpha.58"
   languageName: unknown
   linkType: soft
 
@@ -16557,6 +16558,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tstyche@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "tstyche@npm:2.1.1"
+  peerDependencies:
+    typescript: 4.x || 5.x
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tstyche: ./build/bin.js
+  checksum: 10/f30e7d782e51c262528ededf383c9daf39af8dea063d483667e3ff9f4800434891589c294c4b4f69802dd06daf8fb1d2a10553316d2f4631ba1413d3e48dab81
+  languageName: node
+  linkType: hard
+
 "tsutils@npm:^3.21.0":
   version: 3.21.0
   resolution: "tsutils@npm:3.21.0"
@@ -16724,37 +16739,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:8.0.0-alpha.39":
-  version: 8.0.0-alpha.39
-  resolution: "typescript-eslint@npm:8.0.0-alpha.39"
+"typescript-eslint@npm:8.0.0-alpha.58":
+  version: 8.0.0-alpha.58
+  resolution: "typescript-eslint@npm:8.0.0-alpha.58"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/parser": "npm:8.0.0-alpha.39"
-    "@typescript-eslint/utils": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/eslint-plugin": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/parser": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/utils": "npm:8.0.0-alpha.58"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/51efbb4fe0d107e019d53021208944bb5592e99e6342f53da5b84c9b918377024f6a62c3321e8be77201a1e1eb62a76c1e2938b53654159a7a71b6793ef5ebdb
+  checksum: 10/72903e652c86b713e1526bab4fca61b0e5506ef292fdec3165e9ef7c8f28ea879dff7ac9c74a2eadff72dd7712fe62fc04531c84b945bba21176924dab2ef592
   languageName: node
   linkType: hard
 
-"typescript@npm:5.5.3":
-  version: 5.5.3
-  resolution: "typescript@npm:5.5.3"
+"typescript@npm:5.5.4":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/11a867312419ed497929aafd2f1d28b2cd41810a5eb6c6e9e169559112e9ea073d681c121a29102e67cd4478d0a4ae37a306a5800f3717f59c4337e6a9bd5e8d
+  checksum: 10/1689ccafef894825481fc3d856b4834ba3cc185a9c2878f3c76a9a1ef81af04194849840f3c69e7961e2312771471bb3b460ca92561e1d87599b26c37d0ffb6f
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.5.3#optional!builtin<compat/typescript>":
-  version: 5.5.3
-  resolution: "typescript@patch:typescript@npm%3A5.5.3#optional!builtin<compat/typescript>::version=5.5.3&hash=379a07"
+"typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>":
+  version: 5.5.4
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/7cf7acb78a80f749b82842f2ffe01e90e7b3e709a6f4268588e0b7599c41dca1059be217f47778fe1a380bfaf60933021ef20d002c426d4d7745e1b36c11467b
+  checksum: 10/746fdd0865c5ce4f15e494c57ede03a9e12ede59cfdb40da3a281807853fe63b00ef1c912d7222143499aa82f18b8b472baa1830df8804746d09b55f6cf5b1cc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,15 +5668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.58"
+"@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.39":
+  version: 8.0.0-alpha.39
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.0.0-alpha.39"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/type-utils": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/utils": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/type-utils": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/utils": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.39"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -5687,25 +5687,25 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/5b25c6b18dcecc2cc7bf42ec2d4debe95ec22c6b9c7c2691ab07cb17e23d10d30e6e49d956d50972d8d942e1a76dc26b831606790eaf086fb0f528a396c57836
+  checksum: 10/86f93123c1fada9225d940305780bbec038c217712df7ace61730103817bc14306935c1860e7bc63a332ac8622bbf43e7463d738286f8dbf1fe25ed9590a278f
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/parser@npm:8.0.0-alpha.58"
+"@typescript-eslint/parser@npm:8.0.0-alpha.39":
+  version: 8.0.0-alpha.39
+  resolution: "@typescript-eslint/parser@npm:8.0.0-alpha.39"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.39"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/0b93c998ae404330d1058c6962d638a51fbb8dc1a006e0003bcbf3fd1e8629c41d5f478d0efdffe93f02cf0b78132d92c41522e670f7e50bc159dc9897faca50
+  checksum: 10/39a7f5d945e72ba34b4960bf735fbafd9bb79a1d3cd569a24abf1b6108cc85b0ab765b191ba131f965bd211a08eeed736a5dde312f4d2e44c03de86c04e808e5
   languageName: node
   linkType: hard
 
@@ -5719,13 +5719,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/scope-manager@npm:8.0.0-alpha.58"
+"@typescript-eslint/scope-manager@npm:8.0.0-alpha.39":
+  version: 8.0.0-alpha.39
+  resolution: "@typescript-eslint/scope-manager@npm:8.0.0-alpha.39"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
-  checksum: 10/afc55667b056f9e4f39500436693c1cad06fe8428a92e1ea77e3d6e16b583fa110fb2cff8fc8013db335f58c9dee92b6d01b1322a4db0db1cc2d5aeecac728d6
+    "@typescript-eslint/types": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.39"
+  checksum: 10/b76fb422695725e9ac07320b7096116c5d86cd3be25246b9e5bac41ba63bee783cb07aff365aabbdb743a0e72d1d78958d8b361a485495128bcc197c9b458e0d
   languageName: node
   linkType: hard
 
@@ -5739,18 +5739,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/type-utils@npm:8.0.0-alpha.58"
+"@typescript-eslint/type-utils@npm:8.0.0-alpha.39":
+  version: 8.0.0-alpha.39
+  resolution: "@typescript-eslint/type-utils@npm:8.0.0-alpha.39"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/utils": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/utils": "npm:8.0.0-alpha.39"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^1.3.0"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/a8faff6d431e92c277efe3b097412e93ca49f388945ec85cc297f9ac2c9b5a80c976e4df8bc93352624adf3ad85a719bb633762dfd940f69ed22b518b93081f5
+  checksum: 10/c23d050c82a6261ea5399682333678c65e946bae2e221d3efab4215b61dad27a45a2efa09b3582a608c912385c34797768872819676372a62c26650bb2f00593
   languageName: node
   linkType: hard
 
@@ -5768,10 +5768,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/types@npm:8.0.0-alpha.58"
-  checksum: 10/01ed99d2c670b2078d68e414a7408186d2e92b6df88b7b0d7b2c80b52229b5f70b7a72b990eaf9a32dbd4947a4158e05136b16e011c8e94cccb7725898734f8f
+"@typescript-eslint/types@npm:8.0.0-alpha.39":
+  version: 8.0.0-alpha.39
+  resolution: "@typescript-eslint/types@npm:8.0.0-alpha.39"
+  checksum: 10/8b37ba62b65655dee320869546de5c883f7a4d4308880b33eb1c22929cca28cc1a03c3d19fc0af6aa2cc79518bb8edc7aa5d4c21635083fb5a62105ae3d727aa
   languageName: node
   linkType: hard
 
@@ -5793,12 +5793,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/typescript-estree@npm:8.0.0-alpha.58"
+"@typescript-eslint/typescript-estree@npm:8.0.0-alpha.39":
+  version: 8.0.0-alpha.39
+  resolution: "@typescript-eslint/typescript-estree@npm:8.0.0-alpha.39"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/visitor-keys": "npm:8.0.0-alpha.39"
     debug: "npm:^4.3.4"
     globby: "npm:^11.1.0"
     is-glob: "npm:^4.0.3"
@@ -5808,21 +5808,21 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/fbb6729f993db3e2b3230f579fd705067f56310d73611f8583ab7994cf08c4061134d719820f0a4544f5be62fefbce46a626e9c9df3a4199e6c1804097c9fe10
+  checksum: 10/e5fa11a11eeba8bf836d33effec42df613c7c6fc4612a513c191a57324e77bdeb1ae406836e8850b1c18f2c720d85ebe066e78d75d06eec9402dc649ba027311
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/utils@npm:8.0.0-alpha.58"
+"@typescript-eslint/utils@npm:8.0.0-alpha.39":
+  version: 8.0.0-alpha.39
+  resolution: "@typescript-eslint/utils@npm:8.0.0-alpha.39"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/scope-manager": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/typescript-estree": "npm:8.0.0-alpha.39"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10/08f794d6e0f645f5809cc17bc5fbd6846ce9208b6f0ef1c08cd2d0977fe8adda57c3693f01562af87a395033f9697931d2f6e10fcdde168828020a0f8120b8c2
+  checksum: 10/5b7d6833395b1f939564795c99f6696428a0c086f8c165fc16710780d82d3312a1141be88d2182f7ed953efd2a76f20199f2d75e3b856f2a8a0045a04af7d029
   languageName: node
   linkType: hard
 
@@ -5864,13 +5864,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "@typescript-eslint/visitor-keys@npm:8.0.0-alpha.58"
+"@typescript-eslint/visitor-keys@npm:8.0.0-alpha.39":
+  version: 8.0.0-alpha.39
+  resolution: "@typescript-eslint/visitor-keys@npm:8.0.0-alpha.39"
   dependencies:
-    "@typescript-eslint/types": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/types": "npm:8.0.0-alpha.39"
     eslint-visitor-keys: "npm:^3.4.3"
-  checksum: 10/ff4b4f680ea374ad8148078e1cc9c730da2fbc0479792dfdb6d8641dffa391a633812ade929013d2b153f68a0c84ef4b92789dfc6b7a2aad18f0003c57b597b8
+  checksum: 10/a73a14f1cfd04091a9127fcec68b933b251a24a3a02351015a11a44a71de6e10abfb21a9d4c004a9a08b4eb3debd1606f7b19e8c51400c00f28de3a461ddbeb5
   languageName: node
   linkType: hard
 
@@ -7191,7 +7191,7 @@ __metadata:
     test262-stream: "npm:^1.4.0"
     tstyche: "npm:^2.1.1"
     typescript: "npm:5.5.4"
-    typescript-eslint: "npm:8.0.0-alpha.58"
+    typescript-eslint: "npm:8.0.0-alpha.39"
   languageName: unknown
   linkType: soft
 
@@ -16739,17 +16739,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:8.0.0-alpha.58":
-  version: 8.0.0-alpha.58
-  resolution: "typescript-eslint@npm:8.0.0-alpha.58"
+"typescript-eslint@npm:8.0.0-alpha.39":
+  version: 8.0.0-alpha.39
+  resolution: "typescript-eslint@npm:8.0.0-alpha.39"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/parser": "npm:8.0.0-alpha.58"
-    "@typescript-eslint/utils": "npm:8.0.0-alpha.58"
+    "@typescript-eslint/eslint-plugin": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/parser": "npm:8.0.0-alpha.39"
+    "@typescript-eslint/utils": "npm:8.0.0-alpha.39"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/72903e652c86b713e1526bab4fca61b0e5506ef292fdec3165e9ef7c8f28ea879dff7ac9c74a2eadff72dd7712fe62fc04531c84b945bba21176924dab2ef592
+  checksum: 10/51efbb4fe0d107e019d53021208944bb5592e99e6342f53da5b84c9b918377024f6a62c3321e8be77201a1e1eb62a76c1e2938b53654159a7a71b6793ef5ebdb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Initially I wanted to improve the type of `traverse`, but failed, so I just added cases about type testing.
At the same time, the `Options` type of `@babel/preset-*` was exposed.

In addition, there are some discussions about the type of `traverse`
1. Currently we only expose `Visitor`, but `traverse` accepts and we often use `TraverseOptions`, we should probably unify it or export `TraverseOptions` as well.
2. `path.traverse` currently does not accept `noScope`, but there is such a use case in our code repository.