### PR TITLE
perf: Reduce the use of temporary objects

### DIFF
--- a/packages/babel-generator/src/generators/base.ts
+++ b/packages/babel-generator/src/generators/base.ts
@@ -20,9 +20,7 @@ export function Program(this: Printer, node: t.Program) {
   const directivesLen = node.directives?.length;
   if (directivesLen) {
     const newline = node.body.length ? 2 : 1;
-    this.printSequence(node.directives, {
-      trailingCommentsLineOffset: newline,
-    });
+    this.printSequence(node.directives, undefined, newline);
     if (!node.directives[directivesLen - 1].trailingComments?.length) {
       this.newline(newline);
     }
@@ -38,16 +36,13 @@ export function BlockStatement(this: Printer, node: t.BlockStatement) {
   const directivesLen = node.directives?.length;
   if (directivesLen) {
     const newline = node.body.length ? 2 : 1;
-    this.printSequence(node.directives, {
-      indent: true,
-      trailingCommentsLineOffset: newline,
-    });
+    this.printSequence(node.directives, true, newline);
     if (!node.directives[directivesLen - 1].trailingComments?.length) {
       this.newline(newline);
     }
   }
 
-  this.printSequence(node.body, { indent: true });
+  this.printSequence(node.body, true);
 
   exit();
   this.rightBrace(node);

--- a/packages/babel-generator/src/generators/classes.ts
+++ b/packages/babel-generator/src/generators/classes.ts
@@ -79,12 +79,7 @@ export function ClassBody(this: Printer, node: t.ClassBody) {
     separator?.(-1); // print leading semicolons in preserveFormat mode
 
     const exit = this.enterDelimited();
-    this.printJoin(node.body, {
-      statement: true,
-      indent: true,
-      separator,
-      printTrailingSeparator: true,
-    });
+    this.printJoin(node.body, true, true, separator, true);
     exit();
 
     if (!this.endsWith(charCodes.lineFeed)) this.newline();
@@ -287,7 +282,7 @@ export function StaticBlock(this: Printer, node: t.StaticBlock) {
     this.token("}");
   } else {
     this.newline();
-    this.printSequence(node.body, { indent: true });
+    this.printSequence(node.body, true);
     this.rightBrace(node);
   }
 }

--- a/packages/babel-generator/src/generators/expressions.ts
+++ b/packages/babel-generator/src/generators/expressions.ts
@@ -112,9 +112,7 @@ export function NewExpression(
 
   this.token("(");
   const exit = this.enterDelimited();
-  this.printList(node.arguments, {
-    printTrailingSeparator: this.shouldPrintTrailingComma(")"),
-  });
+  this.printList(node.arguments, this.shouldPrintTrailingComma(")"));
   exit();
   this.rightParens(node);
 }
@@ -210,9 +208,7 @@ export function CallExpression(this: Printer, node: t.CallExpression) {
   this.print(node.typeParameters); // TS
   this.token("(");
   const exit = this.enterDelimited();
-  this.printList(node.arguments, {
-    printTrailingSeparator: this.shouldPrintTrailingComma(")"),
-  });
+  this.printList(node.arguments, this.shouldPrintTrailingComma(")"));
   exit();
   this.rightParens(node);
 }

--- a/packages/babel-generator/src/generators/flow.ts
+++ b/packages/babel-generator/src/generators/flow.ts
@@ -452,7 +452,7 @@ export function IntersectionTypeAnnotation(
   this: Printer,
   node: t.IntersectionTypeAnnotation,
 ) {
-  this.printJoin(node.types, { separator: andSeparator });
+  this.printJoin(node.types, undefined, undefined, andSeparator);
 }
 
 export function MixedTypeAnnotation(this: Printer) {
@@ -544,7 +544,7 @@ export function TypeParameterInstantiation(
   node: t.TypeParameterInstantiation,
 ): void {
   this.token("<");
-  this.printList(node.params, {});
+  this.printList(node.params);
   this.token(">");
 }
 
@@ -615,19 +615,22 @@ export function ObjectTypeAnnotation(
 
     this.space();
 
-    this.printJoin(props, {
-      addNewlines(leading) {
+    this.printJoin(
+      props,
+      true,
+      true,
+      undefined,
+      undefined,
+      function addNewlines(leading) {
         if (leading && !props[0]) return 1;
       },
-      indent: true,
-      statement: true,
-      iterator: () => {
+      () => {
         if (props.length !== 1 || node.inexact) {
           this.token(",");
           this.space();
         }
       },
-    });
+    );
 
     this.space();
   }
@@ -753,7 +756,7 @@ export function UnionTypeAnnotation(
   this: Printer,
   node: t.UnionTypeAnnotation,
 ) {
-  this.printJoin(node.types, { separator: orSeparator });
+  this.printJoin(node.types, undefined, undefined, orSeparator);
 }
 
 export function TypeCastExpression(this: Printer, node: t.TypeCastExpression) {

--- a/packages/babel-generator/src/generators/jsx.ts
+++ b/packages/babel-generator/src/generators/jsx.ts
@@ -85,7 +85,7 @@ export function JSXOpeningElement(this: Printer, node: t.JSXOpeningElement) {
   this.print(node.typeParameters); // TS
   if (node.attributes.length > 0) {
     this.space();
-    this.printJoin(node.attributes, { separator: spaceSeparator });
+    this.printJoin(node.attributes, undefined, undefined, spaceSeparator);
   }
   if (node.selfClosing) {
     this.space();

--- a/packages/babel-generator/src/generators/modules.ts
+++ b/packages/babel-generator/src/generators/modules.ts
@@ -116,9 +116,7 @@ Please specify the "importAttributesKeyword" generator option, whose value can b
 
   this.token("{", null, occurrenceCount);
   this.space();
-  this.printList(attributes || assertions, {
-    printTrailingSeparator: this.shouldPrintTrailingComma("}"),
-  });
+  this.printList(attributes || assertions, this.shouldPrintTrailingComma("}"));
   this.space();
   this.token("}", null, occurrenceCount);
 }
@@ -207,9 +205,7 @@ export function ExportNamedDeclaration(
       this.token("{");
       if (specifiers.length) {
         this.space();
-        this.printList(specifiers, {
-          printTrailingSeparator: this.shouldPrintTrailingComma("}"),
-        });
+        this.printList(specifiers, this.shouldPrintTrailingComma("}"));
         this.space();
       }
       this.token("}");
@@ -290,9 +286,7 @@ export function ImportDeclaration(this: Printer, node: t.ImportDeclaration) {
     hasBrace = true;
     this.token("{");
     this.space();
-    this.printList(specifiers, {
-      printTrailingSeparator: this.shouldPrintTrailingComma("}"),
-    });
+    this.printList(specifiers, this.shouldPrintTrailingComma("}"));
     this.space();
     this.token("}");
   } else if (isTypeKind && !hasSpecifiers) {

--- a/packages/babel-generator/src/generators/statements.ts
+++ b/packages/babel-generator/src/generators/statements.ts
@@ -227,12 +227,14 @@ export function SwitchStatement(this: Printer, node: t.SwitchStatement) {
   this.space();
   this.token("{");
 
-  this.printSequence(node.cases, {
-    indent: true,
-    addNewlines(leading, cas) {
+  this.printSequence(
+    node.cases,
+    true,
+    undefined,
+    function addNewlines(leading, cas) {
       if (!leading && node.cases[node.cases.length - 1] === cas) return -1;
     },
-  });
+  );
 
   this.rightBrace(node);
 }
@@ -250,7 +252,7 @@ export function SwitchCase(this: Printer, node: t.SwitchCase) {
 
   if (node.consequent.length) {
     this.newline();
-    this.printSequence(node.consequent, { indent: true });
+    this.printSequence(node.consequent, true);
   }
 }
 
@@ -303,15 +305,18 @@ export function VariableDeclaration(
   //       bar = "foo";
   //
 
-  this.printList(node.declarations, {
-    separator: hasInits
+  this.printList(
+    node.declarations,
+    undefined,
+    undefined,
+    node.declarations.length > 1,
+    hasInits
       ? function (this: Printer, occurrenceCount: number) {
           this.token(",", false, occurrenceCount);
           this.newline();
         }
       : undefined,
-    indent: node.declarations.length > 1 ? true : false,
-  });
+  );
 
   if (isFor(parent)) {
     // don't give semicolons to these nodes since they'll be inserted in the parent generator

--- a/packages/babel-generator/src/generators/types.ts
+++ b/packages/babel-generator/src/generators/types.ts
@@ -43,11 +43,7 @@ export function ObjectExpression(this: Printer, node: t.ObjectExpression) {
   if (props.length) {
     const exit = this.enterDelimited();
     this.space();
-    this.printList(props, {
-      indent: true,
-      statement: true,
-      printTrailingSeparator: this.shouldPrintTrailingComma("}"),
-    });
+    this.printList(props, this.shouldPrintTrailingComma("}"), true, true);
     this.space();
     exit();
   }
@@ -167,11 +163,7 @@ export function RecordExpression(this: Printer, node: t.RecordExpression) {
 
   if (props.length) {
     this.space();
-    this.printList(props, {
-      indent: true,
-      statement: true,
-      printTrailingSeparator: this.shouldPrintTrailingComma(endToken),
-    });
+    this.printList(props, this.shouldPrintTrailingComma(endToken), true, true);
     this.space();
   }
   this.token(endToken);

--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -44,7 +44,7 @@ export function TSTypeParameterInstantiation(
     printTrailingSeparator ||= this.shouldPrintTrailingComma(">");
   }
 
-  this.printList(node.params, { printTrailingSeparator });
+  this.printList(node.params, printTrailingSeparator);
   this.token(">");
 }
 
@@ -321,9 +321,7 @@ export function TSTypeQuery(this: Printer, node: t.TSTypeQuery) {
 }
 
 export function TSTypeLiteral(this: Printer, node: t.TSTypeLiteral) {
-  printBraced(this, node, () =>
-    this.printJoin(node.members, { indent: true, statement: true }),
-  );
+  printBraced(this, node, () => this.printJoin(node.members, true, true));
 }
 
 export function TSArrayType(this: Printer, node: t.TSArrayType) {
@@ -335,9 +333,7 @@ export function TSArrayType(this: Printer, node: t.TSArrayType) {
 
 export function TSTupleType(this: Printer, node: t.TSTupleType) {
   this.token("[");
-  this.printList(node.elementTypes, {
-    printTrailingSeparator: this.shouldPrintTrailingComma("]"),
-  });
+  this.printList(node.elementTypes, this.shouldPrintTrailingComma("]"));
   this.token("]");
 }
 
@@ -378,12 +374,10 @@ function tsPrintUnionOrIntersectionType(
     printer.token(sep);
   }
 
-  printer.printJoin(node.types, {
-    separator(i) {
-      this.space();
-      this.token(sep, null, i + hasLeadingToken);
-      this.space();
-    },
+  printer.printJoin(node.types, undefined, undefined, function (i) {
+    this.space();
+    this.token(sep, null, i + hasLeadingToken);
+    this.space();
   });
 }
 
@@ -540,9 +534,7 @@ export function TSInterfaceDeclaration(
 }
 
 export function TSInterfaceBody(this: Printer, node: t.TSInterfaceBody) {
-  printBraced(this, node, () =>
-    this.printJoin(node.body, { indent: true, statement: true }),
-  );
+  printBraced(this, node, () => this.printJoin(node.body, true, true));
 }
 
 export function TSTypeAliasDeclaration(
@@ -615,12 +607,13 @@ export function TSEnumDeclaration(this: Printer, node: t.TSEnumDeclaration) {
   this.space();
 
   printBraced(this, node, () =>
-    this.printList(members, {
-      indent: true,
-      statement: true,
+    this.printList(
+      members,
       // TODO: Default to false for consistency with everything else
-      printTrailingSeparator: this.shouldPrintTrailingComma("}") ?? true,
-    }),
+      this.shouldPrintTrailingComma("}") ?? true,
+      true,
+      true,
+    ),
   );
 }
 
@@ -669,9 +662,7 @@ export function TSModuleDeclaration(
 }
 
 export function TSModuleBlock(this: Printer, node: t.TSModuleBlock) {
-  printBraced(this, node, () =>
-    this.printSequence(node.body, { indent: true }),
-  );
+  printBraced(this, node, () => this.printSequence(node.body, true));
 }
 
 export function TSImportType(this: Printer, node: t.TSImportType) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
https://github.com/babel/babel/pull/16958#pullrequestreview-2427825063

main
```
PS F:\babel\benchmark> node --expose-gc .\babel-generator\real-case\jquery.mjs
current 1 jquery 3.6: 151 ops/sec ±2.81% (6.614ms)
current 4 jquery 3.6: 35.75 ops/sec ±0.5% (28ms)
current 16 jquery 3.6: 8.93 ops/sec ±0.7% (112ms)
current 64 jquery 3.6: 2.09 ops/sec ±6.15% (478ms)
baseline 1 jquery 3.6: 162 ops/sec ±0.75% (6.17ms)
baseline 4 jquery 3.6: 37.09 ops/sec ±0.71% (27ms)
baseline 16 jquery 3.6: 9.29 ops/sec ±0.78% (108ms)
baseline 64 jquery 3.6: 2.26 ops/sec ±0.93% (443ms)
```

PR
```
PS F:\babel\benchmark> node --expose-gc .\babel-generator\real-case\jquery.mjs
current 1 jquery 3.6: 159 ops/sec ±0.67% (6.302ms)
current 4 jquery 3.6: 36.54 ops/sec ±1.83% (27ms)
current 16 jquery 3.6: 9.4 ops/sec ±0.54% (106ms)
current 64 jquery 3.6: 2.21 ops/sec ±4.27% (453ms)
baseline 1 jquery 3.6: 162 ops/sec ±0.56% (6.155ms)
baseline 4 jquery 3.6: 37.26 ops/sec ±0.33% (27ms)
baseline 16 jquery 3.6: 9.41 ops/sec ±0.49% (106ms)
baseline 64 jquery 3.6: 2.22 ops/sec ±5.92% (451ms)
```