### PR TITLE
Make the async iterator prototype third in the prototype chain of async generators

### DIFF
--- a/packages/babel-helpers/src/helpers/wrapAsyncGenerator.ts
+++ b/packages/babel-helpers/src/helpers/wrapAsyncGenerator.ts
@@ -145,7 +145,28 @@ function AsyncGenerator<T = unknown, TReturn = any, TNext = unknown>(
   }
 }
 
-AsyncGenerator.prototype[
+// AsyncIteratorPrototype should be third in the prototype chain of an async
+// generator objects returned from async generator function calls.
+// This aligns the prototype chain of transpiled generators to that of
+// native runtime implementations and simplifies the discovery of the
+// Async Iterator Prototype object for the purpose of Async Iterator Helper
+// polyfills and AsyncIterator constructor injection via core-js or other
+// libraries.
+//
+// The prototype chain here is still one step away from the fullest possible
+// alignment with native implementations.
+// Without async generator function marking like what regenerator does, the
+// following behavior will still be out of spec: given `async function* foo() {}`,
+// `foo() instanceof foo` will return false instead of true.
+const AsyncIteratorPrototype: any = {};
+const AsyncGeneratorPrototype: any = Object.create(AsyncIteratorPrototype);
+const AsyncGeneratorInstanceProrotype: any = Object.create(
+  AsyncGeneratorPrototype,
+);
+AsyncGenerator.prototype = AsyncGeneratorInstanceProrotype;
+AsyncGeneratorPrototype.constructor = AsyncGenerator;
+
+AsyncIteratorPrototype[
   ((typeof Symbol === "function" && Symbol.asyncIterator) ||
     "@@asyncIterator") as typeof Symbol.asyncIterator
 ] = function () {


### PR DESCRIPTION
This changes makes discovery of the async iterator prototype object easier in environments with transpiled async generators. 

The async iterator prototype object is useful for polyfilling async iterator helpers and making them available on async generator objects.

Here is an example:

```js
require("core-js/proposals/async-iterator-helpers");

async function* gen() {
  yield* [1, 2, 3, 4, 5];
}

gen()
  .drop(1)
  .take(3)
  .filter(n => n != 3)
  .map(n => n * 10)
  .forEach(n => console.log(n));
```

To make the above work one needs to retrieve and share the async iterator prototype object with core-js. This can be accomplished today like so:

```js
  const asyncGeneratorInstancePrototype = Object.getPrototypeOf(async function*(){}());
  const AsyncGeneratorPrototype = Object.getPrototypeOf(asyncGeneratorInstancePrototype);
  let AsyncIteratorPrototype;
  if (AsyncGeneratorPrototype === Object.prototype) {
    // Fix-up for babel's transform-async-generator-functions
    AsyncIteratorPrototype = {};
    Object.setPrototypeOf(asyncFunctionPrototype, AsyncIteratorPrototype);
  } else {
    AsyncIteratorPrototype = Object.getPrototypeOf(AsyncGeneratorPrototype);
  }
  require("core-js/configurator")({ AsyncIteratorPrototype });
```

This code will work in both transpiled and non-transpiled environments.

Ideally, that code should be uniform across transpiled and non-transpiled environments:

```js
  const asyncGeneratorInstancePrototype = Object.getPrototypeOf(async function*(){}());
  const AsyncGeneratorPrototype = Object.getPrototypeOf(asyncGeneratorInstancePrototype);
  const AsyncIteratorPrototype = Object.getPrototypeOf(AsyncGeneratorPrototype);
  require("core-js/configurator")({ AsyncIteratorPrototype });
```

The PR shared here makes this happen.
