### PR TITLE
[react] Only default to `development` when set through env

### DIFF
--- a/packages/babel-preset-react/src/index.ts
+++ b/packages/babel-preset-react/src/index.ts
@@ -21,7 +21,9 @@ export default declarePreset((api, opts: Options) => {
   api.assertVersion(REQUIRED_VERSION(7));
 
   const {
-    development,
+    development = process.env.BABEL_8_BREAKING
+      ? api.env(env => env === "development")
+      : false,
     importSource,
     pragma,
     pragmaFrag,

--- a/packages/babel-preset-react/src/normalize-options.ts
+++ b/packages/babel-preset-react/src/normalize-options.ts
@@ -40,7 +40,6 @@ export default function normalizeOptions(options: any = {}) {
     const development = v.validateBooleanOption(
       TopLevelOptions.development,
       options.development,
-      false,
     );
     let importSource = v.validateStringOption(
       TopLevelOptions.importSource,
@@ -103,7 +102,8 @@ export default function normalizeOptions(options: any = {}) {
       pragmaFrag = pragmaFrag || "React.Fragment";
     }
 
-    const development = !!options.development;
+    const development =
+      options.development == null ? undefined : !!options.development;
 
     return {
       development,

--- a/packages/babel-preset-react/test/index.js
+++ b/packages/babel-preset-react/test/index.js
@@ -1,3 +1,5 @@
+import * as babel from "@babel/core";
+
 import _reactPreset from "../lib/index.js";
 const reactPreset = _reactPreset.default || _reactPreset;
 
@@ -23,5 +25,34 @@ describe("react preset", () => {
     }).toThrowErrorMatchingInlineSnapshot(
       `"@babel/preset-react: 'runtime' option must be a string."`,
     );
+  });
+
+  itBabel8("respects envName", () => {
+    expect(
+      babel.transformSync("<a />", {
+        configFile: false,
+        presets: [reactPreset],
+        envName: "development",
+      }).code,
+    ).toMatchInlineSnapshot(`
+      "var _jsxFileName = \\"\\";
+      import { jsxDEV as _jsxDEV } from \\"react/jsx-dev-runtime\\";
+      /*#__PURE__*/_jsxDEV(\\"a\\", {}, void 0, false, {
+        fileName: _jsxFileName,
+        lineNumber: 1,
+        columnNumber: 1
+      }, this);"
+    `);
+
+    expect(
+      babel.transformSync("<a />", {
+        configFile: false,
+        presets: [reactPreset],
+        envName: "production",
+      }).code,
+    ).toMatchInlineSnapshot(`
+      "import { jsx as _jsx } from \\"react/jsx-runtime\\";
+      /*#__PURE__*/_jsx(\\"a\\", {});"
+    `);
   });
 });

--- a/packages/babel-preset-react/test/normalize-options.skip-bundled.js
+++ b/packages/babel-preset-react/test/normalize-options.skip-bundled.js
@@ -59,7 +59,7 @@ describe("normalize options", () => {
     it("default values", () => {
       expect(normalizeOptions({})).toMatchInlineSnapshot(`
         Object {
-          "development": false,
+          "development": undefined,
           "importSource": "react",
           "pragma": undefined,
           "pragmaFrag": undefined,
@@ -70,7 +70,7 @@ describe("normalize options", () => {
       `);
       expect(normalizeOptions({ runtime: "classic" })).toMatchInlineSnapshot(`
         Object {
-          "development": false,
+          "development": undefined,
           "importSource": undefined,
           "pragma": "React.createElement",
           "pragmaFrag": "React.Fragment",
@@ -100,7 +100,7 @@ describe("normalize options", () => {
     it("default values in Babel 7", () => {
       expect(normalizeOptions({})).toMatchInlineSnapshot(`
         Object {
-          "development": false,
+          "development": undefined,
           "importSource": undefined,
           "pragma": "React.createElement",
           "pragmaFrag": "React.Fragment",
@@ -113,7 +113,7 @@ describe("normalize options", () => {
       `);
       expect(normalizeOptions({ runtime: "automatic" })).toMatchInlineSnapshot(`
         Object {
-          "development": false,
+          "development": undefined,
           "importSource": undefined,
           "pragma": undefined,
           "pragmaFrag": undefined,

--- a/packages/babel-standalone/test/babel.js
+++ b/packages/babel-standalone/test/babel.js
@@ -91,6 +91,7 @@ describe("@babel/standalone", () => {
       "const someDiv = <div>{getMessage()}</div>",
       {
         presets: [["react", { runtime: "classic" }]],
+        envName: "production",
       },
     ).code;
     expect(output).toBe(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes https://github.com/babel/babel/issues/8902
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Babel 7 defaults to `false`, while Babel 8 currently defaults to `true`. We should keep defaulting to `false`, unless somebody sets `NODE_ENV` (or `BABEL_ENV`) to `development`.