### PR TITLE
chore: remove eslint/compat

### DIFF
--- a/eslint/babel-eslint-tests/package.json
+++ b/eslint/babel-eslint-tests/package.json
@@ -7,10 +7,9 @@
     "@babel/core": "workspace:^",
     "@babel/eslint-parser": "workspace:^",
     "@babel/preset-react": "workspace:^",
-    "@eslint/compat": "^1.1.1",
     "dedent": "^1.5.3",
     "eslint": "^9.7.0",
-    "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-import": "^2.31.0",
     "globals": "^15.9.0",
     "npm-babel-parser": "npm:@babel/parser@^7.14.0"
   },

--- a/eslint/babel-eslint-tests/test/fixtures/eslint-plugin-import/eslint.config.mjs
+++ b/eslint/babel-eslint-tests/test/fixtures/eslint-plugin-import/eslint.config.mjs
@@ -1,11 +1,10 @@
-import _import from "eslint-plugin-import";
-import { fixupPluginRules } from "@eslint/compat";
+import importPlugin from "eslint-plugin-import";
 import babelParser from "@babel/eslint-parser";
 
 export default [
   {
     plugins: {
-      import: fixupPluginRules(_import),
+      import: importPlugin,
     },
 
     languageOptions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,10 +480,9 @@ __metadata:
     "@babel/core": "workspace:^"
     "@babel/eslint-parser": "workspace:^"
     "@babel/preset-react": "workspace:^"
-    "@eslint/compat": "npm:^1.1.1"
     dedent: "npm:^1.5.3"
     eslint: "npm:^9.7.0"
-    eslint-plugin-import: "npm:^2.25.4"
+    eslint-plugin-import: "npm:^2.31.0"
     globals: "npm:^15.9.0"
     npm-babel-parser: "npm:@babel/parser@^7.14.0"
   languageName: unknown
@@ -4307,13 +4306,6 @@ __metadata:
   version: 4.11.0
   resolution: "@eslint-community/regexpp@npm:4.11.0"
   checksum: 10/f053f371c281ba173fe6ee16dbc4fe544c84870d58035ccca08dba7f6ce1830d895ce3237a0db89ba37616524775dca82f1c502066b58e2d5712d7f87f5ba17c
-  languageName: node
-  linkType: hard
-
-"@eslint/compat@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@eslint/compat@npm:1.1.1"
-  checksum: 10/9004697701e9e9a7749d9e37452ee965af3620af46796ac0ee196478bbda490c780d17686c2888353c2a12d764837fa71c027c3ca18b1c3af6136105caa93642
   languageName: node
   linkType: hard
 
@@ -9019,7 +9011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.25.4, eslint-plugin-import@npm:^2.31.0":
+"eslint-plugin-import@npm:^2.31.0":
   version: 2.31.0
   resolution: "eslint-plugin-import@npm:2.31.0"
   dependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Any Dependency Changes?  | Removed `@eslint/compat`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
eslint-plugin-import 2.31.0 has officially supported eslint 9, so we don't have to import eslint/compat now.