### PR TITLE
Update jsesc to ^3.0.2

### DIFF
--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -22,7 +22,7 @@
     "@babel/types": "workspace:^",
     "@jridgewell/gen-mapping": "^0.3.5",
     "@jridgewell/trace-mapping": "^0.3.25",
-    "jsesc": "condition: BABEL_8_BREAKING ? ^3.0.2 : ^2.5.1"
+    "jsesc": "^3.0.2"
   },
   "devDependencies": {
     "@babel/helper-fixtures": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,7 +525,7 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     "@types/jsesc": "npm:^2.5.0"
     charcodes: "npm:^0.2.0"
-    jsesc: "condition: BABEL_8_BREAKING ? ^3.0.2 : ^2.5.1"
+    jsesc: "npm:^3.0.2"
   languageName: unknown
   linkType: soft
 
@@ -12398,7 +12398,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsesc-BABEL_8_BREAKING-false@npm:jsesc@^2.5.1, jsesc@npm:^2.5.1":
+"jsesc@npm:^2.5.1":
   version: 2.5.2
   resolution: "jsesc@npm:2.5.2"
   bin:
@@ -12407,22 +12407,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsesc-BABEL_8_BREAKING-true@npm:jsesc@^3.0.2, jsesc@npm:^3.0.2":
+"jsesc@npm:^3.0.2":
   version: 3.0.2
   resolution: "jsesc@npm:3.0.2"
   bin:
     jsesc: bin/jsesc
   checksum: 10/8e5a7de6b70a8bd71f9cb0b5a7ade6a73ae6ab55e697c74cc997cede97417a3a65ed86c36f7dd6125fe49766e8386c845023d9e213916ca92c9dfdd56e2babf3
-  languageName: node
-  linkType: hard
-
-"jsesc@condition: BABEL_8_BREAKING ? ^3.0.2 : ^2.5.1":
-  version: 0.0.0-condition-5a84f3
-  resolution: "jsesc@condition:BABEL_8_BREAKING?^3.0.2:^2.5.1#5a84f3"
-  dependencies:
-    jsesc-BABEL_8_BREAKING-false: "npm:jsesc@^2.5.1"
-    jsesc-BABEL_8_BREAKING-true: "npm:jsesc@^3.0.2"
-  checksum: 10/9a5432dbbdfd24ceb705f945cc244bdea8d2bc7b227d689d26ac48124356dcf56332ad0030addd97dcac5c5f8ee144b60e8471c263cc2104403e96ec8394273f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This was done for Babel 8 in https://github.com/babel/babel/pull/11384/files#diff-43b07207e2d4997e8f17fa1f1305817296667fa8a8bcfbd5e3bf5a356982ce2a, but we can also do it in Babel 7.

The only relevant change is that, for people that pass `jsescOption: { minimal: true }`, is that non-ASCII whitespace is now escaped. This is an observable difference but I would not consider it to be a breaking change.

The actual breaking change for Babel 8 is that `minimal` defaults to `true` instead of `false`.