### PR TITLE
Respect `BABEL_8_BREAKING` option in babel-types fields test

### DIFF
--- a/packages/babel-types/test/fields.js
+++ b/packages/babel-types/test/fields.js
@@ -2,7 +2,7 @@ import * as t from "../lib/index.js";
 import glob from "glob";
 import { readFileSync } from "fs";
 import { inspect } from "util";
-import { commonJS } from "$repo-utils";
+import { commonJS, IS_BABEL_8 } from "$repo-utils";
 import path from "path";
 
 const { __dirname } = commonJS(import.meta.url);
@@ -34,15 +34,17 @@ describe("NODE_FIELDS contains all fields, and the visitor order is correct, in"
         readFileSync(path.join(fixturePath, "options.json")),
       ).BABEL_8_BREAKING;
     } catch {
-      try {
-        isBabel8Test ??= JSON.parse(
-          readFileSync(path.resolve(fixturePath, "../options.json")),
-        ).BABEL_8_BREAKING;
-      } catch {
-        isBabel8Test = true;
+      if (isBabel8Test === undefined) {
+        try {
+          isBabel8Test = JSON.parse(
+            readFileSync(path.resolve(fixturePath, "../options.json")),
+          ).BABEL_8_BREAKING;
+        } catch {
+          isBabel8Test = true;
+        }
       }
     }
-    if (isBabel8Test !== !!process.env.BABEL_8_BREAKING) return;
+    if (isBabel8Test !== IS_BABEL_8()) return;
 
     const ast = JSON.parse(readFileSync(file, "utf8"));
     if (ast.type === "File" && ast.errors && ast.errors.length) return;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is extracted from #16979: The fields test now respects the `BABEL_8_BREAKING` option and will test the AST nodes that is different between Babel 7 and Babel 8. 

Previously we ignored the Babel 8 AST changes and had to filled in all the AST changes to the test file.