### PR TITLE
Fix CI e2e-babel error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -272,7 +272,7 @@ export default [
             "itBabel7NodeGte14NoESM",
             "itBabel8",
             "itESLint7",
-            "itESLint8",
+            "itESLintGte8",
             "itNoESM",
             "itNoWin32",
             "itESM",

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -38,12 +38,8 @@ const PROPS_TO_REMOVE = [
   { key: "typeArguments", type: null },
   { key: "filename", type: null },
   { key: "identifierName", type: null },
-  // espree doesn't support these yet
-  { key: "attributes", type: "ImportDeclaration" },
-  { key: "attributes", type: "ExportNamedDeclaration" },
-  { key: "attributes", type: "ExportAllDeclaration" },
+  // For legacy estree AST
   { key: "attributes", type: "ImportExpression" },
-  { key: "options", type: "ImportExpression" },
 ];
 
 function deeplyRemoveProperties(obj, props) {
@@ -109,7 +105,6 @@ describe("Babel and Espree", () => {
       }).ast;
 
       deeplyRemoveProperties(babelAST, PROPS_TO_REMOVE);
-      deeplyRemoveProperties(espreeAST, ["offset"]);
       expect(babelAST).toEqual(espreeAST);
     } else {
       // ESLint 8
@@ -126,7 +121,6 @@ describe("Babel and Espree", () => {
       }).ast;
 
       deeplyRemoveProperties(babelAST, PROPS_TO_REMOVE);
-      deeplyRemoveProperties(espreeAST, ["offset"]);
       expect(babelAST).toEqual(espreeAST);
     }
   }

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -24,7 +24,7 @@ const { __dirname: dirname, require } = commonJS(import.meta.url);
 // @babel/eslint-parser 8 will drop ESLint 7 support
 
 const itESLint7 = isESLint7 && !process.env.BABEL_8_BREAKING ? it : itDummy;
-const itESLint8 = isESLint8 ? it : itDummy;
+const itESLintGte8 = isESLint7 ? itDummy : it;
 
 const BABEL_OPTIONS = {
   configFile: path.resolve(
@@ -477,7 +477,7 @@ describe("Babel and Espree", () => {
     expect(babylonAST.tokens[3].value).toEqual("#");
   });
 
-  itESLint8("private identifier (token) - ESLint 8", () => {
+  itESLintGte8("private identifier (token) - ESLint 8", () => {
     const code = "class A { #x }";
     const babylonAST = parseForESLint(code, {
       eslintVisitorKeys: true,
@@ -530,7 +530,7 @@ describe("Babel and Espree", () => {
     expect(classDeclaration.body.body[0].type).toEqual("PropertyDefinition");
   });
 
-  itESLint8("class fields with ESLint 8", () => {
+  itESLintGte8("class fields with ESLint 8", () => {
     parseAndAssertSame(
       `
         class A {
@@ -574,7 +574,7 @@ describe("Babel and Espree", () => {
     ).toMatchObject(staticKw);
   });
 
-  itESLint8("static (token) - ESLint 8", () => {
+  itESLintGte8("static (token) - ESLint 8", () => {
     const code = `
       class A {
         static m() {}
@@ -631,7 +631,7 @@ describe("Babel and Espree", () => {
     expect(babylonAST.tokens[17]).toMatchObject(topicToken);
   });
 
-  itESLint8("pipeline # topic token - ESLint 8", () => {
+  itESLintGte8("pipeline # topic token - ESLint 8", () => {
     const code = `
       x |> #
       y |> #[0]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4322,10 +4322,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/core@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@eslint/core@npm:0.6.0"
-  checksum: 10/ec5cce168c8773fbd60c5a505563c6cf24398b3e1fa352929878d63129e0dd5b134d3232be2f2c49e8124a965d03359b38962aa0dcf7dfaf50746059d2a2f798
+"@eslint/core@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@eslint/core@npm:0.7.0"
+  checksum: 10/69227f33fddd9b402b7b0830732a6e84cae77d202cb5b56f0dbcc462882e07d00e80216b796cf2f243f5b775af3ef27545a0c439d78e66122eab71da4773b81c
   languageName: node
   linkType: hard
 
@@ -4346,10 +4346,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.12.0, @eslint/js@npm:^9.12.0":
-  version: 9.12.0
-  resolution: "@eslint/js@npm:9.12.0"
-  checksum: 10/c4ec9f7ff664f778324002bccdfd63e4a563018e4d7efc838d8149898f9df8649fbc51a379c3d7deea40da4fba9e8e62f39f2df3ff2b9616e2241bbfc10456b0
+"@eslint/js@npm:9.13.0, @eslint/js@npm:^9.12.0":
+  version: 9.13.0
+  resolution: "@eslint/js@npm:9.13.0"
+  checksum: 10/aa7a4c45044a6cf6e14666ecc0b56ad41c80f022bd4718620b4a7e3d892111312f4e4ac4787fd11b3bf5abdb6ff9a95fdae7e73ef790528f150d86e9be1754a2
   languageName: node
   linkType: hard
 
@@ -6170,11 +6170,11 @@ __metadata:
   linkType: hard
 
 "acorn@npm:^8.11.3, acorn@npm:^8.12.0, acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.7.1, acorn@npm:^8.8.2":
-  version: 8.12.1
-  resolution: "acorn@npm:8.12.1"
+  version: 8.14.0
+  resolution: "acorn@npm:8.14.0"
   bin:
     acorn: bin/acorn
-  checksum: 10/d08c2d122bba32d0861e0aa840b2ee25946c286d5dc5990abca991baf8cdbfbe199b05aacb221b979411a2fea36f83e26b5ac4f6b4e0ce49038c62316c1848f0
+  checksum: 10/6df29c35556782ca9e632db461a7f97947772c6c1d5438a81f0c873a3da3a792487e83e404d1c6c25f70513e91aa18745f6eafb1fcc3a43ecd1920b21dd173d2
   languageName: node
   linkType: hard
 
@@ -9207,15 +9207,15 @@ __metadata:
   linkType: hard
 
 "eslint@npm:^9.12.0, eslint@npm:^9.7.0":
-  version: 9.12.0
-  resolution: "eslint@npm:9.12.0"
+  version: 9.13.0
+  resolution: "eslint@npm:9.13.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.11.0"
     "@eslint/config-array": "npm:^0.18.0"
-    "@eslint/core": "npm:^0.6.0"
+    "@eslint/core": "npm:^0.7.0"
     "@eslint/eslintrc": "npm:^3.1.0"
-    "@eslint/js": "npm:9.12.0"
+    "@eslint/js": "npm:9.13.0"
     "@eslint/plugin-kit": "npm:^0.2.0"
     "@humanfs/node": "npm:^0.16.5"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
@@ -9252,7 +9252,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10/c3f10d1ca3798bf1d0f71e43846e254d4bf0ea9ffbb0e61f9686a98e412aa762a454c5e5ef4e74fd71956b1500c04817c9f08dbf7a0cec47317160e28f585e4f
+  checksum: 10/4342cc24a8d73581676f1b4959c2ddac18ed169731d9c55b708d2eacfc066ed5bdbc2c3c129e1f70142f0704bc25884a1a9ae580e15be5921f9c7f7d0f3ebe68
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes current failing babel e2e tests: https://github.com/babel/babel/actions/runs/11559011160/job/32173195703
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Acorn 8.14.0 has supported ES2025 features such as import attributes. So we have to update the AST patching logic in eslint tests.