### PR TITLE
[Babel 8] fix: Throwing exceptions synchronously

### DIFF
--- a/packages/babel-core/cjs-proxy.cjs
+++ b/packages/babel-core/cjs-proxy.cjs
@@ -29,6 +29,15 @@ const propertyNames = [
 
 for (const name of functionNames) {
   exports[name] = function (...args) {
+    if (
+      process.env.BABEL_8_BREAKING &&
+      typeof args[args.length - 1] !== "function"
+    ) {
+      throw new Error(
+        `Starting from Babel 8.0.0, the '${name}' function expects a callback. If you need to call it synchronously, please use '${name}Sync'.`
+      );
+    }
+
     babelP.then(babel => {
       babel[name](...args);
     });

--- a/packages/babel-core/test/api.js
+++ b/packages/babel-core/test/api.js
@@ -10,9 +10,9 @@ import presetEnv from "@babel/preset-env";
 import pluginSyntaxFlow from "@babel/plugin-syntax-flow";
 import pluginSyntaxJSX from "@babel/plugin-syntax-jsx";
 import pluginFlowStripTypes from "@babel/plugin-transform-flow-strip-types";
-import { itBabel8, commonJS } from "$repo-utils";
+import { itBabel8, commonJS, IS_BABEL_8, USE_ESM } from "$repo-utils";
 
-const { __dirname } = commonJS(import.meta.url);
+const { __dirname, require } = commonJS(import.meta.url);
 const cwd = __dirname;
 
 function assertIgnored(result) {
@@ -222,6 +222,7 @@ describe("api", function () {
     // keep user options untouched
     expect(options).toEqual({ babelrc: false });
   });
+
   it("transformFile throws on undefined callback", () => {
     const options = {
       babelrc: false,
@@ -1022,3 +1023,18 @@ describe("api", function () {
     });
   });
 });
+
+if (IS_BABEL_8() && USE_ESM) {
+  describe("cjs-proxy", function () {
+    it("error should be caught", () => {
+      let err;
+      try {
+        const cjs = require("../cjs-proxy.cjs");
+        cjs.parse("foo");
+      } catch (error) {
+        err = error;
+      }
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Not only was it previously impossible to catch, the stack had almost no useful content.
Ref: https://github.com/babel/website/pull/2961
```
file:///F:/git/website/node_modules/@babel/core/lib/config/index.js:22
      throw new Error("Starting from Babel 8.0.0, the 'loadPartialConfig' function expects a callback. If you need to call it synchronously, please use 'loadPartialConfigSync'.");
            ^

Error: Starting from Babel 8.0.0, the 'loadPartialConfig' function expects a callback. If you need to call it synchronously, please use 'loadPartialConfigSync'.
    at Module.loadPartialConfig (file:///F:/git/website/node_modules/@babel/core/lib/config/index.js:22:13)
    at F:\git\website\node_modules\@babel\core\cjs-proxy.cjs:33:18
```