### PR TITLE
Do not try to parse .ts configs as JSON if natively supported

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -283,6 +283,7 @@ export default [
             "nodeGte22_12",
             "nodeLt22_12",
             "nodeLt23_6",
+            "nodeGte23_6",
             "nodeGte12NoESM",
             "testFn",
           ],

--- a/packages/babel-core/src/config/files/configuration.ts
+++ b/packages/babel-core/src/config/files/configuration.ts
@@ -340,7 +340,9 @@ function readConfig(
     case ".js":
     case ".cjs":
     case ".mjs":
+    case ".ts":
     case ".cts":
+    case ".mts":
       return readConfigCode(filepath, { envName, caller });
     default:
       return readConfigJSON5(filepath);

--- a/packages/babel-core/test/config-ts.js
+++ b/packages/babel-core/test/config-ts.js
@@ -1,18 +1,18 @@
-import { loadPartialConfigSync } from "../lib/index.js";
+import { loadPartialConfigSync, loadPartialConfigAsync } from "../lib/index.js";
 import path from "path";
 import semver from "semver";
-import { USE_ESM, commonJS, itLt } from "$repo-utils";
+import { commonJS, itGte, itLt } from "$repo-utils";
 
 const { __dirname, require } = commonJS(import.meta.url);
 
 // We skip older versions of node testing for two reasons.
 // 1. ts-node and ts don't support the old version of node.
 // 2. In the old version of node, jest has been registered in `require.extensions`, which will cause babel to disable the transforming as expected.
-// TODO: Make it work with USE_ESM.
-const shouldSkip = semver.lt(process.version, "14.0.0") || USE_ESM;
+const shouldSkip = semver.lt(process.version, "14.0.0");
 
 // Node.js 23.6 unflags --experimental-strip-types
 const nodeLt23_6 = itLt("23.6.0");
+const nodeGte23_6 = itGte("23.6.0");
 
 (shouldSkip ? describe : describe.skip)(
   "@babel/core config with ts [dummy]",
@@ -24,11 +24,11 @@ const nodeLt23_6 = itLt("23.6.0");
 );
 
 (shouldSkip ? describe.skip : describe)("@babel/core config with ts", () => {
-  it("should work with simple .cts", () => {
+  nodeLt23_6("should transpile .cts when needed", () => {
     const config = loadPartialConfigSync({
       configFile: path.join(
         __dirname,
-        "fixtures/config-ts/simple-cts/babel.config.cts",
+        "fixtures/config-ts/simple-cts-modules/babel.config.cts",
       ),
     });
 
@@ -43,9 +43,10 @@ const nodeLt23_6 = itLt("23.6.0");
 
   // Node.js >=23.6 has builtin .ts register, so this test can be removed
   // when we dropped Node.js 23 support in the future
-  nodeLt23_6("should throw with invalid .ts register", () => {
-    require.extensions[".ts"] = () => {
-      throw new Error("Not support .ts.");
+  nodeLt23_6("should throw with invalid .cts register", () => {
+    const oldHook = require.extensions[".cts"];
+    require.extensions[".cts"] = () => {
+      throw new Error("Scary!");
     };
     try {
       expect(() => {
@@ -55,10 +56,26 @@ const nodeLt23_6 = itLt("23.6.0");
             "fixtures/config-ts/invalid-cts-register/babel.config.cts",
           ),
         });
-      }).toThrow(/Unexpected identifier.*/);
+      }).toThrow(/Scary!/);
     } finally {
-      delete require.extensions[".ts"];
+      require.extensions[".cts"] = oldHook;
     }
+  });
+
+  // This isn't by design, but reflects the status quo when running in Node.js
+  // versions that don't have native support for .ts files.
+  // It can be changed if needed.
+  nodeLt23_6("show not support .ts config file", () => {
+    expect(() => {
+      loadPartialConfigSync({
+        configFile: path.join(
+          __dirname,
+          "fixtures/config-ts/simple-ts-cjs/babel.config.ts",
+        ),
+      });
+    }).toThrow(
+      /You are using a .ts config file, but Babel only supports transpiling .cts configs/,
+    );
   });
 
   it("should work with ts-node", async () => {
@@ -96,4 +113,72 @@ const nodeLt23_6 = itLt("23.6.0");
       service.enabled(false);
     }
   });
+
+  nodeGte23_6("should support .cts when available natively", () => {
+    const config = loadPartialConfigSync({
+      configFile: path.join(
+        __dirname,
+        "fixtures/config-ts/simple-cts-no-modules/babel.config.cts",
+      ),
+    });
+
+    expect(config.options.targets).toMatchInlineSnapshot(`
+      Object {
+        "node": "12.0.0",
+      }
+    `);
+
+    expect(config.options.sourceRoot).toMatchInlineSnapshot(`"/a/b"`);
+  });
+
+  nodeGte23_6("should use native TS support for .cts when available", () => {
+    expect(() => {
+      loadPartialConfigSync({
+        configFile: path.join(
+          __dirname,
+          "fixtures/config-ts/simple-cts-modules/babel.config.cts",
+        ),
+      });
+    }).toThrow(/import equals declaration is not supported in strip-only mode/);
+  });
+
+  nodeGte23_6(
+    "should use native TS support for .ts (cjs) when available",
+    () => {
+      const config = loadPartialConfigSync({
+        configFile: path.join(
+          __dirname,
+          "fixtures/config-ts/simple-ts-cjs/babel.config.ts",
+        ),
+      });
+
+      expect(config.options.targets).toMatchInlineSnapshot(`
+        Object {
+          "node": "12.0.0",
+        }
+      `);
+
+      expect(config.options.sourceRoot).toMatchInlineSnapshot(`"/a/b"`);
+    },
+  );
+
+  nodeGte23_6(
+    "should use native TS support for .ts (esm) when available",
+    async () => {
+      const config = await loadPartialConfigAsync({
+        configFile: path.join(
+          __dirname,
+          "fixtures/config-ts/simple-ts-esm/babel.config.ts",
+        ),
+      });
+
+      expect(config.options.targets).toMatchInlineSnapshot(`
+        Object {
+          "node": "12.0.0",
+        }
+      `);
+
+      expect(config.options.sourceRoot).toMatchInlineSnapshot(`"/a/b"`);
+    },
+  );
 });

--- a/packages/babel-core/test/fixtures/config-ts/simple-cts-modules/babel.config.cts
+++ b/packages/babel-core/test/fixtures/config-ts/simple-cts-modules/babel.config.cts
@@ -1,0 +1,7 @@
+import path = require("path");
+type config = any;
+
+export = {
+  targets: "node 12.0.0",
+  sourceRoot: path.posix.join("/a", "b"),
+} as config;

--- a/packages/babel-core/test/fixtures/config-ts/simple-cts-no-modules/babel.config.cts
+++ b/packages/babel-core/test/fixtures/config-ts/simple-cts-no-modules/babel.config.cts
@@ -1,0 +1,7 @@
+const path = require("path");
+type config = any;
+
+module.exports = {
+  targets: "node 12.0.0",
+  sourceRoot: path.posix.join("/a", "b"),
+} as config;

--- a/packages/babel-core/test/fixtures/config-ts/simple-ts-cjs/babel.config.ts
+++ b/packages/babel-core/test/fixtures/config-ts/simple-ts-cjs/babel.config.ts
@@ -1,0 +1,7 @@
+const path = require("path");
+type config = any;
+
+module.exports = {
+  targets: "node 12.0.0",
+  sourceRoot: path.posix.join("/a", "b"),
+} as config;

--- a/packages/babel-core/test/fixtures/config-ts/simple-ts-cjs/package.json
+++ b/packages/babel-core/test/fixtures/config-ts/simple-ts-cjs/package.json
@@ -1,0 +1,1 @@
+{ "type": "commonjs" }

--- a/packages/babel-core/test/fixtures/config-ts/simple-ts-esm/babel.config.ts
+++ b/packages/babel-core/test/fixtures/config-ts/simple-ts-esm/babel.config.ts
@@ -1,6 +1,9 @@
-const path = require("path");
+import path from "path";
 type config = any;
-module.exports = {
+
+import.meta;
+
+export default {
   targets: "node 12.0.0",
   sourceRoot: path.posix.join("/a", "b"),
 } as config;

--- a/packages/babel-core/test/fixtures/config-ts/simple-ts-esm/package.json
+++ b/packages/babel-core/test/fixtures/config-ts/simple-ts-esm/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Node.js 23.6 has native support for `.ts`/`.mts`/`.cts` files. However, they don't work in Babel because we wrongly try to parse them as JSON.

With this PR:
- When running in Node.js 23.6 or higher, we rely on the native Node.js support for TypeScript
- When running in older versions, if there is already ts-node or another ts hook installed we rely on it
- When running in older versions with no TS hook installed, we only support transpiling `.cts` files

I'd consider this PR to be a bugfix, since it only changes the behavior in Node.js 23.6 to not respect what Node.js already supports by itself. It's a new Node.js feature, and not a new Babel feature.

Ref https://github.com/babel/babel/pull/17051