### PR TITLE
fix: migrate to dirent.parentPath

### DIFF
--- a/packages/babel-cli/src/babel/util.ts
+++ b/packages/babel-cli/src/babel/util.ts
@@ -39,7 +39,7 @@ export function readdir(
             (!filter || filter(filename))
           );
         })
-        .map(dirent => path.join(dirent.path, dirent.name))
+        .map(dirent => path.join(dirent.parentPath, dirent.name))
         // readdirSyncRecursive conducts BFS, sort the entries so we can match the DFS behaviour of fs-readdir-recursive
         // https://github.com/nodejs/node/blob/d6b12f5b77e35c58a611d614cf0aac674ec2c3ed/lib/fs.js#L1421
         .sort(alphasort)

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -671,7 +671,7 @@ const readDir = function (loc: string, pathFilter: (arg0: string) => boolean) {
       fs.readdirSync(loc, { withFileTypes: true, recursive: true })
         .filter(dirent => dirent.isFile() && pathFilter(dirent.name))
         .forEach(dirent => {
-          const fullpath = path.join(dirent.path, dirent.name);
+          const fullpath = path.join(dirent.parentPath, dirent.name);
           files[path.relative(loc, fullpath)] = readFile(fullpath);
         });
     } else {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Deprecation warning due to the `dirent.path` usage
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
According to the [docs](https://nodejs.org/api/fs.html#direntpath), `dirent.path` has been deprecated since: v21.5.0, v20.12.0, v18.20.0. Since both usage are from Babel 8 and Babel 8 supports `^18.20.0 || ^20.17.0 || >=22.8.0`, we can directly migrate to `dirent.parentPath`.