### PR TITLE
perf: Improve scope information collection performance

### DIFF
--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -133,8 +133,31 @@ export function stop(this: NodePath) {
   this._traverseFlags |= SHOULD_SKIP | SHOULD_STOP;
 }
 
-export function setScope(this: NodePath, ignoreNoScope?: boolean) {
-  if (!ignoreNoScope && this.opts?.noScope) return;
+export function _forceSetScope(current: NodePath) {
+  let path = current.parentPath;
+
+  if (
+    // Skip method scope if is computed method key or decorator expression
+    ((current.key === "key" || current.listKey === "decorators") &&
+      path.isMethod()) ||
+    // Skip switch scope if for discriminant (`x` in `switch (x) {}`).
+    (current.key === "discriminant" && path.isSwitchStatement())
+  ) {
+    path = path.parentPath;
+  }
+
+  let target;
+  while (path && !target) {
+    target = path.scope;
+    path = path.parentPath;
+  }
+
+  current.scope = current.getScope(target);
+  current.scope?.init();
+}
+
+export function setScope(this: NodePath) {
+  if (this.opts?.noScope) return;
 
   let path = this.parentPath;
 
@@ -150,7 +173,7 @@ export function setScope(this: NodePath, ignoreNoScope?: boolean) {
 
   let target;
   while (path && !target) {
-    if (!ignoreNoScope && path.opts?.noScope) return;
+    if (path.opts?.noScope) return;
 
     target = path.scope;
     path = path.parentPath;

--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -133,8 +133,8 @@ export function stop(this: NodePath) {
   this._traverseFlags |= SHOULD_SKIP | SHOULD_STOP;
 }
 
-export function setScope(this: NodePath) {
-  if (this.opts?.noScope) return;
+export function setScope(this: NodePath, ignoreNoScope?: boolean) {
+  if (!ignoreNoScope && this.opts?.noScope) return;
 
   let path = this.parentPath;
 
@@ -150,7 +150,7 @@ export function setScope(this: NodePath) {
 
   let target;
   while (path && !target) {
-    if (path.opts?.noScope) return;
+    if (!ignoreNoScope && path.opts?.noScope) return;
 
     target = path.scope;
     path = path.parentPath;

--- a/packages/babel-traverse/src/path/lib/virtual-types.ts
+++ b/packages/babel-traverse/src/path/lib/virtual-types.ts
@@ -2,7 +2,10 @@ import type * as t from "@babel/types";
 
 export interface VirtualTypeAliases {
   BindingIdentifier: t.Identifier;
-  BlockScoped: t.Node;
+  BlockScoped:
+    | t.FunctionDeclaration
+    | t.ClassDeclaration
+    | t.VariableDeclaration;
   ExistentialTypeParam: t.ExistsTypeAnnotation;
   Expression: t.Expression;
   Flow: t.Flow | t.ImportDeclaration | t.ExportDeclaration | t.ImportSpecifier;
@@ -42,7 +45,11 @@ export const Scope: VirtualTypeMapping = ["Scopable", "Pattern"] as const;
 
 export const Referenced: VirtualTypeMapping = null;
 
-export const BlockScoped: VirtualTypeMapping = null;
+export const BlockScoped: VirtualTypeMapping = [
+  "FunctionDeclaration",
+  "ClassDeclaration",
+  "VariableDeclaration",
+] as const;
 
 export const Var: VirtualTypeMapping = ["VariableDeclaration"];
 

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -1,6 +1,7 @@
 import Renamer from "./lib/renamer.ts";
 import type NodePath from "../path/index.ts";
 import traverse from "../index.ts";
+import traverseForScope from "./traverseForScope.ts";
 import Binding from "./binding.ts";
 import type { BindingKind } from "./binding.ts";
 import globals from "globals";
@@ -923,9 +924,6 @@ class Scope {
     // traverse does not visit the root node, here we explicitly collect
     // root node binding info when the root is not a Program.
     if (path.type !== "Program" && isExplodedVisitor(collectorVisitor)) {
-      for (const visit of collectorVisitor.enter) {
-        visit.call(state, path, state);
-      }
       const typeVisitors = collectorVisitor[path.type];
       if (typeVisitors) {
         for (const visit of typeVisitors.enter) {
@@ -933,7 +931,7 @@ class Scope {
         }
       }
     }
-    path.traverse(collectorVisitor, state);
+    traverseForScope(path, collectorVisitor, state);
     this.crawling = false;
 
     // register assignments

--- a/packages/babel-traverse/src/scope/traverseForScope.ts
+++ b/packages/babel-traverse/src/scope/traverseForScope.ts
@@ -3,7 +3,7 @@ import type * as t from "@babel/types";
 import type { HubInterface, Visitor } from "../index.ts";
 import { NodePath } from "../index.ts";
 import { explode } from "../visitors.ts";
-import { setScope } from "../path/context.ts";
+import { _forceSetScope } from "../path/context.ts";
 
 export default function traverseForScope(
   path: NodePath,
@@ -48,7 +48,7 @@ export default function traverseForScope(
       key,
     });
 
-    setScope.call(path, true);
+    _forceSetScope(path);
 
     const visitor = exploded[node.type];
     if (visitor) {

--- a/packages/babel-traverse/src/scope/traverseForScope.ts
+++ b/packages/babel-traverse/src/scope/traverseForScope.ts
@@ -1,0 +1,86 @@
+import { VISITOR_KEYS } from "@babel/types";
+import type * as t from "@babel/types";
+import type { Visitor } from "../index.ts";
+import { NodePath } from "../index.ts";
+import { explode } from "../visitors.ts";
+import { setScope } from "../path/context.ts";
+
+export default function traverseForScope(
+  path: NodePath,
+  visitors: Visitor,
+  state: any,
+) {
+  const exploded = explode(visitors);
+
+  if (exploded.enter || exploded.exit) {
+    throw new Error("Should not be used with enter/exit visitors.");
+  }
+
+  _traverse(
+    path.parentPath,
+    path.parent,
+    path.node,
+    path.container,
+    path.key,
+    path.listKey,
+  );
+
+  function _traverse(
+    parentPath: NodePath,
+    parent: t.Node,
+    node: t.Node,
+    container: t.Node | t.Node[],
+    key: string | number,
+    listKey: string,
+  ) {
+    if (!node) {
+      return;
+    }
+
+    const path = NodePath.get({
+      parentPath,
+      parent,
+      container,
+      listKey,
+      key,
+    });
+
+    setScope.call(path, true);
+
+    const visitor = exploded[node.type];
+    if (visitor) {
+      if (visitor.enter) {
+        for (const visit of visitor.enter) {
+          visit.call(state, path, state);
+        }
+      }
+      if (visitor.exit) {
+        for (const visit of visitor.exit) {
+          visit.call(state, path, state);
+        }
+      }
+    }
+    if (path.shouldSkip) {
+      return;
+    }
+
+    const keys = VISITOR_KEYS[node.type];
+    if (!keys?.length) {
+      return;
+    }
+
+    for (const key of keys) {
+      // @ts-expect-error key must present in node
+      const prop = node[key];
+      if (!prop) continue;
+      if (Array.isArray(prop)) {
+        for (let i = 0; i < prop.length; i++) {
+          const value = prop[i];
+          _traverse(path, node, value, prop, i, key);
+        }
+      } else {
+        _traverse(path, node, prop, node, key, null);
+      }
+    }
+  }
+}

--- a/packages/babel-traverse/src/scope/traverseForScope.ts
+++ b/packages/babel-traverse/src/scope/traverseForScope.ts
@@ -1,6 +1,6 @@
 import { VISITOR_KEYS } from "@babel/types";
 import type * as t from "@babel/types";
-import type { Visitor } from "../index.ts";
+import type { HubInterface, Visitor } from "../index.ts";
 import { NodePath } from "../index.ts";
 import { explode } from "../visitors.ts";
 import { setScope } from "../path/context.ts";
@@ -23,6 +23,7 @@ export default function traverseForScope(
     path.container,
     path.key,
     path.listKey,
+    path.hub,
   );
 
   function _traverse(
@@ -32,12 +33,14 @@ export default function traverseForScope(
     container: t.Node | t.Node[],
     key: string | number,
     listKey: string,
+    hub?: HubInterface,
   ) {
     if (!node) {
       return;
     }
 
     const path = NodePath.get({
+      hub,
       parentPath,
       parent,
       container,

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -104,13 +104,9 @@ function explode$1<S>(visitor: Visitor<S>): ExplodedVisitor<S> {
     const types = virtualTypes[nodeType];
     if (types !== null) {
       for (const type of types) {
-        // merge the visitor if necessary or just put it back in
-        if (visitor[type]) {
-          mergePair(visitor[type], fns);
-        } else {
-          // @ts-expect-error Expression produces too complex union
-          visitor[type] = fns;
-        }
+        // @ts-expect-error Expression produces too complex union
+        visitor[type] ??= {};
+        mergePair(visitor[type], fns);
       }
     } else {
       mergePair(visitor, fns);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Here we introduced a simplified traversal, which improved the overall performance by about 10%. (Well, I don’t understand why it brings such a big performance improvement. I tried more later but failed. 🤦‍♂️)

```
PS F:\babel\benchmark> node --expose-gc .\all\real-case-ts-mjs.mjs 
all/real-case-ts-mjs.mjs babel-parser-express.ts @ current: 36.76 ops/sec ±8.46% 30 runs (27ms)
all/real-case-ts-mjs.mjs babel-parser-express.ts @ baseline: 33.86 ops/sec ±5.73% 30 runs (30ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ current: 6.51 ops/sec ±6.65% 30 runs (154ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ baseline: 5.21 ops/sec ±4.09% 30 runs (192ms)
PS F:\babel\benchmark> node --expose-gc .\all\real-case-mjs-cjs.mjs
all/real-case-mjs-cjs.mjs ts-checker.mjs @ current: 1.11 ops/sec ±2.37% 30 runs (903ms)
all/real-case-mjs-cjs.mjs ts-checker.mjs @ baseline: 0.93 ops/sec ±2.46% 30 runs (1079ms)
all/real-case-mjs-cjs.mjs ts-parser.mjs @ current: 8.29 ops/sec ±3.11% 30 runs (121ms)
all/real-case-mjs-cjs.mjs ts-parser.mjs @ baseline: 7.36 ops/sec ±3.63% 30 runs (136ms)
```