### PR TITLE
perf: Improve `transform` performance a bit

### DIFF
--- a/packages/babel-core/src/transformation/normalize-file.ts
+++ b/packages/babel-core/src/transformation/normalize-file.ts
@@ -16,6 +16,7 @@ const debug = buildDebug("babel:transform:file");
 // These regexps are copied from the convert-source-map package,
 // but without // or /* at the beginning of the comment.
 
+const SOURCEMAP_REGEX = /^[@#]\s+sourceMappingURL=.*$/;
 const INLINE_SOURCEMAP_REGEX =
   /^[@#]\s+sourceMappingURL=data:(?:application|text)\/json;(?:charset[:=]\S+?;)?base64,.*$/;
 const EXTERNAL_SOURCEMAP_REGEX =
@@ -34,6 +35,8 @@ export default function* normalizeFile(
   ast?: t.File | t.Program | null,
 ): Handler<File> {
   code = `${code || ""}`;
+
+  const fromAst = !!ast;
 
   if (ast) {
     if (ast.type === "Program") {
@@ -59,42 +62,105 @@ export default function* normalizeFile(
     }
 
     if (!inputMap) {
-      const lastComment = extractComments(INLINE_SOURCEMAP_REGEX, ast);
-      if (lastComment) {
-        try {
-          inputMap = convertSourceMap.fromComment("//" + lastComment);
-        } catch (err) {
-          if (process.env.BABEL_8_BREAKING) {
-            console.warn(
-              "discarding unknown inline input sourcemap",
-              options.filename,
-              err,
-            );
-          } else {
-            debug("discarding unknown inline input sourcemap");
+      if (process.env.BABEL_8_BREAKING || !fromAst) {
+        const comments = (ast as t.File).comments;
+        for (let i = comments.length - 1; i >= 0; i--) {
+          const comment = comments[i];
+          if (INLINE_SOURCEMAP_REGEX.test(comment.value)) {
+            try {
+              inputMap = convertSourceMap.fromComment("//" + comment.value);
+            } catch (err) {
+              if (process.env.BABEL_8_BREAKING) {
+                console.warn(
+                  "discarding unknown inline input sourcemap",
+                  options.filename,
+                  err,
+                );
+              } else {
+                debug("discarding unknown inline input sourcemap");
+              }
+            }
+            break;
           }
         }
-      }
-    }
 
-    if (!inputMap) {
-      const lastComment = extractComments(EXTERNAL_SOURCEMAP_REGEX, ast);
-      if (typeof options.filename === "string" && lastComment) {
-        try {
-          // when `lastComment` is non-null, EXTERNAL_SOURCEMAP_REGEX must have matches
-          const match: [string, string] = EXTERNAL_SOURCEMAP_REGEX.exec(
-            lastComment,
-          ) as any;
-          const inputMapContent = fs.readFileSync(
-            path.resolve(path.dirname(options.filename), match[1]),
-            "utf8",
-          );
-          inputMap = convertSourceMap.fromJSON(inputMapContent);
-        } catch (err) {
-          debug("discarding unknown file input sourcemap", err);
+        if (!inputMap) {
+          for (let i = comments.length - 1; i >= 0; i--) {
+            const comment = comments[i];
+            if (EXTERNAL_SOURCEMAP_REGEX.test(comment.value)) {
+              if (typeof options.filename === "string") {
+                try {
+                  // when `lastComment` is non-null, EXTERNAL_SOURCEMAP_REGEX must have matches
+                  const match: [string, string] = EXTERNAL_SOURCEMAP_REGEX.exec(
+                    comment.value,
+                  ) as any;
+                  const inputMapContent = fs.readFileSync(
+                    path.resolve(path.dirname(options.filename), match[1]),
+                    "utf8",
+                  );
+                  inputMap = convertSourceMap.fromJSON(inputMapContent);
+                } catch (err) {
+                  debug("discarding unknown file input sourcemap", err);
+                }
+              } else {
+                debug("discarding un-loadable file input sourcemap");
+              }
+              break;
+            }
+          }
         }
-      } else if (lastComment) {
-        debug("discarding un-loadable file input sourcemap");
+        if (inputMap) {
+          function removeComment(comments: t.Comment[]) {
+            for (let i = comments.length - 1; i >= 0; i--)
+              if (SOURCEMAP_REGEX.test(comments[i].value)) {
+                comments.splice(i, 1);
+              }
+          }
+
+          traverseFast(ast, node => {
+            if (node.leadingComments) removeComment(node.leadingComments);
+            if (node.innerComments) removeComment(node.innerComments);
+            if (node.trailingComments) removeComment(node.trailingComments);
+          });
+        }
+      } else {
+        const lastComment = extractComments(INLINE_SOURCEMAP_REGEX, ast);
+        if (lastComment) {
+          try {
+            inputMap = convertSourceMap.fromComment("//" + lastComment);
+          } catch (err) {
+            if (process.env.BABEL_8_BREAKING) {
+              console.warn(
+                "discarding unknown inline input sourcemap",
+                options.filename,
+                err,
+              );
+            } else {
+              debug("discarding unknown inline input sourcemap");
+            }
+          }
+        }
+
+        if (!inputMap) {
+          const lastComment = extractComments(EXTERNAL_SOURCEMAP_REGEX, ast);
+          if (typeof options.filename === "string" && lastComment) {
+            try {
+              // when `lastComment` is non-null, EXTERNAL_SOURCEMAP_REGEX must have matches
+              const match: [string, string] = EXTERNAL_SOURCEMAP_REGEX.exec(
+                lastComment,
+              ) as any;
+              const inputMapContent = fs.readFileSync(
+                path.resolve(path.dirname(options.filename), match[1]),
+                "utf8",
+              );
+              inputMap = convertSourceMap.fromJSON(inputMapContent);
+            } catch (err) {
+              debug("discarding unknown file input sourcemap", err);
+            }
+          } else if (lastComment) {
+            debug("discarding un-loadable file input sourcemap");
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
https://babeljs.io/docs/options#inputsourcemap
I don't know why `inputSourceMap` is `true` by default even though `sourceMaps` is `false`.
This PR improves performance when the input does not contain source maps, avoiding `traverseFast` twice.
