### PR TITLE
[estree] Unify method type parameters handling

### DIFF
--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -175,39 +175,6 @@ export default (superClass: typeof Parser) =>
       delete node.directives;
     }
 
-    pushClassMethod(
-      classBody: N.ClassBody,
-      method: N.ClassMethod,
-      isGenerator: boolean,
-      isAsync: boolean,
-      isConstructor: boolean,
-      allowsDirectSuper: boolean,
-    ): void {
-      this.parseMethod(
-        method,
-        isGenerator,
-        isAsync,
-        isConstructor,
-        allowsDirectSuper,
-        "ClassMethod",
-        true,
-      );
-
-      const { typeParameters } = method;
-      if (typeParameters) {
-        delete method.typeParameters;
-
-        const fn: N.FunctionExpression = (
-          method as unknown as N.EstreeMethodDefinition
-        ).value;
-
-        fn.typeParameters = typeParameters;
-        fn.start = typeParameters.start;
-        fn.loc.start = typeParameters.loc.start;
-      }
-      classBody.body.push(method);
-    }
-
     parsePrivateName(): any {
       const node = super.parsePrivateName();
       if (!process.env.BABEL_8_BREAKING) {
@@ -299,6 +266,13 @@ export default (superClass: typeof Parser) =>
       delete funcNode.kind;
       // @ts-expect-error mutate AST types
       node.value = funcNode;
+      const { typeParameters } = node;
+      if (typeParameters) {
+        delete node.typeParameters;
+        funcNode.typeParameters = typeParameters;
+        funcNode.start = typeParameters.start;
+        funcNode.loc.start = typeParameters.loc.start;
+      }
       if (type === "ClassPrivateMethod") {
         node.computed = false;
       }

--- a/packages/babel-parser/test/fixtures/estree/object-method/flow/input.js
+++ b/packages/babel-parser/test/fixtures/estree/object-method/flow/input.js
@@ -1,0 +1,3 @@
+var bar = {
+  foo<T>(x: T): T { return x }
+};

--- a/packages/babel-parser/test/fixtures/estree/object-method/flow/options.json
+++ b/packages/babel-parser/test/fixtures/estree/object-method/flow/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "flow",
+    "estree"
+  ]
+}

