### PR TITLE
perf: Avoid repeated traversal when creating scope

### DIFF
--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -910,8 +910,15 @@ class Scope {
     this.uids = Object.create(null);
     this.data = Object.create(null);
 
-    const programParent = this.getProgramParent();
-    if (programParent.crawling) return;
+    let scope: Scope = this;
+    do {
+      if (scope.crawling) return;
+      if (scope.path.isProgram()) {
+        break;
+      }
+    } while ((scope = scope.parent));
+
+    const programParent = scope;
 
     const state: CollectVisitorState = {
       references: [],


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I'm surprised this actually works all the time.🤦‍♂️
```
PS F:\babel\benchmark> node --expose-gc .\all\real-case-ts-mjs.mjs
all/real-case-ts-mjs.mjs babel-parser-express.ts @ current: 40.94 ops/sec ±2.98% 205 runs (24ms)
all/real-case-ts-mjs.mjs babel-parser-express.ts @ baseline: 40.57 ops/sec ±3.45% 203 runs (25ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ current: 7.82 ops/sec ±4.09% 40 runs (128ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ baseline: 6.73 ops/sec ±3.09% 34 runs (149ms)
all/real-case-mjs-cjs.mjs ts-checker.mjs @ current: 1.14 ops/sec ±3.77% 10 runs (878ms)
all/real-case-mjs-cjs.mjs ts-checker.mjs @ baseline: 1.11 ops/sec ±6.37% 10 runs (905ms)
all/real-case-mjs-cjs.mjs ts-parser.mjs @ current: 9.26 ops/sec ±3.99% 47 runs (108ms)
all/real-case-mjs-cjs.mjs ts-parser.mjs @ baseline: 9.15 ops/sec ±4.29% 46 runs (109ms)
```

