### PR TITLE
feat: support async plugin's pre/post

### DIFF
--- a/packages/babel-core/src/config/validation/plugins.ts
+++ b/packages/babel-core/src/config/validation/plugins.ts
@@ -85,8 +85,8 @@ export type PluginObject<S extends PluginPass = PluginPass> = {
     options: ValidatedOptions,
     parserOpts: ParserOptions,
   ) => void;
-  pre?: (this: S, file: File) => void;
-  post?: (this: S, file: File) => void;
+  pre?: (this: S, file: File) => void | Promise<void>;
+  post?: (this: S, file: File) => void | Promise<void>;
   inherits?: (
     api: PluginAPI,
     options: unknown,

--- a/packages/babel-core/src/transformation/index.ts
+++ b/packages/babel-core/src/transformation/index.ts
@@ -15,6 +15,7 @@ import generateCode from "./file/generate.ts";
 import type File from "./file/file.ts";
 
 import { flattenToSet } from "../config/helpers/deep-array.ts";
+import { maybeAsync } from "../gensync-utils/async.ts";
 
 export type FileResultCallback = {
   (err: Error, file: null): void;
@@ -93,22 +94,14 @@ function* transformFile(file: File, pluginPasses: PluginPasses): Handler<void> {
     }
 
     for (const [plugin, pass] of passPairs) {
-      const fn = plugin.pre;
-      if (fn) {
-        // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-        const result = fn.call(pass, file);
+      if (plugin.pre) {
+        const fn = maybeAsync(
+          plugin.pre,
+          `You appear to be using an async plugin/preset, but Babel has been called synchronously`,
+        );
 
-        // If we want to support async .pre
-        yield* [];
-
-        if (isThenable(result)) {
-          throw new Error(
-            `You appear to be using an plugin with an async .pre, ` +
-              `which your current version of Babel does not support. ` +
-              `If you're using a published plugin, you may need to upgrade ` +
-              `your @babel/core version.`,
-          );
-        }
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        yield* fn.call(pass, file);
       }
     }
 
@@ -125,32 +118,15 @@ function* transformFile(file: File, pluginPasses: PluginPasses): Handler<void> {
     }
 
     for (const [plugin, pass] of passPairs) {
-      const fn = plugin.post;
-      if (fn) {
-        // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-        const result = fn.call(pass, file);
+      if (plugin.post) {
+        const fn = maybeAsync(
+          plugin.post,
+          `You appear to be using an async plugin/preset, but Babel has been called synchronously`,
+        );
 
-        // If we want to support async .post
-        yield* [];
-
-        if (isThenable(result)) {
-          throw new Error(
-            `You appear to be using an plugin with an async .post, ` +
-              `which your current version of Babel does not support. ` +
-              `If you're using a published plugin, you may need to upgrade ` +
-              `your @babel/core version.`,
-          );
-        }
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        yield* fn.call(pass, file);
       }
     }
   }
-}
-
-function isThenable<T extends PromiseLike<any>>(val: any): val is T {
-  return (
-    !!val &&
-    (typeof val === "object" || typeof val === "function") &&
-    !!val.then &&
-    typeof val.then === "function"
-  );
 }

--- a/packages/babel-core/src/transformation/index.ts
+++ b/packages/babel-core/src/transformation/index.ts
@@ -15,7 +15,7 @@ import generateCode from "./file/generate.ts";
 import type File from "./file/file.ts";
 
 import { flattenToSet } from "../config/helpers/deep-array.ts";
-import { maybeAsync } from "../gensync-utils/async.ts";
+import { isAsync, maybeAsync } from "../gensync-utils/async.ts";
 
 export type FileResultCallback = {
   (err: Error, file: null): void;
@@ -80,13 +80,15 @@ export function* run(
 }
 
 function* transformFile(file: File, pluginPasses: PluginPasses): Handler<void> {
+  const async = yield* isAsync();
+
   for (const pluginPairs of pluginPasses) {
     const passPairs: [Plugin, PluginPass][] = [];
     const passes = [];
     const visitors = [];
 
     for (const plugin of pluginPairs.concat([loadBlockHoistPlugin()])) {
-      const pass = new PluginPass(file, plugin.key, plugin.options);
+      const pass = new PluginPass(file, plugin.key, plugin.options, async);
 
       passPairs.push([plugin, pass]);
       passes.push(pass);

--- a/packages/babel-core/src/transformation/plugin-pass.ts
+++ b/packages/babel-core/src/transformation/plugin-pass.ts
@@ -19,13 +19,13 @@ export default class PluginPass<Options = object> {
   /**
    * Is Babel executed in async mode or not.
    */
-  isAsync: boolean | undefined;
+  isAsync: boolean;
 
   constructor(
     file: File,
-    key?: string | null,
-    options?: Options,
-    isAsync?: boolean,
+    key: string | null,
+    options: Options | undefined,
+    isAsync: boolean,
   ) {
     this.key = key;
     this.file = file;

--- a/packages/babel-core/src/transformation/plugin-pass.ts
+++ b/packages/babel-core/src/transformation/plugin-pass.ts
@@ -7,19 +7,32 @@ export default class PluginPass<Options = object> {
   file: File;
   opts: Partial<Options>;
 
-  // The working directory that Babel's programmatic options are loaded
-  // relative to.
+  /**
+   * The working directory that Babel's programmatic options are loaded
+   * relative to.
+   */
   cwd: string;
 
-  // The absolute path of the file being compiled.
+  /** The absolute path of the file being compiled. */
   filename: string | void;
 
-  constructor(file: File, key?: string | null, options?: Options) {
+  /**
+   * Is Babel executed in async mode or not.
+   */
+  isAsync: boolean | undefined;
+
+  constructor(
+    file: File,
+    key?: string | null,
+    options?: Options,
+    isAsync?: boolean,
+  ) {
     this.key = key;
     this.file = file;
     this.opts = options || {};
     this.cwd = file.opts.cwd;
     this.filename = file.opts.filename;
+    this.isAsync = isAsync;
   }
 
   set(key: unknown, val: unknown) {

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -200,6 +200,32 @@ describe("asynchronicity", () => {
       });
     });
 
+    describe("PluginPass.isAsync", () => {
+      nodeGte8("called synchronously", () => {
+        process.chdir("plugin-pass-is-async");
+
+        expect(babel.transformSync("")).toMatchObject({
+          code: `"sync"`,
+        });
+      });
+
+      nodeGte8("called asynchronously", async () => {
+        process.chdir("plugin-pass-is-async");
+
+        await expect(babel.transformAsync("")).resolves.toMatchObject({
+          code: `"async"`,
+        });
+      });
+
+      nodeGte8("should await inherited .pre", async () => {
+        process.chdir("plugin-pre-chaining");
+
+        await expect(babel.transformAsync("")).resolves.toMatchObject({
+          code: `"pluginC,pluginB,pluginA"`,
+        });
+      });
+    });
+
     describe("inherits", () => {
       nodeGte8("called synchronously", () => {
         process.chdir("plugin-inherits");
@@ -312,7 +338,7 @@ describe("asynchronicity", () => {
   });
 
   describe("misc", () => {
-    it("unknown preset in config file does not trigget unhandledRejection if caught", async () => {
+    it("unknown preset in config file does not trigger unhandledRejection if caught", async () => {
       process.chdir("unknown-preset");
       const handler = jest.fn();
 

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -151,22 +151,24 @@ describe("asynchronicity", () => {
         expect(() =>
           babel.transformSync(""),
         ).toThrowErrorMatchingInlineSnapshot(
-          `"unknown file: You appear to be using an plugin with an async .pre, which your current version` +
-            ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
-            ` @babel/core version."`,
+          `"unknown file: You appear to be using an async plugin/preset, but Babel has been called synchronously"`,
         );
       });
 
       nodeGte8("called asynchronously", async () => {
         process.chdir("plugin-pre");
 
-        await expect(
-          babel.transformAsync(""),
-        ).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"unknown file: You appear to be using an plugin with an async .pre, which your current version` +
-            ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
-            ` @babel/core version."`,
-        );
+        await expect(babel.transformAsync("")).resolves.toMatchObject({
+          code: `"success"`,
+        });
+      });
+
+      nodeGte8("should await inherited .pre", async () => {
+        process.chdir("plugin-pre-chaining");
+
+        await expect(babel.transformAsync("")).resolves.toMatchObject({
+          code: `"pluginC,pluginB,pluginA"`,
+        });
       });
     });
 
@@ -177,22 +179,24 @@ describe("asynchronicity", () => {
         expect(() =>
           babel.transformSync(""),
         ).toThrowErrorMatchingInlineSnapshot(
-          `"unknown file: You appear to be using an plugin with an async .post, which your current version` +
-            ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
-            ` @babel/core version."`,
+          `"unknown file: You appear to be using an async plugin/preset, but Babel has been called synchronously"`,
         );
       });
 
       nodeGte8("called asynchronously", async () => {
         process.chdir("plugin-post");
 
-        await expect(
-          babel.transformAsync(""),
-        ).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"unknown file: You appear to be using an plugin with an async .post, which your current version` +
-            ` of Babel does not support. If you're using a published plugin, you may need to upgrade your` +
-            ` @babel/core version."`,
-        );
+        await expect(babel.transformAsync("")).resolves.toMatchObject({
+          code: `"success"`,
+        });
+      });
+
+      nodeGte8("should await inherited .post", async () => {
+        process.chdir("plugin-post-chaining");
+
+        await expect(babel.transformAsync("")).resolves.toMatchObject({
+          code: `"pluginC,pluginB,pluginA"`,
+        });
       });
     });
 

--- a/packages/babel-core/test/fixtures/async/plugin-pass-is-async/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/plugin-pass-is-async/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["./plugin"],
+};

--- a/packages/babel-core/test/fixtures/async/plugin-pass-is-async/plugin.js
+++ b/packages/babel-core/test/fixtures/async/plugin-pass-is-async/plugin.js
@@ -1,0 +1,11 @@
+module.exports = function pluginA({ types: t }) {
+  return {
+    visitor: {
+      Program(path) {
+        const label = this.isAsync ? "async" : "sync";
+
+        path.pushContainer("body", t.stringLiteral(label));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/plugin-post-chaining/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/plugin-post-chaining/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["./plugin"],
+};

--- a/packages/babel-core/test/fixtures/async/plugin-post-chaining/plugin.js
+++ b/packages/babel-core/test/fixtures/async/plugin-post-chaining/plugin.js
@@ -1,0 +1,35 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+function pluginC({ types: t }) {
+  return {
+    async post() {
+      await wait(50);
+      this.file.ast.program.body[0].value = 'pluginC'
+    },
+  };
+}
+
+function pluginB({ types: t }) {
+  return {
+    inherits: pluginC,
+     post() {
+      this.file.ast.program.body[0].value += ',pluginB';
+    },
+  };
+}
+
+module.exports = function pluginA({ types: t }) {
+  return {
+    inherits: pluginB,
+    async post() {
+      await wait(50);
+      this.file.ast.program.body[0].value += ',pluginA';
+    },
+
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral('failure'));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/plugin-post/plugin.js
+++ b/packages/babel-core/test/fixtures/async/plugin-post/plugin.js
@@ -4,11 +4,12 @@ module.exports = function plugin({ types: t }) {
   return {
     async post() {
       await wait(50);
+      this.file.ast.program.body[0].value = "success"
     },
 
     visitor: {
       Program(path) {
-        path.pushContainer("body", t.stringLiteral("success"));
+        path.pushContainer("body", t.stringLiteral("failure"));
       },
     },
   };

--- a/packages/babel-core/test/fixtures/async/plugin-pre-chaining/babel.config.js
+++ b/packages/babel-core/test/fixtures/async/plugin-pre-chaining/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["./plugin"],
+};

--- a/packages/babel-core/test/fixtures/async/plugin-pre-chaining/plugin.js
+++ b/packages/babel-core/test/fixtures/async/plugin-pre-chaining/plugin.js
@@ -1,0 +1,35 @@
+const wait = t => new Promise(r => setTimeout(r, t));
+
+function pluginC({ types: t }) {
+  return {
+    pre() {
+      this.file.metadata.executionOrder = ['pluginC'];
+    },
+  };
+}
+
+function pluginB({ types: t }) {
+  return {
+    inherits: pluginC,
+    async pre() {
+      await wait(50);
+      this.file.metadata.executionOrder.push('pluginB');
+    },
+  };
+}
+
+module.exports = function pluginA({ types: t }) {
+  return {
+    inherits: pluginB,
+    async pre() {
+      await wait(50);
+      this.file.metadata.executionOrder.push('pluginA');
+    },
+
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral(this.file.metadata.executionOrder.toString()));
+      },
+    },
+  };
+};

--- a/packages/babel-core/test/fixtures/async/plugin-pre/plugin.js
+++ b/packages/babel-core/test/fixtures/async/plugin-pre/plugin.js
@@ -1,14 +1,17 @@
 const wait = t => new Promise(r => setTimeout(r, t));
 
 module.exports = function plugin({ types: t }) {
+  let value = "failure";
+
   return {
     async pre() {
       await wait(50);
+      value = "success";
     },
 
     visitor: {
       Program(path) {
-        path.pushContainer("body", t.stringLiteral("success"));
+        path.pushContainer("body", t.stringLiteral(value));
       },
     },
   };


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #16860 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT


Enable support of async pre/post functions in plugins + update tests.  As discussed here #16860


I'm also wondering of adding a `isAsync` flag for pre/post functions arguments so plugins could adjust it's own logic based on that. However i don't know how exactly to shape this signature, my proposition is: 

```ts
  pre?: (this: S, file: File, ctx: {isAsync: boolean}) => void | Promise<void>;
  post?: (this: S, file: File, ctx: {isAsync: boolean}) => void | Promise<void>;
```

Let me know what you think, maybe there is a better place for that. 