### PR TITLE
Only force-parenthesize `satisfies`'s LHS if it has newlines

### DIFF
--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -526,7 +526,9 @@ function TSTypeExpression(
   node: t.TSAsExpression | t.TSSatisfiesExpression,
 ) {
   const { type, expression, typeAnnotation } = node;
-  const forceParens = !!expression.trailingComments?.length;
+  const forceParens = expression.trailingComments?.some(
+    c => c.type === "CommentLine" || /[\r\n\u2028\u2029]/.test(c.value),
+  );
   this.print(expression, true, undefined, forceParens);
   this.space();
   this.word(type === "TSAsExpression" ? "as" : "satisfies");

--- a/packages/babel-generator/test/fixtures/typescript/satisfies/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/satisfies/input.js
@@ -6,6 +6,12 @@ x satisfies any satisfies T;
 (
   // a
   x
-  /* b */
+  /* b
+  newline */
+) satisfies T;
+(
+  // a
+  x
+  // b
 ) satisfies T;
 x /* c */ satisfies T;

--- a/packages/babel-generator/test/fixtures/typescript/satisfies/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/satisfies/output.js
@@ -5,5 +5,11 @@ x satisfies any satisfies T;
 (
 // a
 x
-/* b */) satisfies T;
-(x /* c */) satisfies T;
+/* b
+newline */) satisfies T;
+(
+// a
+x
+// b
+) satisfies T;
+x /* c */ satisfies T;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

If we only have block comments with no line terminators inside, the expression can be printed on a single line and thus we don't need to force-add parentheses.

The current logic is broken (see https://github.com/babel/babel/issues/16737), but this PR makes it slightly less invasive for now.