### PR TITLE
Do not pass the parent node to `printer.print(...)`

### DIFF
--- a/packages/babel-generator/src/generators/base.ts
+++ b/packages/babel-generator/src/generators/base.ts
@@ -5,10 +5,10 @@ export function File(this: Printer, node: t.File) {
   if (node.program) {
     // Print this here to ensure that Program node 'leadingComments' still
     // get printed after the hashbang.
-    this.print(node.program.interpreter, node);
+    this.print(node.program.interpreter);
   }
 
-  this.print(node.program, node);
+  this.print(node.program);
 }
 
 export function Program(this: Printer, node: t.Program) {
@@ -54,7 +54,7 @@ export function BlockStatement(this: Printer, node: t.BlockStatement) {
 }
 
 export function Directive(this: Printer, node: t.Directive) {
-  this.print(node.value, node);
+  this.print(node.value);
   this.semicolon();
 }
 

--- a/packages/babel-generator/src/generators/classes.ts
+++ b/packages/babel-generator/src/generators/classes.ts
@@ -42,17 +42,17 @@ export function ClassDeclaration(
 
   if (node.id) {
     this.space();
-    this.print(node.id, node);
+    this.print(node.id);
   }
 
-  this.print(node.typeParameters, node);
+  this.print(node.typeParameters);
 
   if (node.superClass) {
     this.space();
     this.word("extends");
     this.space();
-    this.print(node.superClass, node);
-    this.print(node.superTypeParameters, node);
+    this.print(node.superClass);
+    this.print(node.superTypeParameters);
   }
 
   if (node.implements) {
@@ -63,7 +63,7 @@ export function ClassDeclaration(
   }
 
   this.space();
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 export { ClassDeclaration as ClassExpression };
@@ -97,11 +97,11 @@ export function ClassProperty(this: Printer, node: t.ClassProperty) {
 
   if (node.computed) {
     this.token("[");
-    this.print(node.key, node);
+    this.print(node.key);
     this.token("]");
   } else {
     this._variance(node);
-    this.print(node.key, node);
+    this.print(node.key);
   }
 
   // TS
@@ -112,12 +112,12 @@ export function ClassProperty(this: Printer, node: t.ClassProperty) {
     this.token("!");
   }
 
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
   if (node.value) {
     this.space();
     this.token("=");
     this.space();
-    this.print(node.value, node);
+    this.print(node.value);
   }
   this.semicolon();
 }
@@ -141,12 +141,12 @@ export function ClassAccessorProperty(
 
   if (node.computed) {
     this.token("[");
-    this.print(node.key, node);
+    this.print(node.key);
     this.token("]");
   } else {
     // Todo: Flow does not support class accessor property yet.
     this._variance(node);
-    this.print(node.key, node);
+    this.print(node.key);
   }
 
   // TS
@@ -157,12 +157,12 @@ export function ClassAccessorProperty(
     this.token("!");
   }
 
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
   if (node.value) {
     this.space();
     this.token("=");
     this.space();
-    this.print(node.value, node);
+    this.print(node.value);
   }
   this.semicolon();
 }
@@ -176,13 +176,13 @@ export function ClassPrivateProperty(
     this.word("static");
     this.space();
   }
-  this.print(node.key, node);
-  this.print(node.typeAnnotation, node);
+  this.print(node.key);
+  this.print(node.typeAnnotation);
   if (node.value) {
     this.space();
     this.token("=");
     this.space();
-    this.print(node.value, node);
+    this.print(node.value);
   }
   this.semicolon();
 }
@@ -190,13 +190,13 @@ export function ClassPrivateProperty(
 export function ClassMethod(this: Printer, node: t.ClassMethod) {
   this._classMethodHead(node);
   this.space();
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 export function ClassPrivateMethod(this: Printer, node: t.ClassPrivateMethod) {
   this._classMethodHead(node);
   this.space();
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 export function _classMethodHead(

--- a/packages/babel-generator/src/generators/expressions.ts
+++ b/packages/babel-generator/src/generators/expressions.ts
@@ -23,7 +23,7 @@ export function UnaryExpression(this: Printer, node: t.UnaryExpression) {
     this.token(operator);
   }
 
-  this.print(node.argument, node);
+  this.print(node.argument);
 }
 
 export function DoExpression(this: Printer, node: t.DoExpression) {
@@ -33,7 +33,7 @@ export function DoExpression(this: Printer, node: t.DoExpression) {
   }
   this.word("do");
   this.space();
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 export function ParenthesizedExpression(
@@ -41,14 +41,14 @@ export function ParenthesizedExpression(
   node: t.ParenthesizedExpression,
 ) {
   this.token("(");
-  this.print(node.expression, node);
+  this.print(node.expression);
   this.rightParens(node);
 }
 
 export function UpdateExpression(this: Printer, node: t.UpdateExpression) {
   if (node.prefix) {
     this.token(node.operator);
-    this.print(node.argument, node);
+    this.print(node.argument);
   } else {
     this.printTerminatorless(node.argument, node, true);
     this.token(node.operator);
@@ -59,15 +59,15 @@ export function ConditionalExpression(
   this: Printer,
   node: t.ConditionalExpression,
 ) {
-  this.print(node.test, node);
+  this.print(node.test);
   this.space();
   this.token("?");
   this.space();
-  this.print(node.consequent, node);
+  this.print(node.consequent);
   this.space();
   this.token(":");
   this.space();
-  this.print(node.alternate, node);
+  this.print(node.alternate);
 }
 
 export function NewExpression(
@@ -77,7 +77,7 @@ export function NewExpression(
 ) {
   this.word("new");
   this.space();
-  this.print(node.callee, node);
+  this.print(node.callee);
   if (
     this.format.minified &&
     node.arguments.length === 0 &&
@@ -89,8 +89,8 @@ export function NewExpression(
     return;
   }
 
-  this.print(node.typeArguments, node); // Flow
-  this.print(node.typeParameters, node); // TS
+  this.print(node.typeArguments); // Flow
+  this.print(node.typeParameters); // TS
 
   if (node.optional) {
     // TODO: This can never happen
@@ -129,7 +129,7 @@ export function _shouldPrintDecoratorsBeforeExport(
 
 export function Decorator(this: Printer, node: t.Decorator) {
   this.token("@");
-  this.print(node.expression, node);
+  this.print(node.expression);
   this.newline();
 }
 
@@ -140,7 +140,7 @@ export function OptionalMemberExpression(
   let { computed } = node;
   const { optional, property } = node;
 
-  this.print(node.object, node);
+  this.print(node.object);
 
   if (!computed && isMemberExpression(property)) {
     throw new TypeError("Got a MemberExpression for MemberExpression property");
@@ -156,13 +156,13 @@ export function OptionalMemberExpression(
 
   if (computed) {
     this.token("[");
-    this.print(property, node);
+    this.print(property);
     this.token("]");
   } else {
     if (!optional) {
       this.token(".");
     }
-    this.print(property, node);
+    this.print(property);
   }
 }
 
@@ -170,15 +170,15 @@ export function OptionalCallExpression(
   this: Printer,
   node: t.OptionalCallExpression,
 ) {
-  this.print(node.callee, node);
+  this.print(node.callee);
 
-  this.print(node.typeParameters, node); // TS
+  this.print(node.typeParameters); // TS
 
   if (node.optional) {
     this.token("?.");
   }
 
-  this.print(node.typeArguments, node); // Flow
+  this.print(node.typeArguments); // Flow
 
   this.token("(");
   const exit = this.enterForStatementInit(false);
@@ -188,10 +188,10 @@ export function OptionalCallExpression(
 }
 
 export function CallExpression(this: Printer, node: t.CallExpression) {
-  this.print(node.callee, node);
+  this.print(node.callee);
 
-  this.print(node.typeArguments, node); // Flow
-  this.print(node.typeParameters, node); // TS
+  this.print(node.typeArguments); // Flow
+  this.print(node.typeParameters); // TS
   this.token("(");
   const exit = this.enterForStatementInit(false);
   this.printList(node.arguments, node);
@@ -220,7 +220,7 @@ export function YieldExpression(this: Printer, node: t.YieldExpression) {
     if (node.argument) {
       this.space();
       // line terminators are allowed after yield*
-      this.print(node.argument, node);
+      this.print(node.argument);
     }
   } else {
     if (node.argument) {
@@ -239,27 +239,27 @@ export function ExpressionStatement(
   node: t.ExpressionStatement,
 ) {
   this.tokenContext |= TokenContext.expressionStatement;
-  this.print(node.expression, node);
+  this.print(node.expression);
   this.semicolon();
 }
 
 export function AssignmentPattern(this: Printer, node: t.AssignmentPattern) {
-  this.print(node.left, node);
+  this.print(node.left);
   if (node.left.type === "Identifier") {
     if (node.left.optional) this.token("?");
-    this.print(node.left.typeAnnotation, node);
+    this.print(node.left.typeAnnotation);
   }
   this.space();
   this.token("=");
   this.space();
-  this.print(node.right, node);
+  this.print(node.right);
 }
 
 export function AssignmentExpression(
   this: Printer,
   node: t.AssignmentExpression,
 ) {
-  this.print(node.left, node);
+  this.print(node.left);
 
   this.space();
   if (node.operator === "in" || node.operator === "instanceof") {
@@ -269,13 +269,13 @@ export function AssignmentExpression(
   }
   this.space();
 
-  this.print(node.right, node);
+  this.print(node.right);
 }
 
 export function BindExpression(this: Printer, node: t.BindExpression) {
-  this.print(node.object, node);
+  this.print(node.object);
   this.token("::");
-  this.print(node.callee, node);
+  this.print(node.callee);
 }
 
 export {
@@ -284,7 +284,7 @@ export {
 };
 
 export function MemberExpression(this: Printer, node: t.MemberExpression) {
-  this.print(node.object, node);
+  this.print(node.object);
 
   if (!node.computed && isMemberExpression(node.property)) {
     throw new TypeError("Got a MemberExpression for MemberExpression property");
@@ -299,24 +299,24 @@ export function MemberExpression(this: Printer, node: t.MemberExpression) {
   if (computed) {
     const exit = this.enterForStatementInit(false);
     this.token("[");
-    this.print(node.property, node);
+    this.print(node.property);
     this.token("]");
     exit();
   } else {
     this.token(".");
-    this.print(node.property, node);
+    this.print(node.property);
   }
 }
 
 export function MetaProperty(this: Printer, node: t.MetaProperty) {
-  this.print(node.meta, node);
+  this.print(node.meta);
   this.token(".");
-  this.print(node.property, node);
+  this.print(node.property);
 }
 
 export function PrivateName(this: Printer, node: t.PrivateName) {
   this.token("#");
-  this.print(node.id, node);
+  this.print(node.id);
 }
 
 export function V8IntrinsicIdentifier(
@@ -336,7 +336,7 @@ export function ModuleExpression(this: Printer, node: t.ModuleExpression) {
   if (body.body.length || body.directives.length) {
     this.newline();
   }
-  this.print(body, node);
+  this.print(body);
   this.dedent();
   this.rightBrace(node);
 }

--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -12,7 +12,7 @@ export function ArrayTypeAnnotation(
   this: Printer,
   node: t.ArrayTypeAnnotation,
 ) {
-  this.print(node.elementType, node, true);
+  this.print(node.elementType, true);
   this.token("[");
   this.token("]");
 }
@@ -57,13 +57,13 @@ export function DeclareFunction(
   }
   this.word("function");
   this.space();
-  this.print(node.id, node);
+  this.print(node.id);
   // @ts-ignore(Babel 7 vs Babel 8) TODO(Babel 8) Remove this comment, since we'll remove the Noop node
-  this.print(node.id.typeAnnotation.typeAnnotation, node);
+  this.print(node.id.typeAnnotation.typeAnnotation);
 
   if (node.predicate) {
     this.space();
-    this.print(node.predicate, node);
+    this.print(node.predicate);
   }
 
   this.semicolon();
@@ -78,7 +78,7 @@ export function DeclaredPredicate(this: Printer, node: t.DeclaredPredicate) {
   this.token("%");
   this.word("checks");
   this.token("(");
-  this.print(node.value, node);
+  this.print(node.value);
   this.token(")");
 }
 
@@ -93,9 +93,9 @@ export function DeclareModule(this: Printer, node: t.DeclareModule) {
   this.space();
   this.word("module");
   this.space();
-  this.print(node.id, node);
+  this.print(node.id);
   this.space();
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 export function DeclareModuleExports(
@@ -107,7 +107,7 @@ export function DeclareModuleExports(
   this.word("module");
   this.token(".");
   this.word("exports");
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
 }
 
 export function DeclareTypeAlias(this: Printer, node: t.DeclareTypeAlias) {
@@ -139,8 +139,8 @@ export function DeclareVariable(
   }
   this.word("var");
   this.space();
-  this.print(node.id, node);
-  this.print(node.id.typeAnnotation, node);
+  this.print(node.id);
+  this.print(node.id.typeAnnotation);
   this.semicolon();
 }
 
@@ -173,8 +173,8 @@ export function EnumDeclaration(this: Printer, node: t.EnumDeclaration) {
   const { id, body } = node;
   this.word("enum");
   this.space();
-  this.print(id, node);
-  this.print(body, node);
+  this.print(id);
+  this.print(body);
 }
 
 function enumExplicitType(
@@ -197,7 +197,7 @@ function enumBody(context: Printer, node: t.EnumBody) {
   context.indent();
   context.newline();
   for (const member of members) {
-    context.print(member, node);
+    context.print(member);
     context.newline();
   }
   if (node.hasUnknownMembers) {
@@ -236,7 +236,7 @@ export function EnumDefaultedMember(
   node: t.EnumDefaultedMember,
 ) {
   const { id } = node;
-  this.print(id, node);
+  this.print(id);
   this.token(",");
 }
 
@@ -244,12 +244,11 @@ function enumInitializedMember(
   context: Printer,
   node: t.EnumBooleanMember | t.EnumNumberMember | t.EnumStringMember,
 ) {
-  const { id, init } = node;
-  context.print(id, node);
+  context.print(node.id);
   context.space();
   context.token("=");
   context.space();
-  context.print(init, node);
+  context.print(node.init);
   context.token(",");
 }
 
@@ -271,7 +270,7 @@ function FlowExportDeclaration(
 ) {
   if (node.declaration) {
     const declar = node.declaration;
-    this.print(declar, node);
+    this.print(declar);
     if (!isStatement(declar)) this.semicolon();
   } else {
     this.token("{");
@@ -286,7 +285,7 @@ function FlowExportDeclaration(
       this.space();
       this.word("from");
       this.space();
-      this.print(node.source, node);
+      this.print(node.source);
     }
 
     this.semicolon();
@@ -302,14 +301,14 @@ export function FunctionTypeAnnotation(
   node: t.FunctionTypeAnnotation,
   parent?: t.Node,
 ) {
-  this.print(node.typeParameters, node);
+  this.print(node.typeParameters);
   this.token("(");
 
   if (node.this) {
     this.word("this");
     this.token(":");
     this.space();
-    this.print(node.this.typeAnnotation, node);
+    this.print(node.this.typeAnnotation);
     if (node.params.length || node.rest) {
       this.token(",");
       this.space();
@@ -324,7 +323,7 @@ export function FunctionTypeAnnotation(
       this.space();
     }
     this.token("...");
-    this.print(node.rest, node);
+    this.print(node.rest);
   }
 
   this.token(")");
@@ -346,22 +345,22 @@ export function FunctionTypeAnnotation(
   }
 
   this.space();
-  this.print(node.returnType, node);
+  this.print(node.returnType);
 }
 
 export function FunctionTypeParam(this: Printer, node: t.FunctionTypeParam) {
-  this.print(node.name, node);
+  this.print(node.name);
   if (node.optional) this.token("?");
   if (node.name) {
     this.token(":");
     this.space();
   }
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
 }
 
 export function InterfaceExtends(this: Printer, node: t.InterfaceExtends) {
-  this.print(node.id, node);
-  this.print(node.typeParameters, node, true);
+  this.print(node.id);
+  this.print(node.typeParameters, true);
 }
 
 export {
@@ -373,8 +372,8 @@ export function _interfaceish(
   this: Printer,
   node: t.InterfaceDeclaration | t.DeclareInterface | t.DeclareClass,
 ) {
-  this.print(node.id, node);
-  this.print(node.typeParameters, node);
+  this.print(node.id);
+  this.print(node.typeParameters);
   if (node.extends?.length) {
     this.space();
     this.word("extends");
@@ -396,7 +395,7 @@ export function _interfaceish(
     }
   }
   this.space();
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 export function _variance(
@@ -446,7 +445,7 @@ export function InterfaceTypeAnnotation(
     this.printList(node.extends, node);
   }
   this.space();
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 export function IntersectionTypeAnnotation(
@@ -469,7 +468,7 @@ export function NullableTypeAnnotation(
   node: t.NullableTypeAnnotation,
 ) {
   this.token("?");
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
 }
 
 export {
@@ -504,7 +503,7 @@ export function TypeofTypeAnnotation(
 ) {
   this.word("typeof");
   this.space();
-  this.print(node.argument, node);
+  this.print(node.argument);
 }
 
 export function TypeAlias(
@@ -513,12 +512,12 @@ export function TypeAlias(
 ) {
   this.word("type");
   this.space();
-  this.print(node.id, node);
-  this.print(node.typeParameters, node);
+  this.print(node.id);
+  this.print(node.typeParameters);
   this.space();
   this.token("=");
   this.space();
-  this.print(node.right, node);
+  this.print(node.right);
   this.semicolon();
 }
 
@@ -537,7 +536,7 @@ export function TypeAnnotation(
   ) {
     this.token("?");
   }
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
 }
 
 export function TypeParameterInstantiation(
@@ -557,14 +556,14 @@ export function TypeParameter(this: Printer, node: t.TypeParameter) {
   this.word(node.name);
 
   if (node.bound) {
-    this.print(node.bound, node);
+    this.print(node.bound);
   }
 
   if (node.default) {
     this.space();
     this.token("=");
     this.space();
-    this.print(node.default, node);
+    this.print(node.default);
   }
 }
 
@@ -576,19 +575,19 @@ export function OpaqueType(
   this.space();
   this.word("type");
   this.space();
-  this.print(node.id, node);
-  this.print(node.typeParameters, node);
+  this.print(node.id);
+  this.print(node.typeParameters);
   if (node.supertype) {
     this.token(":");
     this.space();
-    this.print(node.supertype, node);
+    this.print(node.supertype);
   }
 
   if (node.impltype) {
     this.space();
     this.token("=");
     this.space();
-    this.print(node.impltype, node);
+    this.print(node.impltype);
   }
   this.semicolon();
 }
@@ -659,7 +658,7 @@ export function ObjectTypeInternalSlot(
   }
   this.token("[");
   this.token("[");
-  this.print(node.id, node);
+  this.print(node.id);
   this.token("]");
   this.token("]");
   if (node.optional) this.token("?");
@@ -667,7 +666,7 @@ export function ObjectTypeInternalSlot(
     this.token(":");
     this.space();
   }
-  this.print(node.value, node);
+  this.print(node.value);
 }
 
 export function ObjectTypeCallProperty(
@@ -678,7 +677,7 @@ export function ObjectTypeCallProperty(
     this.word("static");
     this.space();
   }
-  this.print(node.value, node);
+  this.print(node.value);
 }
 
 export function ObjectTypeIndexer(this: Printer, node: t.ObjectTypeIndexer) {
@@ -689,15 +688,15 @@ export function ObjectTypeIndexer(this: Printer, node: t.ObjectTypeIndexer) {
   this._variance(node);
   this.token("[");
   if (node.id) {
-    this.print(node.id, node);
+    this.print(node.id);
     this.token(":");
     this.space();
   }
-  this.print(node.key, node);
+  this.print(node.key);
   this.token("]");
   this.token(":");
   this.space();
-  this.print(node.value, node);
+  this.print(node.value);
 }
 
 export function ObjectTypeProperty(this: Printer, node: t.ObjectTypeProperty) {
@@ -714,13 +713,13 @@ export function ObjectTypeProperty(this: Printer, node: t.ObjectTypeProperty) {
     this.space();
   }
   this._variance(node);
-  this.print(node.key, node);
+  this.print(node.key);
   if (node.optional) this.token("?");
   if (!node.method) {
     this.token(":");
     this.space();
   }
-  this.print(node.value, node);
+  this.print(node.value);
 }
 
 export function ObjectTypeSpreadProperty(
@@ -728,16 +727,16 @@ export function ObjectTypeSpreadProperty(
   node: t.ObjectTypeSpreadProperty,
 ) {
   this.token("...");
-  this.print(node.argument, node);
+  this.print(node.argument);
 }
 
 export function QualifiedTypeIdentifier(
   this: Printer,
   node: t.QualifiedTypeIdentifier,
 ) {
-  this.print(node.qualification, node);
+  this.print(node.qualification);
   this.token(".");
-  this.print(node.id, node);
+  this.print(node.id);
 }
 
 export function SymbolTypeAnnotation(this: Printer) {
@@ -759,8 +758,8 @@ export function UnionTypeAnnotation(
 
 export function TypeCastExpression(this: Printer, node: t.TypeCastExpression) {
   this.token("(");
-  this.print(node.expression, node);
-  this.print(node.typeAnnotation, node);
+  this.print(node.expression);
+  this.print(node.typeAnnotation);
   this.token(")");
 }
 
@@ -777,9 +776,9 @@ export function VoidTypeAnnotation(this: Printer) {
 }
 
 export function IndexedAccessType(this: Printer, node: t.IndexedAccessType) {
-  this.print(node.objectType, node, true);
+  this.print(node.objectType, true);
   this.token("[");
-  this.print(node.indexType, node);
+  this.print(node.indexType);
   this.token("]");
 }
 
@@ -787,11 +786,11 @@ export function OptionalIndexedAccessType(
   this: Printer,
   node: t.OptionalIndexedAccessType,
 ) {
-  this.print(node.objectType, node);
+  this.print(node.objectType);
   if (node.optional) {
     this.token("?.");
   }
   this.token("[");
-  this.print(node.indexType, node);
+  this.print(node.indexType);
   this.token("]");
 }

--- a/packages/babel-generator/src/generators/jsx.ts
+++ b/packages/babel-generator/src/generators/jsx.ts
@@ -2,10 +2,10 @@ import type Printer from "../printer.ts";
 import type * as t from "@babel/types";
 
 export function JSXAttribute(this: Printer, node: t.JSXAttribute) {
-  this.print(node.name, node);
+  this.print(node.name);
   if (node.value) {
     this.token("=");
-    this.print(node.value, node);
+    this.print(node.value);
   }
 }
 
@@ -14,24 +14,24 @@ export function JSXIdentifier(this: Printer, node: t.JSXIdentifier) {
 }
 
 export function JSXNamespacedName(this: Printer, node: t.JSXNamespacedName) {
-  this.print(node.namespace, node);
+  this.print(node.namespace);
   this.token(":");
-  this.print(node.name, node);
+  this.print(node.name);
 }
 
 export function JSXMemberExpression(
   this: Printer,
   node: t.JSXMemberExpression,
 ) {
-  this.print(node.object, node);
+  this.print(node.object);
   this.token(".");
-  this.print(node.property, node);
+  this.print(node.property);
 }
 
 export function JSXSpreadAttribute(this: Printer, node: t.JSXSpreadAttribute) {
   this.token("{");
   this.token("...");
-  this.print(node.argument, node);
+  this.print(node.argument);
   this.token("}");
 }
 
@@ -40,14 +40,14 @@ export function JSXExpressionContainer(
   node: t.JSXExpressionContainer,
 ) {
   this.token("{");
-  this.print(node.expression, node);
+  this.print(node.expression);
   this.token("}");
 }
 
 export function JSXSpreadChild(this: Printer, node: t.JSXSpreadChild) {
   this.token("{");
   this.token("...");
-  this.print(node.expression, node);
+  this.print(node.expression);
   this.token("}");
 }
 
@@ -63,16 +63,16 @@ export function JSXText(this: Printer, node: t.JSXText) {
 
 export function JSXElement(this: Printer, node: t.JSXElement) {
   const open = node.openingElement;
-  this.print(open, node);
+  this.print(open);
   if (open.selfClosing) return;
 
   this.indent();
   for (const child of node.children) {
-    this.print(child, node);
+    this.print(child);
   }
   this.dedent();
 
-  this.print(node.closingElement, node);
+  this.print(node.closingElement);
 }
 
 function spaceSeparator(this: Printer) {
@@ -81,8 +81,8 @@ function spaceSeparator(this: Printer) {
 
 export function JSXOpeningElement(this: Printer, node: t.JSXOpeningElement) {
   this.token("<");
-  this.print(node.name, node);
-  this.print(node.typeParameters, node); // TS
+  this.print(node.name);
+  this.print(node.typeParameters); // TS
   if (node.attributes.length > 0) {
     this.space();
     this.printJoin(node.attributes, node, { separator: spaceSeparator });
@@ -97,7 +97,7 @@ export function JSXOpeningElement(this: Printer, node: t.JSXOpeningElement) {
 
 export function JSXClosingElement(this: Printer, node: t.JSXClosingElement) {
   this.token("</");
-  this.print(node.name, node);
+  this.print(node.name);
   this.token(">");
 }
 
@@ -107,15 +107,15 @@ export function JSXEmptyExpression(this: Printer) {
 }
 
 export function JSXFragment(this: Printer, node: t.JSXFragment) {
-  this.print(node.openingFragment, node);
+  this.print(node.openingFragment);
 
   this.indent();
   for (const child of node.children) {
-    this.print(child, node);
+    this.print(child);
   }
   this.dedent();
 
-  this.print(node.closingFragment, node);
+  this.print(node.closingFragment);
 }
 
 export function JSXOpeningFragment(this: Printer) {

--- a/packages/babel-generator/src/generators/methods.ts
+++ b/packages/babel-generator/src/generators/methods.ts
@@ -11,7 +11,7 @@ export function _params(
   idNode: t.Expression | t.PrivateName,
   parentNode: ParentsOf<typeof node>,
 ) {
-  this.print(node.typeParameters, node);
+  this.print(node.typeParameters);
 
   const nameInfo = _getFuncIdName.call(this, idNode, parentNode);
   if (nameInfo) {
@@ -19,31 +19,21 @@ export function _params(
   }
 
   this.token("(");
-  this._parameters(node.params, node);
+  this._parameters(node.params);
   this.token(")");
 
   const noLineTerminator = node.type === "ArrowFunctionExpression";
-  this.print(node.returnType, node, noLineTerminator);
+  this.print(node.returnType, noLineTerminator);
 
   this._noLineTerminator = noLineTerminator;
 }
 
-export function _parameters(
-  this: Printer,
-  parameters: t.Function["params"],
-  parent:
-    | t.Function
-    | t.TSIndexSignature
-    | t.TSDeclareMethod
-    | t.TSDeclareFunction
-    | t.TSFunctionType
-    | t.TSConstructorType,
-) {
+export function _parameters(this: Printer, parameters: t.Function["params"]) {
   const exit = this.enterForStatementInit(false);
 
   const paramLength = parameters.length;
   for (let i = 0; i < paramLength; i++) {
-    this._param(parameters[i], parent);
+    this._param(parameters[i]);
 
     if (i < parameters.length - 1) {
       this.token(",");
@@ -57,16 +47,9 @@ export function _parameters(
 export function _param(
   this: Printer,
   parameter: t.Identifier | t.RestElement | t.Pattern | t.TSParameterProperty,
-  parent?:
-    | t.Function
-    | t.TSIndexSignature
-    | t.TSDeclareMethod
-    | t.TSDeclareFunction
-    | t.TSFunctionType
-    | t.TSConstructorType,
 ) {
   this.printJoin(parameter.decorators, parameter);
-  this.print(parameter, parent);
+  this.print(parameter);
   if (
     // @ts-expect-error optional is not in TSParameterProperty
     parameter.optional
@@ -77,7 +60,6 @@ export function _param(
   this.print(
     // @ts-expect-error typeAnnotation is not in TSParameterProperty
     parameter.typeAnnotation,
-    parameter,
   ); // TS / flow
 }
 
@@ -107,10 +89,10 @@ export function _methodHead(this: Printer, node: t.Method | t.TSDeclareMethod) {
 
   if (node.computed) {
     this.token("[");
-    this.print(key, node);
+    this.print(key);
     this.token("]");
   } else {
-    this.print(key, node);
+    this.print(key);
   }
 
   if (
@@ -141,7 +123,7 @@ export function _predicate(
       this.token(":");
     }
     this.space();
-    this.print(node.predicate, node, noLineTerminatorAfter);
+    this.print(node.predicate, noLineTerminatorAfter);
   }
 }
 
@@ -169,7 +151,7 @@ export function _functionHead(
 
   this.space();
   if (node.id) {
-    this.print(node.id, node);
+    this.print(node.id);
   }
 
   this._params(node, node.id, parent);
@@ -185,7 +167,7 @@ export function FunctionExpression(
 ) {
   this._functionHead(node, parent);
   this.space();
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 export { FunctionExpression as FunctionDeclaration };
@@ -209,7 +191,7 @@ export function ArrowFunctionExpression(
     isIdentifier((firstParam = node.params[0])) &&
     !hasTypesOrComments(node, firstParam)
   ) {
-    this.print(firstParam, node, true);
+    this.print(firstParam, true);
   } else {
     this._params(node, undefined, parent);
   }
@@ -225,7 +207,7 @@ export function ArrowFunctionExpression(
   this.space();
 
   this.tokenContext |= TokenContext.arrowBody;
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 function hasTypesOrComments(

--- a/packages/babel-generator/src/generators/modules.ts
+++ b/packages/babel-generator/src/generators/modules.ts
@@ -16,13 +16,13 @@ export function ImportSpecifier(this: Printer, node: t.ImportSpecifier) {
     this.space();
   }
 
-  this.print(node.imported, node);
+  this.print(node.imported);
   // @ts-expect-error todo(flow-ts) maybe check node type instead of relying on name to be undefined on t.StringLiteral
   if (node.local && node.local.name !== node.imported.name) {
     this.space();
     this.word("as");
     this.space();
-    this.print(node.local, node);
+    this.print(node.local);
   }
 }
 
@@ -30,14 +30,14 @@ export function ImportDefaultSpecifier(
   this: Printer,
   node: t.ImportDefaultSpecifier,
 ) {
-  this.print(node.local, node);
+  this.print(node.local);
 }
 
 export function ExportDefaultSpecifier(
   this: Printer,
   node: t.ExportDefaultSpecifier,
 ) {
-  this.print(node.exported, node);
+  this.print(node.exported);
 }
 
 export function ExportSpecifier(this: Printer, node: t.ExportSpecifier) {
@@ -46,13 +46,13 @@ export function ExportSpecifier(this: Printer, node: t.ExportSpecifier) {
     this.space();
   }
 
-  this.print(node.local, node);
+  this.print(node.local);
   // @ts-expect-error todo(flow-ts) maybe check node type instead of relying on name to be undefined on t.StringLiteral
   if (node.exported && node.local.name !== node.exported.name) {
     this.space();
     this.word("as");
     this.space();
-    this.print(node.exported, node);
+    this.print(node.exported);
   }
 }
 
@@ -64,7 +64,7 @@ export function ExportNamespaceSpecifier(
   this.space();
   this.word("as");
   this.space();
-  this.print(node.exported, node);
+  this.print(node.exported);
 }
 
 let warningShown = false;
@@ -129,12 +129,12 @@ export function ExportAllDeclaration(
   this.space();
   // @ts-expect-error Fixme: attributes is not defined in DeclareExportAllDeclaration
   if (node.attributes?.length || node.assertions?.length) {
-    this.print(node.source, node, true);
+    this.print(node.source, true);
     this.space();
     // @ts-expect-error Fixme: attributes is not defined in DeclareExportAllDeclaration
     this._printAttributes(node);
   } else {
-    this.print(node.source, node);
+    this.print(node.source);
   }
 
   this.semicolon();
@@ -164,7 +164,7 @@ export function ExportNamedDeclaration(
   this.space();
   if (node.declaration) {
     const declar = node.declaration;
-    this.print(declar, node);
+    this.print(declar);
     if (!isStatement(declar)) this.semicolon();
   } else {
     if (node.exportKind === "type") {
@@ -183,7 +183,7 @@ export function ExportNamedDeclaration(
         isExportNamespaceSpecifier(first)
       ) {
         hasSpecial = true;
-        this.print(specifiers.shift(), node);
+        this.print(specifiers.shift());
         if (specifiers.length) {
           this.token(",");
           this.space();
@@ -208,11 +208,11 @@ export function ExportNamedDeclaration(
       this.word("from");
       this.space();
       if (node.attributes?.length || node.assertions?.length) {
-        this.print(node.source, node, true);
+        this.print(node.source, true);
         this.space();
         this._printAttributes(node);
       } else {
-        this.print(node.source, node);
+        this.print(node.source);
       }
     }
 
@@ -233,7 +233,7 @@ export function ExportDefaultDeclaration(
   this.space();
   this.tokenContext |= TokenContext.exportDefault;
   const declar = node.declaration;
-  this.print(declar, node);
+  this.print(declar);
   if (!isStatement(declar)) this.semicolon();
 }
 
@@ -263,7 +263,7 @@ export function ImportDeclaration(this: Printer, node: t.ImportDeclaration) {
   while (hasSpecifiers) {
     const first = specifiers[0];
     if (isImportDefaultSpecifier(first) || isImportNamespaceSpecifier(first)) {
-      this.print(specifiers.shift(), node);
+      this.print(specifiers.shift());
       if (specifiers.length) {
         this.token(",");
         this.space();
@@ -291,11 +291,11 @@ export function ImportDeclaration(this: Printer, node: t.ImportDeclaration) {
   }
 
   if (node.attributes?.length || node.assertions?.length) {
-    this.print(node.source, node, true);
+    this.print(node.source, true);
     this.space();
     this._printAttributes(node);
   } else {
-    this.print(node.source, node);
+    this.print(node.source);
   }
 
   this.semicolon();
@@ -316,7 +316,7 @@ export function ImportNamespaceSpecifier(
   this.space();
   this.word("as");
   this.space();
-  this.print(node.local, node);
+  this.print(node.local);
 }
 
 export function ImportExpression(this: Printer, node: t.ImportExpression) {
@@ -326,11 +326,11 @@ export function ImportExpression(this: Printer, node: t.ImportExpression) {
     this.word(node.phase);
   }
   this.token("(");
-  this.print(node.source, node);
+  this.print(node.source);
   if (node.options != null) {
     this.token(",");
     this.space();
-    this.print(node.options, node);
+    this.print(node.options);
   }
   this.token(")");
 }

--- a/packages/babel-generator/src/generators/statements.ts
+++ b/packages/babel-generator/src/generators/statements.ts
@@ -16,7 +16,7 @@ export function WithStatement(this: Printer, node: t.WithStatement) {
   this.word("with");
   this.space();
   this.token("(");
-  this.print(node.object, node);
+  this.print(node.object);
   this.token(")");
   this.printBlock(node);
 }
@@ -25,7 +25,7 @@ export function IfStatement(this: Printer, node: t.IfStatement) {
   this.word("if");
   this.space();
   this.token("(");
-  this.print(node.test, node);
+  this.print(node.test);
   this.token(")");
   this.space();
 
@@ -37,7 +37,7 @@ export function IfStatement(this: Printer, node: t.IfStatement) {
     this.indent();
   }
 
-  this.printAndIndentOnComments(node.consequent, node);
+  this.printAndIndentOnComments(node.consequent);
 
   if (needsBlock) {
     this.dedent();
@@ -49,7 +49,7 @@ export function IfStatement(this: Printer, node: t.IfStatement) {
     if (this.endsWith(charCodes.rightCurlyBrace)) this.space();
     this.word("else");
     this.space();
-    this.printAndIndentOnComments(node.alternate, node);
+    this.printAndIndentOnComments(node.alternate);
   }
 }
 
@@ -72,7 +72,7 @@ export function ForStatement(this: Printer, node: t.ForStatement) {
   {
     const exit = this.enterForStatementInit(true);
     this.tokenContext |= TokenContext.forHead;
-    this.print(node.init, node);
+    this.print(node.init);
     exit();
   }
 
@@ -80,13 +80,13 @@ export function ForStatement(this: Printer, node: t.ForStatement) {
 
   if (node.test) {
     this.space();
-    this.print(node.test, node);
+    this.print(node.test);
   }
   this.token(";");
 
   if (node.update) {
     this.space();
-    this.print(node.update, node);
+    this.print(node.update);
   }
 
   this.token(")");
@@ -97,7 +97,7 @@ export function WhileStatement(this: Printer, node: t.WhileStatement) {
   this.word("while");
   this.space();
   this.token("(");
-  this.print(node.test, node);
+  this.print(node.test);
   this.token(")");
   this.printBlock(node);
 }
@@ -117,13 +117,13 @@ function ForXStatement(this: Printer, node: t.ForXStatement) {
     this.tokenContext |= isForOf
       ? TokenContext.forOfHead
       : TokenContext.forInHead;
-    this.print(node.left, node);
+    this.print(node.left);
     exit?.();
   }
   this.space();
   this.word(isForOf ? "of" : "in");
   this.space();
-  this.print(node.right, node);
+  this.print(node.right);
   this.token(")");
   this.printBlock(node);
 }
@@ -134,12 +134,12 @@ export const ForOfStatement = ForXStatement;
 export function DoWhileStatement(this: Printer, node: t.DoWhileStatement) {
   this.word("do");
   this.space();
-  this.print(node.body, node);
+  this.print(node.body);
   this.space();
   this.word("while");
   this.space();
   this.token("(");
-  this.print(node.test, node);
+  this.print(node.test);
   this.token(")");
   this.semicolon();
 }
@@ -179,16 +179,16 @@ export function ThrowStatement(this: Printer, node: t.ThrowStatement) {
 }
 
 export function LabeledStatement(this: Printer, node: t.LabeledStatement) {
-  this.print(node.label, node);
+  this.print(node.label);
   this.token(":");
   this.space();
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 export function TryStatement(this: Printer, node: t.TryStatement) {
   this.word("try");
   this.space();
-  this.print(node.block, node);
+  this.print(node.block);
   this.space();
 
   // Esprima bug puts the catch clause in a `handlers` array.
@@ -197,16 +197,16 @@ export function TryStatement(this: Printer, node: t.TryStatement) {
   // @ts-expect-error todo(flow->ts) should ast node type be updated to support this?
   if (node.handlers) {
     // @ts-expect-error todo(flow->ts) should ast node type be updated to support this?
-    this.print(node.handlers[0], node);
+    this.print(node.handlers[0]);
   } else {
-    this.print(node.handler, node);
+    this.print(node.handler);
   }
 
   if (node.finalizer) {
     this.space();
     this.word("finally");
     this.space();
-    this.print(node.finalizer, node);
+    this.print(node.finalizer);
   }
 }
 
@@ -215,19 +215,19 @@ export function CatchClause(this: Printer, node: t.CatchClause) {
   this.space();
   if (node.param) {
     this.token("(");
-    this.print(node.param, node);
-    this.print(node.param.typeAnnotation, node);
+    this.print(node.param);
+    this.print(node.param.typeAnnotation);
     this.token(")");
     this.space();
   }
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 export function SwitchStatement(this: Printer, node: t.SwitchStatement) {
   this.word("switch");
   this.space();
   this.token("(");
-  this.print(node.discriminant, node);
+  this.print(node.discriminant);
   this.token(")");
   this.space();
   this.token("{");
@@ -246,7 +246,7 @@ export function SwitchCase(this: Printer, node: t.SwitchCase) {
   if (node.test) {
     this.word("case");
     this.space();
-    this.print(node.test, node);
+    this.print(node.test);
     this.token(":");
   } else {
     this.word("default");
@@ -331,14 +331,14 @@ export function VariableDeclaration(
 }
 
 export function VariableDeclarator(this: Printer, node: t.VariableDeclarator) {
-  this.print(node.id, node);
+  this.print(node.id);
   if (node.definite) this.token("!"); // TS
   // @ts-expect-error todo(flow-ts) Property 'typeAnnotation' does not exist on type 'MemberExpression'.
-  this.print(node.id.typeAnnotation, node);
+  this.print(node.id.typeAnnotation);
   if (node.init) {
     this.space();
     this.token("=");
     this.space();
-    this.print(node.init, node);
+    this.print(node.init);
   }
 }

--- a/packages/babel-generator/src/generators/template-literals.ts
+++ b/packages/babel-generator/src/generators/template-literals.ts
@@ -5,9 +5,9 @@ export function TaggedTemplateExpression(
   this: Printer,
   node: t.TaggedTemplateExpression,
 ) {
-  this.print(node.tag, node);
-  this.print(node.typeParameters, node); // TS
-  this.print(node.quasi, node);
+  this.print(node.tag);
+  this.print(node.typeParameters); // TS
+  this.print(node.quasi);
 }
 
 export function TemplateElement(this: Printer) {
@@ -24,7 +24,7 @@ export function TemplateLiteral(this: Printer, node: t.TemplateLiteral) {
 
     if (i + 1 < quasis.length) {
       this.token(partRaw + "${", true);
-      this.print(node.expressions[i], node);
+      this.print(node.expressions[i]);
       partRaw = "}";
     }
   }

--- a/packages/babel-generator/src/generators/types.ts
+++ b/packages/babel-generator/src/generators/types.ts
@@ -14,7 +14,7 @@ export function ArgumentPlaceholder(this: Printer) {
 
 export function RestElement(this: Printer, node: t.RestElement) {
   this.token("...");
-  this.print(node.argument, node);
+  this.print(node.argument);
 }
 
 export { RestElement as SpreadElement };
@@ -43,7 +43,7 @@ export function ObjectMethod(this: Printer, node: t.ObjectMethod) {
   this.printJoin(node.decorators, node);
   this._methodHead(node);
   this.space();
-  this.print(node.body, node);
+  this.print(node.body);
 }
 
 export function ObjectProperty(this: Printer, node: t.ObjectProperty) {
@@ -51,7 +51,7 @@ export function ObjectProperty(this: Printer, node: t.ObjectProperty) {
 
   if (node.computed) {
     this.token("[");
-    this.print(node.key, node);
+    this.print(node.key);
     this.token("]");
   } else {
     // print `({ foo: foo = 5 } = {})` as `({ foo = 5 } = {});`
@@ -61,11 +61,11 @@ export function ObjectProperty(this: Printer, node: t.ObjectProperty) {
       // @ts-expect-error todo(flow->ts) `.name` does not exist on some types in union
       node.key.name === node.value.left.name
     ) {
-      this.print(node.value, node);
+      this.print(node.value);
       return;
     }
 
-    this.print(node.key, node);
+    this.print(node.key);
 
     // shorthand!
     if (
@@ -80,7 +80,7 @@ export function ObjectProperty(this: Printer, node: t.ObjectProperty) {
 
   this.token(":");
   this.space();
-  this.print(node.value, node);
+  this.print(node.value);
 }
 
 export function ArrayExpression(this: Printer, node: t.ArrayExpression) {
@@ -95,7 +95,7 @@ export function ArrayExpression(this: Printer, node: t.ArrayExpression) {
     const elem = elems[i];
     if (elem) {
       if (i > 0) this.space();
-      this.print(elem, node);
+      this.print(elem);
       if (i < len - 1) this.token(",");
     } else {
       // If the array expression ends with a hole, that hole
@@ -180,7 +180,7 @@ export function TupleExpression(this: Printer, node: t.TupleExpression) {
     const elem = elems[i];
     if (elem) {
       if (i > 0) this.space();
-      this.print(elem, node);
+      this.print(elem);
       if (i < len - 1) this.token(",");
     }
   }
@@ -268,14 +268,14 @@ export function PipelineTopicExpression(
   this: Printer,
   node: t.PipelineTopicExpression,
 ) {
-  this.print(node.expression, node);
+  this.print(node.expression);
 }
 
 export function PipelineBareFunction(
   this: Printer,
   node: t.PipelineBareFunction,
 ) {
-  this.print(node.callee, node);
+  this.print(node.callee);
 }
 
 export function PipelinePrimaryTopicReference(this: Printer) {

--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -6,7 +6,7 @@ export function TSTypeAnnotation(this: Printer, node: t.TSTypeAnnotation) {
   this.space();
   // @ts-expect-error todo(flow->ts) can this be removed? `.optional` looks to be not existing property
   if (node.optional) this.token("?");
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
 }
 
 export function TSTypeParameterInstantiation(
@@ -45,14 +45,14 @@ export function TSTypeParameter(this: Printer, node: t.TSTypeParameter) {
     this.space();
     this.word("extends");
     this.space();
-    this.print(node.constraint, node);
+    this.print(node.constraint);
   }
 
   if (node.default) {
     this.space();
     this.token("=");
     this.space();
-    this.print(node.default, node);
+    this.print(node.default);
   }
 }
 
@@ -92,9 +92,9 @@ export function TSDeclareMethod(this: Printer, node: t.TSDeclareMethod) {
 }
 
 export function TSQualifiedName(this: Printer, node: t.TSQualifiedName) {
-  this.print(node.left, node);
+  this.print(node.left);
   this.token(".");
-  this.print(node.right, node);
+  this.print(node.right);
 }
 
 export function TSCallSignatureDeclaration(
@@ -125,7 +125,7 @@ export function TSPropertySignature(
     this.space();
   }
   this.tsPrintPropertyOrMethodName(node);
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
   this.semicolon();
 }
 
@@ -136,7 +136,7 @@ export function tsPrintPropertyOrMethodName(
   if (node.computed) {
     this.token("[");
   }
-  this.print(node.key, node);
+  this.print(node.key);
   if (node.computed) {
     this.token("]");
   }
@@ -167,9 +167,9 @@ export function TSIndexSignature(this: Printer, node: t.TSIndexSignature) {
     this.space();
   }
   this.token("[");
-  this._parameters(node.parameters, node);
+  this._parameters(node.parameters);
   this.token("]");
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
   this.semicolon();
 }
 
@@ -241,9 +241,9 @@ export function tsPrintFunctionOrConstructorType(
       node.params
     : // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST shape
       node.parameters;
-  this.print(typeParameters, node);
+  this.print(typeParameters);
   this.token("(");
-  this._parameters(parameters, node);
+  this._parameters(parameters);
   this.token(")");
   this.space();
   this.token("=>");
@@ -253,12 +253,12 @@ export function tsPrintFunctionOrConstructorType(
       node.returnType
     : // @ts-ignore(Babel 7 vs Babel 8) Babel 7 AST shape
       node.typeAnnotation;
-  this.print(returnType.typeAnnotation, node);
+  this.print(returnType.typeAnnotation);
 }
 
 export function TSTypeReference(this: Printer, node: t.TSTypeReference) {
-  this.print(node.typeName, node, true);
-  this.print(node.typeParameters, node, true);
+  this.print(node.typeName, true);
+  this.print(node.typeParameters, true);
 }
 
 export function TSTypePredicate(this: Printer, node: t.TSTypePredicate) {
@@ -281,7 +281,7 @@ export function TSTypeQuery(this: Printer, node: t.TSTypeQuery) {
   this.print(node.exprName);
 
   if (node.typeParameters) {
-    this.print(node.typeParameters, node);
+    this.print(node.typeParameters);
   }
 }
 
@@ -303,7 +303,7 @@ function tsPrintBraced(printer: Printer, members: t.Node[], node: t.Node) {
     printer.indent();
     printer.newline();
     for (const member of members) {
-      printer.print(member, node);
+      printer.print(member);
       //this.token(sep);
       printer.newline();
     }
@@ -314,7 +314,7 @@ function tsPrintBraced(printer: Printer, members: t.Node[], node: t.Node) {
 }
 
 export function TSArrayType(this: Printer, node: t.TSArrayType) {
-  this.print(node.elementType, node, true);
+  this.print(node.elementType, true);
 
   this.token("[]");
 }
@@ -326,21 +326,21 @@ export function TSTupleType(this: Printer, node: t.TSTupleType) {
 }
 
 export function TSOptionalType(this: Printer, node: t.TSOptionalType) {
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
   this.token("?");
 }
 
 export function TSRestType(this: Printer, node: t.TSRestType) {
   this.token("...");
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
 }
 
 export function TSNamedTupleMember(this: Printer, node: t.TSNamedTupleMember) {
-  this.print(node.label, node);
+  this.print(node.label);
   if (node.optional) this.token("?");
   this.token(":");
   this.space();
-  this.print(node.elementType, node);
+  this.print(node.elementType);
 }
 
 export function TSUnionType(this: Printer, node: t.TSUnionType) {
@@ -392,23 +392,23 @@ export function TSParenthesizedType(
   node: t.TSParenthesizedType,
 ) {
   this.token("(");
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
   this.token(")");
 }
 
 export function TSTypeOperator(this: Printer, node: t.TSTypeOperator) {
   this.word(node.operator);
   this.space();
-  this.print(node.typeAnnotation, node);
+  this.print(node.typeAnnotation);
 }
 
 export function TSIndexedAccessType(
   this: Printer,
   node: t.TSIndexedAccessType,
 ) {
-  this.print(node.objectType, node, true);
+  this.print(node.objectType, true);
   this.token("[");
-  this.print(node.indexType, node);
+  this.print(node.indexType);
   this.token("]");
 }
 
@@ -431,13 +431,13 @@ export function TSMappedType(this: Printer, node: t.TSMappedType) {
   this.space();
   this.word("in");
   this.space();
-  this.print(typeParameter.constraint, typeParameter);
+  this.print(typeParameter.constraint);
 
   if (nameType) {
     this.space();
     this.word("as");
     this.space();
-    this.print(nameType, node);
+    this.print(nameType);
   }
 
   this.token("]");
@@ -450,7 +450,7 @@ export function TSMappedType(this: Printer, node: t.TSMappedType) {
   if (typeAnnotation) {
     this.token(":");
     this.space();
-    this.print(typeAnnotation, node);
+    this.print(typeAnnotation);
   }
   this.space();
   this.token("}");
@@ -463,15 +463,15 @@ function tokenIfPlusMinus(self: Printer, tok: true | "+" | "-") {
 }
 
 export function TSLiteralType(this: Printer, node: t.TSLiteralType) {
-  this.print(node.literal, node);
+  this.print(node.literal);
 }
 
 export function TSExpressionWithTypeArguments(
   this: Printer,
   node: t.TSExpressionWithTypeArguments,
 ) {
-  this.print(node.expression, node);
-  this.print(node.typeParameters, node);
+  this.print(node.expression);
+  this.print(node.typeParameters);
 }
 
 export function TSInterfaceDeclaration(
@@ -485,8 +485,8 @@ export function TSInterfaceDeclaration(
   }
   this.word("interface");
   this.space();
-  this.print(id, node);
-  this.print(typeParameters, node);
+  this.print(id);
+  this.print(typeParameters);
   if (extendz?.length) {
     this.space();
     this.word("extends");
@@ -494,7 +494,7 @@ export function TSInterfaceDeclaration(
     this.printList(extendz, node);
   }
   this.space();
-  this.print(body, node);
+  this.print(body);
 }
 
 export function TSInterfaceBody(this: Printer, node: t.TSInterfaceBody) {
@@ -512,12 +512,12 @@ export function TSTypeAliasDeclaration(
   }
   this.word("type");
   this.space();
-  this.print(id, node);
-  this.print(typeParameters, node);
+  this.print(id);
+  this.print(typeParameters);
   this.space();
   this.token("=");
   this.space();
-  this.print(typeAnnotation, node);
+  this.print(typeAnnotation);
   this.semicolon();
 }
 
@@ -527,11 +527,11 @@ function TSTypeExpression(
 ) {
   const { type, expression, typeAnnotation } = node;
   const forceParens = !!expression.trailingComments?.length;
-  this.print(expression, node, true, undefined, forceParens);
+  this.print(expression, true, undefined, forceParens);
   this.space();
   this.word(type === "TSAsExpression" ? "as" : "satisfies");
   this.space();
-  this.print(typeAnnotation, node);
+  this.print(typeAnnotation);
 }
 
 export {
@@ -542,18 +542,18 @@ export {
 export function TSTypeAssertion(this: Printer, node: t.TSTypeAssertion) {
   const { typeAnnotation, expression } = node;
   this.token("<");
-  this.print(typeAnnotation, node);
+  this.print(typeAnnotation);
   this.token(">");
   this.space();
-  this.print(expression, node);
+  this.print(expression);
 }
 
 export function TSInstantiationExpression(
   this: Printer,
   node: t.TSInstantiationExpression,
 ) {
-  this.print(node.expression, node);
-  this.print(node.typeParameters, node);
+  this.print(node.expression);
+  this.print(node.typeParameters);
 }
 
 export function TSEnumDeclaration(this: Printer, node: t.TSEnumDeclaration) {
@@ -568,19 +568,19 @@ export function TSEnumDeclaration(this: Printer, node: t.TSEnumDeclaration) {
   }
   this.word("enum");
   this.space();
-  this.print(id, node);
+  this.print(id);
   this.space();
   tsPrintBraced(this, members, node);
 }
 
 export function TSEnumMember(this: Printer, node: t.TSEnumMember) {
   const { id, initializer } = node;
-  this.print(id, node);
+  this.print(id);
   if (initializer) {
     this.space();
     this.token("=");
     this.space();
-    this.print(initializer, node);
+    this.print(initializer);
   }
   this.token(",");
 }
@@ -600,7 +600,7 @@ export function TSModuleDeclaration(
     this.word(id.type === "Identifier" ? "namespace" : "module");
     this.space();
   }
-  this.print(id, node);
+  this.print(id);
 
   if (!node.body) {
     this.semicolon();
@@ -610,12 +610,12 @@ export function TSModuleDeclaration(
   let body = node.body;
   while (body.type === "TSModuleDeclaration") {
     this.token(".");
-    this.print(body.id, body);
+    this.print(body.id);
     body = body.body;
   }
 
   this.space();
-  this.print(body, node);
+  this.print(body);
 }
 
 export function TSModuleBlock(this: Printer, node: t.TSModuleBlock) {
@@ -626,14 +626,14 @@ export function TSImportType(this: Printer, node: t.TSImportType) {
   const { argument, qualifier, typeParameters } = node;
   this.word("import");
   this.token("(");
-  this.print(argument, node);
+  this.print(argument);
   this.token(")");
   if (qualifier) {
     this.token(".");
-    this.print(qualifier, node);
+    this.print(qualifier);
   }
   if (typeParameters) {
-    this.print(typeParameters, node);
+    this.print(typeParameters);
   }
 }
 
@@ -648,11 +648,11 @@ export function TSImportEqualsDeclaration(
   }
   this.word("import");
   this.space();
-  this.print(id, node);
+  this.print(id);
   this.space();
   this.token("=");
   this.space();
-  this.print(moduleReference, node);
+  this.print(moduleReference);
   this.semicolon();
 }
 
@@ -661,7 +661,7 @@ export function TSExternalModuleReference(
   node: t.TSExternalModuleReference,
 ) {
   this.token("require(");
-  this.print(node.expression, node);
+  this.print(node.expression);
   this.token(")");
 }
 
@@ -669,7 +669,7 @@ export function TSNonNullExpression(
   this: Printer,
   node: t.TSNonNullExpression,
 ) {
-  this.print(node.expression, node);
+  this.print(node.expression);
   this.token("!");
 }
 
@@ -678,7 +678,7 @@ export function TSExportAssignment(this: Printer, node: t.TSExportAssignment) {
   this.space();
   this.token("=");
   this.space();
-  this.print(node.expression, node);
+  this.print(node.expression);
   this.semicolon();
 }
 
@@ -692,7 +692,7 @@ export function TSNamespaceExportDeclaration(
   this.space();
   this.word("namespace");
   this.space();
-  this.print(node.id, node);
+  this.print(node.id);
   this.semicolon();
 }
 
@@ -701,14 +701,14 @@ export function tsPrintSignatureDeclarationBase(this: Printer, node: any) {
   const parameters = process.env.BABEL_8_BREAKING
     ? node.params
     : node.parameters;
-  this.print(typeParameters, node);
+  this.print(typeParameters);
   this.token("(");
-  this._parameters(parameters, node);
+  this._parameters(parameters);
   this.token(")");
   const returnType = process.env.BABEL_8_BREAKING
     ? node.returnType
     : node.typeAnnotation;
-  this.print(returnType, node);
+  this.print(returnType);
 }
 
 export function tsPrintClassMemberModifiers(

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -603,13 +603,13 @@ class Printer {
      */
     if (isLabel) {
       this._noLineTerminator = true;
-      this.print(node, parent);
+      this.print(node);
     } else {
       const terminatorState = {
         printed: false,
       };
       this._parenPushNewlineState = terminatorState;
-      this.print(node, parent);
+      this.print(node);
       /**
        * Print an ending parentheses if a starting one has been printed.
        */
@@ -623,7 +623,6 @@ class Printer {
 
   print(
     node: t.Node | null,
-    parent?: t.Node,
     noLineTerminatorAfter?: boolean,
     // trailingCommentsLineOffset also used to check if called from printJoin
     // it will be ignored if `noLineTerminatorAfter||this._noLineTerminator`
@@ -663,7 +662,7 @@ class Printer {
       );
     }
 
-    const oldNode = this._currentNode;
+    const parent = this._currentNode;
     this._currentNode = node;
 
     const oldInAux = this._insideAux;
@@ -736,7 +735,7 @@ class Printer {
     }
 
     // end
-    this._currentNode = oldNode;
+    this._currentNode = parent;
     format.concise = oldConcise;
     this._insideAux = oldInAux;
 
@@ -832,7 +831,7 @@ class Printer {
 
       if (opts.statement) this._printNewline(i === 0, newlineOpts);
 
-      this.print(node, parent, undefined, opts.trailingCommentsLineOffset || 0);
+      this.print(node, undefined, opts.trailingCommentsLineOffset || 0);
 
       opts.iterator?.(node, i);
 
@@ -857,10 +856,10 @@ class Printer {
     if (indent) this.dedent();
   }
 
-  printAndIndentOnComments(node: t.Node, parent: t.Node) {
+  printAndIndentOnComments(node: t.Node) {
     const indent = node.leadingComments && node.leadingComments.length > 0;
     if (indent) this.indent();
-    this.print(node, parent);
+    this.print(node);
     if (indent) this.dedent();
   }
 
@@ -871,7 +870,7 @@ class Printer {
       this.space();
     }
 
-    this.print(node, parent);
+    this.print(node);
   }
 
   _printTrailingComments(node: t.Node, parent?: t.Node, lineOffset?: number) {


### PR DESCRIPTION
This is a minor internal refactor. We don't need to pass it because it's available as `this._currentNode`