### PR TITLE
chore: remove duplicate tscheck from the publish script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ test: lint test-only
 clone-license:
 	$(MAKEJS) clone-license
 
-prepublish-prepare-dts: tscheck
+prepublish-prepare-dts:
 	$(MAKEJS) prepublish-prepare-dts
 
 prepublish-build:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Remove duplicate `tscheck` from the publish script
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`$(MAKEJS) prepublish-prepare-dts` already runs `$(MAKEJS) tscheck`:

https://github.com/babel/babel/blob/44efb5f6b68b81e7797b8a607940c48ad1b67a5c/Makefile.source.mjs#L295-L299