### PR TITLE
fix: Correctly set position for `@(a.b)()`

### DIFF
--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -771,7 +771,7 @@ export default abstract class StatementParser extends ExpressionParser {
         expr = this.wrapParenthesis(startLoc, expr);
 
         const paramsStartLoc = this.state.startLoc;
-        node.expression = this.parseMaybeDecoratorArguments(expr);
+        node.expression = this.parseMaybeDecoratorArguments(expr, startLoc);
         if (
           this.getPluginOption("decorators", "allowCallParenthesized") ===
             false &&
@@ -801,7 +801,7 @@ export default abstract class StatementParser extends ExpressionParser {
           expr = this.finishNode(node, "MemberExpression");
         }
 
-        node.expression = this.parseMaybeDecoratorArguments(expr);
+        node.expression = this.parseMaybeDecoratorArguments(expr, startLoc);
       }
     } else {
       node.expression = this.parseExprSubscripts();
@@ -809,9 +809,13 @@ export default abstract class StatementParser extends ExpressionParser {
     return this.finishNode(node, "Decorator");
   }
 
-  parseMaybeDecoratorArguments(this: Parser, expr: N.Expression): N.Expression {
+  parseMaybeDecoratorArguments(
+    this: Parser,
+    expr: N.Expression,
+    startLoc: Position,
+  ): N.Expression {
     if (this.eat(tt.parenL)) {
-      const node = this.startNodeAtNode<N.CallExpression>(expr);
+      const node = this.startNodeAt<N.CallExpression>(startLoc);
       node.callee = expr;
       node.arguments = this.parseCallExpressionArguments(tt.parenR);
       this.toReferencedList(node.arguments);

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -3739,7 +3739,10 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       return super.parseBindingAtom();
     }
 
-    parseMaybeDecoratorArguments(expr: N.Expression): N.Expression {
+    parseMaybeDecoratorArguments(
+      expr: N.Expression,
+      startLoc: Position,
+    ): N.Expression {
       // handles `@f<<T>`
       if (this.match(tt.lt) || this.match(tt.bitShiftL)) {
         const typeArguments = this.tsParseTypeArgumentsInExpression();
@@ -3747,6 +3750,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         if (this.match(tt.parenL)) {
           const call = super.parseMaybeDecoratorArguments(
             expr,
+            startLoc,
           ) as N.CallExpression;
           call.typeParameters = typeArguments;
           return call;
@@ -3755,7 +3759,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         this.unexpected(null, tt.parenL);
       }
 
-      return super.parseMaybeDecoratorArguments(expr);
+      return super.parseMaybeDecoratorArguments(expr, startLoc);
     }
 
     checkCommaAfterRest(

--- a/packages/babel-parser/test/fixtures/experimental/decorators/parenthesized-allowCallParenthesized-false-invalid/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/parenthesized-allowCallParenthesized-false-invalid/output.json
@@ -32,7 +32,7 @@
                   "start":14,"end":30,"loc":{"start":{"line":2,"column":2,"index":14},"end":{"line":2,"column":18,"index":30}},
                   "expression": {
                     "type": "CallExpression",
-                    "start":16,"end":30,"loc":{"start":{"line":2,"column":4,"index":16},"end":{"line":2,"column":18,"index":30}},
+                    "start":15,"end":30,"loc":{"start":{"line":2,"column":3,"index":15},"end":{"line":2,"column":18,"index":30}},
                     "callee": {
                       "type": "MemberExpression",
                       "start":16,"end":24,"loc":{"start":{"line":2,"column":4,"index":16},"end":{"line":2,"column":12,"index":24}},

--- a/packages/babel-parser/test/fixtures/experimental/decorators/parenthesized-allowCallParenthesized-true/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/parenthesized-allowCallParenthesized-true/output.json
@@ -29,7 +29,7 @@
                   "start":14,"end":30,"loc":{"start":{"line":2,"column":2,"index":14},"end":{"line":2,"column":18,"index":30}},
                   "expression": {
                     "type": "CallExpression",
-                    "start":16,"end":30,"loc":{"start":{"line":2,"column":4,"index":16},"end":{"line":2,"column":18,"index":30}},
+                    "start":15,"end":30,"loc":{"start":{"line":2,"column":3,"index":15},"end":{"line":2,"column":18,"index":30}},
                     "callee": {
                       "type": "MemberExpression",
                       "start":16,"end":24,"loc":{"start":{"line":2,"column":4,"index":16},"end":{"line":2,"column":12,"index":24}},

--- a/packages/babel-parser/test/fixtures/experimental/decorators/parenthesized/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/parenthesized/output.json
@@ -153,7 +153,7 @@
                   "start":93,"end":109,"loc":{"start":{"line":7,"column":2,"index":93},"end":{"line":7,"column":18,"index":109}},
                   "expression": {
                     "type": "CallExpression",
-                    "start":95,"end":109,"loc":{"start":{"line":7,"column":4,"index":95},"end":{"line":7,"column":18,"index":109}},
+                    "start":94,"end":109,"loc":{"start":{"line":7,"column":3,"index":94},"end":{"line":7,"column":18,"index":109}},
                     "callee": {
                       "type": "MemberExpression",
                       "start":95,"end":103,"loc":{"start":{"line":7,"column":4,"index":95},"end":{"line":7,"column":12,"index":103}},


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
![image](https://github.com/user-attachments/assets/27319e5e-13b8-43d9-842c-d321c6b3e828)
Previously, the `start` of `CallExpression` did not contain `(`.