### PR TITLE
fix: issue with node path keys updated on unrelated paths

### DIFF
--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -285,7 +285,11 @@ export function updateSiblingKeys(
   const paths = getCachedPaths(this.hub, this.parent) || ([] as never[]);
 
   for (const [, path] of paths) {
-    if (typeof path.key === "number" && path.key >= fromIndex) {
+    if (
+      typeof path.key === "number" &&
+      path.container === this.container &&
+      path.key >= fromIndex
+    ) {
       path.key += incrementBy;
     }
   }

--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -110,6 +110,24 @@ describe("path/family", function () {
       expect(testHasScope).toBe(true);
       expect(consequentHasScope).toBe(true);
     });
+    it("should be correct after mutating an unrelated container", function () {
+      const ast = parse("`a${a}b${b}`");
+      let secondQuasiValue;
+      let firstExpressionValue;
+
+      traverse(ast, {
+        TemplateLiteral(path) {
+          const [firstQuasi] = path.get("quasis");
+          const [firstExpression] = path.get("expressions");
+          path.unshiftContainer("expressions", t.stringLiteral("hi"));
+          secondQuasiValue = firstQuasi.getNextSibling().node.value.raw;
+          firstExpressionValue = firstExpression.getPrevSibling().node.value;
+        },
+      });
+
+      expect(secondQuasiValue).toBe("b");
+      expect(firstExpressionValue).toBe("hi");
+    });
   });
   describe("getCompletionRecords", function () {
     it("should skip variable declarations", function () {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 👍
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

Fixes a bug where unrelated `NodePath.key` properties were being incremented / decremented when the ast was mutated through the NodePath apis (eg `pushContainer`). This caused other apis that relied on `NodePath.key` to break (in my case `getNextSibling` and `getPrevSibling`).

The bug is that `updateSiblingKeys` was unconditionally updating any "sibling" that had a number `key` property without first checking that it's actually in the same container / list as the current NodePath.

This means that mutating any node via the NodePath apis where the original AST node has more than one directly nested array of data (eg template literal in the example test) would incorrectly update the key property.

The test I added shows that mutating the `expressions` of a `TemplateLiteral` causes it's `quasis` to also be impacted and returns the incorrect next sibling.


Here's also an AST Explorer gist that shows the incorrect behavior with more logs https://astexplorer.net/#/gist/a99fad01e220f92a602900f0702a25a6/8f741050ed43f4e1091748e6e354642c3b7e64d5