### PR TITLE
Add browserslist config to external dependency

### DIFF
--- a/packages/babel-helper-plugin-utils/src/index.ts
+++ b/packages/babel-helper-plugin-utils/src/index.ts
@@ -32,6 +32,8 @@ if (!process.env.BABEL_8_BREAKING) {
     assumption: () => () => {
       return undefined;
     },
+    // This is supported starting from Babel 7.17
+    addExternalDependency: () => () => {},
   });
 }
 

--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -18,7 +18,7 @@ import {
   overlappingPlugins,
 } from "./plugins-compat-data.ts";
 
-import type { CallerMetadata } from "@babel/core";
+import type { CallerMetadata, PresetAPI } from "@babel/core";
 
 import _pluginCoreJS3 from "babel-plugin-polyfill-corejs3";
 // TODO(Babel 8): Just use the default import
@@ -277,6 +277,7 @@ function getLocalTargets(
   ignoreBrowserslistConfig: boolean,
   configPath: string,
   browserslistEnv: string,
+  api: PresetAPI,
 ) {
   if (optionsTargets?.esmodules && optionsTargets.browsers) {
     console.warn(`
@@ -289,6 +290,9 @@ function getLocalTargets(
     ignoreBrowserslistConfig,
     configPath,
     browserslistEnv,
+    onBrowserslistConfigFound(config) {
+      api.addExternalDependency(config);
+    },
   });
 }
 
@@ -378,6 +382,7 @@ option \`forceAllTransforms: true\` instead.
       ignoreBrowserslistConfig,
       configPath,
       browserslistEnv,
+      api,
     );
   }
 

--- a/packages/babel-preset-env/test/index.skip-bundled.js
+++ b/packages/babel-preset-env/test/index.skip-bundled.js
@@ -372,4 +372,21 @@ describe("babel-preset-env", () => {
       },
     );
   });
+
+  it("should add .browserslistrc to external dependencies when configPath is specified", () => {
+    const browserslistConfigFile = require.resolve(
+      "./regressions/.browserslistrc",
+    );
+    const { externalDependencies } = babel.transformSync("", {
+      configFile: false,
+      presets: [
+        [babelPresetEnv.default, { configPath: browserslistConfigFile }],
+      ],
+    });
+    expect(externalDependencies).toContain(browserslistConfigFile);
+  });
+
+  it.todo(
+    "should add .browserslistrc to external dependencies when browserslistConfigFile is specified",
+  );
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel-loader/issues/690
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we pass the browserslist config to the preset API `addExternalDependency`, so that it can be recognized by other build tools. To do so we call the `browserslist.findConfigFile` API available on 4.24.0.