### PR TITLE
perf: Improve @babel/types builders 2

### DIFF
--- a/benchmark/babel-types/builders/multiple.mjs
+++ b/benchmark/babel-types/builders/multiple.mjs
@@ -1,0 +1,26 @@
+import { Benchmark, baselineTypes, currentTypes } from "../../util.mjs";
+
+const bench = new Benchmark();
+
+function benchCases(implementations) {
+  for (const version in implementations) {
+    const t = implementations[version];
+    const func = t.stringLiteral;
+    const func2 = t.memberExpression;
+    const func3 = t.assignmentExpression;
+    const func4 = t.binaryExpression;
+
+    const id = t.identifier("id");
+    const id2 = t.identifier("id2");
+    bench.add(`${version} builder`, () => {
+      func("bar");
+      func2(id, id2, /*computed?*/ false /*, optional? missing*/);
+      func3("=", id, id2);
+      func4("+", id, id2);
+    });
+  }
+}
+
+benchCases({ baselineTypes, currentTypes });
+
+bench.run();

--- a/packages/babel-types/scripts/generators/builders.js
+++ b/packages/babel-types/scripts/generators/builders.js
@@ -6,13 +6,10 @@ import {
 } from "../../lib/index.js";
 import formatBuilderName from "../utils/formatBuilderName.js";
 import stringifyValidator from "../utils/stringifyValidator.js";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { IS_BABEL_8 } from "$repo-utils";
 
