### PR TITLE
Avoid validating visitors produced by `traverse.visitors.merge`

### DIFF
--- a/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/src/index.ts
+++ b/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/src/index.ts
@@ -28,14 +28,6 @@ export default declare(({ types: t, assertVersion }) => {
       if (state.yield) path.stop();
     },
   });
-  if (!process.env.BABEL_8_BREAKING && !t.staticBlock) {
-    // StaticBlock was only introduced in Babel 7.12.0.
-    // If this plugin is being called by an old version
-    // of Babel, but `environmentVisitor` is being imported
-    // by a new one, we would get an error about an
-    // unknown visitor.
-    delete containsYieldOrAwaitVisitor.StaticBlock;
-  }
 
   function containsClassExpression(path: NodePath<t.Node>) {
     if (t.isClassExpression(path.node)) return true;

--- a/packages/babel-traverse/test/visitors.js
+++ b/packages/babel-traverse/test/visitors.js
@@ -1,20 +1,36 @@
 import { parse } from "@babel/parser";
-import { itBabel8 } from "$repo-utils";
+import { itBabel7, itBabel8 } from "$repo-utils";
 import _traverse, { visitors } from "../lib/index.js";
 const traverse = _traverse.default || _traverse;
 
 describe("visitors", () => {
   describe("merge", () => {
-    itBabel8(
-      "should set `_verified` and `_exploded` to `true` if merging catch-all visitors",
-      () => {
-        const visitor = visitors.merge([{ enter() {} }, { enter() {} }]);
-        expect(visitor._verified).toBe(true);
-        expect(visitor._exploded).toBe(true);
-      },
-    );
+    it("should set `_verified` and `_exploded` to `true` if merging catch-all visitors", () => {
+      const visitor = visitors.merge([{ enter() {} }, { enter() {} }]);
+      expect(visitor._verified).toBe(true);
+      expect(visitor._exploded).toBe(true);
+    });
 
-    it("should work when merging node type visitors", () => {
+    itBabel7("should work when merging node type visitors", () => {
+      const ast = parse("1");
+      const visitor = visitors.merge([
+        { ArrayExpression() {} },
+        { ArrayExpression() {} },
+      ]);
+      traverse(ast, visitor);
+      expect(visitor).toMatchInlineSnapshot(`
+        Object {
+          "ArrayExpression": Object {
+            "enter": Array [
+              [Function],
+              [Function],
+            ],
+          },
+        }
+      `);
+    });
+
+    itBabel8("should work when merging node type visitors", () => {
       const ast = parse("1");
       const visitor = visitors.merge([
         { ArrayExpression() {} },
@@ -35,7 +51,21 @@ describe("visitors", () => {
       `);
     });
 
-    it("enter", () => {
+    itBabel7("enter", () => {
+      const ast = parse("1");
+      const visitor = visitors.merge([{ enter() {} }, { enter() {} }]);
+      traverse(ast, visitor);
+      expect(visitor).toMatchInlineSnapshot(`
+        Object {
+          "enter": Array [
+            [Function],
+            [Function],
+          ],
+        }
+      `);
+    });
+
+    itBabel8("enter", () => {
       const ast = parse("1");
       const visitor = visitors.merge([{ enter() {} }, { enter() {} }]);
       traverse(ast, visitor);
@@ -51,7 +81,24 @@ describe("visitors", () => {
       `);
     });
 
-    it("enter with states", () => {
+    itBabel7("enter with states", () => {
+      const ast = parse("1");
+      const visitor = visitors.merge(
+        [{ enter() {} }, { enter() {} }],
+        [{}, {}],
+      );
+      traverse(ast, visitor);
+      expect(visitor).toMatchInlineSnapshot(`
+        Object {
+          "enter": Array [
+            [Function],
+            [Function],
+          ],
+        }
+      `);
+    });
+
+    itBabel8("enter with states", () => {
       const ast = parse("1");
       const visitor = visitors.merge(
         [{ enter() {} }, { enter() {} }],
@@ -70,7 +117,25 @@ describe("visitors", () => {
       `);
     });
 
-    it("enter with wrapper", () => {
+    itBabel7("enter with wrapper", () => {
+      const ast = parse("1");
+      const visitor = visitors.merge(
+        [{ enter() {} }, { enter() {} }],
+        [{}, {}],
+        (stateKey, key, fn) => fn,
+      );
+      traverse(ast, visitor);
+      expect(visitor).toMatchInlineSnapshot(`
+        Object {
+          "enter": Array [
+            [Function],
+            [Function],
+          ],
+        }
+      `);
+    });
+
+    itBabel8("enter with wrapper", () => {
       const ast = parse("1");
       const visitor = visitors.merge(
         [{ enter() {} }, { enter() {} }],


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/16689#issue-2435651149
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR marks as "already validated" all visitors produced by `traverse.visitor.merge`, which internally does validation of all of its inputs. This means that passing those visitors to older versions of `@babel/traverse` will not throw anymore.

With this change I can get the example from https://github.com/babel/babel/issues/16689#issue-2435651149 to build, even if then fails with "regeneratorRuntime is not defined" (which is a completely separate problem, probably a bug in my setup)