### PR TITLE
Restore public API of `resolvePlugin`/`resolvePreset`

### DIFF
--- a/packages/babel-core/src/index.ts
+++ b/packages/babel-core/src/index.ts
@@ -9,7 +9,14 @@ export const version = PACKAGE_JSON.version;
 export { default as File } from "./transformation/file/file.ts";
 export type { default as PluginPass } from "./transformation/plugin-pass.ts";
 export { default as buildExternalHelpers } from "./tools/build-external-helpers.ts";
-export { resolvePlugin, resolvePreset } from "./config/files/index.ts";
+
+import * as resolvers from "./config/files/index.ts";
+// For backwards-compatibility, we expose the resolvers
+// with the old API.
+export const resolvePlugin = (name: string, dirname: string) =>
+  resolvers.resolvePlugin(name, dirname, false).filepath;
+export const resolvePreset = (name: string, dirname: string) =>
+  resolvers.resolvePreset(name, dirname, false).filepath;
 
 export { getEnv } from "./config/helpers/environment.ts";
 
@@ -30,60 +37,62 @@ export type Visitor<S = unknown> = import("@babel/traverse").Visitor<S>;
 
 export {
   createConfigItem,
-  createConfigItemSync,
   createConfigItemAsync,
+  createConfigItemSync,
 } from "./config/index.ts";
 
 export {
-  loadPartialConfig,
-  loadPartialConfigSync,
-  loadPartialConfigAsync,
   loadOptions,
   loadOptionsAsync,
+  loadPartialConfig,
+  loadPartialConfigAsync,
+  loadPartialConfigSync,
 } from "./config/index.ts";
 import { loadOptionsSync } from "./config/index.ts";
 export { loadOptionsSync };
 
 export type {
   CallerMetadata,
+  ConfigItem,
   InputOptions,
   PluginAPI,
   PluginObject,
   PresetAPI,
   PresetObject,
-  ConfigItem,
 } from "./config/index.ts";
 
 export {
-  transform,
-  transformSync,
-  transformAsync,
   type FileResult,
+  transform,
+  transformAsync,
+  transformSync,
 } from "./transform.ts";
 export {
   transformFile,
-  transformFileSync,
   transformFileAsync,
+  transformFileSync,
 } from "./transform-file.ts";
 export {
   transformFromAst,
-  transformFromAstSync,
   transformFromAstAsync,
+  transformFromAstSync,
 } from "./transform-ast.ts";
-export { parse, parseSync, parseAsync } from "./parse.ts";
+export { parse, parseAsync, parseSync } from "./parse.ts";
 
 /**
  * Recommended set of compilable extensions. Not used in @babel/core directly, but meant as
  * as an easy source for tooling making use of @babel/core.
  */
-export const DEFAULT_EXTENSIONS = Object.freeze([
-  ".js",
-  ".jsx",
-  ".es6",
-  ".es",
-  ".mjs",
-  ".cjs",
-] as const);
+export const DEFAULT_EXTENSIONS = Object.freeze(
+  [
+    ".js",
+    ".jsx",
+    ".es6",
+    ".es",
+    ".mjs",
+    ".cjs",
+  ] as const,
+);
 
 import Module from "module";
 import * as thisFile from "./index.ts";

--- a/packages/babel-core/src/index.ts
+++ b/packages/babel-core/src/index.ts
@@ -83,16 +83,14 @@ export { parse, parseAsync, parseSync } from "./parse.ts";
  * Recommended set of compilable extensions. Not used in @babel/core directly, but meant as
  * as an easy source for tooling making use of @babel/core.
  */
-export const DEFAULT_EXTENSIONS = Object.freeze(
-  [
-    ".js",
-    ".jsx",
-    ".es6",
-    ".es",
-    ".mjs",
-    ".cjs",
-  ] as const,
-);
+export const DEFAULT_EXTENSIONS = Object.freeze([
+  ".js",
+  ".jsx",
+  ".es6",
+  ".es",
+  ".mjs",
+  ".cjs",
+] as const);
 
 import Module from "module";
 import * as thisFile from "./index.ts";

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -506,4 +506,20 @@ describe("addon resolution", function () {
       ).code,
     ).toBe(`"ESM"`);
   });
+
+  it("resolvePreset", function () {
+    expect(
+      babel.resolvePreset("@babel/foo", path.join(base, "babel-org-paths")),
+    ).toMatch(
+      /babel-org-paths[\\/]node_modules[\\/]@babel[\\/]preset-foo[\\/]index.js/,
+    );
+  });
+
+  it("resolvePlugin", function () {
+    expect(
+      babel.resolvePlugin("@babel/foo", path.join(base, "babel-org-paths")),
+    ).toMatch(
+      /babel-org-paths[\\/]node_modules[\\/]@babel[\\/]plugin-foo[\\/]index.js/,
+    );
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/16887
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Fixes https://github.com/babel/babel/issues/16887. We probably need a better API, but for now lets restore the old behavior.