### PR TITLE
Analyze `ClassAccessorProperty` to prevent the `no-undef` rule

### DIFF
--- a/eslint/babel-eslint-parser/src/analyze-scope.cts
+++ b/eslint/babel-eslint-parser/src/analyze-scope.cts
@@ -187,6 +187,10 @@ class Referencer extends OriginalReferencer {
     this._visitClassProperty(node);
   }
 
+  ClassAccessorProperty(node: any) {
+    this._visitClassProperty(node);
+  }
+
   PropertyDefinition(node: any) {
     this._visitClassProperty(node);
   }

--- a/eslint/babel-eslint-tests/test/integration/eslint/verify.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/verify.js
@@ -1837,6 +1837,41 @@ describe("verify", () => {
       });
     });
 
+    describe("accessor declarations", () => {
+      it("should not be undefined", () => {
+        verifyAndAssertMessages(
+          `
+              class C {
+                accessor d = 1;
+              }
+          `,
+          { "no-undef": 1 },
+        );
+      });
+
+      it("should not be unused", () => {
+        verifyAndAssertMessages(
+          `
+              export class C {
+                accessor d = 1;
+              }
+          `,
+          { "no-unused-vars": 1 },
+        );
+      });
+
+      it("no-use-before-define allows referencing the class in a accessor", () => {
+        verifyAndAssertMessages(
+          `
+            class C {
+              accessor d = C.name;
+            }
+          `,
+          { "no-use-before-define": 1 },
+        );
+      });
+    });
+
     describe("private methods", () => {
       it("should not be undefined", () => {
         verifyAndAssertMessages(

--- a/eslint/babel-eslint-tests/test/integration/eslint/verify.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/verify.js
@@ -1860,7 +1860,7 @@ describe("verify", () => {
         );
       });
 
-      it("no-use-before-define allows referencing the class in a accessor", () => {
+      it("no-use-before-define allows referencing the class in an accessor", () => {
         verifyAndAssertMessages(
           `
             class C {


### PR DESCRIPTION
a.js:

```js
class A {
  accessor b;
}
```

Current and expected behavior:

```bash
npx eslint a.js
```

```
a.js
  2:11  error  'b' is not defined  no-undef

✖ 1 problem (1 error, 0 warnings)
```

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
