### PR TITLE
Simplify logic for `[no LineTerminator here]` before nodes

### DIFF
--- a/packages/babel-generator/src/generators/expressions.ts
+++ b/packages/babel-generator/src/generators/expressions.ts
@@ -210,7 +210,7 @@ export function AwaitExpression(this: Printer, node: t.AwaitExpression) {
 
   if (node.argument) {
     this.space();
-    this.printTerminatorless(node.argument, false);
+    this.printTerminatorless(node.argument);
   }
 }
 
@@ -227,7 +227,7 @@ export function YieldExpression(this: Printer, node: t.YieldExpression) {
   } else {
     if (node.argument) {
       this.space();
-      this.printTerminatorless(node.argument, false);
+      this.printTerminatorless(node.argument);
     }
   }
 }

--- a/packages/babel-generator/src/generators/statements.ts
+++ b/packages/babel-generator/src/generators/statements.ts
@@ -144,14 +144,10 @@ export function DoWhileStatement(this: Printer, node: t.DoWhileStatement) {
   this.semicolon();
 }
 
-function printStatementAfterKeyword(
-  printer: Printer,
-  node: t.Node,
-  isLabel: boolean,
-) {
+function printStatementAfterKeyword(printer: Printer, node: t.Node) {
   if (node) {
     printer.space();
-    printer.printTerminatorless(node, isLabel);
+    printer.printTerminatorless(node);
   }
 
   printer.semicolon();
@@ -159,22 +155,22 @@ function printStatementAfterKeyword(
 
 export function BreakStatement(this: Printer, node: t.ContinueStatement) {
   this.word("break");
-  printStatementAfterKeyword(this, node.label, true);
+  printStatementAfterKeyword(this, node.label);
 }
 
 export function ContinueStatement(this: Printer, node: t.ContinueStatement) {
   this.word("continue");
-  printStatementAfterKeyword(this, node.label, true);
+  printStatementAfterKeyword(this, node.label);
 }
 
 export function ReturnStatement(this: Printer, node: t.ReturnStatement) {
   this.word("return");
-  printStatementAfterKeyword(this, node.argument, false);
+  printStatementAfterKeyword(this, node.argument);
 }
 
 export function ThrowStatement(this: Printer, node: t.ThrowStatement) {
   this.word("throw");
-  printStatementAfterKeyword(this, node.argument, false);
+  printStatementAfterKeyword(this, node.argument);
 }
 
 export function LabeledStatement(this: Printer, node: t.LabeledStatement) {

--- a/packages/babel-generator/test/fixtures/edgecase/return-with-retainlines-option/output.js
+++ b/packages/babel-generator/test/fixtures/edgecase/return-with-retainlines-option/output.js
@@ -6,6 +6,6 @@ function foo(l) {
 
 function foo2() {
   return (
-    1 && 2 ||
-    3);
+    1 && 2) ||
+  3;
 }

--- a/packages/babel-generator/test/fixtures/regression/11304/output.js
+++ b/packages/babel-generator/test/fixtures/regression/11304/output.js
@@ -1,2 +1,2 @@
-function f(){return/*#__PURE__*/(//test
+function f(){return(/*#__PURE__*///test
 0);}

--- a/packages/babel-generator/test/fixtures/regression/comment-before-parentheses-return-arg/output.js
+++ b/packages/babel-generator/test/fixtures/regression/comment-before-parentheses-return-arg/output.js
@@ -1,7 +1,5 @@
 function assertElement(assertFn, shouldBeElement, opt_message) {
-  return /** @type {!Ele	ment} */(
-    assertType_(assertFn, shouldBeElement, isElement(shouldBeElement), 'Element expected', opt_message)
-  );
+  return /** @type {!Ele	ment} */assertType_(assertFn, shouldBeElement, isElement(shouldBeElement), 'Element expected', opt_message);
 }
 const slot = /** @type {!HTMLSlotElement} */e.target;
 assertElement(/** @type {Element} */el);

--- a/packages/babel-generator/test/fixtures/sourcemaps/comment-before-parentheses-return-arg/output.js
+++ b/packages/babel-generator/test/fixtures/sourcemaps/comment-before-parentheses-return-arg/output.js
@@ -1,5 +1,5 @@
 function assertElement(assertFn, shouldBeElement, opt_message) {
-  return /** @type {!Ele	ment} */(
+  return (/** @type {!Ele	ment} */
     assertType_(
       assertFn,
       shouldBeElement,

--- a/packages/babel-generator/test/fixtures/sourcemaps/comment-before-parentheses-return-arg/source-map.json
+++ b/packages/babel-generator/test/fixtures/sourcemaps/comment-before-parentheses-return-arg/source-map.json
@@ -18,6 +18,6 @@
   "sourcesContent": [
     "function assertElement(assertFn, shouldBeElement, opt_message) {\n  return /** @type {!Ele\tment} */ (\n\t  assertType_(\n\t    assertFn,\n\t\t  shouldBeElement,\n\t\t  isElement(shouldBeElement),\n\t\t  'Element expected',\n\t\t  opt_message\n\t  )\n\t);\n}\n\nconst slot = /** @type {!HTMLSlotElement} */ (e.target);\n\nassertElement(\n  /** @type {Element} */ (el),\n);"
   ],
-  "mappings": "AAAA,SAASA,aAAaA,CAACC,QAAQ,EAAEC,eAAe,EAAEC,WAAW,EAAE;EAC7D,OAAO;IACNC,WAAW;MACTH,QAAQ;MACTC,eAAe;MACfG,SAAS,CAACH,eAAe,CAAC;MAC1B,kBAAkB;MAClBC;IACD,CAAC;;AAEJ;;AAEA,MAAMG,IAAI,GAAG,+BAAiCC,CAAC,CAACC,MAAO;;AAEvDR,aAAa;EACX,sBAAwBS;AAC1B,CAAC",
+  "mappings": "AAAA,SAASA,aAAaA,CAACC,QAAQ,EAAEC,eAAe,EAAEC,WAAW,EAAE;EAC7D,QAAO;IACNC,WAAW;MACTH,QAAQ;MACTC,eAAe;MACfG,SAAS,CAACH,eAAe,CAAC;MAC1B,kBAAkB;MAClBC;IACD,CAAC;;AAEJ;;AAEA,MAAMG,IAAI,GAAG,+BAAiCC,CAAC,CAACC,MAAO;;AAEvDR,aAAa;EACX,sBAAwBS;AAC1B,CAAC",
   "ignoreList": []
 }

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1540,9 +1540,9 @@ describe("programmatic generation", function () {
         concise: true,
       }).code,
     ).toMatchInlineSnapshot(`
-        "return (/*new
-        line*/ val );"
-      `);
+      "return ( /*new
+      line*/ val );"
+    `);
   });
 
   it("correctly indenting when `retainLines`", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Follow up to #16778, only check the second commit. I'll mark as ready once that is merged.

This PR makes the `retainLines: true` output slightly uglier in some cases, but given that `retainLines` already often produces bad output this change is justified by the code simplification benefits.