### PR TITLE
Update node 23.1 experimental warning

### DIFF
--- a/packages/babel-core/test/helpers/esm.js
+++ b/packages/babel-core/test/helpers/esm.js
@@ -56,16 +56,7 @@ async function spawn(runner, filename, cwd = process.cwd()) {
     process.execPath,
     // pass `cwd` as params as `process.cwd()` will normalize `cwd` on macOS
     [require.resolve(`../fixtures/babel-${runner}.mjs`), filename, cwd],
-    {
-      cwd,
-      env: {
-        ...process.env,
-        NODE_OPTIONS:
-          parseInt(process.versions.node) >= 23
-            ? "--disable-warning=ExperimentalWarning"
-            : "",
-      },
-    },
+    { cwd, env: process.env },
   );
 
   const EXPERIMENTAL_WARNING =

--- a/packages/babel-core/test/helpers/esm.js
+++ b/packages/babel-core/test/helpers/esm.js
@@ -60,7 +60,7 @@ async function spawn(runner, filename, cwd = process.cwd()) {
   );
 
   const EXPERIMENTAL_WARNING =
-    /\(node:\d+\) ExperimentalWarning: (The ESM module loader is experimental\.|Support for loading ES Module in require\(\) is an experimental feature and might change at any time\n\(Use `node --trace-warnings ...` to show where the warning was created\))/;
+    /\(node:\d+\) ExperimentalWarning: (The ESM module loader is experimental\.|CommonJS module .+? is loading ES Module .+? using require\(\)\.\nSupport for loading ES Module in require\(\) is an experimental feature and might change at any time\n\(Use `node --trace-warnings ...` to show where the warning was created\))/;
 
   if (stderr.replace(EXPERIMENTAL_WARNING, "").trim()) {
     throw new Error(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Related: https://github.com/babel/babel/pull/16932
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Updated the experimental warning regex so that it can filter the REQUIRE_ESM warning produced by node 23.1.