### PR TITLE
Fix incomplete visitor keys

### DIFF
--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -692,10 +692,14 @@ export function TSModuleBlock(this: Printer, node: t.TSModuleBlock) {
 }
 
 export function TSImportType(this: Printer, node: t.TSImportType) {
-  const { argument, qualifier, typeParameters } = node;
+  const { argument, qualifier, typeParameters, options } = node;
   this.word("import");
   this.token("(");
   this.print(argument);
+  if (options) {
+    this.token(",");
+    this.print(options);
+  }
   this.token(")");
   if (qualifier) {
     this.token(".");

--- a/packages/babel-generator/test/fixtures/typescript/types-import-type-with-options/input.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-import-type-with-options/input.js
@@ -1,0 +1,3 @@
+let x: typeof import('./x', { with: { type: "json" } });
+let Y: import('./y', { with: { type: "json" } }).Y;
+let z: import("/z", { with: { type: "json" } }).foo.bar<string>;

--- a/packages/babel-generator/test/fixtures/typescript/types-import-type-with-options/output.js
+++ b/packages/babel-generator/test/fixtures/typescript/types-import-type-with-options/output.js
@@ -1,0 +1,15 @@
+let x: typeof import('./x',{
+  with: {
+    type: "json"
+  }
+});
+let Y: import('./y',{
+  with: {
+    type: "json"
+  }
+}).Y;
+let z: import("/z",{
+  with: {
+    type: "json"
+  }
+}).foo.bar<string>;

--- a/packages/babel-parser/test/fixtures/estree/typescript/import-with-options/input.js
+++ b/packages/babel-parser/test/fixtures/estree/typescript/import-with-options/input.js
@@ -1,0 +1,3 @@
+let x: typeof import('./x', { with: { type: "json" } });
+let Y: import('./y', { with: { type: "json" } }).Y;
+let z: import("/z", { with: { type: "json" } }).foo.bar<string>;

--- a/packages/babel-parser/test/fixtures/estree/typescript/import-with-options/output.json
+++ b/packages/babel-parser/test/fixtures/estree/typescript/import-with-options/output.json
@@ -1,0 +1,270 @@
+{
+  "type": "File",
+  "start":0,"end":173,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":64}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":173,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":64}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":56,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":56}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":4,"end":55,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":55}},
+            "id": {
+              "type": "Identifier",
+              "start":4,"end":55,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":55},"identifierName":"x"},
+              "name": "x",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":5,"end":55,"loc":{"start":{"line":1,"column":5},"end":{"line":1,"column":55}},
+                "typeAnnotation": {
+                  "type": "TSTypeQuery",
+                  "start":7,"end":55,"loc":{"start":{"line":1,"column":7},"end":{"line":1,"column":55}},
+                  "exprName": {
+                    "type": "TSImportType",
+                    "start":14,"end":55,"loc":{"start":{"line":1,"column":14},"end":{"line":1,"column":55}},
+                    "argument": {
+                      "type": "Literal",
+                      "start":21,"end":26,"loc":{"start":{"line":1,"column":21},"end":{"line":1,"column":26}},
+                      "value": "./x",
+                      "raw": "'./x'"
+                    },
+                    "options": {
+                      "type": "ObjectExpression",
+                      "start":28,"end":54,"loc":{"start":{"line":1,"column":28},"end":{"line":1,"column":54}},
+                      "properties": [
+                        {
+                          "type": "Property",
+                          "start":30,"end":52,"loc":{"start":{"line":1,"column":30},"end":{"line":1,"column":52}},
+                          "method": false,
+                          "key": {
+                            "type": "Identifier",
+                            "start":30,"end":34,"loc":{"start":{"line":1,"column":30},"end":{"line":1,"column":34},"identifierName":"with"},
+                            "name": "with"
+                          },
+                          "computed": false,
+                          "shorthand": false,
+                          "value": {
+                            "type": "ObjectExpression",
+                            "start":36,"end":52,"loc":{"start":{"line":1,"column":36},"end":{"line":1,"column":52}},
+                            "properties": [
+                              {
+                                "type": "Property",
+                                "start":38,"end":50,"loc":{"start":{"line":1,"column":38},"end":{"line":1,"column":50}},
+                                "method": false,
+                                "key": {
+                                  "type": "Identifier",
+                                  "start":38,"end":42,"loc":{"start":{"line":1,"column":38},"end":{"line":1,"column":42},"identifierName":"type"},
+                                  "name": "type"
+                                },
+                                "computed": false,
+                                "shorthand": false,
+                                "value": {
+                                  "type": "Literal",
+                                  "start":44,"end":50,"loc":{"start":{"line":1,"column":44},"end":{"line":1,"column":50}},
+                                  "value": "json",
+                                  "raw": "\"json\""
+                                },
+                                "kind": "init"
+                              }
+                            ]
+                          },
+                          "kind": "init"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start":57,"end":108,"loc":{"start":{"line":2,"column":0},"end":{"line":2,"column":51}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":61,"end":107,"loc":{"start":{"line":2,"column":4},"end":{"line":2,"column":50}},
+            "id": {
+              "type": "Identifier",
+              "start":61,"end":107,"loc":{"start":{"line":2,"column":4},"end":{"line":2,"column":50},"identifierName":"Y"},
+              "name": "Y",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":62,"end":107,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":50}},
+                "typeAnnotation": {
+                  "type": "TSImportType",
+                  "start":64,"end":107,"loc":{"start":{"line":2,"column":7},"end":{"line":2,"column":50}},
+                  "argument": {
+                    "type": "Literal",
+                    "start":71,"end":76,"loc":{"start":{"line":2,"column":14},"end":{"line":2,"column":19}},
+                    "value": "./y",
+                    "raw": "'./y'"
+                  },
+                  "options": {
+                    "type": "ObjectExpression",
+                    "start":78,"end":104,"loc":{"start":{"line":2,"column":21},"end":{"line":2,"column":47}},
+                    "properties": [
+                      {
+                        "type": "Property",
+                        "start":80,"end":102,"loc":{"start":{"line":2,"column":23},"end":{"line":2,"column":45}},
+                        "method": false,
+                        "key": {
+                          "type": "Identifier",
+                          "start":80,"end":84,"loc":{"start":{"line":2,"column":23},"end":{"line":2,"column":27},"identifierName":"with"},
+                          "name": "with"
+                        },
+                        "computed": false,
+                        "shorthand": false,
+                        "value": {
+                          "type": "ObjectExpression",
+                          "start":86,"end":102,"loc":{"start":{"line":2,"column":29},"end":{"line":2,"column":45}},
+                          "properties": [
+                            {
+                              "type": "Property",
+                              "start":88,"end":100,"loc":{"start":{"line":2,"column":31},"end":{"line":2,"column":43}},
+                              "method": false,
+                              "key": {
+                                "type": "Identifier",
+                                "start":88,"end":92,"loc":{"start":{"line":2,"column":31},"end":{"line":2,"column":35},"identifierName":"type"},
+                                "name": "type"
+                              },
+                              "computed": false,
+                              "shorthand": false,
+                              "value": {
+                                "type": "Literal",
+                                "start":94,"end":100,"loc":{"start":{"line":2,"column":37},"end":{"line":2,"column":43}},
+                                "value": "json",
+                                "raw": "\"json\""
+                              },
+                              "kind": "init"
+                            }
+                          ]
+                        },
+                        "kind": "init"
+                      }
+                    ]
+                  },
+                  "qualifier": {
+                    "type": "Identifier",
+                    "start":106,"end":107,"loc":{"start":{"line":2,"column":49},"end":{"line":2,"column":50},"identifierName":"Y"},
+                    "name": "Y"
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "VariableDeclaration",
+        "start":109,"end":173,"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":64}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":113,"end":172,"loc":{"start":{"line":3,"column":4},"end":{"line":3,"column":63}},
+            "id": {
+              "type": "Identifier",
+              "start":113,"end":172,"loc":{"start":{"line":3,"column":4},"end":{"line":3,"column":63},"identifierName":"z"},
+              "name": "z",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start":114,"end":172,"loc":{"start":{"line":3,"column":5},"end":{"line":3,"column":63}},
+                "typeAnnotation": {
+                  "type": "TSImportType",
+                  "start":116,"end":172,"loc":{"start":{"line":3,"column":7},"end":{"line":3,"column":63}},
+                  "argument": {
+                    "type": "Literal",
+                    "start":123,"end":127,"loc":{"start":{"line":3,"column":14},"end":{"line":3,"column":18}},
+                    "value": "/z",
+                    "raw": "\"/z\""
+                  },
+                  "options": {
+                    "type": "ObjectExpression",
+                    "start":129,"end":155,"loc":{"start":{"line":3,"column":20},"end":{"line":3,"column":46}},
+                    "properties": [
+                      {
+                        "type": "Property",
+                        "start":131,"end":153,"loc":{"start":{"line":3,"column":22},"end":{"line":3,"column":44}},
+                        "method": false,
+                        "key": {
+                          "type": "Identifier",
+                          "start":131,"end":135,"loc":{"start":{"line":3,"column":22},"end":{"line":3,"column":26},"identifierName":"with"},
+                          "name": "with"
+                        },
+                        "computed": false,
+                        "shorthand": false,
+                        "value": {
+                          "type": "ObjectExpression",
+                          "start":137,"end":153,"loc":{"start":{"line":3,"column":28},"end":{"line":3,"column":44}},
+                          "properties": [
+                            {
+                              "type": "Property",
+                              "start":139,"end":151,"loc":{"start":{"line":3,"column":30},"end":{"line":3,"column":42}},
+                              "method": false,
+                              "key": {
+                                "type": "Identifier",
+                                "start":139,"end":143,"loc":{"start":{"line":3,"column":30},"end":{"line":3,"column":34},"identifierName":"type"},
+                                "name": "type"
+                              },
+                              "computed": false,
+                              "shorthand": false,
+                              "value": {
+                                "type": "Literal",
+                                "start":145,"end":151,"loc":{"start":{"line":3,"column":36},"end":{"line":3,"column":42}},
+                                "value": "json",
+                                "raw": "\"json\""
+                              },
+                              "kind": "init"
+                            }
+                          ]
+                        },
+                        "kind": "init"
+                      }
+                    ]
+                  },
+                  "qualifier": {
+                    "type": "TSQualifiedName",
+                    "start":157,"end":164,"loc":{"start":{"line":3,"column":48},"end":{"line":3,"column":55}},
+                    "left": {
+                      "type": "Identifier",
+                      "start":157,"end":160,"loc":{"start":{"line":3,"column":48},"end":{"line":3,"column":51},"identifierName":"foo"},
+                      "name": "foo"
+                    },
+                    "right": {
+                      "type": "Identifier",
+                      "start":161,"end":164,"loc":{"start":{"line":3,"column":52},"end":{"line":3,"column":55},"identifierName":"bar"},
+                      "name": "bar"
+                    }
+                  },
+                  "typeParameters": {
+                    "type": "TSTypeParameterInstantiation",
+                    "start":164,"end":172,"loc":{"start":{"line":3,"column":55},"end":{"line":3,"column":63}},
+                    "params": [
+                      {
+                        "type": "TSStringKeyword",
+                        "start":165,"end":171,"loc":{"start":{"line":3,"column":56},"end":{"line":3,"column":62}}
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      }
+    ]
+  }
+}

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -411,7 +411,14 @@ export const functionDeclarationCommon = () => ({
 
 defineType("FunctionDeclaration", {
   builder: ["id", "params", "body", "generator", "async"],
-  visitor: ["id", "typeParameters", "params", "returnType", "body"],
+  visitor: [
+    "id",
+    "typeParameters",
+    "params",
+    "predicate",
+    "returnType",
+    "body",
+  ],
   fields: {
     ...functionDeclarationCommon(),
     ...functionTypeAnnotationCommon(),
@@ -1295,7 +1302,7 @@ defineType("ArrayPattern", {
 
 defineType("ArrowFunctionExpression", {
   builder: ["params", "body", "async"],
-  visitor: ["typeParameters", "params", "returnType", "body"],
+  visitor: ["typeParameters", "params", "predicate", "returnType", "body"],
   aliases: [
     "Scopable",
     "Function",
@@ -2216,7 +2223,7 @@ defineType("OptionalCallExpression", {
 
 // --- ES2022 ---
 defineType("ClassProperty", {
-  visitor: ["decorators", "key", "typeAnnotation", "value"],
+  visitor: ["decorators", "variance", "key", "typeAnnotation", "value"],
   builder: [
     "key",
     "value",
@@ -2345,7 +2352,7 @@ defineType("ClassAccessorProperty", {
 });
 
 defineType("ClassPrivateProperty", {
-  visitor: ["decorators", "key", "typeAnnotation", "value"],
+  visitor: ["decorators", "variance", "key", "typeAnnotation", "value"],
   builder: ["key", "value", "decorators", "static"],
   aliases: ["Property", "Private"],
   fields: {

--- a/packages/babel-types/src/definitions/flow.ts
+++ b/packages/babel-types/src/definitions/flow.ts
@@ -82,7 +82,8 @@ defineType("ClassImplements", {
 defineInterfaceishType("DeclareClass");
 
 defineType("DeclareFunction", {
-  visitor: ["id"],
+  builder: ["id"],
+  visitor: ["id", "predicate"],
   aliases: ["FlowDeclaration", "Statement", "Declaration"],
   fields: {
     id: validateType("Identifier"),
@@ -177,7 +178,8 @@ defineType("ExistsTypeAnnotation", {
 });
 
 defineType("FunctionTypeAnnotation", {
-  visitor: ["typeParameters", "params", "rest", "returnType"],
+  builder: ["typeParameters", "params", "rest", "returnType"],
+  visitor: ["typeParameters", "this", "params", "rest", "returnType"],
   aliases: ["FlowType"],
   fields: {
     typeParameters: validateOptionalType("TypeParameterDeclaration"),
@@ -544,7 +546,8 @@ defineType("EnumSymbolBody", {
 
 defineType("EnumBooleanMember", {
   aliases: ["EnumMember"],
-  visitor: ["id"],
+  builder: ["id"],
+  visitor: ["id", "init"],
   fields: {
     id: validateType("Identifier"),
     init: validateType("BooleanLiteral"),

--- a/packages/babel-types/src/definitions/jsx.ts
+++ b/packages/babel-types/src/definitions/jsx.ts
@@ -129,7 +129,7 @@ defineType("JSXNamespacedName", {
 
 defineType("JSXOpeningElement", {
   builder: ["name", "attributes", "selfClosing"],
-  visitor: ["name", "attributes"],
+  visitor: ["name", "typeParameters", "attributes"],
   aliases: ["Immutable"],
   fields: {
     name: {

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -659,7 +659,9 @@ defineType("TSTypeParameterDeclaration", {
 
 defineType("TSTypeParameter", {
   builder: ["constraint", "default", "name"],
-  visitor: ["constraint", "default"],
+  visitor: process.env.BABEL_8_BREAKING
+    ? ["name", "constraint", "default"]
+    : ["constraint", "default"],
   fields: {
     name: {
       validate: !process.env.BABEL_8_BREAKING

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -576,7 +576,8 @@ defineType("TSModuleBlock", {
 
 defineType("TSImportType", {
   aliases: ["TSType"],
-  visitor: ["argument", "qualifier", "typeParameters"],
+  builder: ["argument", "qualifier", "typeParameters"],
+  visitor: ["argument", "options", "qualifier", "typeParameters"],
   fields: {
     argument: validateType("StringLiteral"),
     qualifier: validateOptionalType("TSEntityName"),

--- a/packages/babel-types/test/fields.js
+++ b/packages/babel-types/test/fields.js
@@ -107,7 +107,8 @@ describe("NODE_FIELDS contains all fields, VISITOR_KEYS contains all AST nodes, 
           node[field].type &&
           !(
             ignoredVisitorKeysCheckTypes[type] === true ||
-            ignoredVisitorKeysCheckTypes[type]?.[field] === true
+            (ignoredVisitorKeysCheckTypes[type] !== undefined &&
+              ignoredVisitorKeysCheckTypes[type][field] === true)
           )
         ) {
           throw new Error(

--- a/packages/babel-types/test/fields.js
+++ b/packages/babel-types/test/fields.js
@@ -23,7 +23,13 @@ const ignoredFields = {
   TSDeclareMethod: { id: true },
 };
 
-describe("NODE_FIELDS contains all fields, and the visitor order is correct, in", function () {
+const ignoredVisitorKeysCheckTypes = {
+  Placeholder: true,
+  // See the Program's definition for why `interpreter` is excluded
+  Program: { interpreter: true },
+};
+
+describe("NODE_FIELDS contains all fields, VISITOR_KEYS contains all AST nodes, and the visitor order is correct, in", function () {
   const reportedVisitorOrders = new Set();
   const testingOnBabel8 = IS_BABEL_8();
   const { traverseFast, VISITOR_KEYS } = t;
@@ -36,7 +42,6 @@ describe("NODE_FIELDS contains all fields, and the visitor order is correct, in"
         readFileSync(path.join(fixturePath, "options.json")),
       ).BABEL_8_BREAKING;
     } catch {
-
     } finally {
       if (isBabel8Test === undefined) {
         try {
@@ -93,6 +98,21 @@ describe("NODE_FIELDS contains all fields, and the visitor order is correct, in"
           if (!missingFields[type][field]) {
             missingFields[type][field] = true;
           }
+        }
+
+        if (
+          !VISITOR_KEYS[type].includes(field) &&
+          node[field] != null &&
+          typeof node[field] === "object" &&
+          node[field].type &&
+          !(
+            ignoredVisitorKeysCheckTypes[type] === true ||
+            ignoredVisitorKeysCheckTypes[type]?.[field] === true
+          )
+        ) {
+          throw new Error(
+            `${type}.${field} is an AST node (type=${node[field].type}), but "${field}" is missing in "${type}"'s current visitors definition: ${inspect(VISITOR_KEYS[type])}`,
+          );
         }
       }
 

--- a/packages/babel-types/test/fields.js
+++ b/packages/babel-types/test/fields.js
@@ -36,17 +36,17 @@ describe("NODE_FIELDS contains all fields, and the visitor order is correct, in"
         readFileSync(path.join(fixturePath, "options.json")),
       ).BABEL_8_BREAKING;
     } catch {
+
+    } finally {
       if (isBabel8Test === undefined) {
         try {
           isBabel8Test = JSON.parse(
             readFileSync(path.resolve(fixturePath, "../options.json")),
           ).BABEL_8_BREAKING;
-        } catch {
-          isBabel8Test = true;
-        }
+        } catch {}
       }
     }
-    if (isBabel8Test !== testingOnBabel8) return;
+    if (isBabel8Test !== undefined && isBabel8Test !== testingOnBabel8) return;
 
     const ast = JSON.parse(readFileSync(file, "utf8"));
     if (ast.type === "File" && ast.errors && ast.errors.length) return;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Babel does not generate the `options` property of the `TSImportType`.
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we ensure that for every AST node, its visitor keys always include the properties whose value is an AST node, with few exemptions. The new test detects quite a few incomplete visitor keys and they are now fixed in this PR.

This PR avoids builder changes so that it can be shipped in patch release. We can sync the builder with visitors in minor release.