--- a/packages/babel-parser/test/fixtures/estree/object-method/flow/output.json
+++ b/packages/babel-parser/test/fixtures/estree/object-method/flow/output.json
@@ -1,0 +1,118 @@
+{
+  "type": "File",
+  "start":0,"end":45,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":2}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":45,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":2}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":45,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":2}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":4,"end":44,"loc":{"start":{"line":1,"column":4},"end":{"line":3,"column":1}},
+            "id": {
+              "type": "Identifier",
+              "start":4,"end":7,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":7},"identifierName":"bar"},
+              "name": "bar"
+            },
+            "init": {
+              "type": "ObjectExpression",
+              "start":10,"end":44,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+              "properties": [
+                {
+                  "type": "Property",
+                  "start":14,"end":42,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":30}},
+                  "method": true,
+                  "key": {
+                    "type": "Identifier",
+                    "start":14,"end":17,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":5},"identifierName":"foo"},
+                    "name": "foo"
+                  },
+                  "computed": false,
+                  "kind": "init",
+                  "value": {
+                    "type": "FunctionExpression",
+                    "start":20,"end":42,"loc":{"start":{"line":2,"column":8},"end":{"line":2,"column":30}},
+                    "id": null,
+                    "generator": false,
+                    "async": false,
+                    "expression": false,
+                    "params": [
+                      {
+                        "type": "Identifier",
+                        "start":21,"end":25,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":13},"identifierName":"x"},
+                        "name": "x",
+                        "typeAnnotation": {
+                          "type": "TypeAnnotation",
+                          "start":22,"end":25,"loc":{"start":{"line":2,"column":10},"end":{"line":2,"column":13}},
+                          "typeAnnotation": {
+                            "type": "GenericTypeAnnotation",
+                            "start":24,"end":25,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":13}},
+                            "typeParameters": null,
+                            "id": {
+                              "type": "Identifier",
+                              "start":24,"end":25,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":13},"identifierName":"T"},
+                              "name": "T"
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "predicate": null,
+                    "returnType": {
+                      "type": "TypeAnnotation",
+                      "start":26,"end":29,"loc":{"start":{"line":2,"column":14},"end":{"line":2,"column":17}},
+                      "typeAnnotation": {
+                        "type": "GenericTypeAnnotation",
+                        "start":28,"end":29,"loc":{"start":{"line":2,"column":16},"end":{"line":2,"column":17}},
+                        "typeParameters": null,
+                        "id": {
+                          "type": "Identifier",
+                          "start":28,"end":29,"loc":{"start":{"line":2,"column":16},"end":{"line":2,"column":17},"identifierName":"T"},
+                          "name": "T"
+                        }
+                      }
+                    },
+                    "body": {
+                      "type": "BlockStatement",
+                      "start":30,"end":42,"loc":{"start":{"line":2,"column":18},"end":{"line":2,"column":30}},
+                      "body": [
+                        {
+                          "type": "ReturnStatement",
+                          "start":32,"end":40,"loc":{"start":{"line":2,"column":20},"end":{"line":2,"column":28}},
+                          "argument": {
+                            "type": "Identifier",
+                            "start":39,"end":40,"loc":{"start":{"line":2,"column":27},"end":{"line":2,"column":28},"identifierName":"x"},
+                            "name": "x"
+                          }
+                        }
+                      ]
+                    },
+                    "typeParameters": {
+                      "type": "TypeParameterDeclaration",
+                      "start":17,"end":20,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":8}},
+                      "params": [
+                        {
+                          "type": "TypeParameter",
+                          "start":18,"end":19,"loc":{"start":{"line":2,"column":6},"end":{"line":2,"column":7}},
+                          "name": "T",
+                          "variance": null
+                        }
+                      ]
+                    }
+                  },
+                  "shorthand": false
+                }
+              ]
+            }
+          }
+        ],
+        "kind": "var"
+      }
+    ]
+  }
+}

--- a/packages/babel-parser/test/fixtures/estree/object-method/typescript-babel-7/input.ts
+++ b/packages/babel-parser/test/fixtures/estree/object-method/typescript-babel-7/input.ts
@@ -1,0 +1,3 @@
+var bar = {
+  foo<T>(x: T): T { return x }
+};

--- a/packages/babel-parser/test/fixtures/estree/object-method/typescript-babel-7/options.json
+++ b/packages/babel-parser/test/fixtures/estree/object-method/typescript-babel-7/options.json
@@ -3,5 +3,5 @@
     "typescript",
     "estree"
   ],
-  "BABEL_8_BREAKING": true
+  "BABEL_8_BREAKING": false
 }

--- a/packages/babel-parser/test/fixtures/estree/object-method/typescript-babel-7/output.json
+++ b/packages/babel-parser/test/fixtures/estree/object-method/typescript-babel-7/output.json
@@ -96,11 +96,7 @@
                         {
                           "type": "TSTypeParameter",
                           "start":18,"end":19,"loc":{"start":{"line":2,"column":6},"end":{"line":2,"column":7}},
-                          "name": {
-                            "type": "Identifier",
-                            "start":18,"end":19,"loc":{"start":{"line":2,"column":6},"end":{"line":2,"column":7},"identifierName":"T"},
-                            "name": "T"
-                          }
+                          "name": "T"
                         }
                       ]
                     }

--- a/packages/babel-parser/test/fixtures/estree/object-method/typescript/input.ts
+++ b/packages/babel-parser/test/fixtures/estree/object-method/typescript/input.ts
@@ -1,0 +1,3 @@
+var bar = {
+  foo<T>(x: T): T { return x }
+};

--- a/packages/babel-parser/test/fixtures/estree/object-method/typescript/options.json
+++ b/packages/babel-parser/test/fixtures/estree/object-method/typescript/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "typescript",
+    "estree"
+  ]
+}

