### PR TITLE
Fix loading of modules with TLA in Node.js 23

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -277,6 +277,7 @@ export default [
             "itNoWin32",
             "itESM",
             "nodeGte8",
+            "nodeGte14",
             "nodeGte12",
             "nodeGte20",
             "nodeGte23",

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -12,6 +12,7 @@ import { itGte, itESM, itLt } from "$repo-utils";
 
 // "minNodeVersion": "8.0.0" <-- For Ctrl+F when dropping node 6
 const nodeGte8 = itGte("8.0.0");
+const nodeGte14 = itGte("14.8.0");
 
 // "minNodeVersion": "23.0.0" <-- For Ctrl+F when dropping node 22
 const nodeGte23 = itGte("23.0.0");
@@ -245,7 +246,7 @@ describe("asynchronicity", () => {
         });
       });
 
-      it("called asynchronously when contain TLA", async () => {
+      nodeGte14("called asynchronously when contain TLA", async () => {
         process.chdir("plugin-mjs-tla-native");
 
         await expect(spawnTransformAsync()).resolves.toMatchObject({

--- a/packages/babel-core/test/async.js
+++ b/packages/babel-core/test/async.js
@@ -244,6 +244,14 @@ describe("asynchronicity", () => {
           code: `"success"`,
         });
       });
+
+      it("called asynchronously when contain TLA", async () => {
+        process.chdir("plugin-mjs-tla-native");
+
+        await expect(spawnTransformAsync()).resolves.toMatchObject({
+          code: `"success"`,
+        });
+      });
     });
   });
 

--- a/packages/babel-core/test/fixtures/async/plugin-mjs-tla-native/babel.config.cjs
+++ b/packages/babel-core/test/fixtures/async/plugin-mjs-tla-native/babel.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["./plugin.js"],
+};

--- a/packages/babel-core/test/fixtures/async/plugin-mjs-tla-native/package.json
+++ b/packages/babel-core/test/fixtures/async/plugin-mjs-tla-native/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/packages/babel-core/test/fixtures/async/plugin-mjs-tla-native/plugin.js
+++ b/packages/babel-core/test/fixtures/async/plugin-mjs-tla-native/plugin.js
@@ -1,0 +1,11 @@
+await Promise.resolve(0);
+
+export default function plugin({ types: t }) {
+  return {
+    visitor: {
+      Program(path) {
+        path.pushContainer("body", t.stringLiteral("success"));
+      },
+    },
+  };
+}

--- a/scripts/integration-tests/e2e-react-native.sh
+++ b/scripts/integration-tests/e2e-react-native.sh
@@ -30,7 +30,7 @@ startLocalRegistry "$root"/verdaccio-config.yml
 
 # Create a React Native project
 cd /tmp
-npx @react-native-community/cli init rnbabel
+YARN_ENABLE_IMMUTABLE_INSTALLS=false npx @react-native-community/cli init rnbabel
 cd rnbabel
 
 if [ "$BABEL_8_BREAKING" = true ] ; then

--- a/scripts/integration-tests/e2e-react-native.sh
+++ b/scripts/integration-tests/e2e-react-native.sh
@@ -30,8 +30,7 @@ startLocalRegistry "$root"/verdaccio-config.yml
 
 # Create a React Native project
 cd /tmp
-npm install react-native
-npx react-native init rnbabel
+npx @react-native-community/cli init rnbabel
 cd rnbabel
 
 if [ "$BABEL_8_BREAKING" = true ] ; then

--- a/scripts/integration-tests/e2e-react-native.sh
+++ b/scripts/integration-tests/e2e-react-native.sh
@@ -30,10 +30,7 @@ startLocalRegistry "$root"/verdaccio-config.yml
 
 # Create a React Native project
 cd /tmp
-# Remove the patch when react-native bumps @react-native-community/cli to 12
 npm install react-native
-npx replace '_fs\(\)\.default\.chmodSync\(destPath, mode\);' '' node_modules/@react-native-community/cli/build/tools/copyFiles.js
-npx replace 'createWriteStream\(destPath\);' 'createWriteStream(destPath, {mode});' node_modules/@react-native-community/cli/build/tools/copyFiles.js
 npx react-native init rnbabel
 cd rnbabel
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes the failures in https://github.com/babel/babel/pull/16850
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In Node.js versions that support `require(esm)`, `require(esm-with-tla)` throws `ERR_REQUIRE_ASYNC_MODULE`. Then our old wrong logic would see that `e.code !== "ERR_REQUIRE_ESM"`, and thus re-throw the error rather than trying to load it with `import()`.

**This means that in Node.js 23 it's currently impossible to use plugins/presets/configs that use TLA, even when loading them with `transformAsync`.**

When doing `import()` after a `require()` failed due to TLA Node.js currently fails an internal assertion (https://github.com/nodejs/node/issues/55500), so this PR also includes a workaround for that.