### PR TITLE
fix: improve static canFollowModifier checks

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -282,23 +282,32 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
     tsTokenCanFollowModifier() {
       return (
-        (this.match(tt.bracketL) ||
-          this.match(tt.braceL) ||
-          this.match(tt.star) ||
-          this.match(tt.ellipsis) ||
-          this.match(tt.privateName) ||
-          this.isLiteralPropertyName()) &&
-        !this.hasPrecedingLineBreak()
+        this.match(tt.bracketL) ||
+        this.match(tt.braceL) ||
+        this.match(tt.star) ||
+        this.match(tt.ellipsis) ||
+        this.match(tt.privateName) ||
+        this.isLiteralPropertyName()
       );
+    }
+
+    tsNextTokenOnSameLineAndCanFollowModifier() {
+      this.next();
+      if (this.hasPrecedingLineBreak()) {
+        return false;
+      }
+      return this.tsTokenCanFollowModifier();
     }
 
     tsNextTokenCanFollowModifier() {
       // Note: TypeScript's implementation is much more complicated because
       // more things are considered modifiers there.
       // This implementation only handles modifiers not handled by @babel/parser itself. And "static".
-      // TODO: Would be nice to avoid lookahead. Want a hasLineBreakUpNext() method...
-      this.next();
-      return this.tsTokenCanFollowModifier();
+      if (this.match(tt._static)) {
+        this.next();
+        return this.tsTokenCanFollowModifier();
+      }
+      return this.tsNextTokenOnSameLineAndCanFollowModifier();
     }
 
     /** Parses a modifier matching one the given modifier names. */

--- a/packages/babel-parser/test/fixtures/typescript/class/method-with-modifiers-asi/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/method-with-modifiers-asi/input.ts
@@ -1,4 +1,7 @@
 class C {
   public
   private() {}
+
+  static readonly
+  protected() {}
 }

