### PR TITLE
TS union/intersection nested in union does not need parens

### DIFF
--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -247,7 +247,6 @@ export function TSUnionType(node: t.TSUnionType, parent: t.Node): boolean {
     parentType === "TSArrayType" ||
     parentType === "TSOptionalType" ||
     parentType === "TSIntersectionType" ||
-    parentType === "TSUnionType" ||
     parentType === "TSRestType"
   );
 }

--- a/packages/babel-generator/test/fixtures/typescript/types-union-intersection/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-union-intersection/output.js
@@ -1,4 +1,4 @@
 let union: number | null | undefined;
 let intersection: number & string;
-let precedence1: number | (string & boolean);
-let precedence2: (number & string) | boolean;
+let precedence1: number | string & boolean;
+let precedence2: number & string | boolean;

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1197,7 +1197,7 @@ describe("programmatic generation", function () {
         ]),
       );
       const output = generate(typeStatement).code;
-      expect(output).toBe("((number & boolean) | null)[]");
+      expect(output).toBe("(number & boolean | null)[]");
     });
     it("wraps around intersection for array", () => {
       const typeStatement = t.tsArrayType(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`a & b | c` does not need explicit parentheses. Note that if the user wrote `(a & b) | c`, we generate a TSParentesizedType node so we preserve them. This PR is just to avoid _introducing_ them when not needed.