### PR TITLE
perf: Avoid extra cloning of namespaces

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/namespace.ts
+++ b/packages/babel-plugin-transform-typescript/src/namespace.ts
@@ -23,7 +23,7 @@ export default function transpileNamespace(
   }
 
   const name = path.node.id.name;
-  const value = handleNested(path, t.cloneNode(path.node, true));
+  const value = handleNested(path, path.node);
   if (value === null) {
     // This means that `path` is a type-only namespace.
     // We call `registerGlobalType` here to allow it to be stripped.


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
I'm not sure what the original intent was here, but the tests all pass.
This has greatly improved the performance of code that uses namespaces, such as the TS repository cases.

> Currently main is a bit slower than baseline, this doesn't seem to be a regression, but there is some unknown reason why the baseline parser is faster.
> Even if I replace baseline and main with the same code, the gap still exists.
> Also seems to have nothing to do with the benchmark library, I tried both.

https://github.com/babel/babel/pull/16873#issue-2557521736
```
all/real-case-ts-mjs.mjs babel-parser-express.ts @ current: 33.54 ops/sec ±6.72% 30 runs (30ms)
all/real-case-ts-mjs.mjs babel-parser-express.ts @ baseline: 35.67 ops/sec ±5.12% 30 runs (28ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ current: 6.03 ops/sec ±2.5% 30 runs (166ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ baseline: 5.09 ops/sec ±4.38% 30 runs (196ms)
```