### PR TITLE
Don't throw when enabling both syntax-import-{assertions,attributes}

### DIFF
--- a/packages/babel-plugin-syntax-import-assertions/src/index.ts
+++ b/packages/babel-plugin-syntax-import-assertions/src/index.ts
@@ -6,8 +6,20 @@ export default declare(api => {
   return {
     name: "syntax-import-assertions",
 
-    manipulateOptions(opts, parserOpts) {
-      parserOpts.plugins.push("importAssertions");
+    manipulateOptions(opts, { plugins }) {
+      for (let i = 0; i < plugins.length; i++) {
+        const plugin = plugins[i];
+        if (plugin === "importAttributes") {
+          plugins[i] = ["importAttributes", { deprecatedAssertSyntax: true }];
+          return;
+        }
+        if (Array.isArray(plugin) && plugin[0] === "importAttributes") {
+          if (plugin.length < 2) (plugins[i] as any[]).push({});
+          plugin[1].deprecatedAssertSyntax = true;
+          return;
+        }
+      }
+      plugins.push("importAssertions");
     },
   };
 });

--- a/packages/babel-plugin-syntax-import-attributes/package.json
+++ b/packages/babel-plugin-syntax-import-attributes/package.json
@@ -22,7 +22,8 @@
     "@babel/core": "^7.0.0-0"
   },
   "devDependencies": {
-    "@babel/core": "workspace:^"
+    "@babel/core": "workspace:^",
+    "@babel/helper-plugin-test-runner": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-plugin-syntax-import-attributes/src/index.ts
+++ b/packages/babel-plugin-syntax-import-attributes/src/index.ts
@@ -21,6 +21,14 @@ export default declare((api, { deprecatedAssertSyntax }: Options) => {
 
     manipulateOptions({ parserOpts, generatorOpts }) {
       generatorOpts.importAttributesKeyword ??= "with";
+
+      const importAssertionsPluginIndex =
+        parserOpts.plugins.indexOf("importAssertions");
+      if (importAssertionsPluginIndex !== -1) {
+        parserOpts.plugins.splice(importAssertionsPluginIndex, 1);
+        deprecatedAssertSyntax = true;
+      }
+
       parserOpts.plugins.push([
         "importAttributes",
         { deprecatedAssertSyntax: Boolean(deprecatedAssertSyntax) },

--- a/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/after/input.js
+++ b/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/after/input.js
@@ -1,0 +1,2 @@
+import "x" with { type: "json" };
+import "x" assert { type: "json" };

--- a/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/after/options.json
+++ b/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/after/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["syntax-import-assertions", "syntax-import-attributes"]
+}

--- a/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/after/output.mjs
+++ b/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/after/output.mjs
@@ -1,0 +1,2 @@
+import "x" with { type: "json" };
+import "x" with { type: "json" };

--- a/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/before/input.js
+++ b/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/before/input.js
@@ -1,0 +1,2 @@
+import "x" with { type: "json" };
+import "x" assert { type: "json" };

--- a/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/before/options.json
+++ b/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/before/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["syntax-import-attributes", "syntax-import-assertions"]
+}

--- a/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/before/output.mjs
+++ b/packages/babel-plugin-syntax-import-attributes/test/fixtures/with-import-assertions-plugin/before/output.mjs
@@ -1,0 +1,2 @@
+import "x" with { type: "json" };
+import "x" with { type: "json" };

--- a/packages/babel-plugin-syntax-import-attributes/test/index.js
+++ b/packages/babel-plugin-syntax-import-attributes/test/index.js
@@ -1,0 +1,3 @@
+import runner from "@babel/helper-plugin-test-runner";
+
+runner(import.meta.url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,6 +1957,7 @@ __metadata:
   resolution: "@babel/plugin-syntax-import-attributes@workspace:packages/babel-plugin-syntax-import-attributes"
   dependencies:
     "@babel/core": "workspace:^"
+    "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/16754
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Users often do not have control over which plugins are enabled, because they are enabled by presets. This PR makes it so that when both `syntax-import-attributes` and `syntax-import-assertions` are enabled, it's equivalent to having import attributes with `deprecatedAssertSyntax: true`.