### PR TITLE
[Babel 8] perf: Improve traverse performance

### DIFF
--- a/packages/babel-traverse/src/cache.ts
+++ b/packages/babel-traverse/src/cache.ts
@@ -1,12 +1,8 @@
 import type { Node } from "@babel/types";
 import type NodePath from "./path/index.ts";
 import type Scope from "./scope/index.ts";
-import type { HubInterface } from "./hub.ts";
 
-let pathsCache: WeakMap<
-  HubInterface | typeof nullHub,
-  WeakMap<Node, Map<Node, NodePath>>
-> = new WeakMap();
+let pathsCache: WeakMap<Node, Map<Node, NodePath>> = new WeakMap();
 export { pathsCache as path };
 export let scope: WeakMap<Node, Scope> = new WeakMap();
 
@@ -23,32 +19,18 @@ export function clearScope() {
   scope = new WeakMap();
 }
 
-// NodePath#hub can be null, but it's not a valid weakmap key because it
-// cannot be collected by GC. Use an object, knowing tht it will not be
-// collected anyway. It's not a memory leak because pathsCache.get(nullHub)
-// is itself a weakmap, so its entries can still be collected.
-const nullHub = Object.freeze({} as const);
-
-export function getCachedPaths(hub: HubInterface | null, parent: Node) {
-  if (!process.env.BABEL_8_BREAKING) {
-    // Only use Hub as part of the cache key in Babel 8, because it is a
-    // breaking change (it causes incompatibilities with older `@babel/core`
-    // versions: see https://github.com/babel/babel/pull/15759)
-    hub = null;
-  }
-  return pathsCache.get(hub ?? nullHub)?.get(parent);
+export function getCachedPaths(path: NodePath) {
+  const { parent, parentPath } = path;
+  return parentPath ? parentPath._store : pathsCache.get(parent);
 }
 
-export function getOrCreateCachedPaths(hub: HubInterface | null, parent: Node) {
-  if (!process.env.BABEL_8_BREAKING) {
-    hub = null;
+export function getOrCreateCachedPaths(node: Node, parentPath?: NodePath) {
+  if (parentPath) {
+    return (parentPath._store ||= new Map());
   }
 
-  let parents = pathsCache.get(hub ?? nullHub);
-  if (!parents) pathsCache.set(hub ?? nullHub, (parents = new WeakMap()));
-
-  let paths = parents.get(parent);
-  if (!paths) parents.set(parent, (paths = new Map()));
+  let paths = pathsCache.get(node);
+  if (!paths) pathsCache.set(node, (paths = new Map()));
 
   return paths;
 }

--- a/packages/babel-traverse/src/cache.ts
+++ b/packages/babel-traverse/src/cache.ts
@@ -21,11 +21,13 @@ export function clearScope() {
 
 export function getCachedPaths(path: NodePath) {
   const { parent, parentPath } = path;
-  return parentPath ? parentPath._store : pathsCache.get(parent);
+  return process.env.BABEL_8_BREAKING && parentPath
+    ? parentPath._store
+    : pathsCache.get(parent);
 }
 
 export function getOrCreateCachedPaths(node: Node, parentPath?: NodePath) {
-  if (parentPath) {
+  if (process.env.BABEL_8_BREAKING && parentPath) {
     return (parentPath._store ||= new Map());
   }
 

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -69,6 +69,7 @@ const NodePath_Final = class NodePath {
   key: string | number | null = null;
   node: t.Node | null = null;
   type: t.Node["type"] | null = null;
+  _store: Map<t.Node, NodePath_Final> | null = null;
 
   static get({
     hub,
@@ -97,7 +98,7 @@ const NodePath_Final = class NodePath {
       // @ts-expect-error key must present in container
       container[key];
 
-    const paths = cache.getOrCreateCachedPaths(hub, parent);
+    const paths = cache.getOrCreateCachedPaths(parent, parentPath);
 
     let path = paths.get(targetNode);
     if (!path) {

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -282,7 +282,8 @@ export function updateSiblingKeys(
 ) {
   if (!this.parent) return;
 
-  const paths = getCachedPaths(this.hub, this.parent) || ([] as never[]);
+  const paths = getCachedPaths(this);
+  if (!paths) return;
 
   for (const [, path] of paths) {
     if (

--- a/packages/babel-traverse/src/path/removal.ts
+++ b/packages/babel-traverse/src/path/removal.ts
@@ -54,7 +54,7 @@ export function _markRemoved(this: NodePath) {
   // this.shouldSkip = true; this.removed = true;
   this._traverseFlags |= SHOULD_SKIP | REMOVED;
   if (this.parent) {
-    getCachedPaths(this.hub, this.parent).delete(this.node);
+    getCachedPaths(this)?.delete(this.node);
   }
   this.node = null;
 }

--- a/packages/babel-traverse/src/path/replacement.ts
+++ b/packages/babel-traverse/src/path/replacement.ts
@@ -56,7 +56,7 @@ export function replaceWithMultiple(
   nodes = _verifyNodeList.call(this, nodes);
   inheritLeadingComments(nodes[0], this.node);
   inheritTrailingComments(nodes[nodes.length - 1], this.node);
-  getCachedPaths(this.hub, this.parent)?.delete(this.node);
+  getCachedPaths(this)?.delete(this.node);
   this.node =
     // @ts-expect-error this.key must present in this.container
     this.container[this.key] = null;
@@ -218,7 +218,7 @@ export function _replaceWith(this: NodePath, node: t.Node) {
   }
 
   this.debug(`Replace with ${node?.type}`);
-  getCachedPaths(this.hub, this.parent)?.set(node, this).delete(this.node);
+  getCachedPaths(this)?.set(node, this).delete(this.node);
 
   this.node =
     // @ts-expect-error this.key must present in this.container

--- a/packages/babel-traverse/src/traverse-node.ts
+++ b/packages/babel-traverse/src/traverse-node.ts
@@ -35,8 +35,9 @@ function _visitPaths(ctx: TraversalContext, paths: NodePath[]): boolean {
     if (path.key === null) continue;
 
     // ensure we don't visit the same node twice
-    if (visited.has(path.node)) continue;
-    visited.add(path.node);
+    const { node } = path;
+    if (visited.has(node)) continue;
+    if (node) visited.add(node);
 
     if (_visit(ctx, path)) {
       stop = true;

--- a/packages/babel-traverse/src/traverse-node.ts
+++ b/packages/babel-traverse/src/traverse-node.ts
@@ -1,9 +1,172 @@
 import TraversalContext from "./context.ts";
 import type { ExplodedTraverseOptions } from "./index.ts";
-import type NodePath from "./path/index.ts";
+import NodePath from "./path/index.ts";
 import type Scope from "./scope/index.ts";
 import type * as t from "@babel/types";
 import { VISITOR_KEYS } from "@babel/types";
+import { _call, popContext, pushContext, resync } from "./path/context.ts";
+
+function _visitPaths(ctx: TraversalContext, paths: NodePath[]): boolean {
+  // set queue
+  ctx.queue = paths;
+  ctx.priorityQueue = [];
+
+  const visited = new Set();
+  let stop = false;
+  let visitIndex = 0;
+
+  for (; visitIndex < paths.length; ) {
+    const path = paths[visitIndex];
+    visitIndex++;
+
+    resync.call(path);
+
+    if (
+      path.contexts.length === 0 ||
+      path.contexts[path.contexts.length - 1] !== ctx
+    ) {
+      // The context might already have been pushed when this path was inserted and queued.
+      // If we always re-pushed here, we could get duplicates and risk leaving contexts
+      // on the stack after the traversal has completed, which could break things.
+      pushContext.call(path, ctx);
+    }
+
+    // this path no longer belongs to the tree
+    if (path.key === null) continue;
+
+    // ensure we don't visit the same node twice
+    if (visited.has(path.node)) continue;
+    visited.add(path.node);
+
+    if (_visit(ctx, path)) {
+      stop = true;
+      break;
+    }
+
+    if (ctx.priorityQueue.length) {
+      stop = _visitPaths(ctx, ctx.priorityQueue);
+      ctx.priorityQueue = [];
+      ctx.queue = paths;
+      if (stop) break;
+    }
+  }
+
+  // pop contexts
+  for (let i = 0; i < visitIndex; i++) {
+    popContext.call(paths[i]);
+  }
+
+  // clear queue
+  ctx.queue = null;
+
+  return stop;
+}
+
+function _visit(ctx: TraversalContext, path: NodePath) {
+  const node = path.node;
+  if (!node) {
+    return false;
+  }
+  const opts = ctx.opts;
+
+  // @ts-expect-error TODO(Babel 8): Remove blacklist
+  const denylist = opts.denylist ?? opts.blacklist;
+  if (denylist?.includes(node.type)) {
+    return false;
+  }
+
+  if (opts.shouldSkip?.(path)) {
+    return false;
+  }
+
+  // Note: We need to check "this.shouldSkip" first because
+  // another visitor can set it to true. Usually .shouldSkip is false
+  // before calling the enter visitor, but it can be true in case of
+  // a requeued node (e.g. by .replaceWith()) that is then marked
+  // with .skip().
+  if (path.shouldSkip) return path.shouldStop;
+
+  if (_call.call(path, opts.enter)) return path.shouldStop;
+  if (path.node) {
+    if (_call.call(path, opts[node.type]?.enter)) return path.shouldStop;
+  }
+
+  path.shouldStop = traverse(
+    path.node,
+    opts,
+    path.scope,
+    ctx.state,
+    path,
+    path.skipKeys,
+  );
+
+  if (path.node) {
+    if (_call.call(path, opts.exit)) return true;
+  }
+  if (path.node) {
+    _call.call(path, opts[node.type]?.exit);
+  }
+
+  return path.shouldStop;
+}
+
+function traverse<S>(
+  node: t.Node,
+  opts: ExplodedTraverseOptions<S>,
+  scope?: Scope,
+  state?: S,
+  path?: NodePath,
+  skipKeys?: Record<string, boolean>,
+  visitSelf?: boolean,
+) {
+  const keys = VISITOR_KEYS[node.type];
+  if (!keys?.length) return false;
+
+  const ctx = new TraversalContext(scope, opts, state, path);
+  if (visitSelf) {
+    if (skipKeys?.[path.parentKey]) return false;
+    return _visitPaths(ctx, [path]);
+  }
+
+  for (const key of keys) {
+    if (skipKeys?.[key]) continue;
+    // @ts-expect-error key must present in node
+    const prop = node[key];
+    if (!prop) continue;
+
+    if (Array.isArray(prop)) {
+      if (!prop.length) continue;
+      const paths = [];
+      for (let i = 0; i < prop.length; i++) {
+        const childPath = NodePath.get({
+          parentPath: path,
+          parent: node,
+          container: prop,
+          key: i,
+          listKey: key,
+        });
+        paths.push(childPath);
+      }
+      if (_visitPaths(ctx, paths)) return true;
+    } else {
+      if (
+        _visitPaths(ctx, [
+          NodePath.get({
+            parentPath: path,
+            parent: node,
+            container: node,
+            key,
+            listKey: null,
+          }),
+        ])
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
 
 /**
  * Traverse the children of given node
@@ -26,21 +189,5 @@ export function traverseNode<S = unknown>(
   skipKeys?: Record<string, boolean>,
   visitSelf?: boolean,
 ): boolean {
-  const keys = VISITOR_KEYS[node.type];
-  if (!keys) return false;
-
-  const context = new TraversalContext<S>(scope, opts, state, path);
-  if (visitSelf) {
-    if (skipKeys?.[path.parentKey]) return false;
-    return context.visitQueue([path]);
-  }
-
-  for (const key of keys) {
-    if (skipKeys?.[key]) continue;
-    if (context.visit(node, key)) {
-      return true;
-    }
-  }
-
-  return false;
+  return traverse(node, opts, scope, state, path, skipKeys, visitSelf);
 }

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -1,5 +1,6 @@
 import { parse } from "@babel/parser";
 import * as t from "@babel/types";
+import { IS_BABEL_8 } from "$repo-utils";
 
 import _traverse from "../lib/index.js";
 import _generate from "@babel/generator";
@@ -388,24 +389,10 @@ describe("modification", function () {
           },
         });
 
-        expect(logs).toMatchInlineSnapshot(`
-          Array [
-            Array [
-              "a",
-              "b",
-              "b",
-              "b",
-              "b",
-            ],
-            Array [
-              "a",
-              "b",
-              "b",
-              "b",
-              "b",
-            ],
-          ]
-        `);
+        expect(logs[0]).toEqual(
+          IS_BABEL_8() ? ["a", "b", "b", "b", "b"] : ["a"],
+        );
+        expect(logs[1]).toEqual(["a", "b", "b", "b", "b"]);
       });
     });
   });

--- a/packages/babel-traverse/test/replacement.js
+++ b/packages/babel-traverse/test/replacement.js
@@ -178,7 +178,8 @@ describe("path/replacement", function () {
         VariableDeclaration(path) {
           visitCounter++;
           if (visitCounter > 1) {
-            return true;
+            path.stop();
+            return;
           }
           path.replaceWithMultiple([path.node, t.emptyStatement()]);
         },
@@ -193,7 +194,8 @@ describe("path/replacement", function () {
         VariableDeclaration(path) {
           visitCounter++;
           if (visitCounter > 1) {
-            return true;
+            path.stop();
+            return;
           }
           path.replaceWithMultiple([t.emptyStatement(), path.node]);
         },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is a bit weird because I can't fully explain the benchmark results. Discussions are welcome!

Overall time reduction of 10%-20, with one benchmark regression (~15%) that can be fixed by merging #16964.
Also reduced reliance on the global cache and almost no global cache in Babel 8.

There are two changes in this PR
1. Organize traversal related logic into one file
2. Store cache in `parentPath`
Each of them alone gives little or no improvement, but together the performance improvement is much larger.

Even weirder is that there is a benchmark `mjs-cjs/ts-checker` that drops by more than 15%, and it has the same drop when only the second change is made, while `js-node6/typescript-5.6.2` (larger file) and `mjs-cjs/ts-parser` (similar benchmark) do not have the same situation.

I recently found that when I merged https://github.com/babel/babel/pull/16964, the situation of 1+1>2 appeared again, and the above issue disappeared.
This is confusing to me, because in my assumption the performance regression comes from recreating part of the `NodePath` (since there is no global cache anymore, when a node is moved to its parent, all related `NodePath` need to be recreated), and that PR just avoids multiple traversals and shouldn't fix it. (Traversals are faster, so the impact of the changes in #16964 in this PR should be less than 3%)

Note: This PR may be risky to merge in Babel 7, but since it doesn't require any changes to our plugins, it might be worth a try.

with #16964
```
PS F:\babel\benchmark> node --expose-gc .\all\real-case-ts-mjs.mjs
all/real-case-ts-mjs.mjs babel-parser-express.ts @ current: 51.15 ops/sec ±1.61% 256 runs (20ms)
all/real-case-ts-mjs.mjs babel-parser-express.ts @ baseline: 40.84 ops/sec ±2.95% 205 runs (24ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ current: 9.41 ops/sec ±2.02% 48 runs (106ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ baseline: 6.82 ops/sec ±2.78% 35 runs (147ms)
PS F:\babel\benchmark> node --expose-gc .\all\real-case-mjs-cjs.mjs
all/real-case-mjs-cjs.mjs ts-checker.mjs @ current: 1.25 ops/sec ±1.91% 10 runs (801ms)
all/real-case-mjs-cjs.mjs ts-checker.mjs @ baseline: 1.09 ops/sec ±3.99% 10 runs (922ms)
all/real-case-mjs-cjs.mjs ts-parser.mjs @ current: 10.07 ops/sec ±2.11% 51 runs (99ms)
all/real-case-mjs-cjs.mjs ts-parser.mjs @ baseline: 8.96 ops/sec ±3.3% 45 runs (112ms)
PS F:\babel\benchmark> node --expose-gc .\all\real-case-js-node6.mjs
all/real-case-js-node6.mjs jquery-3.6.js @ current: 10.35 ops/sec ±2.04% 52 runs (97ms)
all/real-case-js-node6.mjs jquery-3.6.js @ baseline: 9.21 ops/sec ±2.6% 47 runs (109ms)
all/real-case-js-node6.mjs typescript-5.6.2.js @ current: 0.34 ops/sec ±1.14% 10 runs (2970ms)
all/real-case-js-node6.mjs typescript-5.6.2.js @ baseline: 0.28 ops/sec ±4.03% 10 runs (3602ms)
PS F:\babel\benchmark> node --expose-gc .\babel-traverse\real-case.mjs
babel-traverse/real-case.mjs babel-parser-express.ts @ current: 95.92 ops/sec ±1.33% 480 runs (10ms)
babel-traverse/real-case.mjs babel-parser-express.ts @ baseline: 85.51 ops/sec ±0.76% 428 runs (12ms)
babel-traverse/real-case.mjs jquery-3.6.js @ current: 28.58 ops/sec ±1.58% 143 runs (35ms)
babel-traverse/real-case.mjs jquery-3.6.js @ baseline: 22.53 ops/sec ±1.23% 113 runs (44ms)
babel-traverse/real-case.mjs ts-checker.mjs @ current: 4.05 ops/sec ±2.13% 21 runs (247ms)
babel-traverse/real-case.mjs ts-checker.mjs @ baseline: 3.05 ops/sec ±2.34% 16 runs (328ms)
babel-traverse/real-case.mjs ts-parser.mjs @ current: 26.39 ops/sec ±1.64% 132 runs (38ms)
babel-traverse/real-case.mjs ts-parser.mjs @ baseline: 20.6 ops/sec ±1.79% 103 runs (49ms)
babel-traverse/real-case.mjs ts-parser.ts @ current: 21.94 ops/sec ±1.88% 110 runs (46ms)
babel-traverse/real-case.mjs ts-parser.ts @ baseline: 16.91 ops/sec ±1.37% 85 runs (59ms)
babel-traverse/real-case.mjs typescript-5.6.2.js @ current: 0.99 ops/sec ±3.47% 10 runs (1012ms)
babel-traverse/real-case.mjs typescript-5.6.2.js @ baseline: 0.73 ops/sec ±2.19% 10 runs (1369ms)
```

without #16964
```
PS F:\babel\benchmark> node --expose-gc .\all\real-case-ts-mjs.mjs    
all/real-case-ts-mjs.mjs babel-parser-express.ts @ current: 51.02 ops/sec ±1.75% 256 runs (20ms)
all/real-case-ts-mjs.mjs babel-parser-express.ts @ baseline: 40.44 ops/sec ±3.88% 203 runs (25ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ current: 7.45 ops/sec ±1.81% 38 runs (134ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ baseline: 6.85 ops/sec ±3.06% 35 runs (146ms)
PS F:\babel\benchmark> node --expose-gc .\all\real-case-mjs-cjs.mjs
all/real-case-mjs-cjs.mjs ts-checker.mjs @ current: 0.93 ops/sec ±2.63% 10 runs (1072ms)
all/real-case-mjs-cjs.mjs ts-checker.mjs @ baseline: 1.13 ops/sec ±3.04% 10 runs (884ms)
all/real-case-mjs-cjs.mjs ts-parser.mjs @ current: 10.44 ops/sec ±1.89% 53 runs (96ms)
all/real-case-mjs-cjs.mjs ts-parser.mjs @ baseline: 9.14 ops/sec ±3.65% 47 runs (109ms)
PS F:\babel\benchmark> node --expose-gc .\all\real-case-js-node6.mjs  
all/real-case-js-node6.mjs jquery-3.6.js @ current: 10.19 ops/sec ±1.83% 51 runs (98ms)
all/real-case-js-node6.mjs jquery-3.6.js @ baseline: 9.08 ops/sec ±2.76% 46 runs (110ms)
all/real-case-js-node6.mjs typescript-5.6.2.js @ current: 0.33 ops/sec ±1.52% 10 runs (3007ms)
all/real-case-js-node6.mjs typescript-5.6.2.js @ baseline: 0.27 ops/sec ±3.89% 10 runs (3687ms)
PS F:\babel\benchmark> node --expose-gc .\babel-traverse\real-case.mjs
babel-traverse/real-case.mjs babel-parser-express.ts @ current: 97.12 ops/sec ±1.24% 486 runs (10ms)
babel-traverse/real-case.mjs babel-parser-express.ts @ baseline: 84.19 ops/sec ±0.74% 421 runs (12ms)
babel-traverse/real-case.mjs jquery-3.6.js @ current: 28.25 ops/sec ±1.42% 142 runs (35ms)
babel-traverse/real-case.mjs jquery-3.6.js @ baseline: 22.43 ops/sec ±1.37% 113 runs (45ms)
babel-traverse/real-case.mjs ts-checker.mjs @ current: 4.05 ops/sec ±1.74% 21 runs (247ms)
babel-traverse/real-case.mjs ts-checker.mjs @ baseline: 3.07 ops/sec ±2.26% 16 runs (325ms)
babel-traverse/real-case.mjs ts-parser.mjs @ current: 26.19 ops/sec ±1.52% 132 runs (38ms)
babel-traverse/real-case.mjs ts-parser.mjs @ baseline: 20.55 ops/sec ±1.29% 103 runs (49ms)
babel-traverse/real-case.mjs ts-parser.ts @ current: 21.85 ops/sec ±1.67% 110 runs (46ms)
babel-traverse/real-case.mjs ts-parser.ts @ baseline: 16.54 ops/sec ±1.35% 83 runs (60ms)
babel-traverse/real-case.mjs typescript-5.6.2.js @ current: 0.99 ops/sec ±3.61% 10 runs (1014ms)
babel-traverse/real-case.mjs typescript-5.6.2.js @ baseline: 0.71 ops/sec ±3.9% 10 runs (1404ms)
```