### PR TITLE
Rename `typeParameters` to `typeArguments` for `TSTypeQuery`

### DIFF
--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -320,8 +320,12 @@ export function TSTypeQuery(this: Printer, node: t.TSTypeQuery) {
   this.space();
   this.print(node.exprName);
 
-  if (node.typeParameters) {
-    this.print(node.typeParameters);
+  //@ts-ignore(Babel 7 vs Babel 8) Babel 8 AST
+  const typeArguments = process.env.BABEL_8_BREAKING
+    ? node.typeArguments
+    : node.typeParameters;
+  if (typeArguments) {
+    this.print(typeArguments);
   }
 }
 

--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -320,10 +320,11 @@ export function TSTypeQuery(this: Printer, node: t.TSTypeQuery) {
   this.space();
   this.print(node.exprName);
 
-  //@ts-ignore(Babel 7 vs Babel 8) Babel 8 AST
   const typeArguments = process.env.BABEL_8_BREAKING
-    ? node.typeArguments
-    : node.typeParameters;
+    ? //@ts-ignore(Babel 7 vs Babel 8) Babel 8 AST
+      node.typeArguments
+    : //@ts-ignore(Babel 7 vs Babel 8) Babel 7 AST
+      node.typeParameters;
   if (typeArguments) {
     this.print(typeArguments);
   }

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -634,7 +634,11 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         node.exprName = this.tsParseEntityName();
       }
       if (!this.hasPrecedingLineBreak() && this.match(tt.lt)) {
-        node.typeParameters = this.tsParseTypeArguments();
+        if (process.env.BABEL_8_BREAKING) {
+          node.typeArguments = this.tsParseTypeArguments();
+        } else {
+          node.typeParameters = this.tsParseTypeArguments();
+        }
       }
       return this.finishNode(node, "TSTypeQuery");
     }

--- a/packages/babel-parser/src/types.ts
+++ b/packages/babel-parser/src/types.ts
@@ -1625,6 +1625,10 @@ export interface TsTypePredicate extends TsTypeBase {
 export interface TsTypeQuery extends TsTypeBase {
   type: "TSTypeQuery";
   exprName: TsEntityName | TsImportType;
+  typeArguments?: TsTypeParameterInstantiation;
+  /**
+   * @deprecated
+   */
   typeParameters?: TsTypeParameterInstantiation;
 }
 

--- a/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters-babel-7/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters-babel-7/input.ts
@@ -1,0 +1,1 @@
+let x: typeof y.z<w>;

--- a/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters-babel-7/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters-babel-7/options.json
@@ -1,0 +1,3 @@
+{
+  "BABEL_8_BREAKING": false
+}

--- a/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters-babel-7/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters-babel-7/output.json
@@ -38,7 +38,7 @@
                       "name": "z"
                     }
                   },
-                  "typeArguments": {
+                  "typeParameters": {
                     "type": "TSTypeParameterInstantiation",
                     "start":17,"end":20,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":1,"column":20,"index":20}},
                     "params": [

--- a/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters/options.json
@@ -1,0 +1,3 @@
+{
+  "BABEL_8_BREAKING": true
+}

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -241,10 +241,14 @@ defineType("TSTypePredicate", {
 
 defineType("TSTypeQuery", {
   aliases: ["TSType"],
-  visitor: ["exprName", "typeParameters"],
+  visitor: [
+    "exprName",
+    process.env.BABEL_8_BREAKING ? "typeArguments" : "typeParameters",
+  ],
   fields: {
     exprName: validateType("TSEntityName", "TSImportType"),
-    typeParameters: validateOptionalType("TSTypeParameterInstantiation"),
+    [process.env.BABEL_8_BREAKING ? "typeArguments" : "typeParameters"]:
+      validateOptionalType("TSTypeParameterInstantiation"),
   },
 });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/issues/16679
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/3027
| Any Dependency Changes?  |
| License                  | MIT

In this PR we rename the `typeParameters` property of the `TSTypeQuery` node to `typeArguments`.