### PR TITLE
fix: More accurate `transform-typeof-symbol` compat data

### DIFF
--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -704,18 +704,17 @@
     "electron": "1.1"
   },
   "transform-typeof-symbol": {
-    "chrome": "38",
-    "opera": "25",
+    "chrome": "48",
+    "opera": "35",
     "edge": "12",
     "firefox": "36",
     "safari": "9",
-    "node": "0.12",
+    "node": "6",
     "deno": "1",
     "ios": "9",
-    "samsung": "3",
-    "rhino": "1.7.13",
-    "opera_mobile": "25",
-    "electron": "0.20"
+    "samsung": "5",
+    "opera_mobile": "35",
+    "electron": "0.37"
   },
   "transform-new-target": {
     "chrome": "46",

--- a/packages/babel-compat-data/scripts/data/plugin-features.js
+++ b/packages/babel-compat-data/scripts/data/plugin-features.js
@@ -111,7 +111,11 @@ const es2015 = {
     ],
   },
   "transform-typeof-symbol": {
-    features: ["Symbol / typeof support"],
+    features: [
+      "Symbol / typeof support",
+      "Symbol / can convert with String()",
+      "Symbol / Object(symbol)",
+    ],
   },
   "transform-new-target": {
     features: ["new.target", 'arrow functions / lexical "new.target" binding'],

--- a/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes/edge-default-params-chrome-40/stdout.txt
@@ -44,6 +44,7 @@ Using plugins:
   transform-unicode-regex { chrome < 50 }
   transform-spread { chrome < 46 }
   transform-block-scoping { chrome < 50 }
+  transform-typeof-symbol { chrome < 48 }
   transform-new-target { chrome < 46 }
   transform-regenerator { chrome < 50 }
   transform-export-namespace-from { chrome < 72 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-electron/stdout.txt
@@ -35,6 +35,7 @@ Using plugins:
   transform-unicode-regex { electron < 1.1 }
   transform-destructuring { electron < 1.2 }
   transform-block-scoping { electron < 1.1 }
+  transform-typeof-symbol { electron < 0.37 }
   transform-regenerator { electron < 1.1 }
   transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs2-versions-decimals/stdout.txt
@@ -49,7 +49,7 @@ Using plugins:
   transform-spread { ie }
   transform-destructuring { electron < 1.2, ie, node < 6.5 }
   transform-block-scoping { electron < 1.1, ie }
-  transform-typeof-symbol { ie }
+  transform-typeof-symbol { electron < 0.37, ie }
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }
   transform-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-electron/stdout.txt
@@ -35,6 +35,7 @@ Using plugins:
   transform-unicode-regex { electron < 1.1 }
   transform-destructuring { electron < 1.2 }
   transform-block-scoping { electron < 1.1 }
+  transform-typeof-symbol { electron < 0.37 }
   transform-regenerator { electron < 1.1 }
   transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/entry-corejs3-versions-decimals/stdout.txt
@@ -49,7 +49,7 @@ Using plugins:
   transform-spread { ie }
   transform-destructuring { electron < 1.2, ie, node < 6.5 }
   transform-block-scoping { electron < 1.1, ie }
-  transform-typeof-symbol { ie }
+  transform-typeof-symbol { electron < 0.37, ie }
   transform-new-target { ie }
   transform-regenerator { electron < 1.1, ie }
   transform-export-namespace-from { chrome < 72, electron < 5.0, ie, node < 13.2 }

--- a/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/entry-corejs3-electron/stdout.txt
@@ -35,6 +35,7 @@ Using plugins:
   transform-unicode-regex { electron < 1.1 }
   transform-destructuring { electron < 1.2 }
   transform-block-scoping { electron < 1.1 }
+  transform-typeof-symbol { electron < 0.37 }
   transform-regenerator { electron < 1.1 }
   transform-export-namespace-from { electron < 5.0 }
   transform-modules-commonjs


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17030 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Thanks to https://github.com/vitejs/vite/issues/18959#issuecomment-2547035338
Unfortunately I tested manually on chrome 41 and it doesn't work with `Symbol / Object(symbol)`.
