### PR TITLE
perf: Remove use of `simplifyAccess`

### DIFF
--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -14,8 +14,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/helper-module-transforms": "workspace:^",
-    "@babel/helper-plugin-utils": "workspace:^",
-    "@babel/helper-simple-access": "workspace:^"
+    "@babel/helper-plugin-utils": "workspace:^"
   },
   "keywords": [
     "babel-plugin"

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.ts
@@ -9,7 +9,6 @@ import {
   wrapInterop,
   getModuleName,
 } from "@babel/helper-module-transforms";
-import simplifyAccess from "@babel/helper-simple-access";
 import { template, types as t } from "@babel/core";
 import type { PluginPass, Visitor, Scope, NodePath } from "@babel/core";
 import type { PluginOptions } from "@babel/helper-module-transforms";
@@ -208,12 +207,6 @@ export default declare((api, options: Options) => {
           // These objects are specific to CommonJS and are not available in
           // real ES6 implementations.
           if (!allowCommonJSExports) {
-            if (process.env.BABEL_8_BREAKING) {
-              simplifyAccess(path, new Set(["module", "exports"]));
-            } else {
-              // @ts-ignore(Babel 7 vs Babel 8) The third param has been removed in Babel 8.
-              simplifyAccess(path, new Set(["module", "exports"]), false);
-            }
             path.traverse(moduleExportsVisitor, {
               scope: path.scope,
             });

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/module-exports/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/misc/module-exports/output.js
@@ -12,9 +12,7 @@ exports += (function () {
 }(), function () {
   throw new Error("The CommonJS '" + "exports" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
 }());
-exports = (function () {
-  throw new Error("The CommonJS '" + "exports" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
-}() + 4, function () {
+exports += (4, function () {
   throw new Error("The CommonJS '" + "exports" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
 }());
 ({
@@ -42,9 +40,7 @@ module += (function () {
 }(), function () {
   throw new Error("The CommonJS '" + "module" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
 }());
-module = (function () {
-  throw new Error("The CommonJS '" + "module" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
-}() + 4, function () {
+module += (4, function () {
   throw new Error("The CommonJS '" + "module" + "' variable is not available in ES6 modules." + "Consider setting setting sourceType:script or sourceType:unambiguous in your " + "Babel config for this file.");
 }());
 ({

--- a/packages/babel-plugin-transform-modules-commonjs/tsconfig.json
+++ b/packages/babel-plugin-transform-modules-commonjs/tsconfig.json
@@ -17,9 +17,6 @@
       "path": "../../packages/babel-helper-plugin-utils"
     },
     {
-      "path": "../../packages/babel-helper-simple-access"
-    },
-    {
       "path": "../../packages/babel-core"
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,7 +991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-simple-access@workspace:^, @babel/helper-simple-access@workspace:packages/babel-helper-simple-access":
+"@babel/helper-simple-access@workspace:packages/babel-helper-simple-access":
   version: 0.0.0-use.local
   resolution: "@babel/helper-simple-access@workspace:packages/babel-helper-simple-access"
   dependencies:
@@ -2806,7 +2806,6 @@ __metadata:
     "@babel/helper-module-transforms": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
-    "@babel/helper-simple-access": "workspace:^"
     "@babel/plugin-external-helpers": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This may affect some very corner cases (`allowCommonJSExports=false`, using e.g. `export??=1` and the node version does not support `??=` and is not executed), But I don't think anyone does.
I haven't shown performance data because this doesn't affect the performance of the default options.

