### PR TITLE
[Babel 8] Create TSEmptyBodyFunctionExpression also on invalid input

### DIFF
--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -276,21 +276,19 @@ export default (superClass: typeof Parser) =>
       if (type === "ClassPrivateMethod") {
         node.computed = false;
       }
-      if (
-        process.env.BABEL_8_BREAKING &&
-        // @ts-expect-error todo(flow->ts) property not defined for all types in union
-        node.abstract &&
-        this.hasPlugin("typescript")
-      ) {
+      if (process.env.BABEL_8_BREAKING && this.hasPlugin("typescript")) {
         if (!funcNode.body) {
           (funcNode as unknown as N.EstreeTSEmptyBodyFunctionExpression).type =
             "TSEmptyBodyFunctionExpression";
         }
-        return this.finishNode(
-          // @ts-expect-error cast methods to estree types
-          node as Undone<N.EstreeTSAbstractMethodDefinition>,
-          "TSAbstractMethodDefinition",
-        );
+        // @ts-expect-error todo(flow->ts) property not defined for all types in union
+        if (node.abstract) {
+          return this.finishNode(
+            // @ts-expect-error cast methods to estree types
+            node as Undone<N.EstreeTSAbstractMethodDefinition>,
+            "TSAbstractMethodDefinition",
+          );
+        }
       }
       return this.finishNode(
         // @ts-expect-error cast methods to estree types

--- a/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body-babel-7/input.js
+++ b/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body-babel-7/input.js
@@ -1,0 +1,5 @@
+class C {
+  method();
+  #method();
+  declare method();
+}

--- a/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body-babel-7/options.json
+++ b/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body-babel-7/options.json
@@ -1,0 +1,3 @@
+{
+  "BABEL_8_BREAKING": false
+}

--- a/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body-babel-7/output.json
+++ b/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body-babel-7/output.json
@@ -35,7 +35,7 @@
               "computed": false,
               "kind": "method",
               "value": {
-                "type": "TSEmptyBodyFunctionExpression",
+                "type": "FunctionExpression",
                 "start":18,"end":21,"loc":{"start":{"line":2,"column":8},"end":{"line":2,"column":11}},
                 "id": null,
                 "generator": false,
@@ -49,13 +49,17 @@
               "start":24,"end":34,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":12}},
               "static": false,
               "key": {
-                "type": "PrivateIdentifier",
+                "type": "PrivateName",
                 "start":24,"end":31,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":9}},
-                "name": "method"
+                "id": {
+                  "type": "Identifier",
+                  "start":25,"end":31,"loc":{"start":{"line":3,"column":3},"end":{"line":3,"column":9},"identifierName":"method"},
+                  "name": "method"
+                }
               },
               "kind": "method",
               "value": {
-                "type": "TSEmptyBodyFunctionExpression",
+                "type": "FunctionExpression",
                 "start":31,"end":34,"loc":{"start":{"line":3,"column":9},"end":{"line":3,"column":12}},
                 "id": null,
                 "generator": false,
@@ -78,7 +82,7 @@
               "computed": false,
               "kind": "method",
               "value": {
-                "type": "TSEmptyBodyFunctionExpression",
+                "type": "FunctionExpression",
                 "start":51,"end":54,"loc":{"start":{"line":4,"column":16},"end":{"line":4,"column":19}},
                 "id": null,
                 "generator": false,

--- a/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body/input.js
+++ b/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body/input.js
@@ -1,0 +1,5 @@
+class C {
+  method();
+  #method();
+  declare method();
+}

--- a/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body/options.json
+++ b/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body/options.json
@@ -1,0 +1,3 @@
+{
+  "BABEL_8_BREAKING": true
+}

--- a/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body/output.json
+++ b/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body/output.json
@@ -1,0 +1,99 @@
+{
+  "type": "File",
+  "start":0,"end":56,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+  "errors": [
+    "SyntaxError: Class methods cannot have the 'declare' modifier. (4:2)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":56,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":56,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"C"},
+          "name": "C"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":8,"end":56,"loc":{"start":{"line":1,"column":8},"end":{"line":5,"column":1}},
+          "body": [
+            {
+              "type": "MethodDefinition",
+              "start":12,"end":21,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":11}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":12,"end":18,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":8},"identifierName":"method"},
+                "name": "method"
+              },
+              "computed": false,
+              "kind": "method",
+              "value": {
+                "type": "FunctionExpression",
+                "start":18,"end":21,"loc":{"start":{"line":2,"column":8},"end":{"line":2,"column":11}},
+                "id": null,
+                "generator": false,
+                "async": false,
+                "expression": false,
+                "params": []
+              }
+            },
+            {
+              "type": "MethodDefinition",
+              "start":24,"end":34,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":12}},
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start":24,"end":31,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":9}},
+                "id": {
+                  "type": "Identifier",
+                  "start":25,"end":31,"loc":{"start":{"line":3,"column":3},"end":{"line":3,"column":9},"identifierName":"method"},
+                  "name": "method"
+                }
+              },
+              "kind": "method",
+              "value": {
+                "type": "FunctionExpression",
+                "start":31,"end":34,"loc":{"start":{"line":3,"column":9},"end":{"line":3,"column":12}},
+                "id": null,
+                "generator": false,
+                "async": false,
+                "expression": false,
+                "params": []
+              },
+              "computed": false
+            },
+            {
+              "type": "MethodDefinition",
+              "start":37,"end":54,"loc":{"start":{"line":4,"column":2},"end":{"line":4,"column":19}},
+              "declare": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":45,"end":51,"loc":{"start":{"line":4,"column":10},"end":{"line":4,"column":16},"identifierName":"method"},
+                "name": "method"
+              },
+              "computed": false,
+              "kind": "method",
+              "value": {
+                "type": "FunctionExpression",
+                "start":51,"end":54,"loc":{"start":{"line":4,"column":16},"end":{"line":4,"column":19}},
+                "id": null,
+                "generator": false,
+                "async": false,
+                "expression": false,
+                "params": []
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/issues/16679
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As a follow-up to #17014, in this PR we create the `TSEmptyBodyFunctionExpression` type as long as the function body is nullish.