--- a/packages/babel-parser/test/fixtures/typescript/class/method-with-modifiers-asi/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/method-with-modifiers-asi/output.json
@@ -1,15 +1,15 @@
 {
   "type": "File",
-  "start":0,"end":35,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":1,"index":35}},
+  "start":0,"end":71,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":71}},
   "program": {
     "type": "Program",
-    "start":0,"end":35,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":1,"index":35}},
+    "start":0,"end":71,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":71}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
-        "start":0,"end":35,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":1,"index":35}},
+        "start":0,"end":71,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":71}},
         "id": {
           "type": "Identifier",
           "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"C"},
@@ -18,7 +18,7 @@
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start":8,"end":35,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":4,"column":1,"index":35}},
+          "start":8,"end":71,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":7,"column":1,"index":71}},
           "body": [
             {
               "type": "ClassProperty",
@@ -50,6 +50,40 @@
               "body": {
                 "type": "BlockStatement",
                 "start":31,"end":33,"loc":{"start":{"line":3,"column":12,"index":31},"end":{"line":3,"column":14,"index":33}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassProperty",
+              "start":37,"end":52,"loc":{"start":{"line":5,"column":2,"index":37},"end":{"line":5,"column":17,"index":52}},
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start":44,"end":52,"loc":{"start":{"line":5,"column":9,"index":44},"end":{"line":5,"column":17,"index":52},"identifierName":"readonly"},
+                "name": "readonly"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "ClassMethod",
+              "start":55,"end":69,"loc":{"start":{"line":6,"column":2,"index":55},"end":{"line":6,"column":16,"index":69}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":55,"end":64,"loc":{"start":{"line":6,"column":2,"index":55},"end":{"line":6,"column":11,"index":64},"identifierName":"protected"},
+                "name": "protected"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":67,"end":69,"loc":{"start":{"line":6,"column":14,"index":67},"end":{"line":6,"column":16,"index":69}},
                 "body": [],
                 "directives": []
               }

--- a/packages/babel-parser/test/fixtures/typescript/class/static-asi/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/class/static-asi/input.ts
@@ -1,0 +1,22 @@
+class A {
+    static
+    prop = 1
+
+    static
+    #prop = 2
+
+    static
+    ["computed prop"]: any
+
+    static
+    method() {}
+
+    static
+    #method() {}
+
+    static
+    *generator() {}
+
+    static
+    async asyncMethod() {}
+}

--- a/packages/babel-parser/test/fixtures/typescript/class/static-asi/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/static-asi/output.json
@@ -1,0 +1,190 @@
+{
+  "type": "File",
+  "start":0,"end":228,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":22,"column":1,"index":228}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":228,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":22,"column":1,"index":228}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":228,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":22,"column":1,"index":228}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"A"},
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":8,"end":228,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":22,"column":1,"index":228}},
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start":14,"end":33,"loc":{"start":{"line":2,"column":4,"index":14},"end":{"line":3,"column":12,"index":33}},
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start":25,"end":29,"loc":{"start":{"line":3,"column":4,"index":25},"end":{"line":3,"column":8,"index":29},"identifierName":"prop"},
+                "name": "prop"
+              },
+              "computed": false,
+              "value": {
+                "type": "NumericLiteral",
+                "start":32,"end":33,"loc":{"start":{"line":3,"column":11,"index":32},"end":{"line":3,"column":12,"index":33}},
+                "extra": {
+                  "rawValue": 1,
+                  "raw": "1"
+                },
+                "value": 1
+              }
+            },
+            {
+              "type": "ClassPrivateProperty",
+              "start":39,"end":59,"loc":{"start":{"line":5,"column":4,"index":39},"end":{"line":6,"column":13,"index":59}},
+              "static": true,
+              "key": {
+                "type": "PrivateName",
+                "start":50,"end":55,"loc":{"start":{"line":6,"column":4,"index":50},"end":{"line":6,"column":9,"index":55}},
+                "id": {
+                  "type": "Identifier",
+                  "start":51,"end":55,"loc":{"start":{"line":6,"column":5,"index":51},"end":{"line":6,"column":9,"index":55},"identifierName":"prop"},
+                  "name": "prop"
+                }
+              },
+              "value": {
+                "type": "NumericLiteral",
+                "start":58,"end":59,"loc":{"start":{"line":6,"column":12,"index":58},"end":{"line":6,"column":13,"index":59}},
+                "extra": {
+                  "rawValue": 2,
+                  "raw": "2"
+                },
+                "value": 2
+              }
+            },
+            {
+              "type": "ClassProperty",
+              "start":65,"end":98,"loc":{"start":{"line":8,"column":4,"index":65},"end":{"line":9,"column":26,"index":98}},
+              "static": true,
+              "computed": true,
+              "key": {
+                "type": "StringLiteral",
+                "start":77,"end":92,"loc":{"start":{"line":9,"column":5,"index":77},"end":{"line":9,"column":20,"index":92}},
+                "extra": {
+                  "rawValue": "computed prop",
+                  "raw": "\"computed prop\""
+                },
+                "value": "computed prop"
+              },
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":93,"end":98,"loc":{"start":{"line":9,"column":21,"index":93},"end":{"line":9,"column":26,"index":98}},
+                "typeAnnotation": {
+                  "type": "TSAnyKeyword",
+                  "start":95,"end":98,"loc":{"start":{"line":9,"column":23,"index":95},"end":{"line":9,"column":26,"index":98}}
+                }
+              },
+              "value": null
+            },
+            {
+              "type": "ClassMethod",
+              "start":104,"end":126,"loc":{"start":{"line":11,"column":4,"index":104},"end":{"line":12,"column":15,"index":126}},
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start":115,"end":121,"loc":{"start":{"line":12,"column":4,"index":115},"end":{"line":12,"column":10,"index":121},"identifierName":"method"},
+                "name": "method"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":124,"end":126,"loc":{"start":{"line":12,"column":13,"index":124},"end":{"line":12,"column":15,"index":126}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassPrivateMethod",
+              "start":132,"end":155,"loc":{"start":{"line":14,"column":4,"index":132},"end":{"line":15,"column":16,"index":155}},
+              "static": true,
+              "key": {
+                "type": "PrivateName",
+                "start":143,"end":150,"loc":{"start":{"line":15,"column":4,"index":143},"end":{"line":15,"column":11,"index":150}},
+                "id": {
+                  "type": "Identifier",
+                  "start":144,"end":150,"loc":{"start":{"line":15,"column":5,"index":144},"end":{"line":15,"column":11,"index":150},"identifierName":"method"},
+                  "name": "method"
+                }
+              },
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":153,"end":155,"loc":{"start":{"line":15,"column":14,"index":153},"end":{"line":15,"column":16,"index":155}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":161,"end":187,"loc":{"start":{"line":17,"column":4,"index":161},"end":{"line":18,"column":19,"index":187}},
+              "static": true,
+              "kind": "method",
+              "key": {
+                "type": "Identifier",
+                "start":173,"end":182,"loc":{"start":{"line":18,"column":5,"index":173},"end":{"line":18,"column":14,"index":182},"identifierName":"generator"},
+                "name": "generator"
+              },
+              "computed": false,
+              "id": null,
+              "generator": true,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":185,"end":187,"loc":{"start":{"line":18,"column":17,"index":185},"end":{"line":18,"column":19,"index":187}},
+                "body": [],
+                "directives": []
+              }
+            },
+            {
+              "type": "ClassMethod",
+              "start":193,"end":226,"loc":{"start":{"line":20,"column":4,"index":193},"end":{"line":21,"column":26,"index":226}},
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start":210,"end":221,"loc":{"start":{"line":21,"column":10,"index":210},"end":{"line":21,"column":21,"index":221},"identifierName":"asyncMethod"},
+                "name": "asyncMethod"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": true,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start":224,"end":226,"loc":{"start":{"line":21,"column":24,"index":224},"end":{"line":21,"column":26,"index":226}},
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/interface/get-set-ambiguous-babel-7/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/interface/get-set-ambiguous-babel-7/output.json
@@ -20,24 +20,15 @@
           "start":14,"end":56,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":6,"column":1,"index":56}},
           "body": [
             {
-              "type": "TSPropertySignature",
-              "start":18,"end":21,"loc":{"start":{"line":2,"column":2,"index":18},"end":{"line":2,"column":5,"index":21}},
-              "key": {
-                "type": "Identifier",
-                "start":18,"end":21,"loc":{"start":{"line":2,"column":2,"index":18},"end":{"line":2,"column":5,"index":21},"identifierName":"get"},
-                "name": "get"
-              },
-              "computed": false
-            },
-            {
               "type": "TSMethodSignature",
-              "start":24,"end":38,"loc":{"start":{"line":3,"column":2,"index":24},"end":{"line":3,"column":16,"index":38}},
+              "start":18,"end":38,"loc":{"start":{"line":2,"column":2,"index":18},"end":{"line":3,"column":16,"index":38}},
               "key": {
                 "type": "Identifier",
                 "start":24,"end":27,"loc":{"start":{"line":3,"column":2,"index":24},"end":{"line":3,"column":5,"index":27},"identifierName":"foo"},
                 "name": "foo"
               },
               "computed": false,
+              "kind": "get",
               "parameters": [],
               "typeAnnotation": {
                 "type": "TSTypeAnnotation",
@@ -46,36 +37,25 @@
                   "type": "TSStringKeyword",
                   "start":31,"end":37,"loc":{"start":{"line":3,"column":9,"index":31},"end":{"line":3,"column":15,"index":37}}
                 }
-              },
-              "kind": "method"
-            },
-            {
-              "type": "TSPropertySignature",
-              "start":41,"end":44,"loc":{"start":{"line":4,"column":2,"index":41},"end":{"line":4,"column":5,"index":44}},
-              "key": {
-                "type": "Identifier",
-                "start":41,"end":44,"loc":{"start":{"line":4,"column":2,"index":41},"end":{"line":4,"column":5,"index":44},"identifierName":"set"},
-                "name": "set"
-              },
-              "computed": false
+              }
             },
             {
               "type": "TSMethodSignature",
-              "start":47,"end":54,"loc":{"start":{"line":5,"column":2,"index":47},"end":{"line":5,"column":9,"index":54}},
+              "start":41,"end":54,"loc":{"start":{"line":4,"column":2,"index":41},"end":{"line":5,"column":9,"index":54}},
               "key": {
                 "type": "Identifier",
                 "start":47,"end":50,"loc":{"start":{"line":5,"column":2,"index":47},"end":{"line":5,"column":5,"index":50},"identifierName":"bar"},
                 "name": "bar"
               },
               "computed": false,
+              "kind": "set",
               "parameters": [
                 {
                   "type": "Identifier",
                   "start":51,"end":52,"loc":{"start":{"line":5,"column":6,"index":51},"end":{"line":5,"column":7,"index":52},"identifierName":"v"},
                   "name": "v"
                 }
-              ],
-              "kind": "method"
+              ]
             }
           ]
         }

