### PR TITLE
Remove warning when not specifying the `importAttributesKeyword` option

### DIFF
--- a/packages/babel-generator/src/generators/modules.ts
+++ b/packages/babel-generator/src/generators/modules.ts
@@ -67,31 +67,12 @@ export function ExportNamespaceSpecifier(
   this.print(node.exported);
 }
 
-let warningShown = false;
-
 export function _printAttributes(
   this: Printer,
   node: Extract<t.Node, { attributes?: t.ImportAttribute[] }>,
 ) {
   const { importAttributesKeyword } = this.format;
   const { attributes, assertions } = node;
-
-  if (
-    attributes &&
-    !importAttributesKeyword &&
-    // In the production build only show the warning once.
-    // We want to show it per-usage locally for tests.
-    (!process.env.IS_PUBLISH || !warningShown)
-  ) {
-    warningShown = true;
-    console.warn(`\
-You are using import attributes, without specifying the desired output syntax.
-Please specify the "importAttributesKeyword" generator option, whose value can be one of:
- - "with"        : \`import { a } from "b" with { type: "json" };\`
- - "assert"      : \`import { a } from "b" assert { type: "json" };\`
- - "with-legacy" : \`import { a } from "b" with type: "json";\`
-`);
-  }
 
   const useAssertKeyword =
     importAttributesKeyword === "assert" ||

--- a/packages/babel-generator/test/fixtures/importAttributesKeyword/assertions-with-to-default/options.json
+++ b/packages/babel-generator/test/fixtures/importAttributesKeyword/assertions-with-to-default/options.json
@@ -1,5 +1,4 @@
 {
   "plugins": ["importAssertions"],
-  "warns": "You are using import attributes, without specifying the desired output syntax.",
   "expectedReParseError": true
 }

--- a/packages/babel-generator/test/fixtures/importAttributesKeyword/attributes-assert-to-default-babel-7/options.json
+++ b/packages/babel-generator/test/fixtures/importAttributesKeyword/attributes-assert-to-default-babel-7/options.json
@@ -1,4 +1,5 @@
 {
+  "BABEL_8_BREAKING": false,
   "plugins": [["importAttributes", { "deprecatedAssertSyntax": true }]],
   "expectedReParseError": true
 }

--- a/packages/babel-generator/test/fixtures/importAttributesKeyword/attributes-with-to-default/options.json
+++ b/packages/babel-generator/test/fixtures/importAttributesKeyword/attributes-with-to-default/options.json
@@ -1,7 +1,4 @@
 {
-  "_": "The warning is only shown once in the release build, tested by the assertions-with-to-default fixture",
-  "noWarnInPublishBuild": true,
   "plugins": ["importAttributes"],
-  "warns": "You are using import attributes, without specifying the desired output syntax.",
   "expectedReParseError": true
 }

--- a/packages/babel-generator/test/fixtures/importAttributesKeyword/legacy-module-attributes-to-default/options.json
+++ b/packages/babel-generator/test/fixtures/importAttributesKeyword/legacy-module-attributes-to-default/options.json
@@ -1,7 +1,4 @@
 {
-  "_": "The warning is only shown once in the release build, tested by the assertions-with-to-default fixture",
-  "noWarnInPublishBuild": true,
   "plugins": [["moduleAttributes", { "version": "may-2020" }]],
-  "warns": "You are using import attributes, without specifying the desired output syntax.",
   "BABEL_8_BREAKING": false
 }

--- a/packages/babel-generator/test/fixtures/types/ModuleAttributes/options.json
+++ b/packages/babel-generator/test/fixtures/types/ModuleAttributes/options.json
@@ -1,8 +1,5 @@
 {
-  "_": "The warning is only shown once in the release build, tested by the assertions-with-to-default fixture",
-  "noWarnInPublishBuild": true,
   "plugins": [["moduleAttributes", { "version": "may-2020" }]],
   "sourceType": "module",
-  "warns": "You are using import attributes, without specifying the desired output syntax.",
   "BABEL_8_BREAKING": false
 }

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1641,10 +1641,7 @@ suites.forEach(function (testSuite) {
 
               const result = run();
 
-              if (
-                options.warns &&
-                (!process.env.IS_PUBLISH || !options.noWarnInPublishBuild)
-              ) {
+              if (options.warns) {
                 expect(console.warn).toHaveBeenCalledWith(
                   expect.stringContaining(options.warns),
                 );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Given that the proposal now only has `with`, it makes sense to default to `with` with no warning.