-// env vars from the cli are always strings, so !!ENV_VAR returns true for "false"
-function bool(value) {
-  return value && value !== "false" && value !== "0";
-}
-
-if (!bool(process.env.BABEL_8_BREAKING)) {
+if (!IS_BABEL_8()) {
   // eslint-disable-next-line no-var
   var lowerFirst = function (string) {
     return string[0].toLowerCase() + string.slice(1);
@@ -100,9 +97,14 @@ function generateLowercaseBuilders() {
  * This file is auto-generated! Do not modify it directly.
  * To re-generate run 'make build'
  */
-import validateNode from "../validateNode.ts";
+import * as _validate from "../../validators/validate.ts";
 import type * as t from "../../index.ts";
 import deprecationWarning from "../../utils/deprecationWarning.ts";
+import * as utils from "../../definitions/utils.ts";
+
+const { validateInternal: validate } = _validate;
+const { NODE_FIELDS } = utils;
+
 `;
 
   const reservedNames = new Set(["super", "import"]);
@@ -136,7 +138,23 @@ import deprecationWarning from "../../utils/deprecationWarning.ts";
       .join("\n")}\n  }`;
 
     if (builderNames.length > 0) {
-      output += `\n  return validateNode<t.${type}>(${nodeObjectExpression});`;
+      output += `\n  const node:t.${type} = ${nodeObjectExpression};`;
+      output += `\n  const defs = NODE_FIELDS.${type};`;
+
+      fieldNames.forEach(fieldName => {
+        const field = NODE_FIELDS[type][fieldName];
+        if (field && builderNames.includes(fieldName)) {
+          const argName = toBindingIdentifierName(fieldName);
+          output += `\n  validate(defs, node, "${fieldName}", ${argName}${
+            JSON.stringify(
+              stringifyValidator(field.validate, "#node#")
+            ).includes("#node#")
+              ? ", 1"
+              : ""
+          });`;
+        }
+      });
+      output += `\n  return node;`;
     } else {
       output += `\n  return ${nodeObjectExpression};`;
     }
@@ -146,7 +164,7 @@ import deprecationWarning from "../../utils/deprecationWarning.ts";
       output += `export { ${formattedBuilderNameLocal} as ${formattedBuilderName} };\n`;
     }
 
-    if (!bool(process.env.BABEL_8_BREAKING)) {
+    if (!IS_BABEL_8()) {
       // This is needed for backwards compatibility.
       // JSXIdentifier -> jSXIdentifier
       if (/^[A-Z]{2}/.test(type)) {
@@ -168,7 +186,7 @@ function ${type}(${generateBuilderArgs(newType).join(", ")}) {
 }
 export { ${type} as ${formattedBuilderName} };\n`;
 
-    if (!bool(process.env.BABEL_8_BREAKING)) {
+    if (!IS_BABEL_8()) {
       // This is needed for backwards compatibility.
       // JSXIdentifier -> jSXIdentifier
       if (/^[A-Z]{2}/.test(type)) {
@@ -191,7 +209,7 @@ function generateUppercaseBuilders() {
  * conflict with AST types. TypeScript reads the uppercase.d.ts file instead.
  */
 
- export {\n`;
+  export {\n`;
 
   Object.keys(BUILDER_KEYS).forEach(type => {
     const formattedBuilderName = formatBuilderName(type);

--- a/packages/babel-types/scripts/generators/builders.js
+++ b/packages/babel-types/scripts/generators/builders.js
@@ -145,7 +145,7 @@ const { NODE_FIELDS } = utils;
         const field = NODE_FIELDS[type][fieldName];
         if (field && builderNames.includes(fieldName)) {
           const argName = toBindingIdentifierName(fieldName);
-          output += `\n  validate(defs, node, "${fieldName}", ${argName}${
+          output += `\n  validate(defs.${fieldName}, node, "${fieldName}", ${argName}${
             JSON.stringify(
               stringifyValidator(field.validate, "#node#")
             ).includes("#node#")

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -2,28 +2,41 @@
  * This file is auto-generated! Do not modify it directly.
  * To re-generate run 'make build'
  */
-import validateNode from "../validateNode.ts";
+import * as _validate from "../../validators/validate.ts";
 import type * as t from "../../index.ts";
 import deprecationWarning from "../../utils/deprecationWarning.ts";
+import * as utils from "../../definitions/utils.ts";
+
+const { validateInternal: validate } = _validate;
+const { NODE_FIELDS } = utils;
+
 export function arrayExpression(
   elements: Array<null | t.Expression | t.SpreadElement> = [],
 ): t.ArrayExpression {
-  return validateNode<t.ArrayExpression>({
+  const node: t.ArrayExpression = {
     type: "ArrayExpression",
     elements,
-  });
+  };
+  const defs = NODE_FIELDS.ArrayExpression;
+  validate(defs, node, "elements", elements, 1);
+  return node;
 }
 export function assignmentExpression(
   operator: string,
   left: t.LVal | t.OptionalMemberExpression,
   right: t.Expression,
 ): t.AssignmentExpression {
-  return validateNode<t.AssignmentExpression>({
+  const node: t.AssignmentExpression = {
     type: "AssignmentExpression",
     operator,
     left,
     right,
-  });
+  };
+  const defs = NODE_FIELDS.AssignmentExpression;
+  validate(defs, node, "operator", operator);
+  validate(defs, node, "left", left, 1);
+  validate(defs, node, "right", right, 1);
+  return node;
 }
 export function binaryExpression(
   operator:
@@ -53,58 +66,83 @@ export function binaryExpression(
   left: t.Expression | t.PrivateName,
   right: t.Expression,
 ): t.BinaryExpression {
-  return validateNode<t.BinaryExpression>({
+  const node: t.BinaryExpression = {
     type: "BinaryExpression",
     operator,
     left,
     right,
-  });
+  };
+  const defs = NODE_FIELDS.BinaryExpression;
+  validate(defs, node, "operator", operator);
+  validate(defs, node, "left", left, 1);
+  validate(defs, node, "right", right, 1);
+  return node;
 }
 export function interpreterDirective(value: string): t.InterpreterDirective {
-  return validateNode<t.InterpreterDirective>({
+  const node: t.InterpreterDirective = {
     type: "InterpreterDirective",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.InterpreterDirective;
+  validate(defs, node, "value", value);
+  return node;
 }
 export function directive(value: t.DirectiveLiteral): t.Directive {
-  return validateNode<t.Directive>({
+  const node: t.Directive = {
     type: "Directive",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.Directive;
+  validate(defs, node, "value", value, 1);
+  return node;
 }
 export function directiveLiteral(value: string): t.DirectiveLiteral {
-  return validateNode<t.DirectiveLiteral>({
+  const node: t.DirectiveLiteral = {
     type: "DirectiveLiteral",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.DirectiveLiteral;
+  validate(defs, node, "value", value);
+  return node;
 }
 export function blockStatement(
   body: Array<t.Statement>,
   directives: Array<t.Directive> = [],
 ): t.BlockStatement {
-  return validateNode<t.BlockStatement>({
+  const node: t.BlockStatement = {
     type: "BlockStatement",
     body,
     directives,
-  });
+  };
+  const defs = NODE_FIELDS.BlockStatement;
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "directives", directives, 1);
+  return node;
 }
 export function breakStatement(
   label: t.Identifier | null = null,
 ): t.BreakStatement {
-  return validateNode<t.BreakStatement>({
+  const node: t.BreakStatement = {
     type: "BreakStatement",
     label,
-  });
+  };
+  const defs = NODE_FIELDS.BreakStatement;
+  validate(defs, node, "label", label, 1);
+  return node;
 }
 export function callExpression(
   callee: t.Expression | t.Super | t.V8IntrinsicIdentifier,
   _arguments: Array<t.Expression | t.SpreadElement | t.ArgumentPlaceholder>,
 ): t.CallExpression {
-  return validateNode<t.CallExpression>({
+  const node: t.CallExpression = {
     type: "CallExpression",
     callee,
     arguments: _arguments,
-  });
+  };
+  const defs = NODE_FIELDS.CallExpression;
+  validate(defs, node, "callee", callee, 1);
+  validate(defs, node, "arguments", _arguments, 1);
+  return node;
 }
 export function catchClause(
   param:
@@ -115,31 +153,43 @@ export function catchClause(
     | undefined = null,
   body: t.BlockStatement,
 ): t.CatchClause {
-  return validateNode<t.CatchClause>({
+  const node: t.CatchClause = {
     type: "CatchClause",
     param,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.CatchClause;
+  validate(defs, node, "param", param, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function conditionalExpression(
   test: t.Expression,
   consequent: t.Expression,
   alternate: t.Expression,
 ): t.ConditionalExpression {
-  return validateNode<t.ConditionalExpression>({
+  const node: t.ConditionalExpression = {
     type: "ConditionalExpression",
     test,
     consequent,
     alternate,
-  });
+  };
+  const defs = NODE_FIELDS.ConditionalExpression;
+  validate(defs, node, "test", test, 1);
+  validate(defs, node, "consequent", consequent, 1);
+  validate(defs, node, "alternate", alternate, 1);
+  return node;
 }
 export function continueStatement(
   label: t.Identifier | null = null,
 ): t.ContinueStatement {
-  return validateNode<t.ContinueStatement>({
+  const node: t.ContinueStatement = {
     type: "ContinueStatement",
     label,
-  });
+  };
+  const defs = NODE_FIELDS.ContinueStatement;
+  validate(defs, node, "label", label, 1);
+  return node;
 }
 export function debuggerStatement(): t.DebuggerStatement {
   return {
@@ -150,11 +200,15 @@ export function doWhileStatement(
   test: t.Expression,
   body: t.Statement,
 ): t.DoWhileStatement {
-  return validateNode<t.DoWhileStatement>({
+  const node: t.DoWhileStatement = {
     type: "DoWhileStatement",
     test,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.DoWhileStatement;
+  validate(defs, node, "test", test, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function emptyStatement(): t.EmptyStatement {
   return {
@@ -164,34 +218,47 @@ export function emptyStatement(): t.EmptyStatement {
 export function expressionStatement(
   expression: t.Expression,
 ): t.ExpressionStatement {
-  return validateNode<t.ExpressionStatement>({
+  const node: t.ExpressionStatement = {
     type: "ExpressionStatement",
     expression,
-  });
+  };
+  const defs = NODE_FIELDS.ExpressionStatement;
+  validate(defs, node, "expression", expression, 1);
+  return node;
 }
 export function file(
   program: t.Program,
   comments: Array<t.CommentBlock | t.CommentLine> | null = null,
   tokens: Array<any> | null = null,
 ): t.File {
-  return validateNode<t.File>({
+  const node: t.File = {
     type: "File",
     program,
     comments,
     tokens,
-  });
+  };
+  const defs = NODE_FIELDS.File;
+  validate(defs, node, "program", program, 1);
+  validate(defs, node, "comments", comments, 1);
+  validate(defs, node, "tokens", tokens);
+  return node;
 }
 export function forInStatement(
   left: t.VariableDeclaration | t.LVal,
   right: t.Expression,
   body: t.Statement,
 ): t.ForInStatement {
-  return validateNode<t.ForInStatement>({
+  const node: t.ForInStatement = {
     type: "ForInStatement",
     left,
     right,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.ForInStatement;
+  validate(defs, node, "left", left, 1);
+  validate(defs, node, "right", right, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function forStatement(
   init: t.VariableDeclaration | t.Expression | null | undefined = null,
@@ -199,13 +266,19 @@ export function forStatement(
   update: t.Expression | null | undefined = null,
   body: t.Statement,
 ): t.ForStatement {
-  return validateNode<t.ForStatement>({
+  const node: t.ForStatement = {
     type: "ForStatement",
     init,
     test,
     update,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.ForStatement;
+  validate(defs, node, "init", init, 1);
+  validate(defs, node, "test", test, 1);
+  validate(defs, node, "update", update, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function functionDeclaration(
   id: t.Identifier | null | undefined = null,
@@ -214,14 +287,21 @@ export function functionDeclaration(
   generator: boolean = false,
   async: boolean = false,
 ): t.FunctionDeclaration {
-  return validateNode<t.FunctionDeclaration>({
+  const node: t.FunctionDeclaration = {
     type: "FunctionDeclaration",
     id,
     params,
     body,
     generator,
     async,
-  });
+  };
+  const defs = NODE_FIELDS.FunctionDeclaration;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "params", params, 1);
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "generator", generator);
+  validate(defs, node, "async", async);
+  return node;
 }
 export function functionExpression(
   id: t.Identifier | null | undefined = null,
@@ -230,54 +310,79 @@ export function functionExpression(
   generator: boolean = false,
   async: boolean = false,
 ): t.FunctionExpression {
-  return validateNode<t.FunctionExpression>({
+  const node: t.FunctionExpression = {
     type: "FunctionExpression",
     id,
     params,
     body,
     generator,
     async,
-  });
+  };
+  const defs = NODE_FIELDS.FunctionExpression;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "params", params, 1);
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "generator", generator);
+  validate(defs, node, "async", async);
+  return node;
 }
 export function identifier(name: string): t.Identifier {
-  return validateNode<t.Identifier>({
+  const node: t.Identifier = {
     type: "Identifier",
     name,
-  });
+  };
+  const defs = NODE_FIELDS.Identifier;
+  validate(defs, node, "name", name);
+  return node;
 }
 export function ifStatement(
   test: t.Expression,
   consequent: t.Statement,
   alternate: t.Statement | null = null,
 ): t.IfStatement {
-  return validateNode<t.IfStatement>({
+  const node: t.IfStatement = {
     type: "IfStatement",
     test,
     consequent,
     alternate,
-  });
+  };
+  const defs = NODE_FIELDS.IfStatement;
+  validate(defs, node, "test", test, 1);
+  validate(defs, node, "consequent", consequent, 1);
+  validate(defs, node, "alternate", alternate, 1);
+  return node;
 }
 export function labeledStatement(
   label: t.Identifier,
   body: t.Statement,
 ): t.LabeledStatement {
-  return validateNode<t.LabeledStatement>({
+  const node: t.LabeledStatement = {
     type: "LabeledStatement",
     label,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.LabeledStatement;
+  validate(defs, node, "label", label, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function stringLiteral(value: string): t.StringLiteral {
-  return validateNode<t.StringLiteral>({
+  const node: t.StringLiteral = {
     type: "StringLiteral",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.StringLiteral;
+  validate(defs, node, "value", value);
+  return node;
 }
 export function numericLiteral(value: number): t.NumericLiteral {
-  return validateNode<t.NumericLiteral>({
+  const node: t.NumericLiteral = {
     type: "NumericLiteral",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.NumericLiteral;
+  validate(defs, node, "value", value);
+  return node;
 }
 export function nullLiteral(): t.NullLiteral {
   return {
@@ -285,32 +390,44 @@ export function nullLiteral(): t.NullLiteral {
   };
 }
 export function booleanLiteral(value: boolean): t.BooleanLiteral {
-  return validateNode<t.BooleanLiteral>({
+  const node: t.BooleanLiteral = {
     type: "BooleanLiteral",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.BooleanLiteral;
+  validate(defs, node, "value", value);
+  return node;
 }
 export function regExpLiteral(
   pattern: string,
   flags: string = "",
 ): t.RegExpLiteral {
-  return validateNode<t.RegExpLiteral>({
+  const node: t.RegExpLiteral = {
     type: "RegExpLiteral",
     pattern,
     flags,
-  });
+  };
+  const defs = NODE_FIELDS.RegExpLiteral;
+  validate(defs, node, "pattern", pattern);
+  validate(defs, node, "flags", flags);
+  return node;
 }
 export function logicalExpression(
   operator: "||" | "&&" | "??",
   left: t.Expression,
   right: t.Expression,
 ): t.LogicalExpression {
-  return validateNode<t.LogicalExpression>({
+  const node: t.LogicalExpression = {
     type: "LogicalExpression",
     operator,
     left,
     right,
-  });
+  };
+  const defs = NODE_FIELDS.LogicalExpression;
+  validate(defs, node, "operator", operator);
+  validate(defs, node, "left", left, 1);
+  validate(defs, node, "right", right, 1);
+  return node;
 }
 export function memberExpression(
   object: t.Expression | t.Super,
@@ -318,23 +435,33 @@ export function memberExpression(
   computed: boolean = false,
   optional: boolean | null = null,
 ): t.MemberExpression {
-  return validateNode<t.MemberExpression>({
+  const node: t.MemberExpression = {
     type: "MemberExpression",
     object,
     property,
     computed,
     optional,
-  });
+  };
+  const defs = NODE_FIELDS.MemberExpression;
+  validate(defs, node, "object", object, 1);
+  validate(defs, node, "property", property, 1);
+  validate(defs, node, "computed", computed);
+  validate(defs, node, "optional", optional);
+  return node;
 }
 export function newExpression(
   callee: t.Expression | t.Super | t.V8IntrinsicIdentifier,
   _arguments: Array<t.Expression | t.SpreadElement | t.ArgumentPlaceholder>,
 ): t.NewExpression {
-  return validateNode<t.NewExpression>({
+  const node: t.NewExpression = {
     type: "NewExpression",
     callee,
     arguments: _arguments,
-  });
+  };
+  const defs = NODE_FIELDS.NewExpression;
+  validate(defs, node, "callee", callee, 1);
+  validate(defs, node, "arguments", _arguments, 1);
+  return node;
 }
 export function program(
   body: Array<t.Statement>,
@@ -342,21 +469,30 @@ export function program(
   sourceType: "script" | "module" = "script",
   interpreter: t.InterpreterDirective | null = null,
 ): t.Program {
-  return validateNode<t.Program>({
+  const node: t.Program = {
     type: "Program",
     body,
     directives,
     sourceType,
     interpreter,
-  });
+  };
+  const defs = NODE_FIELDS.Program;
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "directives", directives, 1);
+  validate(defs, node, "sourceType", sourceType);
+  validate(defs, node, "interpreter", interpreter, 1);
+  return node;
 }
 export function objectExpression(
   properties: Array<t.ObjectMethod | t.ObjectProperty | t.SpreadElement>,
 ): t.ObjectExpression {
-  return validateNode<t.ObjectExpression>({
+  const node: t.ObjectExpression = {
     type: "ObjectExpression",
     properties,
-  });
+  };
+  const defs = NODE_FIELDS.ObjectExpression;
+  validate(defs, node, "properties", properties, 1);
+  return node;
 }
 export function objectMethod(
   kind: "method" | "get" | "set" | undefined = "method",
@@ -372,7 +508,7 @@ export function objectMethod(
   generator: boolean = false,
   async: boolean = false,
 ): t.ObjectMethod {
-  return validateNode<t.ObjectMethod>({
+  const node: t.ObjectMethod = {
     type: "ObjectMethod",
     kind,
     key,
@@ -381,7 +517,16 @@ export function objectMethod(
     computed,
     generator,
     async,
-  });
+  };
+  const defs = NODE_FIELDS.ObjectMethod;
+  validate(defs, node, "kind", kind);
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "params", params, 1);
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "computed", computed);
+  validate(defs, node, "generator", generator);
+  validate(defs, node, "async", async);
+  return node;
 }
 export function objectProperty(
   key:
@@ -397,64 +542,91 @@ export function objectProperty(
   shorthand: boolean = false,
   decorators: Array<t.Decorator> | null = null,
 ): t.ObjectProperty {
-  return validateNode<t.ObjectProperty>({
+  const node: t.ObjectProperty = {
     type: "ObjectProperty",
     key,
     value,
     computed,
     shorthand,
     decorators,
-  });
+  };
+  const defs = NODE_FIELDS.ObjectProperty;
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "value", value, 1);
+  validate(defs, node, "computed", computed);
+  validate(defs, node, "shorthand", shorthand);
+  validate(defs, node, "decorators", decorators, 1);
+  return node;
 }
 export function restElement(argument: t.LVal): t.RestElement {
-  return validateNode<t.RestElement>({
+  const node: t.RestElement = {
     type: "RestElement",
     argument,
-  });
+  };
+  const defs = NODE_FIELDS.RestElement;
+  validate(defs, node, "argument", argument, 1);
+  return node;
 }
 export function returnStatement(
   argument: t.Expression | null = null,
 ): t.ReturnStatement {
-  return validateNode<t.ReturnStatement>({
+  const node: t.ReturnStatement = {
     type: "ReturnStatement",
     argument,
-  });
+  };
+  const defs = NODE_FIELDS.ReturnStatement;
+  validate(defs, node, "argument", argument, 1);
+  return node;
 }
 export function sequenceExpression(
   expressions: Array<t.Expression>,
 ): t.SequenceExpression {
-  return validateNode<t.SequenceExpression>({
+  const node: t.SequenceExpression = {
     type: "SequenceExpression",
     expressions,
-  });
+  };
+  const defs = NODE_FIELDS.SequenceExpression;
+  validate(defs, node, "expressions", expressions, 1);
+  return node;
 }
 export function parenthesizedExpression(
   expression: t.Expression,
 ): t.ParenthesizedExpression {
-  return validateNode<t.ParenthesizedExpression>({
+  const node: t.ParenthesizedExpression = {
     type: "ParenthesizedExpression",
     expression,
-  });
+  };
+  const defs = NODE_FIELDS.ParenthesizedExpression;
+  validate(defs, node, "expression", expression, 1);
+  return node;
 }
 export function switchCase(
   test: t.Expression | null | undefined = null,
   consequent: Array<t.Statement>,
 ): t.SwitchCase {
-  return validateNode<t.SwitchCase>({
+  const node: t.SwitchCase = {
     type: "SwitchCase",
     test,
     consequent,
-  });
+  };
+  const defs = NODE_FIELDS.SwitchCase;
+  validate(defs, node, "test", test, 1);
+  validate(defs, node, "consequent", consequent, 1);
+  return node;
 }
 export function switchStatement(
   discriminant: t.Expression,
   cases: Array<t.SwitchCase>,
 ): t.SwitchStatement {
-  return validateNode<t.SwitchStatement>({
+  const node: t.SwitchStatement = {
     type: "SwitchStatement",
     discriminant,
     cases,
-  });
+  };
+  const defs = NODE_FIELDS.SwitchStatement;
+  validate(defs, node, "discriminant", discriminant, 1);
+  validate(defs, node, "cases", cases, 1);
+  return node;
 }
 export function thisExpression(): t.ThisExpression {
   return {
@@ -462,86 +634,120 @@ export function thisExpression(): t.ThisExpression {
   };
 }
 export function throwStatement(argument: t.Expression): t.ThrowStatement {
-  return validateNode<t.ThrowStatement>({
+  const node: t.ThrowStatement = {
     type: "ThrowStatement",
     argument,
-  });
+  };
+  const defs = NODE_FIELDS.ThrowStatement;
+  validate(defs, node, "argument", argument, 1);
+  return node;
 }
 export function tryStatement(
   block: t.BlockStatement,
   handler: t.CatchClause | null = null,
   finalizer: t.BlockStatement | null = null,
 ): t.TryStatement {
-  return validateNode<t.TryStatement>({
+  const node: t.TryStatement = {
     type: "TryStatement",
     block,
     handler,
     finalizer,
-  });
+  };
+  const defs = NODE_FIELDS.TryStatement;
+  validate(defs, node, "block", block, 1);
+  validate(defs, node, "handler", handler, 1);
+  validate(defs, node, "finalizer", finalizer, 1);
+  return node;
 }
 export function unaryExpression(
   operator: "void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof",
   argument: t.Expression,
   prefix: boolean = true,
 ): t.UnaryExpression {
-  return validateNode<t.UnaryExpression>({
+  const node: t.UnaryExpression = {
     type: "UnaryExpression",
     operator,
     argument,
     prefix,
-  });
+  };
+  const defs = NODE_FIELDS.UnaryExpression;
+  validate(defs, node, "operator", operator);
+  validate(defs, node, "argument", argument, 1);
+  validate(defs, node, "prefix", prefix);
+  return node;
 }
 export function updateExpression(
   operator: "++" | "--",
   argument: t.Expression,
   prefix: boolean = false,
 ): t.UpdateExpression {
-  return validateNode<t.UpdateExpression>({
+  const node: t.UpdateExpression = {
     type: "UpdateExpression",
     operator,
     argument,
     prefix,
-  });
+  };
+  const defs = NODE_FIELDS.UpdateExpression;
+  validate(defs, node, "operator", operator);
+  validate(defs, node, "argument", argument, 1);
+  validate(defs, node, "prefix", prefix);
+  return node;
 }
 export function variableDeclaration(
   kind: "var" | "let" | "const" | "using" | "await using",
   declarations: Array<t.VariableDeclarator>,
 ): t.VariableDeclaration {
-  return validateNode<t.VariableDeclaration>({
+  const node: t.VariableDeclaration = {
     type: "VariableDeclaration",
     kind,
     declarations,
-  });
+  };
+  const defs = NODE_FIELDS.VariableDeclaration;
+  validate(defs, node, "kind", kind);
+  validate(defs, node, "declarations", declarations, 1);
+  return node;
 }
 export function variableDeclarator(
   id: t.LVal,
   init: t.Expression | null = null,
 ): t.VariableDeclarator {
-  return validateNode<t.VariableDeclarator>({
+  const node: t.VariableDeclarator = {
     type: "VariableDeclarator",
     id,
     init,
-  });
+  };
+  const defs = NODE_FIELDS.VariableDeclarator;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "init", init, 1);
+  return node;
 }
 export function whileStatement(
   test: t.Expression,
   body: t.Statement,
 ): t.WhileStatement {
-  return validateNode<t.WhileStatement>({
+  const node: t.WhileStatement = {
     type: "WhileStatement",
     test,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.WhileStatement;
+  validate(defs, node, "test", test, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function withStatement(
   object: t.Expression,
   body: t.Statement,
 ): t.WithStatement {
-  return validateNode<t.WithStatement>({
+  const node: t.WithStatement = {
     type: "WithStatement",
     object,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.WithStatement;
+  validate(defs, node, "object", object, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function assignmentPattern(
   left:
@@ -555,32 +761,44 @@ export function assignmentPattern(
     | t.TSNonNullExpression,
   right: t.Expression,
 ): t.AssignmentPattern {
-  return validateNode<t.AssignmentPattern>({
+  const node: t.AssignmentPattern = {
     type: "AssignmentPattern",
     left,
     right,
-  });
+  };
+  const defs = NODE_FIELDS.AssignmentPattern;
+  validate(defs, node, "left", left, 1);
+  validate(defs, node, "right", right, 1);
+  return node;
 }
 export function arrayPattern(
   elements: Array<null | t.PatternLike | t.LVal>,
 ): t.ArrayPattern {
-  return validateNode<t.ArrayPattern>({
+  const node: t.ArrayPattern = {
     type: "ArrayPattern",
     elements,
-  });
+  };
+  const defs = NODE_FIELDS.ArrayPattern;
+  validate(defs, node, "elements", elements, 1);
+  return node;
 }
 export function arrowFunctionExpression(
   params: Array<t.Identifier | t.Pattern | t.RestElement>,
   body: t.BlockStatement | t.Expression,
   async: boolean = false,
 ): t.ArrowFunctionExpression {
-  return validateNode<t.ArrowFunctionExpression>({
+  const node: t.ArrowFunctionExpression = {
     type: "ArrowFunctionExpression",
     params,
     body,
     async,
     expression: null,
-  });
+  };
+  const defs = NODE_FIELDS.ArrowFunctionExpression;
+  validate(defs, node, "params", params, 1);
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "async", async);
+  return node;
 }
 export function classBody(
   body: Array<
@@ -594,10 +812,13 @@ export function classBody(
     | t.StaticBlock
   >,
 ): t.ClassBody {
-  return validateNode<t.ClassBody>({
+  const node: t.ClassBody = {
     type: "ClassBody",
     body,
-  });
+  };
+  const defs = NODE_FIELDS.ClassBody;
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function classExpression(
   id: t.Identifier | null | undefined = null,
@@ -605,13 +826,19 @@ export function classExpression(
   body: t.ClassBody,
   decorators: Array<t.Decorator> | null = null,
 ): t.ClassExpression {
-  return validateNode<t.ClassExpression>({
+  const node: t.ClassExpression = {
     type: "ClassExpression",
     id,
     superClass,
     body,
     decorators,
-  });
+  };
+  const defs = NODE_FIELDS.ClassExpression;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "superClass", superClass, 1);
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "decorators", decorators, 1);
+  return node;
 }
 export function classDeclaration(
   id: t.Identifier | null | undefined = null,
@@ -619,21 +846,30 @@ export function classDeclaration(
   body: t.ClassBody,
   decorators: Array<t.Decorator> | null = null,
 ): t.ClassDeclaration {
-  return validateNode<t.ClassDeclaration>({
+  const node: t.ClassDeclaration = {
     type: "ClassDeclaration",
     id,
     superClass,
     body,
     decorators,
-  });
+  };
+  const defs = NODE_FIELDS.ClassDeclaration;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "superClass", superClass, 1);
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "decorators", decorators, 1);
+  return node;
 }
 export function exportAllDeclaration(
   source: t.StringLiteral,
 ): t.ExportAllDeclaration {
-  return validateNode<t.ExportAllDeclaration>({
+  const node: t.ExportAllDeclaration = {
     type: "ExportAllDeclaration",
     source,
-  });
+  };
+  const defs = NODE_FIELDS.ExportAllDeclaration;
+  validate(defs, node, "source", source, 1);
+  return node;
 }
 export function exportDefaultDeclaration(
   declaration:
@@ -642,10 +878,13 @@ export function exportDefaultDeclaration(
     | t.ClassDeclaration
     | t.Expression,
 ): t.ExportDefaultDeclaration {
-  return validateNode<t.ExportDefaultDeclaration>({
+  const node: t.ExportDefaultDeclaration = {
     type: "ExportDefaultDeclaration",
     declaration,
-  });
+  };
+  const defs = NODE_FIELDS.ExportDefaultDeclaration;
+  validate(defs, node, "declaration", declaration, 1);
+  return node;
 }
 export function exportNamedDeclaration(
   declaration: t.Declaration | null = null,
@@ -654,22 +893,31 @@ export function exportNamedDeclaration(
   > = [],
   source: t.StringLiteral | null = null,
 ): t.ExportNamedDeclaration {
-  return validateNode<t.ExportNamedDeclaration>({
+  const node: t.ExportNamedDeclaration = {
     type: "ExportNamedDeclaration",
     declaration,
     specifiers,
     source,
-  });
+  };
+  const defs = NODE_FIELDS.ExportNamedDeclaration;
+  validate(defs, node, "declaration", declaration, 1);
+  validate(defs, node, "specifiers", specifiers, 1);
+  validate(defs, node, "source", source, 1);
+  return node;
 }
 export function exportSpecifier(
   local: t.Identifier,
   exported: t.Identifier | t.StringLiteral,
 ): t.ExportSpecifier {
-  return validateNode<t.ExportSpecifier>({
+  const node: t.ExportSpecifier = {
     type: "ExportSpecifier",
     local,
     exported,
-  });
+  };
+  const defs = NODE_FIELDS.ExportSpecifier;
+  validate(defs, node, "local", local, 1);
+  validate(defs, node, "exported", exported, 1);
+  return node;
 }
 export function forOfStatement(
   left: t.VariableDeclaration | t.LVal,
@@ -677,13 +925,19 @@ export function forOfStatement(
   body: t.Statement,
   _await: boolean = false,
 ): t.ForOfStatement {
-  return validateNode<t.ForOfStatement>({
+  const node: t.ForOfStatement = {
     type: "ForOfStatement",
     left,
     right,
     body,
     await: _await,
-  });
+  };
+  const defs = NODE_FIELDS.ForOfStatement;
+  validate(defs, node, "left", left, 1);
+  validate(defs, node, "right", right, 1);
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "await", _await);
+  return node;
 }
 export function importDeclaration(
   specifiers: Array<
@@ -691,57 +945,79 @@ export function importDeclaration(
   >,
   source: t.StringLiteral,
 ): t.ImportDeclaration {
-  return validateNode<t.ImportDeclaration>({
+  const node: t.ImportDeclaration = {
     type: "ImportDeclaration",
     specifiers,
     source,
-  });
+  };
+  const defs = NODE_FIELDS.ImportDeclaration;
+  validate(defs, node, "specifiers", specifiers, 1);
+  validate(defs, node, "source", source, 1);
+  return node;
 }
 export function importDefaultSpecifier(
   local: t.Identifier,
 ): t.ImportDefaultSpecifier {
-  return validateNode<t.ImportDefaultSpecifier>({
+  const node: t.ImportDefaultSpecifier = {
     type: "ImportDefaultSpecifier",
     local,
-  });
+  };
+  const defs = NODE_FIELDS.ImportDefaultSpecifier;
+  validate(defs, node, "local", local, 1);
+  return node;
 }
 export function importNamespaceSpecifier(
   local: t.Identifier,
 ): t.ImportNamespaceSpecifier {
-  return validateNode<t.ImportNamespaceSpecifier>({
+  const node: t.ImportNamespaceSpecifier = {
     type: "ImportNamespaceSpecifier",
     local,
-  });
+  };
+  const defs = NODE_FIELDS.ImportNamespaceSpecifier;
+  validate(defs, node, "local", local, 1);
+  return node;
 }
 export function importSpecifier(
   local: t.Identifier,
   imported: t.Identifier | t.StringLiteral,
 ): t.ImportSpecifier {
-  return validateNode<t.ImportSpecifier>({
+  const node: t.ImportSpecifier = {
     type: "ImportSpecifier",
     local,
     imported,
-  });
+  };
+  const defs = NODE_FIELDS.ImportSpecifier;
+  validate(defs, node, "local", local, 1);
+  validate(defs, node, "imported", imported, 1);
+  return node;
 }
 export function importExpression(
   source: t.Expression,
   options: t.Expression | null = null,
 ): t.ImportExpression {
-  return validateNode<t.ImportExpression>({
+  const node: t.ImportExpression = {
     type: "ImportExpression",
     source,
     options,
-  });
+  };
+  const defs = NODE_FIELDS.ImportExpression;
+  validate(defs, node, "source", source, 1);
+  validate(defs, node, "options", options, 1);
+  return node;
 }
 export function metaProperty(
   meta: t.Identifier,
   property: t.Identifier,
 ): t.MetaProperty {
-  return validateNode<t.MetaProperty>({
+  const node: t.MetaProperty = {
     type: "MetaProperty",
     meta,
     property,
-  });
+  };
+  const defs = NODE_FIELDS.MetaProperty;
+  validate(defs, node, "meta", meta, 1);
+  validate(defs, node, "property", property, 1);
+  return node;
 }
 export function classMethod(
   kind: "get" | "set" | "method" | "constructor" | undefined = "method",
@@ -760,7 +1036,7 @@ export function classMethod(
   generator: boolean = false,
   async: boolean = false,
 ): t.ClassMethod {
-  return validateNode<t.ClassMethod>({
+  const node: t.ClassMethod = {
     type: "ClassMethod",
     kind,
     key,
@@ -770,21 +1046,37 @@ export function classMethod(
     static: _static,
     generator,
     async,
-  });
+  };
+  const defs = NODE_FIELDS.ClassMethod;
+  validate(defs, node, "kind", kind);
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "params", params, 1);
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "computed", computed);
+  validate(defs, node, "static", _static);
+  validate(defs, node, "generator", generator);
+  validate(defs, node, "async", async);
+  return node;
 }
 export function objectPattern(
   properties: Array<t.RestElement | t.ObjectProperty>,
 ): t.ObjectPattern {
-  return validateNode<t.ObjectPattern>({
+  const node: t.ObjectPattern = {
     type: "ObjectPattern",
     properties,
-  });
+  };
+  const defs = NODE_FIELDS.ObjectPattern;
+  validate(defs, node, "properties", properties, 1);
+  return node;
 }
 export function spreadElement(argument: t.Expression): t.SpreadElement {
-  return validateNode<t.SpreadElement>({
+  const node: t.SpreadElement = {
     type: "SpreadElement",
     argument,
-  });
+  };
+  const defs = NODE_FIELDS.SpreadElement;
+  validate(defs, node, "argument", argument, 1);
+  return node;
 }
 function _super(): t.Super {
   return {
@@ -796,47 +1088,66 @@ export function taggedTemplateExpression(
   tag: t.Expression,
   quasi: t.TemplateLiteral,
 ): t.TaggedTemplateExpression {
-  return validateNode<t.TaggedTemplateExpression>({
+  const node: t.TaggedTemplateExpression = {
     type: "TaggedTemplateExpression",
     tag,
     quasi,
-  });
+  };
+  const defs = NODE_FIELDS.TaggedTemplateExpression;
+  validate(defs, node, "tag", tag, 1);
+  validate(defs, node, "quasi", quasi, 1);
+  return node;
 }
 export function templateElement(
   value: { raw: string; cooked?: string },
   tail: boolean = false,
 ): t.TemplateElement {
-  return validateNode<t.TemplateElement>({
+  const node: t.TemplateElement = {
     type: "TemplateElement",
     value,
     tail,
-  });
+  };
+  const defs = NODE_FIELDS.TemplateElement;
+  validate(defs, node, "value", value);
+  validate(defs, node, "tail", tail);
+  return node;
 }
 export function templateLiteral(
   quasis: Array<t.TemplateElement>,
   expressions: Array<t.Expression | t.TSType>,
 ): t.TemplateLiteral {
-  return validateNode<t.TemplateLiteral>({
+  const node: t.TemplateLiteral = {
     type: "TemplateLiteral",
     quasis,
     expressions,
-  });
+  };
+  const defs = NODE_FIELDS.TemplateLiteral;
+  validate(defs, node, "quasis", quasis, 1);
+  validate(defs, node, "expressions", expressions, 1);
+  return node;
 }
 export function yieldExpression(
   argument: t.Expression | null = null,
   delegate: boolean = false,
 ): t.YieldExpression {
-  return validateNode<t.YieldExpression>({
+  const node: t.YieldExpression = {
     type: "YieldExpression",
     argument,
     delegate,
-  });
+  };
+  const defs = NODE_FIELDS.YieldExpression;
+  validate(defs, node, "argument", argument, 1);
+  validate(defs, node, "delegate", delegate);
+  return node;
 }
 export function awaitExpression(argument: t.Expression): t.AwaitExpression {
-  return validateNode<t.AwaitExpression>({
+  const node: t.AwaitExpression = {
     type: "AwaitExpression",
     argument,
-  });
+  };
+  const defs = NODE_FIELDS.AwaitExpression;
+  validate(defs, node, "argument", argument, 1);
+  return node;
 }
 function _import(): t.Import {
   return {
@@ -845,18 +1156,24 @@ function _import(): t.Import {
 }
 export { _import as import };
 export function bigIntLiteral(value: string): t.BigIntLiteral {
-  return validateNode<t.BigIntLiteral>({
+  const node: t.BigIntLiteral = {
     type: "BigIntLiteral",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.BigIntLiteral;
+  validate(defs, node, "value", value);
+  return node;
 }
 export function exportNamespaceSpecifier(
   exported: t.Identifier,
 ): t.ExportNamespaceSpecifier {
-  return validateNode<t.ExportNamespaceSpecifier>({
+  const node: t.ExportNamespaceSpecifier = {
     type: "ExportNamespaceSpecifier",
     exported,
-  });
+  };
+  const defs = NODE_FIELDS.ExportNamespaceSpecifier;
+  validate(defs, node, "exported", exported, 1);
+  return node;
 }
 export function optionalMemberExpression(
   object: t.Expression,
@@ -864,25 +1181,36 @@ export function optionalMemberExpression(
   computed: boolean | undefined = false,
   optional: boolean,
 ): t.OptionalMemberExpression {
-  return validateNode<t.OptionalMemberExpression>({
+  const node: t.OptionalMemberExpression = {
     type: "OptionalMemberExpression",
     object,
     property,
     computed,
     optional,
-  });
+  };
+  const defs = NODE_FIELDS.OptionalMemberExpression;
+  validate(defs, node, "object", object, 1);
+  validate(defs, node, "property", property, 1);
+  validate(defs, node, "computed", computed);
+  validate(defs, node, "optional", optional);
+  return node;
 }
 export function optionalCallExpression(
   callee: t.Expression,
   _arguments: Array<t.Expression | t.SpreadElement | t.ArgumentPlaceholder>,
   optional: boolean,
 ): t.OptionalCallExpression {
-  return validateNode<t.OptionalCallExpression>({
+  const node: t.OptionalCallExpression = {
     type: "OptionalCallExpression",
     callee,
     arguments: _arguments,
     optional,
-  });
+  };
+  const defs = NODE_FIELDS.OptionalCallExpression;
+  validate(defs, node, "callee", callee, 1);
+  validate(defs, node, "arguments", _arguments, 1);
+  validate(defs, node, "optional", optional);
+  return node;
 }
 export function classProperty(
   key:
@@ -897,7 +1225,7 @@ export function classProperty(
   computed: boolean = false,
   _static: boolean = false,
 ): t.ClassProperty {
-  return validateNode<t.ClassProperty>({
+  const node: t.ClassProperty = {
     type: "ClassProperty",
     key,
     value,
@@ -905,7 +1233,15 @@ export function classProperty(
     decorators,
     computed,
     static: _static,
-  });
+  };
+  const defs = NODE_FIELDS.ClassProperty;
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "value", value, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs, node, "decorators", decorators, 1);
+  validate(defs, node, "computed", computed);
+  validate(defs, node, "static", _static);
+  return node;
 }
 export function classAccessorProperty(
   key:
@@ -921,7 +1257,7 @@ export function classAccessorProperty(
   computed: boolean = false,
   _static: boolean = false,
 ): t.ClassAccessorProperty {
-  return validateNode<t.ClassAccessorProperty>({
+  const node: t.ClassAccessorProperty = {
     type: "ClassAccessorProperty",
     key,
     value,
@@ -929,7 +1265,15 @@ export function classAccessorProperty(
     decorators,
     computed,
     static: _static,
-  });
+  };
+  const defs = NODE_FIELDS.ClassAccessorProperty;
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "value", value, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs, node, "decorators", decorators, 1);
+  validate(defs, node, "computed", computed);
+  validate(defs, node, "static", _static);
+  return node;
 }
 export function classPrivateProperty(
   key: t.PrivateName,
@@ -937,13 +1281,19 @@ export function classPrivateProperty(
   decorators: Array<t.Decorator> | null = null,
   _static: boolean = false,
 ): t.ClassPrivateProperty {
-  return validateNode<t.ClassPrivateProperty>({
+  const node: t.ClassPrivateProperty = {
     type: "ClassPrivateProperty",
     key,
     value,
     decorators,
     static: _static,
-  });
+  };
+  const defs = NODE_FIELDS.ClassPrivateProperty;
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "value", value, 1);
+  validate(defs, node, "decorators", decorators, 1);
+  validate(defs, node, "static", _static);
+  return node;
 }
 export function classPrivateMethod(
   kind: "get" | "set" | "method" | undefined = "method",
@@ -954,26 +1304,39 @@ export function classPrivateMethod(
   body: t.BlockStatement,
   _static: boolean = false,
 ): t.ClassPrivateMethod {
-  return validateNode<t.ClassPrivateMethod>({
+  const node: t.ClassPrivateMethod = {
     type: "ClassPrivateMethod",
     kind,
     key,
     params,
     body,
     static: _static,
-  });
+  };
+  const defs = NODE_FIELDS.ClassPrivateMethod;
+  validate(defs, node, "kind", kind);
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "params", params, 1);
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "static", _static);
+  return node;
 }
 export function privateName(id: t.Identifier): t.PrivateName {
-  return validateNode<t.PrivateName>({
+  const node: t.PrivateName = {
     type: "PrivateName",
     id,
-  });
+  };
+  const defs = NODE_FIELDS.PrivateName;
+  validate(defs, node, "id", id, 1);
+  return node;
 }
 export function staticBlock(body: Array<t.Statement>): t.StaticBlock {
-  return validateNode<t.StaticBlock>({
+  const node: t.StaticBlock = {
     type: "StaticBlock",
     body,
-  });
+  };
+  const defs = NODE_FIELDS.StaticBlock;
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function anyTypeAnnotation(): t.AnyTypeAnnotation {
   return {
@@ -983,10 +1346,13 @@ export function anyTypeAnnotation(): t.AnyTypeAnnotation {
 export function arrayTypeAnnotation(
   elementType: t.FlowType,
 ): t.ArrayTypeAnnotation {
-  return validateNode<t.ArrayTypeAnnotation>({
+  const node: t.ArrayTypeAnnotation = {
     type: "ArrayTypeAnnotation",
     elementType,
-  });
+  };
+  const defs = NODE_FIELDS.ArrayTypeAnnotation;
+  validate(defs, node, "elementType", elementType, 1);
+  return node;
 }
 export function booleanTypeAnnotation(): t.BooleanTypeAnnotation {
   return {
@@ -996,10 +1362,13 @@ export function booleanTypeAnnotation(): t.BooleanTypeAnnotation {
 export function booleanLiteralTypeAnnotation(
   value: boolean,
 ): t.BooleanLiteralTypeAnnotation {
-  return validateNode<t.BooleanLiteralTypeAnnotation>({
+  const node: t.BooleanLiteralTypeAnnotation = {
     type: "BooleanLiteralTypeAnnotation",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.BooleanLiteralTypeAnnotation;
+  validate(defs, node, "value", value);
+  return node;
 }
 export function nullLiteralTypeAnnotation(): t.NullLiteralTypeAnnotation {
   return {
@@ -1010,11 +1379,15 @@ export function classImplements(
   id: t.Identifier,
   typeParameters: t.TypeParameterInstantiation | null = null,
 ): t.ClassImplements {
-  return validateNode<t.ClassImplements>({
+  const node: t.ClassImplements = {
     type: "ClassImplements",
     id,
     typeParameters,
-  });
+  };
+  const defs = NODE_FIELDS.ClassImplements;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  return node;
 }
 export function declareClass(
   id: t.Identifier,
@@ -1022,19 +1395,28 @@ export function declareClass(
   _extends: Array<t.InterfaceExtends> | null | undefined = null,
   body: t.ObjectTypeAnnotation,
 ): t.DeclareClass {
-  return validateNode<t.DeclareClass>({
+  const node: t.DeclareClass = {
     type: "DeclareClass",
     id,
     typeParameters,
     extends: _extends,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.DeclareClass;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "extends", _extends, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function declareFunction(id: t.Identifier): t.DeclareFunction {
-  return validateNode<t.DeclareFunction>({
+  const node: t.DeclareFunction = {
     type: "DeclareFunction",
     id,
-  });
+  };
+  const defs = NODE_FIELDS.DeclareFunction;
+  validate(defs, node, "id", id, 1);
+  return node;
 }
 export function declareInterface(
   id: t.Identifier,
@@ -1042,63 +1424,90 @@ export function declareInterface(
   _extends: Array<t.InterfaceExtends> | null | undefined = null,
   body: t.ObjectTypeAnnotation,
 ): t.DeclareInterface {
-  return validateNode<t.DeclareInterface>({
+  const node: t.DeclareInterface = {
     type: "DeclareInterface",
     id,
     typeParameters,
     extends: _extends,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.DeclareInterface;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "extends", _extends, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function declareModule(
   id: t.Identifier | t.StringLiteral,
   body: t.BlockStatement,
   kind: "CommonJS" | "ES" | null = null,
 ): t.DeclareModule {
-  return validateNode<t.DeclareModule>({
+  const node: t.DeclareModule = {
     type: "DeclareModule",
     id,
     body,
     kind,
-  });
+  };
+  const defs = NODE_FIELDS.DeclareModule;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "kind", kind);
+  return node;
 }
 export function declareModuleExports(
   typeAnnotation: t.TypeAnnotation,
 ): t.DeclareModuleExports {
-  return validateNode<t.DeclareModuleExports>({
+  const node: t.DeclareModuleExports = {
     type: "DeclareModuleExports",
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.DeclareModuleExports;
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export function declareTypeAlias(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined = null,
   right: t.FlowType,
 ): t.DeclareTypeAlias {
-  return validateNode<t.DeclareTypeAlias>({
+  const node: t.DeclareTypeAlias = {
     type: "DeclareTypeAlias",
     id,
     typeParameters,
     right,
-  });
+  };
+  const defs = NODE_FIELDS.DeclareTypeAlias;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "right", right, 1);
+  return node;
 }
 export function declareOpaqueType(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null = null,
   supertype: t.FlowType | null = null,
 ): t.DeclareOpaqueType {
-  return validateNode<t.DeclareOpaqueType>({
+  const node: t.DeclareOpaqueType = {
     type: "DeclareOpaqueType",
     id,
     typeParameters,
     supertype,
-  });
+  };
+  const defs = NODE_FIELDS.DeclareOpaqueType;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "supertype", supertype, 1);
+  return node;
 }
 export function declareVariable(id: t.Identifier): t.DeclareVariable {
-  return validateNode<t.DeclareVariable>({
+  const node: t.DeclareVariable = {
     type: "DeclareVariable",
     id,
-  });
+  };
+  const defs = NODE_FIELDS.DeclareVariable;
+  validate(defs, node, "id", id, 1);
+  return node;
 }
 export function declareExportDeclaration(
   declaration: t.Flow | null = null,
@@ -1107,26 +1516,37 @@ export function declareExportDeclaration(
   > | null = null,
   source: t.StringLiteral | null = null,
 ): t.DeclareExportDeclaration {
-  return validateNode<t.DeclareExportDeclaration>({
+  const node: t.DeclareExportDeclaration = {
     type: "DeclareExportDeclaration",
     declaration,
     specifiers,
     source,
-  });
+  };
+  const defs = NODE_FIELDS.DeclareExportDeclaration;
+  validate(defs, node, "declaration", declaration, 1);
+  validate(defs, node, "specifiers", specifiers, 1);
+  validate(defs, node, "source", source, 1);
+  return node;
 }
 export function declareExportAllDeclaration(
   source: t.StringLiteral,
 ): t.DeclareExportAllDeclaration {
-  return validateNode<t.DeclareExportAllDeclaration>({
+  const node: t.DeclareExportAllDeclaration = {
     type: "DeclareExportAllDeclaration",
     source,
-  });
+  };
+  const defs = NODE_FIELDS.DeclareExportAllDeclaration;
+  validate(defs, node, "source", source, 1);
+  return node;
 }
 export function declaredPredicate(value: t.Flow): t.DeclaredPredicate {
-  return validateNode<t.DeclaredPredicate>({
+  const node: t.DeclaredPredicate = {
     type: "DeclaredPredicate",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.DeclaredPredicate;
+  validate(defs, node, "value", value, 1);
+  return node;
 }
 export function existsTypeAnnotation(): t.ExistsTypeAnnotation {
   return {
@@ -1139,33 +1559,47 @@ export function functionTypeAnnotation(
   rest: t.FunctionTypeParam | null | undefined = null,
   returnType: t.FlowType,
 ): t.FunctionTypeAnnotation {
-  return validateNode<t.FunctionTypeAnnotation>({
+  const node: t.FunctionTypeAnnotation = {
     type: "FunctionTypeAnnotation",
     typeParameters,
     params,
     rest,
     returnType,
-  });
+  };
+  const defs = NODE_FIELDS.FunctionTypeAnnotation;
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "params", params, 1);
+  validate(defs, node, "rest", rest, 1);
+  validate(defs, node, "returnType", returnType, 1);
+  return node;
 }
 export function functionTypeParam(
   name: t.Identifier | null | undefined = null,
   typeAnnotation: t.FlowType,
 ): t.FunctionTypeParam {
-  return validateNode<t.FunctionTypeParam>({
+  const node: t.FunctionTypeParam = {
     type: "FunctionTypeParam",
     name,
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.FunctionTypeParam;
+  validate(defs, node, "name", name, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export function genericTypeAnnotation(
   id: t.Identifier | t.QualifiedTypeIdentifier,
   typeParameters: t.TypeParameterInstantiation | null = null,
 ): t.GenericTypeAnnotation {
-  return validateNode<t.GenericTypeAnnotation>({
+  const node: t.GenericTypeAnnotation = {
     type: "GenericTypeAnnotation",
     id,
     typeParameters,
-  });
+  };
+  const defs = NODE_FIELDS.GenericTypeAnnotation;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  return node;
 }
 export function inferredPredicate(): t.InferredPredicate {
   return {
@@ -1176,11 +1610,15 @@ export function interfaceExtends(
   id: t.Identifier | t.QualifiedTypeIdentifier,
   typeParameters: t.TypeParameterInstantiation | null = null,
 ): t.InterfaceExtends {
-  return validateNode<t.InterfaceExtends>({
+  const node: t.InterfaceExtends = {
     type: "InterfaceExtends",
     id,
     typeParameters,
-  });
+  };
+  const defs = NODE_FIELDS.InterfaceExtends;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  return node;
 }
 export function interfaceDeclaration(
   id: t.Identifier,
@@ -1188,31 +1626,44 @@ export function interfaceDeclaration(
   _extends: Array<t.InterfaceExtends> | null | undefined = null,
   body: t.ObjectTypeAnnotation,
 ): t.InterfaceDeclaration {
-  return validateNode<t.InterfaceDeclaration>({
+  const node: t.InterfaceDeclaration = {
     type: "InterfaceDeclaration",
     id,
     typeParameters,
     extends: _extends,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.InterfaceDeclaration;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "extends", _extends, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function interfaceTypeAnnotation(
   _extends: Array<t.InterfaceExtends> | null | undefined = null,
   body: t.ObjectTypeAnnotation,
 ): t.InterfaceTypeAnnotation {
-  return validateNode<t.InterfaceTypeAnnotation>({
+  const node: t.InterfaceTypeAnnotation = {
     type: "InterfaceTypeAnnotation",
     extends: _extends,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.InterfaceTypeAnnotation;
+  validate(defs, node, "extends", _extends, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function intersectionTypeAnnotation(
   types: Array<t.FlowType>,
 ): t.IntersectionTypeAnnotation {
-  return validateNode<t.IntersectionTypeAnnotation>({
+  const node: t.IntersectionTypeAnnotation = {
     type: "IntersectionTypeAnnotation",
     types,
-  });
+  };
+  const defs = NODE_FIELDS.IntersectionTypeAnnotation;
+  validate(defs, node, "types", types, 1);
+  return node;
 }
 export function mixedTypeAnnotation(): t.MixedTypeAnnotation {
   return {
@@ -1227,18 +1678,24 @@ export function emptyTypeAnnotation(): t.EmptyTypeAnnotation {
 export function nullableTypeAnnotation(
   typeAnnotation: t.FlowType,
 ): t.NullableTypeAnnotation {
-  return validateNode<t.NullableTypeAnnotation>({
+  const node: t.NullableTypeAnnotation = {
     type: "NullableTypeAnnotation",
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.NullableTypeAnnotation;
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export function numberLiteralTypeAnnotation(
   value: number,
 ): t.NumberLiteralTypeAnnotation {
-  return validateNode<t.NumberLiteralTypeAnnotation>({
+  const node: t.NumberLiteralTypeAnnotation = {
     type: "NumberLiteralTypeAnnotation",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.NumberLiteralTypeAnnotation;
+  validate(defs, node, "value", value);
+  return node;
 }
 export function numberTypeAnnotation(): t.NumberTypeAnnotation {
   return {
@@ -1252,14 +1709,21 @@ export function objectTypeAnnotation(
   internalSlots: Array<t.ObjectTypeInternalSlot> = [],
   exact: boolean = false,
 ): t.ObjectTypeAnnotation {
-  return validateNode<t.ObjectTypeAnnotation>({
+  const node: t.ObjectTypeAnnotation = {
     type: "ObjectTypeAnnotation",
     properties,
     indexers,
     callProperties,
     internalSlots,
     exact,
-  });
+  };
+  const defs = NODE_FIELDS.ObjectTypeAnnotation;
+  validate(defs, node, "properties", properties, 1);
+  validate(defs, node, "indexers", indexers, 1);
+  validate(defs, node, "callProperties", callProperties, 1);
+  validate(defs, node, "internalSlots", internalSlots, 1);
+  validate(defs, node, "exact", exact);
+  return node;
 }
 export function objectTypeInternalSlot(
   id: t.Identifier,
@@ -1268,23 +1732,33 @@ export function objectTypeInternalSlot(
   _static: boolean,
   method: boolean,
 ): t.ObjectTypeInternalSlot {
-  return validateNode<t.ObjectTypeInternalSlot>({
+  const node: t.ObjectTypeInternalSlot = {
     type: "ObjectTypeInternalSlot",
     id,
     value,
     optional,
     static: _static,
     method,
-  });
+  };
+  const defs = NODE_FIELDS.ObjectTypeInternalSlot;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "value", value, 1);
+  validate(defs, node, "optional", optional);
+  validate(defs, node, "static", _static);
+  validate(defs, node, "method", method);
+  return node;
 }
 export function objectTypeCallProperty(
   value: t.FlowType,
 ): t.ObjectTypeCallProperty {
-  return validateNode<t.ObjectTypeCallProperty>({
+  const node: t.ObjectTypeCallProperty = {
     type: "ObjectTypeCallProperty",
     value,
     static: null,
-  });
+  };
+  const defs = NODE_FIELDS.ObjectTypeCallProperty;
+  validate(defs, node, "value", value, 1);
+  return node;
 }
 export function objectTypeIndexer(
   id: t.Identifier | null | undefined = null,
@@ -1292,21 +1766,27 @@ export function objectTypeIndexer(
   value: t.FlowType,
   variance: t.Variance | null = null,
 ): t.ObjectTypeIndexer {
-  return validateNode<t.ObjectTypeIndexer>({
+  const node: t.ObjectTypeIndexer = {
     type: "ObjectTypeIndexer",
     id,
     key,
     value,
     variance,
     static: null,
-  });
+  };
+  const defs = NODE_FIELDS.ObjectTypeIndexer;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "value", value, 1);
+  validate(defs, node, "variance", variance, 1);
+  return node;
 }
 export function objectTypeProperty(
   key: t.Identifier | t.StringLiteral,
   value: t.FlowType,
   variance: t.Variance | null = null,
 ): t.ObjectTypeProperty {
-  return validateNode<t.ObjectTypeProperty>({
+  const node: t.ObjectTypeProperty = {
     type: "ObjectTypeProperty",
     key,
     value,
@@ -1316,15 +1796,23 @@ export function objectTypeProperty(
     optional: null,
     proto: null,
     static: null,
-  });
+  };
+  const defs = NODE_FIELDS.ObjectTypeProperty;
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "value", value, 1);
+  validate(defs, node, "variance", variance, 1);
+  return node;
 }
 export function objectTypeSpreadProperty(
   argument: t.FlowType,
 ): t.ObjectTypeSpreadProperty {
-  return validateNode<t.ObjectTypeSpreadProperty>({
+  const node: t.ObjectTypeSpreadProperty = {
     type: "ObjectTypeSpreadProperty",
     argument,
-  });
+  };
+  const defs = NODE_FIELDS.ObjectTypeSpreadProperty;
+  validate(defs, node, "argument", argument, 1);
+  return node;
 }
 export function opaqueType(
   id: t.Identifier,
@@ -1332,31 +1820,44 @@ export function opaqueType(
   supertype: t.FlowType | null | undefined = null,
   impltype: t.FlowType,
 ): t.OpaqueType {
-  return validateNode<t.OpaqueType>({
+  const node: t.OpaqueType = {
     type: "OpaqueType",
     id,
     typeParameters,
     supertype,
     impltype,
-  });
+  };
+  const defs = NODE_FIELDS.OpaqueType;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "supertype", supertype, 1);
+  validate(defs, node, "impltype", impltype, 1);
+  return node;
 }
 export function qualifiedTypeIdentifier(
   id: t.Identifier,
   qualification: t.Identifier | t.QualifiedTypeIdentifier,
 ): t.QualifiedTypeIdentifier {
-  return validateNode<t.QualifiedTypeIdentifier>({
+  const node: t.QualifiedTypeIdentifier = {
     type: "QualifiedTypeIdentifier",
     id,
     qualification,
-  });
+  };
+  const defs = NODE_FIELDS.QualifiedTypeIdentifier;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "qualification", qualification, 1);
+  return node;
 }
 export function stringLiteralTypeAnnotation(
   value: string,
 ): t.StringLiteralTypeAnnotation {
-  return validateNode<t.StringLiteralTypeAnnotation>({
+  const node: t.StringLiteralTypeAnnotation = {
     type: "StringLiteralTypeAnnotation",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.StringLiteralTypeAnnotation;
+  validate(defs, node, "value", value);
+  return node;
 }
 export function stringTypeAnnotation(): t.StringTypeAnnotation {
   return {
@@ -1376,89 +1877,124 @@ export function thisTypeAnnotation(): t.ThisTypeAnnotation {
 export function tupleTypeAnnotation(
   types: Array<t.FlowType>,
 ): t.TupleTypeAnnotation {
-  return validateNode<t.TupleTypeAnnotation>({
+  const node: t.TupleTypeAnnotation = {
     type: "TupleTypeAnnotation",
     types,
-  });
+  };
+  const defs = NODE_FIELDS.TupleTypeAnnotation;
+  validate(defs, node, "types", types, 1);
+  return node;
 }
 export function typeofTypeAnnotation(
   argument: t.FlowType,
 ): t.TypeofTypeAnnotation {
-  return validateNode<t.TypeofTypeAnnotation>({
+  const node: t.TypeofTypeAnnotation = {
     type: "TypeofTypeAnnotation",
     argument,
-  });
+  };
+  const defs = NODE_FIELDS.TypeofTypeAnnotation;
+  validate(defs, node, "argument", argument, 1);
+  return node;
 }
 export function typeAlias(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined = null,
   right: t.FlowType,
 ): t.TypeAlias {
-  return validateNode<t.TypeAlias>({
+  const node: t.TypeAlias = {
     type: "TypeAlias",
     id,
     typeParameters,
     right,
-  });
+  };
+  const defs = NODE_FIELDS.TypeAlias;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "right", right, 1);
+  return node;
 }
 export function typeAnnotation(typeAnnotation: t.FlowType): t.TypeAnnotation {
-  return validateNode<t.TypeAnnotation>({
+  const node: t.TypeAnnotation = {
     type: "TypeAnnotation",
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TypeAnnotation;
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export function typeCastExpression(
   expression: t.Expression,
   typeAnnotation: t.TypeAnnotation,
 ): t.TypeCastExpression {
-  return validateNode<t.TypeCastExpression>({
+  const node: t.TypeCastExpression = {
     type: "TypeCastExpression",
     expression,
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TypeCastExpression;
+  validate(defs, node, "expression", expression, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export function typeParameter(
   bound: t.TypeAnnotation | null = null,
   _default: t.FlowType | null = null,
   variance: t.Variance | null = null,
 ): t.TypeParameter {
-  return validateNode<t.TypeParameter>({
+  const node: t.TypeParameter = {
     type: "TypeParameter",
     bound,
     default: _default,
     variance,
     name: null,
-  });
+  };
+  const defs = NODE_FIELDS.TypeParameter;
+  validate(defs, node, "bound", bound, 1);
+  validate(defs, node, "default", _default, 1);
+  validate(defs, node, "variance", variance, 1);
+  return node;
 }
 export function typeParameterDeclaration(
   params: Array<t.TypeParameter>,
 ): t.TypeParameterDeclaration {
-  return validateNode<t.TypeParameterDeclaration>({
+  const node: t.TypeParameterDeclaration = {
     type: "TypeParameterDeclaration",
     params,
-  });
+  };
+  const defs = NODE_FIELDS.TypeParameterDeclaration;
+  validate(defs, node, "params", params, 1);
+  return node;
 }
 export function typeParameterInstantiation(
   params: Array<t.FlowType>,
 ): t.TypeParameterInstantiation {
-  return validateNode<t.TypeParameterInstantiation>({
+  const node: t.TypeParameterInstantiation = {
     type: "TypeParameterInstantiation",
     params,
-  });
+  };
+  const defs = NODE_FIELDS.TypeParameterInstantiation;
+  validate(defs, node, "params", params, 1);
+  return node;
 }
 export function unionTypeAnnotation(
   types: Array<t.FlowType>,
 ): t.UnionTypeAnnotation {
-  return validateNode<t.UnionTypeAnnotation>({
+  const node: t.UnionTypeAnnotation = {
     type: "UnionTypeAnnotation",
     types,
-  });
+  };
+  const defs = NODE_FIELDS.UnionTypeAnnotation;
+  validate(defs, node, "types", types, 1);
+  return node;
 }
 export function variance(kind: "minus" | "plus"): t.Variance {
-  return validateNode<t.Variance>({
+  const node: t.Variance = {
     type: "Variance",
     kind,
-  });
+  };
+  const defs = NODE_FIELDS.Variance;
+  validate(defs, node, "kind", kind);
+  return node;
 }
 export function voidTypeAnnotation(): t.VoidTypeAnnotation {
   return {
@@ -1473,104 +2009,142 @@ export function enumDeclaration(
     | t.EnumStringBody
     | t.EnumSymbolBody,
 ): t.EnumDeclaration {
-  return validateNode<t.EnumDeclaration>({
+  const node: t.EnumDeclaration = {
     type: "EnumDeclaration",
     id,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.EnumDeclaration;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function enumBooleanBody(
   members: Array<t.EnumBooleanMember>,
 ): t.EnumBooleanBody {
-  return validateNode<t.EnumBooleanBody>({
+  const node: t.EnumBooleanBody = {
     type: "EnumBooleanBody",
     members,
     explicitType: null,
     hasUnknownMembers: null,
-  });
+  };
+  const defs = NODE_FIELDS.EnumBooleanBody;
+  validate(defs, node, "members", members, 1);
+  return node;
 }
 export function enumNumberBody(
   members: Array<t.EnumNumberMember>,
 ): t.EnumNumberBody {
-  return validateNode<t.EnumNumberBody>({
+  const node: t.EnumNumberBody = {
     type: "EnumNumberBody",
     members,
     explicitType: null,
     hasUnknownMembers: null,
-  });
+  };
+  const defs = NODE_FIELDS.EnumNumberBody;
+  validate(defs, node, "members", members, 1);
+  return node;
 }
 export function enumStringBody(
   members: Array<t.EnumStringMember | t.EnumDefaultedMember>,
 ): t.EnumStringBody {
-  return validateNode<t.EnumStringBody>({
+  const node: t.EnumStringBody = {
     type: "EnumStringBody",
     members,
     explicitType: null,
     hasUnknownMembers: null,
-  });
+  };
+  const defs = NODE_FIELDS.EnumStringBody;
+  validate(defs, node, "members", members, 1);
+  return node;
 }
 export function enumSymbolBody(
   members: Array<t.EnumDefaultedMember>,
 ): t.EnumSymbolBody {
-  return validateNode<t.EnumSymbolBody>({
+  const node: t.EnumSymbolBody = {
     type: "EnumSymbolBody",
     members,
     hasUnknownMembers: null,
-  });
+  };
+  const defs = NODE_FIELDS.EnumSymbolBody;
+  validate(defs, node, "members", members, 1);
+  return node;
 }
 export function enumBooleanMember(id: t.Identifier): t.EnumBooleanMember {
-  return validateNode<t.EnumBooleanMember>({
+  const node: t.EnumBooleanMember = {
     type: "EnumBooleanMember",
     id,
     init: null,
-  });
+  };
+  const defs = NODE_FIELDS.EnumBooleanMember;
+  validate(defs, node, "id", id, 1);
+  return node;
 }
 export function enumNumberMember(
   id: t.Identifier,
   init: t.NumericLiteral,
 ): t.EnumNumberMember {
-  return validateNode<t.EnumNumberMember>({
+  const node: t.EnumNumberMember = {
     type: "EnumNumberMember",
     id,
     init,
-  });
+  };
+  const defs = NODE_FIELDS.EnumNumberMember;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "init", init, 1);
+  return node;
 }
 export function enumStringMember(
   id: t.Identifier,
   init: t.StringLiteral,
 ): t.EnumStringMember {
-  return validateNode<t.EnumStringMember>({
+  const node: t.EnumStringMember = {
     type: "EnumStringMember",
     id,
     init,
-  });
+  };
+  const defs = NODE_FIELDS.EnumStringMember;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "init", init, 1);
+  return node;
 }
 export function enumDefaultedMember(id: t.Identifier): t.EnumDefaultedMember {
-  return validateNode<t.EnumDefaultedMember>({
+  const node: t.EnumDefaultedMember = {
     type: "EnumDefaultedMember",
     id,
-  });
+  };
+  const defs = NODE_FIELDS.EnumDefaultedMember;
+  validate(defs, node, "id", id, 1);
+  return node;
 }
 export function indexedAccessType(
   objectType: t.FlowType,
   indexType: t.FlowType,
 ): t.IndexedAccessType {
-  return validateNode<t.IndexedAccessType>({
+  const node: t.IndexedAccessType = {
     type: "IndexedAccessType",
     objectType,
     indexType,
-  });
+  };
+  const defs = NODE_FIELDS.IndexedAccessType;
+  validate(defs, node, "objectType", objectType, 1);
+  validate(defs, node, "indexType", indexType, 1);
+  return node;
 }
 export function optionalIndexedAccessType(
   objectType: t.FlowType,
   indexType: t.FlowType,
 ): t.OptionalIndexedAccessType {
-  return validateNode<t.OptionalIndexedAccessType>({
+  const node: t.OptionalIndexedAccessType = {
     type: "OptionalIndexedAccessType",
     objectType,
     indexType,
     optional: null,
-  });
+  };
+  const defs = NODE_FIELDS.OptionalIndexedAccessType;
+  validate(defs, node, "objectType", objectType, 1);
+  validate(defs, node, "indexType", indexType, 1);
+  return node;
 }
 export function jsxAttribute(
   name: t.JSXIdentifier | t.JSXNamespacedName,
@@ -1581,20 +2155,27 @@ export function jsxAttribute(
     | t.JSXExpressionContainer
     | null = null,
 ): t.JSXAttribute {
-  return validateNode<t.JSXAttribute>({
+  const node: t.JSXAttribute = {
     type: "JSXAttribute",
     name,
     value,
-  });
+  };
+  const defs = NODE_FIELDS.JSXAttribute;
+  validate(defs, node, "name", name, 1);
+  validate(defs, node, "value", value, 1);
+  return node;
 }
 export { jsxAttribute as jSXAttribute };
 export function jsxClosingElement(
   name: t.JSXIdentifier | t.JSXMemberExpression | t.JSXNamespacedName,
 ): t.JSXClosingElement {
-  return validateNode<t.JSXClosingElement>({
+  const node: t.JSXClosingElement = {
     type: "JSXClosingElement",
     name,
-  });
+  };
+  const defs = NODE_FIELDS.JSXClosingElement;
+  validate(defs, node, "name", name, 1);
+  return node;
 }
 export { jsxClosingElement as jSXClosingElement };
 export function jsxElement(
@@ -1609,13 +2190,19 @@ export function jsxElement(
   >,
   selfClosing: boolean | null = null,
 ): t.JSXElement {
-  return validateNode<t.JSXElement>({
+  const node: t.JSXElement = {
     type: "JSXElement",
     openingElement,
     closingElement,
     children,
     selfClosing,
-  });
+  };
+  const defs = NODE_FIELDS.JSXElement;
+  validate(defs, node, "openingElement", openingElement, 1);
+  validate(defs, node, "closingElement", closingElement, 1);
+  validate(defs, node, "children", children, 1);
+  validate(defs, node, "selfClosing", selfClosing);
+  return node;
 }
 export { jsxElement as jSXElement };
 export function jsxEmptyExpression(): t.JSXEmptyExpression {
@@ -1627,46 +2214,63 @@ export { jsxEmptyExpression as jSXEmptyExpression };
 export function jsxExpressionContainer(
   expression: t.Expression | t.JSXEmptyExpression,
 ): t.JSXExpressionContainer {
-  return validateNode<t.JSXExpressionContainer>({
+  const node: t.JSXExpressionContainer = {
     type: "JSXExpressionContainer",
     expression,
-  });
+  };
+  const defs = NODE_FIELDS.JSXExpressionContainer;
+  validate(defs, node, "expression", expression, 1);
+  return node;
 }
 export { jsxExpressionContainer as jSXExpressionContainer };
 export function jsxSpreadChild(expression: t.Expression): t.JSXSpreadChild {
-  return validateNode<t.JSXSpreadChild>({
+  const node: t.JSXSpreadChild = {
     type: "JSXSpreadChild",
     expression,
-  });
+  };
+  const defs = NODE_FIELDS.JSXSpreadChild;
+  validate(defs, node, "expression", expression, 1);
+  return node;
 }
 export { jsxSpreadChild as jSXSpreadChild };
 export function jsxIdentifier(name: string): t.JSXIdentifier {
-  return validateNode<t.JSXIdentifier>({
+  const node: t.JSXIdentifier = {
     type: "JSXIdentifier",
     name,
-  });
+  };
+  const defs = NODE_FIELDS.JSXIdentifier;
+  validate(defs, node, "name", name);
+  return node;
 }
 export { jsxIdentifier as jSXIdentifier };
 export function jsxMemberExpression(
   object: t.JSXMemberExpression | t.JSXIdentifier,
   property: t.JSXIdentifier,
 ): t.JSXMemberExpression {
-  return validateNode<t.JSXMemberExpression>({
+  const node: t.JSXMemberExpression = {
     type: "JSXMemberExpression",
     object,
     property,
-  });
+  };
+  const defs = NODE_FIELDS.JSXMemberExpression;
+  validate(defs, node, "object", object, 1);
+  validate(defs, node, "property", property, 1);
+  return node;
 }
 export { jsxMemberExpression as jSXMemberExpression };
 export function jsxNamespacedName(
   namespace: t.JSXIdentifier,
   name: t.JSXIdentifier,
 ): t.JSXNamespacedName {
-  return validateNode<t.JSXNamespacedName>({
+  const node: t.JSXNamespacedName = {
     type: "JSXNamespacedName",
     namespace,
     name,
-  });
+  };
+  const defs = NODE_FIELDS.JSXNamespacedName;
+  validate(defs, node, "namespace", namespace, 1);
+  validate(defs, node, "name", name, 1);
+  return node;
 }
 export { jsxNamespacedName as jSXNamespacedName };
 export function jsxOpeningElement(
@@ -1674,28 +2278,39 @@ export function jsxOpeningElement(
   attributes: Array<t.JSXAttribute | t.JSXSpreadAttribute>,
   selfClosing: boolean = false,
 ): t.JSXOpeningElement {
-  return validateNode<t.JSXOpeningElement>({
+  const node: t.JSXOpeningElement = {
     type: "JSXOpeningElement",
     name,
     attributes,
     selfClosing,
-  });
+  };
+  const defs = NODE_FIELDS.JSXOpeningElement;
+  validate(defs, node, "name", name, 1);
+  validate(defs, node, "attributes", attributes, 1);
+  validate(defs, node, "selfClosing", selfClosing);
+  return node;
 }
 export { jsxOpeningElement as jSXOpeningElement };
 export function jsxSpreadAttribute(
   argument: t.Expression,
 ): t.JSXSpreadAttribute {
-  return validateNode<t.JSXSpreadAttribute>({
+  const node: t.JSXSpreadAttribute = {
     type: "JSXSpreadAttribute",
     argument,
-  });
+  };
+  const defs = NODE_FIELDS.JSXSpreadAttribute;
+  validate(defs, node, "argument", argument, 1);
+  return node;
 }
 export { jsxSpreadAttribute as jSXSpreadAttribute };
 export function jsxText(value: string): t.JSXText {
-  return validateNode<t.JSXText>({
+  const node: t.JSXText = {
     type: "JSXText",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.JSXText;
+  validate(defs, node, "value", value);
+  return node;
 }
 export { jsxText as jSXText };
 export function jsxFragment(
@@ -1709,12 +2324,17 @@ export function jsxFragment(
     | t.JSXFragment
   >,
 ): t.JSXFragment {
-  return validateNode<t.JSXFragment>({
+  const node: t.JSXFragment = {
     type: "JSXFragment",
     openingFragment,
     closingFragment,
     children,
-  });
+  };
+  const defs = NODE_FIELDS.JSXFragment;
+  validate(defs, node, "openingFragment", openingFragment, 1);
+  validate(defs, node, "closingFragment", closingFragment, 1);
+  validate(defs, node, "children", children, 1);
+  return node;
 }
 export { jsxFragment as jSXFragment };
 export function jsxOpeningFragment(): t.JSXOpeningFragment {
@@ -1746,17 +2366,24 @@ export function placeholder(
     | "Pattern",
   name: t.Identifier,
 ): t.Placeholder {
-  return validateNode<t.Placeholder>({
+  const node: t.Placeholder = {
     type: "Placeholder",
     expectedNode,
     name,
-  });
+  };
+  const defs = NODE_FIELDS.Placeholder;
+  validate(defs, node, "expectedNode", expectedNode);
+  validate(defs, node, "name", name, 1);
+  return node;
 }
 export function v8IntrinsicIdentifier(name: string): t.V8IntrinsicIdentifier {
-  return validateNode<t.V8IntrinsicIdentifier>({
+  const node: t.V8IntrinsicIdentifier = {
     type: "V8IntrinsicIdentifier",
     name,
-  });
+  };
+  const defs = NODE_FIELDS.V8IntrinsicIdentifier;
+  validate(defs, node, "name", name);
+  return node;
 }
 export function argumentPlaceholder(): t.ArgumentPlaceholder {
   return {
@@ -1767,73 +2394,103 @@ export function bindExpression(
   object: t.Expression,
   callee: t.Expression,
 ): t.BindExpression {
-  return validateNode<t.BindExpression>({
+  const node: t.BindExpression = {
     type: "BindExpression",
     object,
     callee,
-  });
+  };
+  const defs = NODE_FIELDS.BindExpression;
+  validate(defs, node, "object", object, 1);
+  validate(defs, node, "callee", callee, 1);
+  return node;
 }
 export function importAttribute(
   key: t.Identifier | t.StringLiteral,
   value: t.StringLiteral,
 ): t.ImportAttribute {
-  return validateNode<t.ImportAttribute>({
+  const node: t.ImportAttribute = {
     type: "ImportAttribute",
     key,
     value,
-  });
+  };
+  const defs = NODE_FIELDS.ImportAttribute;
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "value", value, 1);
+  return node;
 }
 export function decorator(expression: t.Expression): t.Decorator {
-  return validateNode<t.Decorator>({
+  const node: t.Decorator = {
     type: "Decorator",
     expression,
-  });
+  };
+  const defs = NODE_FIELDS.Decorator;
+  validate(defs, node, "expression", expression, 1);
+  return node;
 }
 export function doExpression(
   body: t.BlockStatement,
   async: boolean = false,
 ): t.DoExpression {
-  return validateNode<t.DoExpression>({
+  const node: t.DoExpression = {
     type: "DoExpression",
     body,
     async,
-  });
+  };
+  const defs = NODE_FIELDS.DoExpression;
+  validate(defs, node, "body", body, 1);
+  validate(defs, node, "async", async);
+  return node;
 }
 export function exportDefaultSpecifier(
   exported: t.Identifier,
 ): t.ExportDefaultSpecifier {
-  return validateNode<t.ExportDefaultSpecifier>({
+  const node: t.ExportDefaultSpecifier = {
     type: "ExportDefaultSpecifier",
     exported,
-  });
+  };
+  const defs = NODE_FIELDS.ExportDefaultSpecifier;
+  validate(defs, node, "exported", exported, 1);
+  return node;
 }
 export function recordExpression(
   properties: Array<t.ObjectProperty | t.SpreadElement>,
 ): t.RecordExpression {
-  return validateNode<t.RecordExpression>({
+  const node: t.RecordExpression = {
     type: "RecordExpression",
     properties,
-  });
+  };
+  const defs = NODE_FIELDS.RecordExpression;
+  validate(defs, node, "properties", properties, 1);
+  return node;
 }
 export function tupleExpression(
   elements: Array<t.Expression | t.SpreadElement> = [],
 ): t.TupleExpression {
-  return validateNode<t.TupleExpression>({
+  const node: t.TupleExpression = {
     type: "TupleExpression",
     elements,
-  });
+  };
+  const defs = NODE_FIELDS.TupleExpression;
+  validate(defs, node, "elements", elements, 1);
+  return node;
 }
 export function decimalLiteral(value: string): t.DecimalLiteral {
-  return validateNode<t.DecimalLiteral>({
+  const node: t.DecimalLiteral = {
     type: "DecimalLiteral",
     value,
-  });
+  };
+  const defs = NODE_FIELDS.DecimalLiteral;
+  validate(defs, node, "value", value);
+  return node;
 }
 export function moduleExpression(body: t.Program): t.ModuleExpression {
-  return validateNode<t.ModuleExpression>({
+  const node: t.ModuleExpression = {
     type: "ModuleExpression",
     body,
-  });
+  };
+  const defs = NODE_FIELDS.ModuleExpression;
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export function topicReference(): t.TopicReference {
   return {
@@ -1843,18 +2500,24 @@ export function topicReference(): t.TopicReference {
 export function pipelineTopicExpression(
   expression: t.Expression,
 ): t.PipelineTopicExpression {
-  return validateNode<t.PipelineTopicExpression>({
+  const node: t.PipelineTopicExpression = {
     type: "PipelineTopicExpression",
     expression,
-  });
+  };
+  const defs = NODE_FIELDS.PipelineTopicExpression;
+  validate(defs, node, "expression", expression, 1);
+  return node;
 }
 export function pipelineBareFunction(
   callee: t.Expression,
 ): t.PipelineBareFunction {
-  return validateNode<t.PipelineBareFunction>({
+  const node: t.PipelineBareFunction = {
     type: "PipelineBareFunction",
     callee,
-  });
+  };
+  const defs = NODE_FIELDS.PipelineBareFunction;
+  validate(defs, node, "callee", callee, 1);
+  return node;
 }
 export function pipelinePrimaryTopicReference(): t.PipelinePrimaryTopicReference {
   return {
@@ -1864,10 +2527,13 @@ export function pipelinePrimaryTopicReference(): t.PipelinePrimaryTopicReference
 export function tsParameterProperty(
   parameter: t.Identifier | t.AssignmentPattern,
 ): t.TSParameterProperty {
-  return validateNode<t.TSParameterProperty>({
+  const node: t.TSParameterProperty = {
     type: "TSParameterProperty",
     parameter,
-  });
+  };
+  const defs = NODE_FIELDS.TSParameterProperty;
+  validate(defs, node, "parameter", parameter, 1);
+  return node;
 }
 export { tsParameterProperty as tSParameterProperty };
 export function tsDeclareFunction(
@@ -1880,13 +2546,19 @@ export function tsDeclareFunction(
   params: Array<t.Identifier | t.Pattern | t.RestElement>,
   returnType: t.TSTypeAnnotation | t.Noop | null = null,
 ): t.TSDeclareFunction {
-  return validateNode<t.TSDeclareFunction>({
+  const node: t.TSDeclareFunction = {
     type: "TSDeclareFunction",
     id,
     typeParameters,
     params,
     returnType,
-  });
+  };
+  const defs = NODE_FIELDS.TSDeclareFunction;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "params", params, 1);
+  validate(defs, node, "returnType", returnType, 1);
+  return node;
 }
 export { tsDeclareFunction as tSDeclareFunction };
 export function tsDeclareMethod(
@@ -1907,25 +2579,36 @@ export function tsDeclareMethod(
   >,
   returnType: t.TSTypeAnnotation | t.Noop | null = null,
 ): t.TSDeclareMethod {
-  return validateNode<t.TSDeclareMethod>({
+  const node: t.TSDeclareMethod = {
     type: "TSDeclareMethod",
     decorators,
     key,
     typeParameters,
     params,
     returnType,
-  });
+  };
+  const defs = NODE_FIELDS.TSDeclareMethod;
+  validate(defs, node, "decorators", decorators, 1);
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "params", params, 1);
+  validate(defs, node, "returnType", returnType, 1);
+  return node;
 }
 export { tsDeclareMethod as tSDeclareMethod };
 export function tsQualifiedName(
   left: t.TSEntityName,
   right: t.Identifier,
 ): t.TSQualifiedName {
-  return validateNode<t.TSQualifiedName>({
+  const node: t.TSQualifiedName = {
     type: "TSQualifiedName",
     left,
     right,
-  });
+  };
+  const defs = NODE_FIELDS.TSQualifiedName;
+  validate(defs, node, "left", left, 1);
+  validate(defs, node, "right", right, 1);
+  return node;
 }
 export { tsQualifiedName as tSQualifiedName };
 export function tsCallSignatureDeclaration(
@@ -1935,12 +2618,17 @@ export function tsCallSignatureDeclaration(
   >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSCallSignatureDeclaration {
-  return validateNode<t.TSCallSignatureDeclaration>({
+  const node: t.TSCallSignatureDeclaration = {
     type: "TSCallSignatureDeclaration",
     typeParameters,
     parameters,
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSCallSignatureDeclaration;
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "parameters", parameters, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsCallSignatureDeclaration as tSCallSignatureDeclaration };
 export function tsConstructSignatureDeclaration(
@@ -1950,24 +2638,33 @@ export function tsConstructSignatureDeclaration(
   >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSConstructSignatureDeclaration {
-  return validateNode<t.TSConstructSignatureDeclaration>({
+  const node: t.TSConstructSignatureDeclaration = {
     type: "TSConstructSignatureDeclaration",
     typeParameters,
     parameters,
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSConstructSignatureDeclaration;
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "parameters", parameters, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsConstructSignatureDeclaration as tSConstructSignatureDeclaration };
 export function tsPropertySignature(
   key: t.Expression,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSPropertySignature {
-  return validateNode<t.TSPropertySignature>({
+  const node: t.TSPropertySignature = {
     type: "TSPropertySignature",
     key,
     typeAnnotation,
     kind: null,
-  });
+  };
+  const defs = NODE_FIELDS.TSPropertySignature;
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsPropertySignature as tSPropertySignature };
 export function tsMethodSignature(
@@ -1978,25 +2675,35 @@ export function tsMethodSignature(
   >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSMethodSignature {
-  return validateNode<t.TSMethodSignature>({
+  const node: t.TSMethodSignature = {
     type: "TSMethodSignature",
     key,
     typeParameters,
     parameters,
     typeAnnotation,
     kind: null,
-  });
+  };
+  const defs = NODE_FIELDS.TSMethodSignature;
+  validate(defs, node, "key", key, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "parameters", parameters, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsMethodSignature as tSMethodSignature };
 export function tsIndexSignature(
   parameters: Array<t.Identifier>,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSIndexSignature {
-  return validateNode<t.TSIndexSignature>({
+  const node: t.TSIndexSignature = {
     type: "TSIndexSignature",
     parameters,
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSIndexSignature;
+  validate(defs, node, "parameters", parameters, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsIndexSignature as tSIndexSignature };
 export function tsAnyKeyword(): t.TSAnyKeyword {
@@ -2090,12 +2797,17 @@ export function tsFunctionType(
   >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSFunctionType {
-  return validateNode<t.TSFunctionType>({
+  const node: t.TSFunctionType = {
     type: "TSFunctionType",
     typeParameters,
     parameters,
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSFunctionType;
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "parameters", parameters, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsFunctionType as tSFunctionType };
 export function tsConstructorType(
@@ -2105,23 +2817,32 @@ export function tsConstructorType(
   >,
   typeAnnotation: t.TSTypeAnnotation | null = null,
 ): t.TSConstructorType {
-  return validateNode<t.TSConstructorType>({
+  const node: t.TSConstructorType = {
     type: "TSConstructorType",
     typeParameters,
     parameters,
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSConstructorType;
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "parameters", parameters, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsConstructorType as tSConstructorType };
 export function tsTypeReference(
   typeName: t.TSEntityName,
   typeParameters: t.TSTypeParameterInstantiation | null = null,
 ): t.TSTypeReference {
-  return validateNode<t.TSTypeReference>({
+  const node: t.TSTypeReference = {
     type: "TSTypeReference",
     typeName,
     typeParameters,
-  });
+  };
+  const defs = NODE_FIELDS.TSTypeReference;
+  validate(defs, node, "typeName", typeName, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  return node;
 }
 export { tsTypeReference as tSTypeReference };
 export function tsTypePredicate(
@@ -2129,62 +2850,86 @@ export function tsTypePredicate(
   typeAnnotation: t.TSTypeAnnotation | null = null,
   asserts: boolean | null = null,
 ): t.TSTypePredicate {
-  return validateNode<t.TSTypePredicate>({
+  const node: t.TSTypePredicate = {
     type: "TSTypePredicate",
     parameterName,
     typeAnnotation,
     asserts,
-  });
+  };
+  const defs = NODE_FIELDS.TSTypePredicate;
+  validate(defs, node, "parameterName", parameterName, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs, node, "asserts", asserts);
+  return node;
 }
 export { tsTypePredicate as tSTypePredicate };
 export function tsTypeQuery(
   exprName: t.TSEntityName | t.TSImportType,
   typeParameters: t.TSTypeParameterInstantiation | null = null,
 ): t.TSTypeQuery {
-  return validateNode<t.TSTypeQuery>({
+  const node: t.TSTypeQuery = {
     type: "TSTypeQuery",
     exprName,
     typeParameters,
-  });
+  };
+  const defs = NODE_FIELDS.TSTypeQuery;
+  validate(defs, node, "exprName", exprName, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  return node;
 }
 export { tsTypeQuery as tSTypeQuery };
 export function tsTypeLiteral(
   members: Array<t.TSTypeElement>,
 ): t.TSTypeLiteral {
-  return validateNode<t.TSTypeLiteral>({
+  const node: t.TSTypeLiteral = {
     type: "TSTypeLiteral",
     members,
-  });
+  };
+  const defs = NODE_FIELDS.TSTypeLiteral;
+  validate(defs, node, "members", members, 1);
+  return node;
 }
 export { tsTypeLiteral as tSTypeLiteral };
 export function tsArrayType(elementType: t.TSType): t.TSArrayType {
-  return validateNode<t.TSArrayType>({
+  const node: t.TSArrayType = {
     type: "TSArrayType",
     elementType,
-  });
+  };
+  const defs = NODE_FIELDS.TSArrayType;
+  validate(defs, node, "elementType", elementType, 1);
+  return node;
 }
 export { tsArrayType as tSArrayType };
 export function tsTupleType(
   elementTypes: Array<t.TSType | t.TSNamedTupleMember>,
 ): t.TSTupleType {
-  return validateNode<t.TSTupleType>({
+  const node: t.TSTupleType = {
     type: "TSTupleType",
     elementTypes,
-  });
+  };
+  const defs = NODE_FIELDS.TSTupleType;
+  validate(defs, node, "elementTypes", elementTypes, 1);
+  return node;
 }
 export { tsTupleType as tSTupleType };
 export function tsOptionalType(typeAnnotation: t.TSType): t.TSOptionalType {
-  return validateNode<t.TSOptionalType>({
+  const node: t.TSOptionalType = {
     type: "TSOptionalType",
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSOptionalType;
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsOptionalType as tSOptionalType };
 export function tsRestType(typeAnnotation: t.TSType): t.TSRestType {
-  return validateNode<t.TSRestType>({
+  const node: t.TSRestType = {
     type: "TSRestType",
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSRestType;
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsRestType as tSRestType };
 export function tsNamedTupleMember(
@@ -2192,28 +2937,39 @@ export function tsNamedTupleMember(
   elementType: t.TSType,
   optional: boolean = false,
 ): t.TSNamedTupleMember {
-  return validateNode<t.TSNamedTupleMember>({
+  const node: t.TSNamedTupleMember = {
     type: "TSNamedTupleMember",
     label,
     elementType,
     optional,
-  });
+  };
+  const defs = NODE_FIELDS.TSNamedTupleMember;
+  validate(defs, node, "label", label, 1);
+  validate(defs, node, "elementType", elementType, 1);
+  validate(defs, node, "optional", optional);
+  return node;
 }
 export { tsNamedTupleMember as tSNamedTupleMember };
 export function tsUnionType(types: Array<t.TSType>): t.TSUnionType {
-  return validateNode<t.TSUnionType>({
+  const node: t.TSUnionType = {
     type: "TSUnionType",
     types,
-  });
+  };
+  const defs = NODE_FIELDS.TSUnionType;
+  validate(defs, node, "types", types, 1);
+  return node;
 }
 export { tsUnionType as tSUnionType };
 export function tsIntersectionType(
   types: Array<t.TSType>,
 ): t.TSIntersectionType {
-  return validateNode<t.TSIntersectionType>({
+  const node: t.TSIntersectionType = {
     type: "TSIntersectionType",
     types,
-  });
+  };
+  const defs = NODE_FIELDS.TSIntersectionType;
+  validate(defs, node, "types", types, 1);
+  return node;
 }
 export { tsIntersectionType as tSIntersectionType };
 export function tsConditionalType(
@@ -2222,48 +2978,67 @@ export function tsConditionalType(
   trueType: t.TSType,
   falseType: t.TSType,
 ): t.TSConditionalType {
-  return validateNode<t.TSConditionalType>({
+  const node: t.TSConditionalType = {
     type: "TSConditionalType",
     checkType,
     extendsType,
     trueType,
     falseType,
-  });
+  };
+  const defs = NODE_FIELDS.TSConditionalType;
+  validate(defs, node, "checkType", checkType, 1);
+  validate(defs, node, "extendsType", extendsType, 1);
+  validate(defs, node, "trueType", trueType, 1);
+  validate(defs, node, "falseType", falseType, 1);
+  return node;
 }
 export { tsConditionalType as tSConditionalType };
 export function tsInferType(typeParameter: t.TSTypeParameter): t.TSInferType {
-  return validateNode<t.TSInferType>({
+  const node: t.TSInferType = {
     type: "TSInferType",
     typeParameter,
-  });
+  };
+  const defs = NODE_FIELDS.TSInferType;
+  validate(defs, node, "typeParameter", typeParameter, 1);
+  return node;
 }
 export { tsInferType as tSInferType };
 export function tsParenthesizedType(
   typeAnnotation: t.TSType,
 ): t.TSParenthesizedType {
-  return validateNode<t.TSParenthesizedType>({
+  const node: t.TSParenthesizedType = {
     type: "TSParenthesizedType",
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSParenthesizedType;
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsParenthesizedType as tSParenthesizedType };
 export function tsTypeOperator(typeAnnotation: t.TSType): t.TSTypeOperator {
-  return validateNode<t.TSTypeOperator>({
+  const node: t.TSTypeOperator = {
     type: "TSTypeOperator",
     typeAnnotation,
     operator: null,
-  });
+  };
+  const defs = NODE_FIELDS.TSTypeOperator;
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsTypeOperator as tSTypeOperator };
 export function tsIndexedAccessType(
   objectType: t.TSType,
   indexType: t.TSType,
 ): t.TSIndexedAccessType {
-  return validateNode<t.TSIndexedAccessType>({
+  const node: t.TSIndexedAccessType = {
     type: "TSIndexedAccessType",
     objectType,
     indexType,
-  });
+  };
+  const defs = NODE_FIELDS.TSIndexedAccessType;
+  validate(defs, node, "objectType", objectType, 1);
+  validate(defs, node, "indexType", indexType, 1);
+  return node;
 }
 export { tsIndexedAccessType as tSIndexedAccessType };
 export function tsMappedType(
@@ -2271,12 +3046,17 @@ export function tsMappedType(
   typeAnnotation: t.TSType | null = null,
   nameType: t.TSType | null = null,
 ): t.TSMappedType {
-  return validateNode<t.TSMappedType>({
+  const node: t.TSMappedType = {
     type: "TSMappedType",
     typeParameter,
     typeAnnotation,
     nameType,
-  });
+  };
+  const defs = NODE_FIELDS.TSMappedType;
+  validate(defs, node, "typeParameter", typeParameter, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs, node, "nameType", nameType, 1);
+  return node;
 }
 export { tsMappedType as tSMappedType };
 export function tsLiteralType(
@@ -2288,21 +3068,28 @@ export function tsLiteralType(
     | t.TemplateLiteral
     | t.UnaryExpression,
 ): t.TSLiteralType {
-  return validateNode<t.TSLiteralType>({
+  const node: t.TSLiteralType = {
     type: "TSLiteralType",
     literal,
-  });
+  };
+  const defs = NODE_FIELDS.TSLiteralType;
+  validate(defs, node, "literal", literal, 1);
+  return node;
 }
 export { tsLiteralType as tSLiteralType };
 export function tsExpressionWithTypeArguments(
   expression: t.TSEntityName,
   typeParameters: t.TSTypeParameterInstantiation | null = null,
 ): t.TSExpressionWithTypeArguments {
-  return validateNode<t.TSExpressionWithTypeArguments>({
+  const node: t.TSExpressionWithTypeArguments = {
     type: "TSExpressionWithTypeArguments",
     expression,
     typeParameters,
-  });
+  };
+  const defs = NODE_FIELDS.TSExpressionWithTypeArguments;
+  validate(defs, node, "expression", expression, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  return node;
 }
 export { tsExpressionWithTypeArguments as tSExpressionWithTypeArguments };
 export function tsInterfaceDeclaration(
@@ -2311,22 +3098,31 @@ export function tsInterfaceDeclaration(
   _extends: Array<t.TSExpressionWithTypeArguments> | null | undefined = null,
   body: t.TSInterfaceBody,
 ): t.TSInterfaceDeclaration {
-  return validateNode<t.TSInterfaceDeclaration>({
+  const node: t.TSInterfaceDeclaration = {
     type: "TSInterfaceDeclaration",
     id,
     typeParameters,
     extends: _extends,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.TSInterfaceDeclaration;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "extends", _extends, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export { tsInterfaceDeclaration as tSInterfaceDeclaration };
 export function tsInterfaceBody(
   body: Array<t.TSTypeElement>,
 ): t.TSInterfaceBody {
-  return validateNode<t.TSInterfaceBody>({
+  const node: t.TSInterfaceBody = {
     type: "TSInterfaceBody",
     body,
-  });
+  };
+  const defs = NODE_FIELDS.TSInterfaceBody;
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export { tsInterfaceBody as tSInterfaceBody };
 export function tsTypeAliasDeclaration(
@@ -2334,96 +3130,132 @@ export function tsTypeAliasDeclaration(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined = null,
   typeAnnotation: t.TSType,
 ): t.TSTypeAliasDeclaration {
-  return validateNode<t.TSTypeAliasDeclaration>({
+  const node: t.TSTypeAliasDeclaration = {
     type: "TSTypeAliasDeclaration",
     id,
     typeParameters,
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSTypeAliasDeclaration;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsTypeAliasDeclaration as tSTypeAliasDeclaration };
 export function tsInstantiationExpression(
   expression: t.Expression,
   typeParameters: t.TSTypeParameterInstantiation | null = null,
 ): t.TSInstantiationExpression {
-  return validateNode<t.TSInstantiationExpression>({
+  const node: t.TSInstantiationExpression = {
     type: "TSInstantiationExpression",
     expression,
     typeParameters,
-  });
+  };
+  const defs = NODE_FIELDS.TSInstantiationExpression;
+  validate(defs, node, "expression", expression, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  return node;
 }
 export { tsInstantiationExpression as tSInstantiationExpression };
 export function tsAsExpression(
   expression: t.Expression,
   typeAnnotation: t.TSType,
 ): t.TSAsExpression {
-  return validateNode<t.TSAsExpression>({
+  const node: t.TSAsExpression = {
     type: "TSAsExpression",
     expression,
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSAsExpression;
+  validate(defs, node, "expression", expression, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsAsExpression as tSAsExpression };
 export function tsSatisfiesExpression(
   expression: t.Expression,
   typeAnnotation: t.TSType,
 ): t.TSSatisfiesExpression {
-  return validateNode<t.TSSatisfiesExpression>({
+  const node: t.TSSatisfiesExpression = {
     type: "TSSatisfiesExpression",
     expression,
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSSatisfiesExpression;
+  validate(defs, node, "expression", expression, 1);
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsSatisfiesExpression as tSSatisfiesExpression };
 export function tsTypeAssertion(
   typeAnnotation: t.TSType,
   expression: t.Expression,
 ): t.TSTypeAssertion {
-  return validateNode<t.TSTypeAssertion>({
+  const node: t.TSTypeAssertion = {
     type: "TSTypeAssertion",
     typeAnnotation,
     expression,
-  });
+  };
+  const defs = NODE_FIELDS.TSTypeAssertion;
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs, node, "expression", expression, 1);
+  return node;
 }
 export { tsTypeAssertion as tSTypeAssertion };
 export function tsEnumDeclaration(
   id: t.Identifier,
   members: Array<t.TSEnumMember>,
 ): t.TSEnumDeclaration {
-  return validateNode<t.TSEnumDeclaration>({
+  const node: t.TSEnumDeclaration = {
     type: "TSEnumDeclaration",
     id,
     members,
-  });
+  };
+  const defs = NODE_FIELDS.TSEnumDeclaration;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "members", members, 1);
+  return node;
 }
 export { tsEnumDeclaration as tSEnumDeclaration };
 export function tsEnumMember(
   id: t.Identifier | t.StringLiteral,
   initializer: t.Expression | null = null,
 ): t.TSEnumMember {
-  return validateNode<t.TSEnumMember>({
+  const node: t.TSEnumMember = {
     type: "TSEnumMember",
     id,
     initializer,
-  });
+  };
+  const defs = NODE_FIELDS.TSEnumMember;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "initializer", initializer, 1);
+  return node;
 }
 export { tsEnumMember as tSEnumMember };
 export function tsModuleDeclaration(
   id: t.Identifier | t.StringLiteral,
   body: t.TSModuleBlock | t.TSModuleDeclaration,
 ): t.TSModuleDeclaration {
-  return validateNode<t.TSModuleDeclaration>({
+  const node: t.TSModuleDeclaration = {
     type: "TSModuleDeclaration",
     id,
     body,
-  });
+  };
+  const defs = NODE_FIELDS.TSModuleDeclaration;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export { tsModuleDeclaration as tSModuleDeclaration };
 export function tsModuleBlock(body: Array<t.Statement>): t.TSModuleBlock {
-  return validateNode<t.TSModuleBlock>({
+  const node: t.TSModuleBlock = {
     type: "TSModuleBlock",
     body,
-  });
+  };
+  const defs = NODE_FIELDS.TSModuleBlock;
+  validate(defs, node, "body", body, 1);
+  return node;
 }
 export { tsModuleBlock as tSModuleBlock };
 export function tsImportType(
@@ -2431,85 +3263,115 @@ export function tsImportType(
   qualifier: t.TSEntityName | null = null,
   typeParameters: t.TSTypeParameterInstantiation | null = null,
 ): t.TSImportType {
-  return validateNode<t.TSImportType>({
+  const node: t.TSImportType = {
     type: "TSImportType",
     argument,
     qualifier,
     typeParameters,
-  });
+  };
+  const defs = NODE_FIELDS.TSImportType;
+  validate(defs, node, "argument", argument, 1);
+  validate(defs, node, "qualifier", qualifier, 1);
+  validate(defs, node, "typeParameters", typeParameters, 1);
+  return node;
 }
 export { tsImportType as tSImportType };
 export function tsImportEqualsDeclaration(
   id: t.Identifier,
   moduleReference: t.TSEntityName | t.TSExternalModuleReference,
 ): t.TSImportEqualsDeclaration {
-  return validateNode<t.TSImportEqualsDeclaration>({
+  const node: t.TSImportEqualsDeclaration = {
     type: "TSImportEqualsDeclaration",
     id,
     moduleReference,
     isExport: null,
-  });
+  };
+  const defs = NODE_FIELDS.TSImportEqualsDeclaration;
+  validate(defs, node, "id", id, 1);
+  validate(defs, node, "moduleReference", moduleReference, 1);
+  return node;
 }
 export { tsImportEqualsDeclaration as tSImportEqualsDeclaration };
 export function tsExternalModuleReference(
   expression: t.StringLiteral,
 ): t.TSExternalModuleReference {
-  return validateNode<t.TSExternalModuleReference>({
+  const node: t.TSExternalModuleReference = {
     type: "TSExternalModuleReference",
     expression,
-  });
+  };
+  const defs = NODE_FIELDS.TSExternalModuleReference;
+  validate(defs, node, "expression", expression, 1);
+  return node;
 }
 export { tsExternalModuleReference as tSExternalModuleReference };
 export function tsNonNullExpression(
   expression: t.Expression,
 ): t.TSNonNullExpression {
-  return validateNode<t.TSNonNullExpression>({
+  const node: t.TSNonNullExpression = {
     type: "TSNonNullExpression",
     expression,
-  });
+  };
+  const defs = NODE_FIELDS.TSNonNullExpression;
+  validate(defs, node, "expression", expression, 1);
+  return node;
 }
 export { tsNonNullExpression as tSNonNullExpression };
 export function tsExportAssignment(
   expression: t.Expression,
 ): t.TSExportAssignment {
-  return validateNode<t.TSExportAssignment>({
+  const node: t.TSExportAssignment = {
     type: "TSExportAssignment",
     expression,
-  });
+  };
+  const defs = NODE_FIELDS.TSExportAssignment;
+  validate(defs, node, "expression", expression, 1);
+  return node;
 }
 export { tsExportAssignment as tSExportAssignment };
 export function tsNamespaceExportDeclaration(
   id: t.Identifier,
 ): t.TSNamespaceExportDeclaration {
-  return validateNode<t.TSNamespaceExportDeclaration>({
+  const node: t.TSNamespaceExportDeclaration = {
     type: "TSNamespaceExportDeclaration",
     id,
-  });
+  };
+  const defs = NODE_FIELDS.TSNamespaceExportDeclaration;
+  validate(defs, node, "id", id, 1);
+  return node;
 }
 export { tsNamespaceExportDeclaration as tSNamespaceExportDeclaration };
 export function tsTypeAnnotation(typeAnnotation: t.TSType): t.TSTypeAnnotation {
-  return validateNode<t.TSTypeAnnotation>({
+  const node: t.TSTypeAnnotation = {
     type: "TSTypeAnnotation",
     typeAnnotation,
-  });
+  };
+  const defs = NODE_FIELDS.TSTypeAnnotation;
+  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  return node;
 }
 export { tsTypeAnnotation as tSTypeAnnotation };
 export function tsTypeParameterInstantiation(
   params: Array<t.TSType>,
 ): t.TSTypeParameterInstantiation {
-  return validateNode<t.TSTypeParameterInstantiation>({
+  const node: t.TSTypeParameterInstantiation = {
     type: "TSTypeParameterInstantiation",
     params,
-  });
+  };
+  const defs = NODE_FIELDS.TSTypeParameterInstantiation;
+  validate(defs, node, "params", params, 1);
+  return node;
 }
 export { tsTypeParameterInstantiation as tSTypeParameterInstantiation };
 export function tsTypeParameterDeclaration(
   params: Array<t.TSTypeParameter>,
 ): t.TSTypeParameterDeclaration {
-  return validateNode<t.TSTypeParameterDeclaration>({
+  const node: t.TSTypeParameterDeclaration = {
     type: "TSTypeParameterDeclaration",
     params,
-  });
+  };
+  const defs = NODE_FIELDS.TSTypeParameterDeclaration;
+  validate(defs, node, "params", params, 1);
+  return node;
 }
 export { tsTypeParameterDeclaration as tSTypeParameterDeclaration };
 export function tsTypeParameter(
@@ -2517,12 +3379,17 @@ export function tsTypeParameter(
   _default: t.TSType | null | undefined = null,
   name: string,
 ): t.TSTypeParameter {
-  return validateNode<t.TSTypeParameter>({
+  const node: t.TSTypeParameter = {
     type: "TSTypeParameter",
     constraint,
     default: _default,
     name,
-  });
+  };
+  const defs = NODE_FIELDS.TSTypeParameter;
+  validate(defs, node, "constraint", constraint, 1);
+  validate(defs, node, "default", _default, 1);
+  validate(defs, node, "name", name);
+  return node;
 }
 export { tsTypeParameter as tSTypeParameter };
 /** @deprecated */

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -18,7 +18,7 @@ export function arrayExpression(
     elements,
   };
   const defs = NODE_FIELDS.ArrayExpression;
-  validate(defs, node, "elements", elements, 1);
+  validate(defs.elements, node, "elements", elements, 1);
   return node;
 }
 export function assignmentExpression(
@@ -33,9 +33,9 @@ export function assignmentExpression(
     right,
   };
   const defs = NODE_FIELDS.AssignmentExpression;
-  validate(defs, node, "operator", operator);
-  validate(defs, node, "left", left, 1);
-  validate(defs, node, "right", right, 1);
+  validate(defs.operator, node, "operator", operator);
+  validate(defs.left, node, "left", left, 1);
+  validate(defs.right, node, "right", right, 1);
   return node;
 }
 export function binaryExpression(
@@ -73,9 +73,9 @@ export function binaryExpression(
     right,
   };
   const defs = NODE_FIELDS.BinaryExpression;
-  validate(defs, node, "operator", operator);
-  validate(defs, node, "left", left, 1);
-  validate(defs, node, "right", right, 1);
+  validate(defs.operator, node, "operator", operator);
+  validate(defs.left, node, "left", left, 1);
+  validate(defs.right, node, "right", right, 1);
   return node;
 }
 export function interpreterDirective(value: string): t.InterpreterDirective {
@@ -84,7 +84,7 @@ export function interpreterDirective(value: string): t.InterpreterDirective {
     value,
   };
   const defs = NODE_FIELDS.InterpreterDirective;
-  validate(defs, node, "value", value);
+  validate(defs.value, node, "value", value);
   return node;
 }
 export function directive(value: t.DirectiveLiteral): t.Directive {
@@ -93,7 +93,7 @@ export function directive(value: t.DirectiveLiteral): t.Directive {
     value,
   };
   const defs = NODE_FIELDS.Directive;
-  validate(defs, node, "value", value, 1);
+  validate(defs.value, node, "value", value, 1);
   return node;
 }
 export function directiveLiteral(value: string): t.DirectiveLiteral {
@@ -102,7 +102,7 @@ export function directiveLiteral(value: string): t.DirectiveLiteral {
     value,
   };
   const defs = NODE_FIELDS.DirectiveLiteral;
-  validate(defs, node, "value", value);
+  validate(defs.value, node, "value", value);
   return node;
 }
 export function blockStatement(
@@ -115,8 +115,8 @@ export function blockStatement(
     directives,
   };
   const defs = NODE_FIELDS.BlockStatement;
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "directives", directives, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.directives, node, "directives", directives, 1);
   return node;
 }
 export function breakStatement(
@@ -127,7 +127,7 @@ export function breakStatement(
     label,
   };
   const defs = NODE_FIELDS.BreakStatement;
-  validate(defs, node, "label", label, 1);
+  validate(defs.label, node, "label", label, 1);
   return node;
 }
 export function callExpression(
@@ -140,8 +140,8 @@ export function callExpression(
     arguments: _arguments,
   };
   const defs = NODE_FIELDS.CallExpression;
-  validate(defs, node, "callee", callee, 1);
-  validate(defs, node, "arguments", _arguments, 1);
+  validate(defs.callee, node, "callee", callee, 1);
+  validate(defs.arguments, node, "arguments", _arguments, 1);
   return node;
 }
 export function catchClause(
@@ -159,8 +159,8 @@ export function catchClause(
     body,
   };
   const defs = NODE_FIELDS.CatchClause;
-  validate(defs, node, "param", param, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.param, node, "param", param, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function conditionalExpression(
@@ -175,9 +175,9 @@ export function conditionalExpression(
     alternate,
   };
   const defs = NODE_FIELDS.ConditionalExpression;
-  validate(defs, node, "test", test, 1);
-  validate(defs, node, "consequent", consequent, 1);
-  validate(defs, node, "alternate", alternate, 1);
+  validate(defs.test, node, "test", test, 1);
+  validate(defs.consequent, node, "consequent", consequent, 1);
+  validate(defs.alternate, node, "alternate", alternate, 1);
   return node;
 }
 export function continueStatement(
@@ -188,7 +188,7 @@ export function continueStatement(
     label,
   };
   const defs = NODE_FIELDS.ContinueStatement;
-  validate(defs, node, "label", label, 1);
+  validate(defs.label, node, "label", label, 1);
   return node;
 }
 export function debuggerStatement(): t.DebuggerStatement {
@@ -206,8 +206,8 @@ export function doWhileStatement(
     body,
   };
   const defs = NODE_FIELDS.DoWhileStatement;
-  validate(defs, node, "test", test, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.test, node, "test", test, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function emptyStatement(): t.EmptyStatement {
@@ -223,7 +223,7 @@ export function expressionStatement(
     expression,
   };
   const defs = NODE_FIELDS.ExpressionStatement;
-  validate(defs, node, "expression", expression, 1);
+  validate(defs.expression, node, "expression", expression, 1);
   return node;
 }
 export function file(
@@ -238,9 +238,9 @@ export function file(
     tokens,
   };
   const defs = NODE_FIELDS.File;
-  validate(defs, node, "program", program, 1);
-  validate(defs, node, "comments", comments, 1);
-  validate(defs, node, "tokens", tokens);
+  validate(defs.program, node, "program", program, 1);
+  validate(defs.comments, node, "comments", comments, 1);
+  validate(defs.tokens, node, "tokens", tokens);
   return node;
 }
 export function forInStatement(
@@ -255,9 +255,9 @@ export function forInStatement(
     body,
   };
   const defs = NODE_FIELDS.ForInStatement;
-  validate(defs, node, "left", left, 1);
-  validate(defs, node, "right", right, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.left, node, "left", left, 1);
+  validate(defs.right, node, "right", right, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function forStatement(
@@ -274,10 +274,10 @@ export function forStatement(
     body,
   };
   const defs = NODE_FIELDS.ForStatement;
-  validate(defs, node, "init", init, 1);
-  validate(defs, node, "test", test, 1);
-  validate(defs, node, "update", update, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.init, node, "init", init, 1);
+  validate(defs.test, node, "test", test, 1);
+  validate(defs.update, node, "update", update, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function functionDeclaration(
@@ -296,11 +296,11 @@ export function functionDeclaration(
     async,
   };
   const defs = NODE_FIELDS.FunctionDeclaration;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "params", params, 1);
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "generator", generator);
-  validate(defs, node, "async", async);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.params, node, "params", params, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.generator, node, "generator", generator);
+  validate(defs.async, node, "async", async);
   return node;
 }
 export function functionExpression(
@@ -319,11 +319,11 @@ export function functionExpression(
     async,
   };
   const defs = NODE_FIELDS.FunctionExpression;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "params", params, 1);
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "generator", generator);
-  validate(defs, node, "async", async);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.params, node, "params", params, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.generator, node, "generator", generator);
+  validate(defs.async, node, "async", async);
   return node;
 }
 export function identifier(name: string): t.Identifier {
@@ -332,7 +332,7 @@ export function identifier(name: string): t.Identifier {
     name,
   };
   const defs = NODE_FIELDS.Identifier;
-  validate(defs, node, "name", name);
+  validate(defs.name, node, "name", name);
   return node;
 }
 export function ifStatement(
@@ -347,9 +347,9 @@ export function ifStatement(
     alternate,
   };
   const defs = NODE_FIELDS.IfStatement;
-  validate(defs, node, "test", test, 1);
-  validate(defs, node, "consequent", consequent, 1);
-  validate(defs, node, "alternate", alternate, 1);
+  validate(defs.test, node, "test", test, 1);
+  validate(defs.consequent, node, "consequent", consequent, 1);
+  validate(defs.alternate, node, "alternate", alternate, 1);
   return node;
 }
 export function labeledStatement(
@@ -362,8 +362,8 @@ export function labeledStatement(
     body,
   };
   const defs = NODE_FIELDS.LabeledStatement;
-  validate(defs, node, "label", label, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.label, node, "label", label, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function stringLiteral(value: string): t.StringLiteral {
@@ -372,7 +372,7 @@ export function stringLiteral(value: string): t.StringLiteral {
     value,
   };
   const defs = NODE_FIELDS.StringLiteral;
-  validate(defs, node, "value", value);
+  validate(defs.value, node, "value", value);
   return node;
 }
 export function numericLiteral(value: number): t.NumericLiteral {
@@ -381,7 +381,7 @@ export function numericLiteral(value: number): t.NumericLiteral {
     value,
   };
   const defs = NODE_FIELDS.NumericLiteral;
-  validate(defs, node, "value", value);
+  validate(defs.value, node, "value", value);
   return node;
 }
 export function nullLiteral(): t.NullLiteral {
@@ -395,7 +395,7 @@ export function booleanLiteral(value: boolean): t.BooleanLiteral {
     value,
   };
   const defs = NODE_FIELDS.BooleanLiteral;
-  validate(defs, node, "value", value);
+  validate(defs.value, node, "value", value);
   return node;
 }
 export function regExpLiteral(
@@ -408,8 +408,8 @@ export function regExpLiteral(
     flags,
   };
   const defs = NODE_FIELDS.RegExpLiteral;
-  validate(defs, node, "pattern", pattern);
-  validate(defs, node, "flags", flags);
+  validate(defs.pattern, node, "pattern", pattern);
+  validate(defs.flags, node, "flags", flags);
   return node;
 }
 export function logicalExpression(
@@ -424,9 +424,9 @@ export function logicalExpression(
     right,
   };
   const defs = NODE_FIELDS.LogicalExpression;
-  validate(defs, node, "operator", operator);
-  validate(defs, node, "left", left, 1);
-  validate(defs, node, "right", right, 1);
+  validate(defs.operator, node, "operator", operator);
+  validate(defs.left, node, "left", left, 1);
+  validate(defs.right, node, "right", right, 1);
   return node;
 }
 export function memberExpression(
@@ -443,10 +443,10 @@ export function memberExpression(
     optional,
   };
   const defs = NODE_FIELDS.MemberExpression;
-  validate(defs, node, "object", object, 1);
-  validate(defs, node, "property", property, 1);
-  validate(defs, node, "computed", computed);
-  validate(defs, node, "optional", optional);
+  validate(defs.object, node, "object", object, 1);
+  validate(defs.property, node, "property", property, 1);
+  validate(defs.computed, node, "computed", computed);
+  validate(defs.optional, node, "optional", optional);
   return node;
 }
 export function newExpression(
@@ -459,8 +459,8 @@ export function newExpression(
     arguments: _arguments,
   };
   const defs = NODE_FIELDS.NewExpression;
-  validate(defs, node, "callee", callee, 1);
-  validate(defs, node, "arguments", _arguments, 1);
+  validate(defs.callee, node, "callee", callee, 1);
+  validate(defs.arguments, node, "arguments", _arguments, 1);
   return node;
 }
 export function program(
@@ -477,10 +477,10 @@ export function program(
     interpreter,
   };
   const defs = NODE_FIELDS.Program;
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "directives", directives, 1);
-  validate(defs, node, "sourceType", sourceType);
-  validate(defs, node, "interpreter", interpreter, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.directives, node, "directives", directives, 1);
+  validate(defs.sourceType, node, "sourceType", sourceType);
+  validate(defs.interpreter, node, "interpreter", interpreter, 1);
   return node;
 }
 export function objectExpression(
@@ -491,7 +491,7 @@ export function objectExpression(
     properties,
   };
   const defs = NODE_FIELDS.ObjectExpression;
-  validate(defs, node, "properties", properties, 1);
+  validate(defs.properties, node, "properties", properties, 1);
   return node;
 }
 export function objectMethod(
@@ -519,13 +519,13 @@ export function objectMethod(
     async,
   };
   const defs = NODE_FIELDS.ObjectMethod;
-  validate(defs, node, "kind", kind);
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "params", params, 1);
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "computed", computed);
-  validate(defs, node, "generator", generator);
-  validate(defs, node, "async", async);
+  validate(defs.kind, node, "kind", kind);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.params, node, "params", params, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.computed, node, "computed", computed);
+  validate(defs.generator, node, "generator", generator);
+  validate(defs.async, node, "async", async);
   return node;
 }
 export function objectProperty(
@@ -551,11 +551,11 @@ export function objectProperty(
     decorators,
   };
   const defs = NODE_FIELDS.ObjectProperty;
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "value", value, 1);
-  validate(defs, node, "computed", computed);
-  validate(defs, node, "shorthand", shorthand);
-  validate(defs, node, "decorators", decorators, 1);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.value, node, "value", value, 1);
+  validate(defs.computed, node, "computed", computed);
+  validate(defs.shorthand, node, "shorthand", shorthand);
+  validate(defs.decorators, node, "decorators", decorators, 1);
   return node;
 }
 export function restElement(argument: t.LVal): t.RestElement {
@@ -564,7 +564,7 @@ export function restElement(argument: t.LVal): t.RestElement {
     argument,
   };
   const defs = NODE_FIELDS.RestElement;
-  validate(defs, node, "argument", argument, 1);
+  validate(defs.argument, node, "argument", argument, 1);
   return node;
 }
 export function returnStatement(
@@ -575,7 +575,7 @@ export function returnStatement(
     argument,
   };
   const defs = NODE_FIELDS.ReturnStatement;
-  validate(defs, node, "argument", argument, 1);
+  validate(defs.argument, node, "argument", argument, 1);
   return node;
 }
 export function sequenceExpression(
@@ -586,7 +586,7 @@ export function sequenceExpression(
     expressions,
   };
   const defs = NODE_FIELDS.SequenceExpression;
-  validate(defs, node, "expressions", expressions, 1);
+  validate(defs.expressions, node, "expressions", expressions, 1);
   return node;
 }
 export function parenthesizedExpression(
@@ -597,7 +597,7 @@ export function parenthesizedExpression(
     expression,
   };
   const defs = NODE_FIELDS.ParenthesizedExpression;
-  validate(defs, node, "expression", expression, 1);
+  validate(defs.expression, node, "expression", expression, 1);
   return node;
 }
 export function switchCase(
@@ -610,8 +610,8 @@ export function switchCase(
     consequent,
   };
   const defs = NODE_FIELDS.SwitchCase;
-  validate(defs, node, "test", test, 1);
-  validate(defs, node, "consequent", consequent, 1);
+  validate(defs.test, node, "test", test, 1);
+  validate(defs.consequent, node, "consequent", consequent, 1);
   return node;
 }
 export function switchStatement(
@@ -624,8 +624,8 @@ export function switchStatement(
     cases,
   };
   const defs = NODE_FIELDS.SwitchStatement;
-  validate(defs, node, "discriminant", discriminant, 1);
-  validate(defs, node, "cases", cases, 1);
+  validate(defs.discriminant, node, "discriminant", discriminant, 1);
+  validate(defs.cases, node, "cases", cases, 1);
   return node;
 }
 export function thisExpression(): t.ThisExpression {
@@ -639,7 +639,7 @@ export function throwStatement(argument: t.Expression): t.ThrowStatement {
     argument,
   };
   const defs = NODE_FIELDS.ThrowStatement;
-  validate(defs, node, "argument", argument, 1);
+  validate(defs.argument, node, "argument", argument, 1);
   return node;
 }
 export function tryStatement(
@@ -654,9 +654,9 @@ export function tryStatement(
     finalizer,
   };
   const defs = NODE_FIELDS.TryStatement;
-  validate(defs, node, "block", block, 1);
-  validate(defs, node, "handler", handler, 1);
-  validate(defs, node, "finalizer", finalizer, 1);
+  validate(defs.block, node, "block", block, 1);
+  validate(defs.handler, node, "handler", handler, 1);
+  validate(defs.finalizer, node, "finalizer", finalizer, 1);
   return node;
 }
 export function unaryExpression(
@@ -671,9 +671,9 @@ export function unaryExpression(
     prefix,
   };
   const defs = NODE_FIELDS.UnaryExpression;
-  validate(defs, node, "operator", operator);
-  validate(defs, node, "argument", argument, 1);
-  validate(defs, node, "prefix", prefix);
+  validate(defs.operator, node, "operator", operator);
+  validate(defs.argument, node, "argument", argument, 1);
+  validate(defs.prefix, node, "prefix", prefix);
   return node;
 }
 export function updateExpression(
@@ -688,9 +688,9 @@ export function updateExpression(
     prefix,
   };
   const defs = NODE_FIELDS.UpdateExpression;
-  validate(defs, node, "operator", operator);
-  validate(defs, node, "argument", argument, 1);
-  validate(defs, node, "prefix", prefix);
+  validate(defs.operator, node, "operator", operator);
+  validate(defs.argument, node, "argument", argument, 1);
+  validate(defs.prefix, node, "prefix", prefix);
   return node;
 }
 export function variableDeclaration(
@@ -703,8 +703,8 @@ export function variableDeclaration(
     declarations,
   };
   const defs = NODE_FIELDS.VariableDeclaration;
-  validate(defs, node, "kind", kind);
-  validate(defs, node, "declarations", declarations, 1);
+  validate(defs.kind, node, "kind", kind);
+  validate(defs.declarations, node, "declarations", declarations, 1);
   return node;
 }
 export function variableDeclarator(
@@ -717,8 +717,8 @@ export function variableDeclarator(
     init,
   };
   const defs = NODE_FIELDS.VariableDeclarator;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "init", init, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.init, node, "init", init, 1);
   return node;
 }
 export function whileStatement(
@@ -731,8 +731,8 @@ export function whileStatement(
     body,
   };
   const defs = NODE_FIELDS.WhileStatement;
-  validate(defs, node, "test", test, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.test, node, "test", test, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function withStatement(
@@ -745,8 +745,8 @@ export function withStatement(
     body,
   };
   const defs = NODE_FIELDS.WithStatement;
-  validate(defs, node, "object", object, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.object, node, "object", object, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function assignmentPattern(
@@ -767,8 +767,8 @@ export function assignmentPattern(
     right,
   };
   const defs = NODE_FIELDS.AssignmentPattern;
-  validate(defs, node, "left", left, 1);
-  validate(defs, node, "right", right, 1);
+  validate(defs.left, node, "left", left, 1);
+  validate(defs.right, node, "right", right, 1);
   return node;
 }
 export function arrayPattern(
@@ -779,7 +779,7 @@ export function arrayPattern(
     elements,
   };
   const defs = NODE_FIELDS.ArrayPattern;
-  validate(defs, node, "elements", elements, 1);
+  validate(defs.elements, node, "elements", elements, 1);
   return node;
 }
 export function arrowFunctionExpression(
@@ -795,9 +795,9 @@ export function arrowFunctionExpression(
     expression: null,
   };
   const defs = NODE_FIELDS.ArrowFunctionExpression;
-  validate(defs, node, "params", params, 1);
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "async", async);
+  validate(defs.params, node, "params", params, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.async, node, "async", async);
   return node;
 }
 export function classBody(
@@ -817,7 +817,7 @@ export function classBody(
     body,
   };
   const defs = NODE_FIELDS.ClassBody;
-  validate(defs, node, "body", body, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function classExpression(
@@ -834,10 +834,10 @@ export function classExpression(
     decorators,
   };
   const defs = NODE_FIELDS.ClassExpression;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "superClass", superClass, 1);
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "decorators", decorators, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.superClass, node, "superClass", superClass, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.decorators, node, "decorators", decorators, 1);
   return node;
 }
 export function classDeclaration(
@@ -854,10 +854,10 @@ export function classDeclaration(
     decorators,
   };
   const defs = NODE_FIELDS.ClassDeclaration;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "superClass", superClass, 1);
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "decorators", decorators, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.superClass, node, "superClass", superClass, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.decorators, node, "decorators", decorators, 1);
   return node;
 }
 export function exportAllDeclaration(
@@ -868,7 +868,7 @@ export function exportAllDeclaration(
     source,
   };
   const defs = NODE_FIELDS.ExportAllDeclaration;
-  validate(defs, node, "source", source, 1);
+  validate(defs.source, node, "source", source, 1);
   return node;
 }
 export function exportDefaultDeclaration(
@@ -883,7 +883,7 @@ export function exportDefaultDeclaration(
     declaration,
   };
   const defs = NODE_FIELDS.ExportDefaultDeclaration;
-  validate(defs, node, "declaration", declaration, 1);
+  validate(defs.declaration, node, "declaration", declaration, 1);
   return node;
 }
 export function exportNamedDeclaration(
@@ -900,9 +900,9 @@ export function exportNamedDeclaration(
     source,
   };
   const defs = NODE_FIELDS.ExportNamedDeclaration;
-  validate(defs, node, "declaration", declaration, 1);
-  validate(defs, node, "specifiers", specifiers, 1);
-  validate(defs, node, "source", source, 1);
+  validate(defs.declaration, node, "declaration", declaration, 1);
+  validate(defs.specifiers, node, "specifiers", specifiers, 1);
+  validate(defs.source, node, "source", source, 1);
   return node;
 }
 export function exportSpecifier(
@@ -915,8 +915,8 @@ export function exportSpecifier(
     exported,
   };
   const defs = NODE_FIELDS.ExportSpecifier;
-  validate(defs, node, "local", local, 1);
-  validate(defs, node, "exported", exported, 1);
+  validate(defs.local, node, "local", local, 1);
+  validate(defs.exported, node, "exported", exported, 1);
   return node;
 }
 export function forOfStatement(
@@ -933,10 +933,10 @@ export function forOfStatement(
     await: _await,
   };
   const defs = NODE_FIELDS.ForOfStatement;
-  validate(defs, node, "left", left, 1);
-  validate(defs, node, "right", right, 1);
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "await", _await);
+  validate(defs.left, node, "left", left, 1);
+  validate(defs.right, node, "right", right, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.await, node, "await", _await);
   return node;
 }
 export function importDeclaration(
@@ -951,8 +951,8 @@ export function importDeclaration(
     source,
   };
   const defs = NODE_FIELDS.ImportDeclaration;
-  validate(defs, node, "specifiers", specifiers, 1);
-  validate(defs, node, "source", source, 1);
+  validate(defs.specifiers, node, "specifiers", specifiers, 1);
+  validate(defs.source, node, "source", source, 1);
   return node;
 }
 export function importDefaultSpecifier(
@@ -963,7 +963,7 @@ export function importDefaultSpecifier(
     local,
   };
   const defs = NODE_FIELDS.ImportDefaultSpecifier;
-  validate(defs, node, "local", local, 1);
+  validate(defs.local, node, "local", local, 1);
   return node;
 }
 export function importNamespaceSpecifier(
@@ -974,7 +974,7 @@ export function importNamespaceSpecifier(
     local,
   };
   const defs = NODE_FIELDS.ImportNamespaceSpecifier;
-  validate(defs, node, "local", local, 1);
+  validate(defs.local, node, "local", local, 1);
   return node;
 }
 export function importSpecifier(
@@ -987,8 +987,8 @@ export function importSpecifier(
     imported,
   };
   const defs = NODE_FIELDS.ImportSpecifier;
-  validate(defs, node, "local", local, 1);
-  validate(defs, node, "imported", imported, 1);
+  validate(defs.local, node, "local", local, 1);
+  validate(defs.imported, node, "imported", imported, 1);
   return node;
 }
 export function importExpression(
@@ -1001,8 +1001,8 @@ export function importExpression(
     options,
   };
   const defs = NODE_FIELDS.ImportExpression;
-  validate(defs, node, "source", source, 1);
-  validate(defs, node, "options", options, 1);
+  validate(defs.source, node, "source", source, 1);
+  validate(defs.options, node, "options", options, 1);
   return node;
 }
 export function metaProperty(
@@ -1015,8 +1015,8 @@ export function metaProperty(
     property,
   };
   const defs = NODE_FIELDS.MetaProperty;
-  validate(defs, node, "meta", meta, 1);
-  validate(defs, node, "property", property, 1);
+  validate(defs.meta, node, "meta", meta, 1);
+  validate(defs.property, node, "property", property, 1);
   return node;
 }
 export function classMethod(
@@ -1048,14 +1048,14 @@ export function classMethod(
     async,
   };
   const defs = NODE_FIELDS.ClassMethod;
-  validate(defs, node, "kind", kind);
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "params", params, 1);
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "computed", computed);
-  validate(defs, node, "static", _static);
-  validate(defs, node, "generator", generator);
-  validate(defs, node, "async", async);
+  validate(defs.kind, node, "kind", kind);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.params, node, "params", params, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.computed, node, "computed", computed);
+  validate(defs.static, node, "static", _static);
+  validate(defs.generator, node, "generator", generator);
+  validate(defs.async, node, "async", async);
   return node;
 }
 export function objectPattern(
@@ -1066,7 +1066,7 @@ export function objectPattern(
     properties,
   };
   const defs = NODE_FIELDS.ObjectPattern;
-  validate(defs, node, "properties", properties, 1);
+  validate(defs.properties, node, "properties", properties, 1);
   return node;
 }
 export function spreadElement(argument: t.Expression): t.SpreadElement {
@@ -1075,7 +1075,7 @@ export function spreadElement(argument: t.Expression): t.SpreadElement {
     argument,
   };
   const defs = NODE_FIELDS.SpreadElement;
-  validate(defs, node, "argument", argument, 1);
+  validate(defs.argument, node, "argument", argument, 1);
   return node;
 }
 function _super(): t.Super {
@@ -1094,8 +1094,8 @@ export function taggedTemplateExpression(
     quasi,
   };
   const defs = NODE_FIELDS.TaggedTemplateExpression;
-  validate(defs, node, "tag", tag, 1);
-  validate(defs, node, "quasi", quasi, 1);
+  validate(defs.tag, node, "tag", tag, 1);
+  validate(defs.quasi, node, "quasi", quasi, 1);
   return node;
 }
 export function templateElement(
@@ -1108,8 +1108,8 @@ export function templateElement(
     tail,
   };
   const defs = NODE_FIELDS.TemplateElement;
-  validate(defs, node, "value", value);
-  validate(defs, node, "tail", tail);
+  validate(defs.value, node, "value", value);
+  validate(defs.tail, node, "tail", tail);
   return node;
 }
 export function templateLiteral(
@@ -1122,8 +1122,8 @@ export function templateLiteral(
     expressions,
   };
   const defs = NODE_FIELDS.TemplateLiteral;
-  validate(defs, node, "quasis", quasis, 1);
-  validate(defs, node, "expressions", expressions, 1);
+  validate(defs.quasis, node, "quasis", quasis, 1);
+  validate(defs.expressions, node, "expressions", expressions, 1);
   return node;
 }
 export function yieldExpression(
@@ -1136,8 +1136,8 @@ export function yieldExpression(
     delegate,
   };
   const defs = NODE_FIELDS.YieldExpression;
-  validate(defs, node, "argument", argument, 1);
-  validate(defs, node, "delegate", delegate);
+  validate(defs.argument, node, "argument", argument, 1);
+  validate(defs.delegate, node, "delegate", delegate);
   return node;
 }
 export function awaitExpression(argument: t.Expression): t.AwaitExpression {
@@ -1146,7 +1146,7 @@ export function awaitExpression(argument: t.Expression): t.AwaitExpression {
     argument,
   };
   const defs = NODE_FIELDS.AwaitExpression;
-  validate(defs, node, "argument", argument, 1);
+  validate(defs.argument, node, "argument", argument, 1);
   return node;
 }
 function _import(): t.Import {
@@ -1161,7 +1161,7 @@ export function bigIntLiteral(value: string): t.BigIntLiteral {
     value,
   };
   const defs = NODE_FIELDS.BigIntLiteral;
-  validate(defs, node, "value", value);
+  validate(defs.value, node, "value", value);
   return node;
 }
 export function exportNamespaceSpecifier(
@@ -1172,7 +1172,7 @@ export function exportNamespaceSpecifier(
     exported,
   };
   const defs = NODE_FIELDS.ExportNamespaceSpecifier;
-  validate(defs, node, "exported", exported, 1);
+  validate(defs.exported, node, "exported", exported, 1);
   return node;
 }
 export function optionalMemberExpression(
@@ -1189,10 +1189,10 @@ export function optionalMemberExpression(
     optional,
   };
   const defs = NODE_FIELDS.OptionalMemberExpression;
-  validate(defs, node, "object", object, 1);
-  validate(defs, node, "property", property, 1);
-  validate(defs, node, "computed", computed);
-  validate(defs, node, "optional", optional);
+  validate(defs.object, node, "object", object, 1);
+  validate(defs.property, node, "property", property, 1);
+  validate(defs.computed, node, "computed", computed);
+  validate(defs.optional, node, "optional", optional);
   return node;
 }
 export function optionalCallExpression(
@@ -1207,9 +1207,9 @@ export function optionalCallExpression(
     optional,
   };
   const defs = NODE_FIELDS.OptionalCallExpression;
-  validate(defs, node, "callee", callee, 1);
-  validate(defs, node, "arguments", _arguments, 1);
-  validate(defs, node, "optional", optional);
+  validate(defs.callee, node, "callee", callee, 1);
+  validate(defs.arguments, node, "arguments", _arguments, 1);
+  validate(defs.optional, node, "optional", optional);
   return node;
 }
 export function classProperty(
@@ -1235,12 +1235,12 @@ export function classProperty(
     static: _static,
   };
   const defs = NODE_FIELDS.ClassProperty;
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "value", value, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
-  validate(defs, node, "decorators", decorators, 1);
-  validate(defs, node, "computed", computed);
-  validate(defs, node, "static", _static);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.value, node, "value", value, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.decorators, node, "decorators", decorators, 1);
+  validate(defs.computed, node, "computed", computed);
+  validate(defs.static, node, "static", _static);
   return node;
 }
 export function classAccessorProperty(
@@ -1267,12 +1267,12 @@ export function classAccessorProperty(
     static: _static,
   };
   const defs = NODE_FIELDS.ClassAccessorProperty;
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "value", value, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
-  validate(defs, node, "decorators", decorators, 1);
-  validate(defs, node, "computed", computed);
-  validate(defs, node, "static", _static);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.value, node, "value", value, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.decorators, node, "decorators", decorators, 1);
+  validate(defs.computed, node, "computed", computed);
+  validate(defs.static, node, "static", _static);
   return node;
 }
 export function classPrivateProperty(
@@ -1289,10 +1289,10 @@ export function classPrivateProperty(
     static: _static,
   };
   const defs = NODE_FIELDS.ClassPrivateProperty;
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "value", value, 1);
-  validate(defs, node, "decorators", decorators, 1);
-  validate(defs, node, "static", _static);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.value, node, "value", value, 1);
+  validate(defs.decorators, node, "decorators", decorators, 1);
+  validate(defs.static, node, "static", _static);
   return node;
 }
 export function classPrivateMethod(
@@ -1313,11 +1313,11 @@ export function classPrivateMethod(
     static: _static,
   };
   const defs = NODE_FIELDS.ClassPrivateMethod;
-  validate(defs, node, "kind", kind);
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "params", params, 1);
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "static", _static);
+  validate(defs.kind, node, "kind", kind);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.params, node, "params", params, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.static, node, "static", _static);
   return node;
 }
 export function privateName(id: t.Identifier): t.PrivateName {
@@ -1326,7 +1326,7 @@ export function privateName(id: t.Identifier): t.PrivateName {
     id,
   };
   const defs = NODE_FIELDS.PrivateName;
-  validate(defs, node, "id", id, 1);
+  validate(defs.id, node, "id", id, 1);
   return node;
 }
 export function staticBlock(body: Array<t.Statement>): t.StaticBlock {
@@ -1335,7 +1335,7 @@ export function staticBlock(body: Array<t.Statement>): t.StaticBlock {
     body,
   };
   const defs = NODE_FIELDS.StaticBlock;
-  validate(defs, node, "body", body, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function anyTypeAnnotation(): t.AnyTypeAnnotation {
@@ -1351,7 +1351,7 @@ export function arrayTypeAnnotation(
     elementType,
   };
   const defs = NODE_FIELDS.ArrayTypeAnnotation;
-  validate(defs, node, "elementType", elementType, 1);
+  validate(defs.elementType, node, "elementType", elementType, 1);
   return node;
 }
 export function booleanTypeAnnotation(): t.BooleanTypeAnnotation {
@@ -1367,7 +1367,7 @@ export function booleanLiteralTypeAnnotation(
     value,
   };
   const defs = NODE_FIELDS.BooleanLiteralTypeAnnotation;
-  validate(defs, node, "value", value);
+  validate(defs.value, node, "value", value);
   return node;
 }
 export function nullLiteralTypeAnnotation(): t.NullLiteralTypeAnnotation {
@@ -1385,8 +1385,8 @@ export function classImplements(
     typeParameters,
   };
   const defs = NODE_FIELDS.ClassImplements;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
   return node;
 }
 export function declareClass(
@@ -1403,10 +1403,10 @@ export function declareClass(
     body,
   };
   const defs = NODE_FIELDS.DeclareClass;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "extends", _extends, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.extends, node, "extends", _extends, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function declareFunction(id: t.Identifier): t.DeclareFunction {
@@ -1415,7 +1415,7 @@ export function declareFunction(id: t.Identifier): t.DeclareFunction {
     id,
   };
   const defs = NODE_FIELDS.DeclareFunction;
-  validate(defs, node, "id", id, 1);
+  validate(defs.id, node, "id", id, 1);
   return node;
 }
 export function declareInterface(
@@ -1432,10 +1432,10 @@ export function declareInterface(
     body,
   };
   const defs = NODE_FIELDS.DeclareInterface;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "extends", _extends, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.extends, node, "extends", _extends, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function declareModule(
@@ -1450,9 +1450,9 @@ export function declareModule(
     kind,
   };
   const defs = NODE_FIELDS.DeclareModule;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "kind", kind);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.kind, node, "kind", kind);
   return node;
 }
 export function declareModuleExports(
@@ -1463,7 +1463,7 @@ export function declareModuleExports(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.DeclareModuleExports;
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export function declareTypeAlias(
@@ -1478,9 +1478,9 @@ export function declareTypeAlias(
     right,
   };
   const defs = NODE_FIELDS.DeclareTypeAlias;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "right", right, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.right, node, "right", right, 1);
   return node;
 }
 export function declareOpaqueType(
@@ -1495,9 +1495,9 @@ export function declareOpaqueType(
     supertype,
   };
   const defs = NODE_FIELDS.DeclareOpaqueType;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "supertype", supertype, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.supertype, node, "supertype", supertype, 1);
   return node;
 }
 export function declareVariable(id: t.Identifier): t.DeclareVariable {
@@ -1506,7 +1506,7 @@ export function declareVariable(id: t.Identifier): t.DeclareVariable {
     id,
   };
   const defs = NODE_FIELDS.DeclareVariable;
-  validate(defs, node, "id", id, 1);
+  validate(defs.id, node, "id", id, 1);
   return node;
 }
 export function declareExportDeclaration(
@@ -1523,9 +1523,9 @@ export function declareExportDeclaration(
     source,
   };
   const defs = NODE_FIELDS.DeclareExportDeclaration;
-  validate(defs, node, "declaration", declaration, 1);
-  validate(defs, node, "specifiers", specifiers, 1);
-  validate(defs, node, "source", source, 1);
+  validate(defs.declaration, node, "declaration", declaration, 1);
+  validate(defs.specifiers, node, "specifiers", specifiers, 1);
+  validate(defs.source, node, "source", source, 1);
   return node;
 }
 export function declareExportAllDeclaration(
@@ -1536,7 +1536,7 @@ export function declareExportAllDeclaration(
     source,
   };
   const defs = NODE_FIELDS.DeclareExportAllDeclaration;
-  validate(defs, node, "source", source, 1);
+  validate(defs.source, node, "source", source, 1);
   return node;
 }
 export function declaredPredicate(value: t.Flow): t.DeclaredPredicate {
@@ -1545,7 +1545,7 @@ export function declaredPredicate(value: t.Flow): t.DeclaredPredicate {
     value,
   };
   const defs = NODE_FIELDS.DeclaredPredicate;
-  validate(defs, node, "value", value, 1);
+  validate(defs.value, node, "value", value, 1);
   return node;
 }
 export function existsTypeAnnotation(): t.ExistsTypeAnnotation {
@@ -1567,10 +1567,10 @@ export function functionTypeAnnotation(
     returnType,
   };
   const defs = NODE_FIELDS.FunctionTypeAnnotation;
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "params", params, 1);
-  validate(defs, node, "rest", rest, 1);
-  validate(defs, node, "returnType", returnType, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.params, node, "params", params, 1);
+  validate(defs.rest, node, "rest", rest, 1);
+  validate(defs.returnType, node, "returnType", returnType, 1);
   return node;
 }
 export function functionTypeParam(
@@ -1583,8 +1583,8 @@ export function functionTypeParam(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.FunctionTypeParam;
-  validate(defs, node, "name", name, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.name, node, "name", name, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export function genericTypeAnnotation(
@@ -1597,8 +1597,8 @@ export function genericTypeAnnotation(
     typeParameters,
   };
   const defs = NODE_FIELDS.GenericTypeAnnotation;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
   return node;
 }
 export function inferredPredicate(): t.InferredPredicate {
@@ -1616,8 +1616,8 @@ export function interfaceExtends(
     typeParameters,
   };
   const defs = NODE_FIELDS.InterfaceExtends;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
   return node;
 }
 export function interfaceDeclaration(
@@ -1634,10 +1634,10 @@ export function interfaceDeclaration(
     body,
   };
   const defs = NODE_FIELDS.InterfaceDeclaration;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "extends", _extends, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.extends, node, "extends", _extends, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function interfaceTypeAnnotation(
@@ -1650,8 +1650,8 @@ export function interfaceTypeAnnotation(
     body,
   };
   const defs = NODE_FIELDS.InterfaceTypeAnnotation;
-  validate(defs, node, "extends", _extends, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.extends, node, "extends", _extends, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function intersectionTypeAnnotation(
@@ -1662,7 +1662,7 @@ export function intersectionTypeAnnotation(
     types,
   };
   const defs = NODE_FIELDS.IntersectionTypeAnnotation;
-  validate(defs, node, "types", types, 1);
+  validate(defs.types, node, "types", types, 1);
   return node;
 }
 export function mixedTypeAnnotation(): t.MixedTypeAnnotation {
@@ -1683,7 +1683,7 @@ export function nullableTypeAnnotation(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.NullableTypeAnnotation;
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export function numberLiteralTypeAnnotation(
@@ -1694,7 +1694,7 @@ export function numberLiteralTypeAnnotation(
     value,
   };
   const defs = NODE_FIELDS.NumberLiteralTypeAnnotation;
-  validate(defs, node, "value", value);
+  validate(defs.value, node, "value", value);
   return node;
 }
 export function numberTypeAnnotation(): t.NumberTypeAnnotation {
@@ -1718,11 +1718,11 @@ export function objectTypeAnnotation(
     exact,
   };
   const defs = NODE_FIELDS.ObjectTypeAnnotation;
-  validate(defs, node, "properties", properties, 1);
-  validate(defs, node, "indexers", indexers, 1);
-  validate(defs, node, "callProperties", callProperties, 1);
-  validate(defs, node, "internalSlots", internalSlots, 1);
-  validate(defs, node, "exact", exact);
+  validate(defs.properties, node, "properties", properties, 1);
+  validate(defs.indexers, node, "indexers", indexers, 1);
+  validate(defs.callProperties, node, "callProperties", callProperties, 1);
+  validate(defs.internalSlots, node, "internalSlots", internalSlots, 1);
+  validate(defs.exact, node, "exact", exact);
   return node;
 }
 export function objectTypeInternalSlot(
@@ -1741,11 +1741,11 @@ export function objectTypeInternalSlot(
     method,
   };
   const defs = NODE_FIELDS.ObjectTypeInternalSlot;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "value", value, 1);
-  validate(defs, node, "optional", optional);
-  validate(defs, node, "static", _static);
-  validate(defs, node, "method", method);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.value, node, "value", value, 1);
+  validate(defs.optional, node, "optional", optional);
+  validate(defs.static, node, "static", _static);
+  validate(defs.method, node, "method", method);
   return node;
 }
 export function objectTypeCallProperty(
@@ -1757,7 +1757,7 @@ export function objectTypeCallProperty(
     static: null,
   };
   const defs = NODE_FIELDS.ObjectTypeCallProperty;
-  validate(defs, node, "value", value, 1);
+  validate(defs.value, node, "value", value, 1);
   return node;
 }
 export function objectTypeIndexer(
@@ -1775,10 +1775,10 @@ export function objectTypeIndexer(
     static: null,
   };
   const defs = NODE_FIELDS.ObjectTypeIndexer;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "value", value, 1);
-  validate(defs, node, "variance", variance, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.value, node, "value", value, 1);
+  validate(defs.variance, node, "variance", variance, 1);
   return node;
 }
 export function objectTypeProperty(
@@ -1798,9 +1798,9 @@ export function objectTypeProperty(
     static: null,
   };
   const defs = NODE_FIELDS.ObjectTypeProperty;
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "value", value, 1);
-  validate(defs, node, "variance", variance, 1);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.value, node, "value", value, 1);
+  validate(defs.variance, node, "variance", variance, 1);
   return node;
 }
 export function objectTypeSpreadProperty(
@@ -1811,7 +1811,7 @@ export function objectTypeSpreadProperty(
     argument,
   };
   const defs = NODE_FIELDS.ObjectTypeSpreadProperty;
-  validate(defs, node, "argument", argument, 1);
+  validate(defs.argument, node, "argument", argument, 1);
   return node;
 }
 export function opaqueType(
@@ -1828,10 +1828,10 @@ export function opaqueType(
     impltype,
   };
   const defs = NODE_FIELDS.OpaqueType;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "supertype", supertype, 1);
-  validate(defs, node, "impltype", impltype, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.supertype, node, "supertype", supertype, 1);
+  validate(defs.impltype, node, "impltype", impltype, 1);
   return node;
 }
 export function qualifiedTypeIdentifier(
@@ -1844,8 +1844,8 @@ export function qualifiedTypeIdentifier(
     qualification,
   };
   const defs = NODE_FIELDS.QualifiedTypeIdentifier;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "qualification", qualification, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.qualification, node, "qualification", qualification, 1);
   return node;
 }
 export function stringLiteralTypeAnnotation(
@@ -1856,7 +1856,7 @@ export function stringLiteralTypeAnnotation(
     value,
   };
   const defs = NODE_FIELDS.StringLiteralTypeAnnotation;
-  validate(defs, node, "value", value);
+  validate(defs.value, node, "value", value);
   return node;
 }
 export function stringTypeAnnotation(): t.StringTypeAnnotation {
@@ -1882,7 +1882,7 @@ export function tupleTypeAnnotation(
     types,
   };
   const defs = NODE_FIELDS.TupleTypeAnnotation;
-  validate(defs, node, "types", types, 1);
+  validate(defs.types, node, "types", types, 1);
   return node;
 }
 export function typeofTypeAnnotation(
@@ -1893,7 +1893,7 @@ export function typeofTypeAnnotation(
     argument,
   };
   const defs = NODE_FIELDS.TypeofTypeAnnotation;
-  validate(defs, node, "argument", argument, 1);
+  validate(defs.argument, node, "argument", argument, 1);
   return node;
 }
 export function typeAlias(
@@ -1908,9 +1908,9 @@ export function typeAlias(
     right,
   };
   const defs = NODE_FIELDS.TypeAlias;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "right", right, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.right, node, "right", right, 1);
   return node;
 }
 export function typeAnnotation(typeAnnotation: t.FlowType): t.TypeAnnotation {
@@ -1919,7 +1919,7 @@ export function typeAnnotation(typeAnnotation: t.FlowType): t.TypeAnnotation {
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TypeAnnotation;
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export function typeCastExpression(
@@ -1932,8 +1932,8 @@ export function typeCastExpression(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TypeCastExpression;
-  validate(defs, node, "expression", expression, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.expression, node, "expression", expression, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export function typeParameter(
@@ -1949,9 +1949,9 @@ export function typeParameter(
     name: null,
   };
   const defs = NODE_FIELDS.TypeParameter;
-  validate(defs, node, "bound", bound, 1);
-  validate(defs, node, "default", _default, 1);
-  validate(defs, node, "variance", variance, 1);
+  validate(defs.bound, node, "bound", bound, 1);
+  validate(defs.default, node, "default", _default, 1);
+  validate(defs.variance, node, "variance", variance, 1);
   return node;
 }
 export function typeParameterDeclaration(
@@ -1962,7 +1962,7 @@ export function typeParameterDeclaration(
     params,
   };
   const defs = NODE_FIELDS.TypeParameterDeclaration;
-  validate(defs, node, "params", params, 1);
+  validate(defs.params, node, "params", params, 1);
   return node;
 }
 export function typeParameterInstantiation(
@@ -1973,7 +1973,7 @@ export function typeParameterInstantiation(
     params,
   };
   const defs = NODE_FIELDS.TypeParameterInstantiation;
-  validate(defs, node, "params", params, 1);
+  validate(defs.params, node, "params", params, 1);
   return node;
 }
 export function unionTypeAnnotation(
@@ -1984,7 +1984,7 @@ export function unionTypeAnnotation(
     types,
   };
   const defs = NODE_FIELDS.UnionTypeAnnotation;
-  validate(defs, node, "types", types, 1);
+  validate(defs.types, node, "types", types, 1);
   return node;
 }
 export function variance(kind: "minus" | "plus"): t.Variance {
@@ -1993,7 +1993,7 @@ export function variance(kind: "minus" | "plus"): t.Variance {
     kind,
   };
   const defs = NODE_FIELDS.Variance;
-  validate(defs, node, "kind", kind);
+  validate(defs.kind, node, "kind", kind);
   return node;
 }
 export function voidTypeAnnotation(): t.VoidTypeAnnotation {
@@ -2015,8 +2015,8 @@ export function enumDeclaration(
     body,
   };
   const defs = NODE_FIELDS.EnumDeclaration;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function enumBooleanBody(
@@ -2029,7 +2029,7 @@ export function enumBooleanBody(
     hasUnknownMembers: null,
   };
   const defs = NODE_FIELDS.EnumBooleanBody;
-  validate(defs, node, "members", members, 1);
+  validate(defs.members, node, "members", members, 1);
   return node;
 }
 export function enumNumberBody(
@@ -2042,7 +2042,7 @@ export function enumNumberBody(
     hasUnknownMembers: null,
   };
   const defs = NODE_FIELDS.EnumNumberBody;
-  validate(defs, node, "members", members, 1);
+  validate(defs.members, node, "members", members, 1);
   return node;
 }
 export function enumStringBody(
@@ -2055,7 +2055,7 @@ export function enumStringBody(
     hasUnknownMembers: null,
   };
   const defs = NODE_FIELDS.EnumStringBody;
-  validate(defs, node, "members", members, 1);
+  validate(defs.members, node, "members", members, 1);
   return node;
 }
 export function enumSymbolBody(
@@ -2067,7 +2067,7 @@ export function enumSymbolBody(
     hasUnknownMembers: null,
   };
   const defs = NODE_FIELDS.EnumSymbolBody;
-  validate(defs, node, "members", members, 1);
+  validate(defs.members, node, "members", members, 1);
   return node;
 }
 export function enumBooleanMember(id: t.Identifier): t.EnumBooleanMember {
@@ -2077,7 +2077,7 @@ export function enumBooleanMember(id: t.Identifier): t.EnumBooleanMember {
     init: null,
   };
   const defs = NODE_FIELDS.EnumBooleanMember;
-  validate(defs, node, "id", id, 1);
+  validate(defs.id, node, "id", id, 1);
   return node;
 }
 export function enumNumberMember(
@@ -2090,8 +2090,8 @@ export function enumNumberMember(
     init,
   };
   const defs = NODE_FIELDS.EnumNumberMember;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "init", init, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.init, node, "init", init, 1);
   return node;
 }
 export function enumStringMember(
@@ -2104,8 +2104,8 @@ export function enumStringMember(
     init,
   };
   const defs = NODE_FIELDS.EnumStringMember;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "init", init, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.init, node, "init", init, 1);
   return node;
 }
 export function enumDefaultedMember(id: t.Identifier): t.EnumDefaultedMember {
@@ -2114,7 +2114,7 @@ export function enumDefaultedMember(id: t.Identifier): t.EnumDefaultedMember {
     id,
   };
   const defs = NODE_FIELDS.EnumDefaultedMember;
-  validate(defs, node, "id", id, 1);
+  validate(defs.id, node, "id", id, 1);
   return node;
 }
 export function indexedAccessType(
@@ -2127,8 +2127,8 @@ export function indexedAccessType(
     indexType,
   };
   const defs = NODE_FIELDS.IndexedAccessType;
-  validate(defs, node, "objectType", objectType, 1);
-  validate(defs, node, "indexType", indexType, 1);
+  validate(defs.objectType, node, "objectType", objectType, 1);
+  validate(defs.indexType, node, "indexType", indexType, 1);
   return node;
 }
 export function optionalIndexedAccessType(
@@ -2142,8 +2142,8 @@ export function optionalIndexedAccessType(
     optional: null,
   };
   const defs = NODE_FIELDS.OptionalIndexedAccessType;
-  validate(defs, node, "objectType", objectType, 1);
-  validate(defs, node, "indexType", indexType, 1);
+  validate(defs.objectType, node, "objectType", objectType, 1);
+  validate(defs.indexType, node, "indexType", indexType, 1);
   return node;
 }
 export function jsxAttribute(
@@ -2161,8 +2161,8 @@ export function jsxAttribute(
     value,
   };
   const defs = NODE_FIELDS.JSXAttribute;
-  validate(defs, node, "name", name, 1);
-  validate(defs, node, "value", value, 1);
+  validate(defs.name, node, "name", name, 1);
+  validate(defs.value, node, "value", value, 1);
   return node;
 }
 export { jsxAttribute as jSXAttribute };
@@ -2174,7 +2174,7 @@ export function jsxClosingElement(
     name,
   };
   const defs = NODE_FIELDS.JSXClosingElement;
-  validate(defs, node, "name", name, 1);
+  validate(defs.name, node, "name", name, 1);
   return node;
 }
 export { jsxClosingElement as jSXClosingElement };
@@ -2198,10 +2198,10 @@ export function jsxElement(
     selfClosing,
   };
   const defs = NODE_FIELDS.JSXElement;
-  validate(defs, node, "openingElement", openingElement, 1);
-  validate(defs, node, "closingElement", closingElement, 1);
-  validate(defs, node, "children", children, 1);
-  validate(defs, node, "selfClosing", selfClosing);
+  validate(defs.openingElement, node, "openingElement", openingElement, 1);
+  validate(defs.closingElement, node, "closingElement", closingElement, 1);
+  validate(defs.children, node, "children", children, 1);
+  validate(defs.selfClosing, node, "selfClosing", selfClosing);
   return node;
 }
 export { jsxElement as jSXElement };
@@ -2219,7 +2219,7 @@ export function jsxExpressionContainer(
     expression,
   };
   const defs = NODE_FIELDS.JSXExpressionContainer;
-  validate(defs, node, "expression", expression, 1);
+  validate(defs.expression, node, "expression", expression, 1);
   return node;
 }
 export { jsxExpressionContainer as jSXExpressionContainer };
@@ -2229,7 +2229,7 @@ export function jsxSpreadChild(expression: t.Expression): t.JSXSpreadChild {
     expression,
   };
   const defs = NODE_FIELDS.JSXSpreadChild;
-  validate(defs, node, "expression", expression, 1);
+  validate(defs.expression, node, "expression", expression, 1);
   return node;
 }
 export { jsxSpreadChild as jSXSpreadChild };
@@ -2239,7 +2239,7 @@ export function jsxIdentifier(name: string): t.JSXIdentifier {
     name,
   };
   const defs = NODE_FIELDS.JSXIdentifier;
-  validate(defs, node, "name", name);
+  validate(defs.name, node, "name", name);
   return node;
 }
 export { jsxIdentifier as jSXIdentifier };
@@ -2253,8 +2253,8 @@ export function jsxMemberExpression(
     property,
   };
   const defs = NODE_FIELDS.JSXMemberExpression;
-  validate(defs, node, "object", object, 1);
-  validate(defs, node, "property", property, 1);
+  validate(defs.object, node, "object", object, 1);
+  validate(defs.property, node, "property", property, 1);
   return node;
 }
 export { jsxMemberExpression as jSXMemberExpression };
@@ -2268,8 +2268,8 @@ export function jsxNamespacedName(
     name,
   };
   const defs = NODE_FIELDS.JSXNamespacedName;
-  validate(defs, node, "namespace", namespace, 1);
-  validate(defs, node, "name", name, 1);
+  validate(defs.namespace, node, "namespace", namespace, 1);
+  validate(defs.name, node, "name", name, 1);
   return node;
 }
 export { jsxNamespacedName as jSXNamespacedName };
@@ -2285,9 +2285,9 @@ export function jsxOpeningElement(
     selfClosing,
   };
   const defs = NODE_FIELDS.JSXOpeningElement;
-  validate(defs, node, "name", name, 1);
-  validate(defs, node, "attributes", attributes, 1);
-  validate(defs, node, "selfClosing", selfClosing);
+  validate(defs.name, node, "name", name, 1);
+  validate(defs.attributes, node, "attributes", attributes, 1);
+  validate(defs.selfClosing, node, "selfClosing", selfClosing);
   return node;
 }
 export { jsxOpeningElement as jSXOpeningElement };
@@ -2299,7 +2299,7 @@ export function jsxSpreadAttribute(
     argument,
   };
   const defs = NODE_FIELDS.JSXSpreadAttribute;
-  validate(defs, node, "argument", argument, 1);
+  validate(defs.argument, node, "argument", argument, 1);
   return node;
 }
 export { jsxSpreadAttribute as jSXSpreadAttribute };
@@ -2309,7 +2309,7 @@ export function jsxText(value: string): t.JSXText {
     value,
   };
   const defs = NODE_FIELDS.JSXText;
-  validate(defs, node, "value", value);
+  validate(defs.value, node, "value", value);
   return node;
 }
 export { jsxText as jSXText };
@@ -2331,9 +2331,9 @@ export function jsxFragment(
     children,
   };
   const defs = NODE_FIELDS.JSXFragment;
-  validate(defs, node, "openingFragment", openingFragment, 1);
-  validate(defs, node, "closingFragment", closingFragment, 1);
-  validate(defs, node, "children", children, 1);
+  validate(defs.openingFragment, node, "openingFragment", openingFragment, 1);
+  validate(defs.closingFragment, node, "closingFragment", closingFragment, 1);
+  validate(defs.children, node, "children", children, 1);
   return node;
 }
 export { jsxFragment as jSXFragment };
@@ -2372,8 +2372,8 @@ export function placeholder(
     name,
   };
   const defs = NODE_FIELDS.Placeholder;
-  validate(defs, node, "expectedNode", expectedNode);
-  validate(defs, node, "name", name, 1);
+  validate(defs.expectedNode, node, "expectedNode", expectedNode);
+  validate(defs.name, node, "name", name, 1);
   return node;
 }
 export function v8IntrinsicIdentifier(name: string): t.V8IntrinsicIdentifier {
@@ -2382,7 +2382,7 @@ export function v8IntrinsicIdentifier(name: string): t.V8IntrinsicIdentifier {
     name,
   };
   const defs = NODE_FIELDS.V8IntrinsicIdentifier;
-  validate(defs, node, "name", name);
+  validate(defs.name, node, "name", name);
   return node;
 }
 export function argumentPlaceholder(): t.ArgumentPlaceholder {
@@ -2400,8 +2400,8 @@ export function bindExpression(
     callee,
   };
   const defs = NODE_FIELDS.BindExpression;
-  validate(defs, node, "object", object, 1);
-  validate(defs, node, "callee", callee, 1);
+  validate(defs.object, node, "object", object, 1);
+  validate(defs.callee, node, "callee", callee, 1);
   return node;
 }
 export function importAttribute(
@@ -2414,8 +2414,8 @@ export function importAttribute(
     value,
   };
   const defs = NODE_FIELDS.ImportAttribute;
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "value", value, 1);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.value, node, "value", value, 1);
   return node;
 }
 export function decorator(expression: t.Expression): t.Decorator {
@@ -2424,7 +2424,7 @@ export function decorator(expression: t.Expression): t.Decorator {
     expression,
   };
   const defs = NODE_FIELDS.Decorator;
-  validate(defs, node, "expression", expression, 1);
+  validate(defs.expression, node, "expression", expression, 1);
   return node;
 }
 export function doExpression(
@@ -2437,8 +2437,8 @@ export function doExpression(
     async,
   };
   const defs = NODE_FIELDS.DoExpression;
-  validate(defs, node, "body", body, 1);
-  validate(defs, node, "async", async);
+  validate(defs.body, node, "body", body, 1);
+  validate(defs.async, node, "async", async);
   return node;
 }
 export function exportDefaultSpecifier(
@@ -2449,7 +2449,7 @@ export function exportDefaultSpecifier(
     exported,
   };
   const defs = NODE_FIELDS.ExportDefaultSpecifier;
-  validate(defs, node, "exported", exported, 1);
+  validate(defs.exported, node, "exported", exported, 1);
   return node;
 }
 export function recordExpression(
@@ -2460,7 +2460,7 @@ export function recordExpression(
     properties,
   };
   const defs = NODE_FIELDS.RecordExpression;
-  validate(defs, node, "properties", properties, 1);
+  validate(defs.properties, node, "properties", properties, 1);
   return node;
 }
 export function tupleExpression(
@@ -2471,7 +2471,7 @@ export function tupleExpression(
     elements,
   };
   const defs = NODE_FIELDS.TupleExpression;
-  validate(defs, node, "elements", elements, 1);
+  validate(defs.elements, node, "elements", elements, 1);
   return node;
 }
 export function decimalLiteral(value: string): t.DecimalLiteral {
@@ -2480,7 +2480,7 @@ export function decimalLiteral(value: string): t.DecimalLiteral {
     value,
   };
   const defs = NODE_FIELDS.DecimalLiteral;
-  validate(defs, node, "value", value);
+  validate(defs.value, node, "value", value);
   return node;
 }
 export function moduleExpression(body: t.Program): t.ModuleExpression {
@@ -2489,7 +2489,7 @@ export function moduleExpression(body: t.Program): t.ModuleExpression {
     body,
   };
   const defs = NODE_FIELDS.ModuleExpression;
-  validate(defs, node, "body", body, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export function topicReference(): t.TopicReference {
@@ -2505,7 +2505,7 @@ export function pipelineTopicExpression(
     expression,
   };
   const defs = NODE_FIELDS.PipelineTopicExpression;
-  validate(defs, node, "expression", expression, 1);
+  validate(defs.expression, node, "expression", expression, 1);
   return node;
 }
 export function pipelineBareFunction(
@@ -2516,7 +2516,7 @@ export function pipelineBareFunction(
     callee,
   };
   const defs = NODE_FIELDS.PipelineBareFunction;
-  validate(defs, node, "callee", callee, 1);
+  validate(defs.callee, node, "callee", callee, 1);
   return node;
 }
 export function pipelinePrimaryTopicReference(): t.PipelinePrimaryTopicReference {
@@ -2532,7 +2532,7 @@ export function tsParameterProperty(
     parameter,
   };
   const defs = NODE_FIELDS.TSParameterProperty;
-  validate(defs, node, "parameter", parameter, 1);
+  validate(defs.parameter, node, "parameter", parameter, 1);
   return node;
 }
 export { tsParameterProperty as tSParameterProperty };
@@ -2554,10 +2554,10 @@ export function tsDeclareFunction(
     returnType,
   };
   const defs = NODE_FIELDS.TSDeclareFunction;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "params", params, 1);
-  validate(defs, node, "returnType", returnType, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.params, node, "params", params, 1);
+  validate(defs.returnType, node, "returnType", returnType, 1);
   return node;
 }
 export { tsDeclareFunction as tSDeclareFunction };
@@ -2588,11 +2588,11 @@ export function tsDeclareMethod(
     returnType,
   };
   const defs = NODE_FIELDS.TSDeclareMethod;
-  validate(defs, node, "decorators", decorators, 1);
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "params", params, 1);
-  validate(defs, node, "returnType", returnType, 1);
+  validate(defs.decorators, node, "decorators", decorators, 1);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.params, node, "params", params, 1);
+  validate(defs.returnType, node, "returnType", returnType, 1);
   return node;
 }
 export { tsDeclareMethod as tSDeclareMethod };
@@ -2606,8 +2606,8 @@ export function tsQualifiedName(
     right,
   };
   const defs = NODE_FIELDS.TSQualifiedName;
-  validate(defs, node, "left", left, 1);
-  validate(defs, node, "right", right, 1);
+  validate(defs.left, node, "left", left, 1);
+  validate(defs.right, node, "right", right, 1);
   return node;
 }
 export { tsQualifiedName as tSQualifiedName };
@@ -2625,9 +2625,9 @@ export function tsCallSignatureDeclaration(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSCallSignatureDeclaration;
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "parameters", parameters, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.parameters, node, "parameters", parameters, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsCallSignatureDeclaration as tSCallSignatureDeclaration };
@@ -2645,9 +2645,9 @@ export function tsConstructSignatureDeclaration(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSConstructSignatureDeclaration;
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "parameters", parameters, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.parameters, node, "parameters", parameters, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsConstructSignatureDeclaration as tSConstructSignatureDeclaration };
@@ -2662,8 +2662,8 @@ export function tsPropertySignature(
     kind: null,
   };
   const defs = NODE_FIELDS.TSPropertySignature;
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsPropertySignature as tSPropertySignature };
@@ -2684,10 +2684,10 @@ export function tsMethodSignature(
     kind: null,
   };
   const defs = NODE_FIELDS.TSMethodSignature;
-  validate(defs, node, "key", key, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "parameters", parameters, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.key, node, "key", key, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.parameters, node, "parameters", parameters, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsMethodSignature as tSMethodSignature };
@@ -2701,8 +2701,8 @@ export function tsIndexSignature(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSIndexSignature;
-  validate(defs, node, "parameters", parameters, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.parameters, node, "parameters", parameters, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsIndexSignature as tSIndexSignature };
@@ -2804,9 +2804,9 @@ export function tsFunctionType(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSFunctionType;
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "parameters", parameters, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.parameters, node, "parameters", parameters, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsFunctionType as tSFunctionType };
@@ -2824,9 +2824,9 @@ export function tsConstructorType(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSConstructorType;
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "parameters", parameters, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.parameters, node, "parameters", parameters, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsConstructorType as tSConstructorType };
@@ -2840,8 +2840,8 @@ export function tsTypeReference(
     typeParameters,
   };
   const defs = NODE_FIELDS.TSTypeReference;
-  validate(defs, node, "typeName", typeName, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs.typeName, node, "typeName", typeName, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
   return node;
 }
 export { tsTypeReference as tSTypeReference };
@@ -2857,9 +2857,9 @@ export function tsTypePredicate(
     asserts,
   };
   const defs = NODE_FIELDS.TSTypePredicate;
-  validate(defs, node, "parameterName", parameterName, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
-  validate(defs, node, "asserts", asserts);
+  validate(defs.parameterName, node, "parameterName", parameterName, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.asserts, node, "asserts", asserts);
   return node;
 }
 export { tsTypePredicate as tSTypePredicate };
@@ -2873,8 +2873,8 @@ export function tsTypeQuery(
     typeParameters,
   };
   const defs = NODE_FIELDS.TSTypeQuery;
-  validate(defs, node, "exprName", exprName, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs.exprName, node, "exprName", exprName, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
   return node;
 }
 export { tsTypeQuery as tSTypeQuery };
@@ -2886,7 +2886,7 @@ export function tsTypeLiteral(
     members,
   };
   const defs = NODE_FIELDS.TSTypeLiteral;
-  validate(defs, node, "members", members, 1);
+  validate(defs.members, node, "members", members, 1);
   return node;
 }
 export { tsTypeLiteral as tSTypeLiteral };
@@ -2896,7 +2896,7 @@ export function tsArrayType(elementType: t.TSType): t.TSArrayType {
     elementType,
   };
   const defs = NODE_FIELDS.TSArrayType;
-  validate(defs, node, "elementType", elementType, 1);
+  validate(defs.elementType, node, "elementType", elementType, 1);
   return node;
 }
 export { tsArrayType as tSArrayType };
@@ -2908,7 +2908,7 @@ export function tsTupleType(
     elementTypes,
   };
   const defs = NODE_FIELDS.TSTupleType;
-  validate(defs, node, "elementTypes", elementTypes, 1);
+  validate(defs.elementTypes, node, "elementTypes", elementTypes, 1);
   return node;
 }
 export { tsTupleType as tSTupleType };
@@ -2918,7 +2918,7 @@ export function tsOptionalType(typeAnnotation: t.TSType): t.TSOptionalType {
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSOptionalType;
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsOptionalType as tSOptionalType };
@@ -2928,7 +2928,7 @@ export function tsRestType(typeAnnotation: t.TSType): t.TSRestType {
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSRestType;
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsRestType as tSRestType };
@@ -2944,9 +2944,9 @@ export function tsNamedTupleMember(
     optional,
   };
   const defs = NODE_FIELDS.TSNamedTupleMember;
-  validate(defs, node, "label", label, 1);
-  validate(defs, node, "elementType", elementType, 1);
-  validate(defs, node, "optional", optional);
+  validate(defs.label, node, "label", label, 1);
+  validate(defs.elementType, node, "elementType", elementType, 1);
+  validate(defs.optional, node, "optional", optional);
   return node;
 }
 export { tsNamedTupleMember as tSNamedTupleMember };
@@ -2956,7 +2956,7 @@ export function tsUnionType(types: Array<t.TSType>): t.TSUnionType {
     types,
   };
   const defs = NODE_FIELDS.TSUnionType;
-  validate(defs, node, "types", types, 1);
+  validate(defs.types, node, "types", types, 1);
   return node;
 }
 export { tsUnionType as tSUnionType };
@@ -2968,7 +2968,7 @@ export function tsIntersectionType(
     types,
   };
   const defs = NODE_FIELDS.TSIntersectionType;
-  validate(defs, node, "types", types, 1);
+  validate(defs.types, node, "types", types, 1);
   return node;
 }
 export { tsIntersectionType as tSIntersectionType };
@@ -2986,10 +2986,10 @@ export function tsConditionalType(
     falseType,
   };
   const defs = NODE_FIELDS.TSConditionalType;
-  validate(defs, node, "checkType", checkType, 1);
-  validate(defs, node, "extendsType", extendsType, 1);
-  validate(defs, node, "trueType", trueType, 1);
-  validate(defs, node, "falseType", falseType, 1);
+  validate(defs.checkType, node, "checkType", checkType, 1);
+  validate(defs.extendsType, node, "extendsType", extendsType, 1);
+  validate(defs.trueType, node, "trueType", trueType, 1);
+  validate(defs.falseType, node, "falseType", falseType, 1);
   return node;
 }
 export { tsConditionalType as tSConditionalType };
@@ -2999,7 +2999,7 @@ export function tsInferType(typeParameter: t.TSTypeParameter): t.TSInferType {
     typeParameter,
   };
   const defs = NODE_FIELDS.TSInferType;
-  validate(defs, node, "typeParameter", typeParameter, 1);
+  validate(defs.typeParameter, node, "typeParameter", typeParameter, 1);
   return node;
 }
 export { tsInferType as tSInferType };
@@ -3011,7 +3011,7 @@ export function tsParenthesizedType(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSParenthesizedType;
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsParenthesizedType as tSParenthesizedType };
@@ -3022,7 +3022,7 @@ export function tsTypeOperator(typeAnnotation: t.TSType): t.TSTypeOperator {
     operator: null,
   };
   const defs = NODE_FIELDS.TSTypeOperator;
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsTypeOperator as tSTypeOperator };
@@ -3036,8 +3036,8 @@ export function tsIndexedAccessType(
     indexType,
   };
   const defs = NODE_FIELDS.TSIndexedAccessType;
-  validate(defs, node, "objectType", objectType, 1);
-  validate(defs, node, "indexType", indexType, 1);
+  validate(defs.objectType, node, "objectType", objectType, 1);
+  validate(defs.indexType, node, "indexType", indexType, 1);
   return node;
 }
 export { tsIndexedAccessType as tSIndexedAccessType };
@@ -3053,9 +3053,9 @@ export function tsMappedType(
     nameType,
   };
   const defs = NODE_FIELDS.TSMappedType;
-  validate(defs, node, "typeParameter", typeParameter, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
-  validate(defs, node, "nameType", nameType, 1);
+  validate(defs.typeParameter, node, "typeParameter", typeParameter, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.nameType, node, "nameType", nameType, 1);
   return node;
 }
 export { tsMappedType as tSMappedType };
@@ -3073,7 +3073,7 @@ export function tsLiteralType(
     literal,
   };
   const defs = NODE_FIELDS.TSLiteralType;
-  validate(defs, node, "literal", literal, 1);
+  validate(defs.literal, node, "literal", literal, 1);
   return node;
 }
 export { tsLiteralType as tSLiteralType };
@@ -3087,8 +3087,8 @@ export function tsExpressionWithTypeArguments(
     typeParameters,
   };
   const defs = NODE_FIELDS.TSExpressionWithTypeArguments;
-  validate(defs, node, "expression", expression, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs.expression, node, "expression", expression, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
   return node;
 }
 export { tsExpressionWithTypeArguments as tSExpressionWithTypeArguments };
@@ -3106,10 +3106,10 @@ export function tsInterfaceDeclaration(
     body,
   };
   const defs = NODE_FIELDS.TSInterfaceDeclaration;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "extends", _extends, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.extends, node, "extends", _extends, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export { tsInterfaceDeclaration as tSInterfaceDeclaration };
@@ -3121,7 +3121,7 @@ export function tsInterfaceBody(
     body,
   };
   const defs = NODE_FIELDS.TSInterfaceBody;
-  validate(defs, node, "body", body, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export { tsInterfaceBody as tSInterfaceBody };
@@ -3137,9 +3137,9 @@ export function tsTypeAliasDeclaration(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSTypeAliasDeclaration;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsTypeAliasDeclaration as tSTypeAliasDeclaration };
@@ -3153,8 +3153,8 @@ export function tsInstantiationExpression(
     typeParameters,
   };
   const defs = NODE_FIELDS.TSInstantiationExpression;
-  validate(defs, node, "expression", expression, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs.expression, node, "expression", expression, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
   return node;
 }
 export { tsInstantiationExpression as tSInstantiationExpression };
@@ -3168,8 +3168,8 @@ export function tsAsExpression(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSAsExpression;
-  validate(defs, node, "expression", expression, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.expression, node, "expression", expression, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsAsExpression as tSAsExpression };
@@ -3183,8 +3183,8 @@ export function tsSatisfiesExpression(
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSSatisfiesExpression;
-  validate(defs, node, "expression", expression, 1);
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.expression, node, "expression", expression, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsSatisfiesExpression as tSSatisfiesExpression };
@@ -3198,8 +3198,8 @@ export function tsTypeAssertion(
     expression,
   };
   const defs = NODE_FIELDS.TSTypeAssertion;
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
-  validate(defs, node, "expression", expression, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.expression, node, "expression", expression, 1);
   return node;
 }
 export { tsTypeAssertion as tSTypeAssertion };
@@ -3213,8 +3213,8 @@ export function tsEnumDeclaration(
     members,
   };
   const defs = NODE_FIELDS.TSEnumDeclaration;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "members", members, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.members, node, "members", members, 1);
   return node;
 }
 export { tsEnumDeclaration as tSEnumDeclaration };
@@ -3228,8 +3228,8 @@ export function tsEnumMember(
     initializer,
   };
   const defs = NODE_FIELDS.TSEnumMember;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "initializer", initializer, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.initializer, node, "initializer", initializer, 1);
   return node;
 }
 export { tsEnumMember as tSEnumMember };
@@ -3243,8 +3243,8 @@ export function tsModuleDeclaration(
     body,
   };
   const defs = NODE_FIELDS.TSModuleDeclaration;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "body", body, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export { tsModuleDeclaration as tSModuleDeclaration };
@@ -3254,7 +3254,7 @@ export function tsModuleBlock(body: Array<t.Statement>): t.TSModuleBlock {
     body,
   };
   const defs = NODE_FIELDS.TSModuleBlock;
-  validate(defs, node, "body", body, 1);
+  validate(defs.body, node, "body", body, 1);
   return node;
 }
 export { tsModuleBlock as tSModuleBlock };
@@ -3270,9 +3270,9 @@ export function tsImportType(
     typeParameters,
   };
   const defs = NODE_FIELDS.TSImportType;
-  validate(defs, node, "argument", argument, 1);
-  validate(defs, node, "qualifier", qualifier, 1);
-  validate(defs, node, "typeParameters", typeParameters, 1);
+  validate(defs.argument, node, "argument", argument, 1);
+  validate(defs.qualifier, node, "qualifier", qualifier, 1);
+  validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
   return node;
 }
 export { tsImportType as tSImportType };
@@ -3287,8 +3287,8 @@ export function tsImportEqualsDeclaration(
     isExport: null,
   };
   const defs = NODE_FIELDS.TSImportEqualsDeclaration;
-  validate(defs, node, "id", id, 1);
-  validate(defs, node, "moduleReference", moduleReference, 1);
+  validate(defs.id, node, "id", id, 1);
+  validate(defs.moduleReference, node, "moduleReference", moduleReference, 1);
   return node;
 }
 export { tsImportEqualsDeclaration as tSImportEqualsDeclaration };
@@ -3300,7 +3300,7 @@ export function tsExternalModuleReference(
     expression,
   };
   const defs = NODE_FIELDS.TSExternalModuleReference;
-  validate(defs, node, "expression", expression, 1);
+  validate(defs.expression, node, "expression", expression, 1);
   return node;
 }
 export { tsExternalModuleReference as tSExternalModuleReference };
@@ -3312,7 +3312,7 @@ export function tsNonNullExpression(
     expression,
   };
   const defs = NODE_FIELDS.TSNonNullExpression;
-  validate(defs, node, "expression", expression, 1);
+  validate(defs.expression, node, "expression", expression, 1);
   return node;
 }
 export { tsNonNullExpression as tSNonNullExpression };
@@ -3324,7 +3324,7 @@ export function tsExportAssignment(
     expression,
   };
   const defs = NODE_FIELDS.TSExportAssignment;
-  validate(defs, node, "expression", expression, 1);
+  validate(defs.expression, node, "expression", expression, 1);
   return node;
 }
 export { tsExportAssignment as tSExportAssignment };
@@ -3336,7 +3336,7 @@ export function tsNamespaceExportDeclaration(
     id,
   };
   const defs = NODE_FIELDS.TSNamespaceExportDeclaration;
-  validate(defs, node, "id", id, 1);
+  validate(defs.id, node, "id", id, 1);
   return node;
 }
 export { tsNamespaceExportDeclaration as tSNamespaceExportDeclaration };
@@ -3346,7 +3346,7 @@ export function tsTypeAnnotation(typeAnnotation: t.TSType): t.TSTypeAnnotation {
     typeAnnotation,
   };
   const defs = NODE_FIELDS.TSTypeAnnotation;
-  validate(defs, node, "typeAnnotation", typeAnnotation, 1);
+  validate(defs.typeAnnotation, node, "typeAnnotation", typeAnnotation, 1);
   return node;
 }
 export { tsTypeAnnotation as tSTypeAnnotation };
@@ -3358,7 +3358,7 @@ export function tsTypeParameterInstantiation(
     params,
   };
   const defs = NODE_FIELDS.TSTypeParameterInstantiation;
-  validate(defs, node, "params", params, 1);
+  validate(defs.params, node, "params", params, 1);
   return node;
 }
 export { tsTypeParameterInstantiation as tSTypeParameterInstantiation };
@@ -3370,7 +3370,7 @@ export function tsTypeParameterDeclaration(
     params,
   };
   const defs = NODE_FIELDS.TSTypeParameterDeclaration;
-  validate(defs, node, "params", params, 1);
+  validate(defs.params, node, "params", params, 1);
   return node;
 }
 export { tsTypeParameterDeclaration as tSTypeParameterDeclaration };
@@ -3386,9 +3386,9 @@ export function tsTypeParameter(
     name,
   };
   const defs = NODE_FIELDS.TSTypeParameter;
-  validate(defs, node, "constraint", constraint, 1);
-  validate(defs, node, "default", _default, 1);
-  validate(defs, node, "name", name);
+  validate(defs.constraint, node, "constraint", constraint, 1);
+  validate(defs.default, node, "default", _default, 1);
+  validate(defs.name, node, "name", name);
   return node;
 }
 export { tsTypeParameter as tSTypeParameter };

--- a/packages/babel-types/src/builders/validateNode.ts
+++ b/packages/babel-types/src/builders/validateNode.ts
@@ -1,12 +1,17 @@
-import validate from "../validators/validate.ts";
+import { validateInternal } from "../validators/validate.ts";
 import type * as t from "../index.ts";
-import { BUILDER_KEYS } from "../index.ts";
+import { BUILDER_KEYS, NODE_FIELDS } from "../index.ts";
 
 export default function validateNode<N extends t.Node>(node: N) {
+  if (node == null || typeof node !== "object") return;
+  const fields = NODE_FIELDS[node.type];
+  if (!fields) return;
+
   // todo: because keys not in BUILDER_KEYS are not validated - this actually allows invalid nodes in some cases
   const keys = BUILDER_KEYS[node.type] as (keyof N & string)[];
   for (const key of keys) {
-    validate(node, key, node[key]);
+    const field = fields[key];
+    if (field != null) validateInternal(field, node, key, node[key]);
   }
   return node;
 }

--- a/packages/babel-types/src/definitions/utils.ts
+++ b/packages/babel-types/src/definitions/utils.ts
@@ -27,7 +27,7 @@ type NodeTypes = NodeTypesWithoutComment | t.Comment["type"];
 
 type PrimitiveTypes = ReturnType<typeof getType>;
 
-export type FieldDefinitions = {
+type FieldDefinitions = {
   [x: string]: FieldOptions;
 };
 

--- a/packages/babel-types/src/definitions/utils.ts
+++ b/packages/babel-types/src/definitions/utils.ts
@@ -27,7 +27,7 @@ type NodeTypes = NodeTypesWithoutComment | t.Comment["type"];
 
 type PrimitiveTypes = ReturnType<typeof getType>;
 
-type FieldDefinitions = {
+export type FieldDefinitions = {
   [x: string]: FieldOptions;
 };
 

--- a/packages/babel-types/src/validators/validate.ts
+++ b/packages/babel-types/src/validators/validate.ts
@@ -3,7 +3,6 @@ import {
   NODE_PARENT_VALIDATIONS,
   type FieldOptions,
 } from "../definitions/index.ts";
-import type { FieldDefinitions } from "../definitions/utils.ts";
 import type * as t from "../index.ts";
 
 export default function validate(
@@ -22,14 +21,12 @@ export default function validate(
 }
 
 export function validateInternal(
-  defs: FieldDefinitions,
+  field: FieldOptions,
   node: t.Node | undefined | null,
   key: string,
   val: unknown,
   maybeNode?: 1,
 ): void {
-  const field = defs[key];
-
   if (!field?.validate) return;
   if (field.optional && val == null) return;
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Ref: https://github.com/babel/babel/pull/15843
I was surprised that the second commit improved performance by nearly 40%.

```
PS F:\babel\benchmark\babel-types\builders> node .\stringLiteral.mjs
baseline stringLiteral builder: 33_969_770 ops/sec ±0.87% (0ms)
current stringLiteral builder: 233_913_245 ops/sec ±4.54% (0ms)
PS F:\babel\benchmark\babel-types\builders> node .\memberExpression.mjs
baseline memberExpression builder: 882_488 ops/sec ±0.2% (0.001ms)
current memberExpression builder: 15_058_197 ops/sec ±0.45% (0ms)
```