--- a/packages/babel-parser/test/fixtures/typescript/interface/get-set-ambiguous/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/interface/get-set-ambiguous/output.json
@@ -20,24 +20,15 @@
           "start":14,"end":56,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":6,"column":1,"index":56}},
           "body": [
             {
-              "type": "TSPropertySignature",
-              "start":18,"end":21,"loc":{"start":{"line":2,"column":2,"index":18},"end":{"line":2,"column":5,"index":21}},
-              "key": {
-                "type": "Identifier",
-                "start":18,"end":21,"loc":{"start":{"line":2,"column":2,"index":18},"end":{"line":2,"column":5,"index":21},"identifierName":"get"},
-                "name": "get"
-              },
-              "computed": false
-            },
-            {
               "type": "TSMethodSignature",
-              "start":24,"end":38,"loc":{"start":{"line":3,"column":2,"index":24},"end":{"line":3,"column":16,"index":38}},
+              "start":18,"end":38,"loc":{"start":{"line":2,"column":2,"index":18},"end":{"line":3,"column":16,"index":38}},
               "key": {
                 "type": "Identifier",
                 "start":24,"end":27,"loc":{"start":{"line":3,"column":2,"index":24},"end":{"line":3,"column":5,"index":27},"identifierName":"foo"},
                 "name": "foo"
               },
               "computed": false,
+              "kind": "get",
               "params": [],
               "returnType": {
                 "type": "TSTypeAnnotation",
@@ -46,36 +37,25 @@
                   "type": "TSStringKeyword",
                   "start":31,"end":37,"loc":{"start":{"line":3,"column":9,"index":31},"end":{"line":3,"column":15,"index":37}}
                 }
-              },
-              "kind": "method"
-            },
-            {
-              "type": "TSPropertySignature",
-              "start":41,"end":44,"loc":{"start":{"line":4,"column":2,"index":41},"end":{"line":4,"column":5,"index":44}},
-              "key": {
-                "type": "Identifier",
-                "start":41,"end":44,"loc":{"start":{"line":4,"column":2,"index":41},"end":{"line":4,"column":5,"index":44},"identifierName":"set"},
-                "name": "set"
-              },
-              "computed": false
+              }
             },
             {
               "type": "TSMethodSignature",
-              "start":47,"end":54,"loc":{"start":{"line":5,"column":2,"index":47},"end":{"line":5,"column":9,"index":54}},
+              "start":41,"end":54,"loc":{"start":{"line":4,"column":2,"index":41},"end":{"line":5,"column":9,"index":54}},
               "key": {
                 "type": "Identifier",
                 "start":47,"end":50,"loc":{"start":{"line":5,"column":2,"index":47},"end":{"line":5,"column":5,"index":50},"identifierName":"bar"},
                 "name": "bar"
               },
               "computed": false,
+              "kind": "set",
               "params": [
                 {
                   "type": "Identifier",
                   "start":51,"end":52,"loc":{"start":{"line":5,"column":6,"index":51},"end":{"line":5,"column":7,"index":52},"identifierName":"v"},
                   "name": "v"
                 }
-              ],
-              "kind": "method"
+              ]
             }
           ]
         }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16759 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we also fixed the following case:
```ts
interface Foo {
  get
  foo(): string;
  set
  bar(v);
}
```
Previously Babel parsed it as two property and two method signatures, however, it diverts from the TS4.3+ behaviour.