### PR TITLE
fix: Remove type-only `import x = y.z`

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -374,6 +374,7 @@ export default declare((api, opts: Options) => {
               const { id, isExport } = stmt.node;
               const binding = stmt.scope.getBinding(id.name);
               if (
+                binding &&
                 !isExport &&
                 isImportTypeOnly({
                   binding,

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -370,7 +370,7 @@ export default declare((api, opts: Options) => {
               continue;
             }
 
-            if (stmt.isTSImportEqualsDeclaration()) {
+            if (!onlyRemoveTypeImports && stmt.isTSImportEqualsDeclaration()) {
               const { id, isExport } = stmt.node;
               const binding = stmt.scope.getBinding(id.name);
               if (

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -370,6 +370,23 @@ export default declare((api, opts: Options) => {
               continue;
             }
 
+            if (stmt.isTSImportEqualsDeclaration()) {
+              const { id, isExport } = stmt.node;
+              const binding = stmt.scope.getBinding(id.name);
+              if (
+                !isExport &&
+                isImportTypeOnly({
+                  binding,
+                  programPath: path,
+                  pragmaImportName,
+                  pragmaFragImportName,
+                })
+              ) {
+                stmt.remove();
+                continue;
+              }
+            }
+
             if (stmt.isExportDeclaration()) {
               stmt = stmt.get("declaration");
             }
@@ -616,12 +633,6 @@ export default declare((api, opts: Options) => {
         pass,
       ) {
         const { id, moduleReference, isExport } = path.node;
-
-        const binding = path.scope.getBinding(id.name);
-        if (binding?.referencePaths.every(ref => isInType(ref))) {
-          path.remove();
-          return;
-        }
 
         let init: t.Expression;
         let varKind: "var" | "const";

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -617,6 +617,12 @@ export default declare((api, opts: Options) => {
       ) {
         const { id, moduleReference, isExport } = path.node;
 
+        const binding = path.scope.getBinding(id.name);
+        if (binding?.referencePaths.every(ref => isInType(ref))) {
+          path.remove();
+          return;
+        }
+
         let init: t.Expression;
         let varKind: "var" | "const";
         if (t.isTSExternalModuleReference(moduleReference)) {

--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/export-import=/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/export-import=/output.mjs
@@ -1,2 +1,1 @@
 import * as joint from '@joint/core';
-export var JGraph = joint.dia.Graph;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/exports/export-import=/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/exports/export-import=/output.mjs
@@ -1,1 +1,2 @@
 import * as joint from '@joint/core';
+export var JGraph = joint.dia.Graph;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-type-referenced-in-imports-equal-no/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-type-referenced-in-imports-equal-no/output.mjs
@@ -1,4 +1,2 @@
 import nsa from "./module-a";
-var foo = nsa.bar;
 import nsb from "./module-b";
-var bar = nsb.foo.bar;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=-declaration/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=-declaration/input.ts
@@ -1,1 +1,2 @@
 import foo = bar
+foo.x

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=-declaration/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/import=-declaration/output.mjs
@@ -1,1 +1,2 @@
 var foo = bar;
+foo.x;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/only-remove-type-imports/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/only-remove-type-imports/input.ts
@@ -12,4 +12,5 @@ import type { I, I2 } from "i";
 import type * as J from "j";
 import { type K1, type K2 } from "k";
 import { type L1, L2, type L3 } from "l";
-;
+
+import x = a;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/imports/only-remove-type-imports/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/imports/only-remove-type-imports/output.mjs
@@ -7,4 +7,4 @@ import "f";
 import "g";
 import "k";
 import { L2 } from "l";
-;
+var x = a;

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/alias/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/alias/output.mjs
@@ -1,7 +1,4 @@
-import * as babel from '@babel/core';
-
 /** type only */
-var b = babel;
 var AliasModule = LongNameModule;
 const some = 3;
 const bar = AliasModule.foo;
@@ -9,3 +6,4 @@ const baz = AliasModule.Inner.bar;
 let str;
 let node;
 console.log(some);
+export {};

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -268,7 +268,17 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
     parent.registerDeclaration(path);
   },
 
+  TSImportEqualsDeclaration(path) {
+    const parent = path.scope.getBlockParent();
+
+    parent.registerDeclaration(path);
+  },
+
   ReferencedIdentifier(path, state) {
+    if (t.isTSQualifiedName(path.parent) && path.parent.right === path.node) {
+      return;
+    }
+    if (path.parentPath.isTSImportEqualsDeclaration()) return;
     state.references.push(path);
   },
 
@@ -374,6 +384,7 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
       path.scope.registerBinding("local", path.get("id"), path);
     }
   },
+
   TSTypeAnnotation(path) {
     path.skip();
   },

--- a/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
+++ b/packages/babel-types/src/retrievers/getBindingIdentifiers.ts
@@ -145,6 +145,7 @@ const keys: KeysMap = {
   ImportNamespaceSpecifier: ["local"],
   ImportDefaultSpecifier: ["local"],
   ImportDeclaration: ["specifiers"],
+  TSImportEqualsDeclaration: ["id"],
 
   ExportSpecifier: ["exported"],
   ExportNamespaceSpecifier: ["exported"],


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15942 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This seems a bit dangerous and I'm not sure if this will cause a regression.