### PR TITLE
[Babel 8] Ignore config files by default for `eslint-parser`

### DIFF
--- a/eslint/babel-eslint-parser/src/worker/configuration.cts
+++ b/eslint/babel-eslint-parser/src/worker/configuration.cts
@@ -78,12 +78,11 @@ function validateResolvedConfig(
   if (process.env.BABEL_8_BREAKING) {
     const configOptions: InputOptions = {
       plugins: [],
-      ...config?.options,
       babelrc: false,
+      ...(config?.options || parseOptions),
       configFile: false,
       ignore: null,
       only: null,
-      ...parseOptions,
       browserslistConfigFile: false,
     };
 

--- a/eslint/babel-eslint-parser/src/worker/configuration.cts
+++ b/eslint/babel-eslint-parser/src/worker/configuration.cts
@@ -73,22 +73,34 @@ function validateResolvedConfig(
         throw new Error(error);
       }
     }
-    if (config.options) return config.options;
   }
 
-  return getDefaultParserOptions(parseOptions);
-}
+  if (process.env.BABEL_8_BREAKING) {
+    const configOptions: InputOptions = {
+      plugins: [],
+      ...config?.options,
+      babelrc: false,
+      configFile: false,
+      ignore: null,
+      only: null,
+      ...parseOptions,
+      browserslistConfigFile: false,
+    };
 
-function getDefaultParserOptions(options: InputOptions): InputOptions {
-  return {
-    plugins: [],
-    ...options,
-    babelrc: false,
-    configFile: false,
-    browserslistConfigFile: false,
-    ignore: null,
-    only: null,
-  };
+    return configOptions;
+  } else {
+    return (
+      config?.options || {
+        plugins: [],
+        ...parseOptions,
+        babelrc: false,
+        configFile: false,
+        browserslistConfigFile: false,
+        ignore: null,
+        only: null,
+      }
+    );
+  }
 }
 
 export async function normalizeBabelParseConfig(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I changed the order and added `browserslistConfigFile: false`.