### PR TITLE
Only access `BABEL_TYPES_8_BREAKING` at startup

### DIFF
--- a/packages/babel-types/src/definitions/utils.ts
+++ b/packages/babel-types/src/definitions/utils.ts
@@ -97,6 +97,10 @@ export function validateArrayOfType(typeName: NodeTypes | NodeTypes[]) {
 }
 
 export function assertEach(callback: Validator): Validator {
+  const childValidator = process.env.BABEL_TYPES_8_BREAKING
+    ? validateChild
+    : () => {};
+
   function validator(node: t.Node, key: string, val: any) {
     if (!Array.isArray(val)) return;
 
@@ -104,7 +108,7 @@ export function assertEach(callback: Validator): Validator {
       const subkey = `${key}[${i}]`;
       const v = val[i];
       callback(node, subkey, v);
-      if (process.env.BABEL_TYPES_8_BREAKING) validateChild(node, subkey, v);
+      childValidator(node, subkey, v);
     }
   }
   validator.each = callback;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

@liuxingbaoyu Could you check if this solves the performance problem? It moves the env variable checks to only happen at startup and not during validation.