### PR TITLE
[babel 8] Remove unused make-dir dependency

### DIFF
--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -23,7 +23,7 @@
     "fs-readdir-recursive": "^1.1.0",
     "jest-diff": "^29.6.4",
     "lru-cache": "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1",
-    "make-dir": "^2.1.0"
+    "make-dir": "condition:BABEL_8_BREAKING ? : ^2.1.0"
   },
   "devDependencies": {
     "@types/fs-readdir-recursive": "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,7 +1055,7 @@ __metadata:
     fs-readdir-recursive: "npm:^1.1.0"
     jest-diff: "npm:^29.6.4"
     lru-cache: "condition:BABEL_8_BREAKING ? ^7.14.1 : ^5.1.1"
-    make-dir: "npm:^2.1.0"
+    make-dir: "condition:BABEL_8_BREAKING ? : ^2.1.0"
   languageName: unknown
   linkType: soft
 
@@ -12583,7 +12583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-dir-BABEL_8_BREAKING-false@npm:make-dir@^2.1.0, make-dir@npm:^2.0.0, make-dir@npm:^2.1.0":
+"make-dir-BABEL_8_BREAKING-false@npm:make-dir@^2.1.0, make-dir@npm:^2.0.0":
   version: 2.1.0
   resolution: "make-dir@npm:2.1.0"
   dependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is only used in a polyfill we only inject in Babel 7: https://github.com/babel/babel/blob/9949db5f3cab167aac0a3191e15274b6a79e2958/babel.config.js#L455

Other packages already use the conditional dependency: https://github.com/babel/babel/blob/9949db5f3cab167aac0a3191e15274b6a79e2958/packages/babel-cli/package.json#L32