### PR TITLE
fix: incorret `babel.config.cts` test fixtures

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -282,6 +282,7 @@ export default [
             "nodeGte20",
             "nodeGte22_12",
             "nodeLt22_12",
+            "nodeLt23_6",
             "nodeGte12NoESM",
             "testFn",
           ],

--- a/packages/babel-core/test/config-ts.js
+++ b/packages/babel-core/test/config-ts.js
@@ -1,7 +1,7 @@
 import { loadPartialConfigSync } from "../lib/index.js";
 import path from "path";
 import semver from "semver";
-import { USE_ESM, commonJS } from "$repo-utils";
+import { USE_ESM, commonJS, itLt } from "$repo-utils";
 
 const { __dirname, require } = commonJS(import.meta.url);
 
@@ -10,6 +10,9 @@ const { __dirname, require } = commonJS(import.meta.url);
 // 2. In the old version of node, jest has been registered in `require.extensions`, which will cause babel to disable the transforming as expected.
 // TODO: Make it work with USE_ESM.
 const shouldSkip = semver.lt(process.version, "14.0.0") || USE_ESM;
+
+// Node.js 23.6 unflags --experimental-strip-types
+const nodeLt23_6 = itLt("23.6.0");
 
 (shouldSkip ? describe : describe.skip)(
   "@babel/core config with ts [dummy]",
@@ -38,7 +41,9 @@ const shouldSkip = semver.lt(process.version, "14.0.0") || USE_ESM;
     expect(config.options.sourceRoot).toMatchInlineSnapshot(`"/a/b"`);
   });
 
-  it("should throw with invalid .ts register", () => {
+  // Node.js >=23.6 has builtin .ts register, so this test can be removed
+  // when we dropped Node.js 23 support in the future
+  nodeLt23_6("should throw with invalid .ts register", () => {
     require.extensions[".ts"] = () => {
       throw new Error("Not support .ts.");
     };

--- a/packages/babel-core/test/fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts
+++ b/packages/babel-core/test/fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts
@@ -1,6 +1,6 @@
-import path from "path";
+const path = require("path");
 type config = any;
-export default {
+module.exports = {
   targets: "node 12.0.0",
   sourceRoot: path.posix.join("/a", "b"),
 } as config;

--- a/packages/babel-core/test/fixtures/config-ts/simple-cts/babel.config.cts
+++ b/packages/babel-core/test/fixtures/config-ts/simple-cts/babel.config.cts
@@ -1,6 +1,6 @@
-import path from "path";
+const path = require("path");
 type config = any;
-export default {
+module.exports = {
   targets: "node 12.0.0",
   sourceRoot: path.posix.join("/a", "b"),
 } as config;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes current failing CI
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Node.js 23.6 unflags the `--experimental-strip-types` support, which reveals incorrect `.cts` fixtures in our test suites.