### PR TITLE
Add test for current wrong behavior

### DIFF
--- a/packages/babel-generator/src/token-map.ts
+++ b/packages/babel-generator/src/token-map.ts
@@ -158,7 +158,8 @@ export class TokenMap {
     const indexes = [];
 
     for (const child of children) {
-      if (!child) continue;
+      if (child == null) continue;
+      if (child.start == null || child.end == null) continue;
 
       const childTok = this._findTokensOfNode(child, low, last);
 

--- a/packages/babel-generator/test/preserve-format.js
+++ b/packages/babel-generator/test/preserve-format.js
@@ -215,8 +215,8 @@ describe("experimental_preserveFormat", () => {
       const expected = `
         const    foo
             = 3;hello;
-                  const  bar=
-            3
+                  const  bar          =
+            3;
         bax
       `;
 

--- a/packages/babel-generator/test/preserve-format.js
+++ b/packages/babel-generator/test/preserve-format.js
@@ -203,5 +203,47 @@ describe("experimental_preserveFormat", () => {
 
       expect(out.code.trimEnd()).toBe(expected.trimEnd());
     });
+
+    it("node injection", () => {
+      const input = `
+        const    foo
+            = 3;
+                  const  bar          =
+            3;
+        bax
+      `;
+      const expected = `
+        const    foo
+            = 3;hello;
+                  const  bar=
+            3
+        bax
+      `;
+
+      const out = babel.transformSync(input, {
+        configFile: false,
+        plugins: [
+          ({ types: t }) => ({
+            visitor: {
+              Program(path) {
+                path
+                  .get("body.0")
+                  .insertAfter(t.expressionStatement(t.identifier("hello")));
+              },
+            },
+          }),
+        ],
+        parserOpts: {
+          createParenthesizedExpressions: true,
+          tokens: true,
+        },
+        generatorOpts: {
+          retainLines: true,
+          experimental_preserveFormat: true,
+        },
+      });
+
+      expect(out.code.trimEnd()).toBe(expected.trimEnd());
+    });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

See the first commit to see the wrong output. The problem was that a `null` start was flowing to the binary search, failing both `<` and `>` comparisons, and thus considering it as "matched" and returning the middle point.

cc @kriskowal