--- a/packages/babel-parser/test/fixtures/estree/object-method/typescript/output.json
+++ b/packages/babel-parser/test/fixtures/estree/object-method/typescript/output.json
@@ -1,0 +1,114 @@
+{
+  "type": "File",
+  "start":0,"end":45,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":2}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":45,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":2}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":45,"loc":{"start":{"line":1,"column":0},"end":{"line":3,"column":2}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":4,"end":44,"loc":{"start":{"line":1,"column":4},"end":{"line":3,"column":1}},
+            "id": {
+              "type": "Identifier",
+              "start":4,"end":7,"loc":{"start":{"line":1,"column":4},"end":{"line":1,"column":7},"identifierName":"bar"},
+              "name": "bar"
+            },
+            "init": {
+              "type": "ObjectExpression",
+              "start":10,"end":44,"loc":{"start":{"line":1,"column":10},"end":{"line":3,"column":1}},
+              "properties": [
+                {
+                  "type": "Property",
+                  "start":14,"end":42,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":30}},
+                  "method": true,
+                  "key": {
+                    "type": "Identifier",
+                    "start":14,"end":17,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":5},"identifierName":"foo"},
+                    "name": "foo"
+                  },
+                  "computed": false,
+                  "kind": "init",
+                  "value": {
+                    "type": "FunctionExpression",
+                    "start":17,"end":42,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":30}},
+                    "id": null,
+                    "generator": false,
+                    "async": false,
+                    "expression": false,
+                    "params": [
+                      {
+                        "type": "Identifier",
+                        "start":21,"end":25,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":13},"identifierName":"x"},
+                        "name": "x",
+                        "typeAnnotation": {
+                          "type": "TSTypeAnnotation",
+                          "start":22,"end":25,"loc":{"start":{"line":2,"column":10},"end":{"line":2,"column":13}},
+                          "typeAnnotation": {
+                            "type": "TSTypeReference",
+                            "start":24,"end":25,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":13}},
+                            "typeName": {
+                              "type": "Identifier",
+                              "start":24,"end":25,"loc":{"start":{"line":2,"column":12},"end":{"line":2,"column":13},"identifierName":"T"},
+                              "name": "T"
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "returnType": {
+                      "type": "TSTypeAnnotation",
+                      "start":26,"end":29,"loc":{"start":{"line":2,"column":14},"end":{"line":2,"column":17}},
+                      "typeAnnotation": {
+                        "type": "TSTypeReference",
+                        "start":28,"end":29,"loc":{"start":{"line":2,"column":16},"end":{"line":2,"column":17}},
+                        "typeName": {
+                          "type": "Identifier",
+                          "start":28,"end":29,"loc":{"start":{"line":2,"column":16},"end":{"line":2,"column":17},"identifierName":"T"},
+                          "name": "T"
+                        }
+                      }
+                    },
+                    "body": {
+                      "type": "BlockStatement",
+                      "start":30,"end":42,"loc":{"start":{"line":2,"column":18},"end":{"line":2,"column":30}},
+                      "body": [
+                        {
+                          "type": "ReturnStatement",
+                          "start":32,"end":40,"loc":{"start":{"line":2,"column":20},"end":{"line":2,"column":28}},
+                          "argument": {
+                            "type": "Identifier",
+                            "start":39,"end":40,"loc":{"start":{"line":2,"column":27},"end":{"line":2,"column":28},"identifierName":"x"},
+                            "name": "x"
+                          }
+                        }
+                      ]
+                    },
+                    "typeParameters": {
+                      "type": "TSTypeParameterDeclaration",
+                      "start":17,"end":20,"loc":{"start":{"line":2,"column":5},"end":{"line":2,"column":8}},
+                      "params": [
+                        {
+                          "type": "TSTypeParameter",
+                          "start":18,"end":19,"loc":{"start":{"line":2,"column":6},"end":{"line":2,"column":7}},
+                          "name": "T"
+                        }
+                      ]
+                    }
+                  },
+                  "shorthand": false
+                }
+              ]
+            }
+          }
+        ],
+        "kind": "var"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/issues/16679
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we move the typeParameters handling to the `parseMethod` routine so that the type parameters of an object method is also covered. Previously we only handled class methods and overlooked object methods.

Given that the Babel 7 eslint-parser has never officially supported typescript-eslint, I think the impact of this change is minimal and thus could be shipped in a patch or minor release.