### PR TITLE
fix: show correct code frame for `startLine`

### DIFF
--- a/packages/babel-core/src/parser/index.ts
+++ b/packages/babel-core/src/parser/index.ts
@@ -49,6 +49,13 @@ export default function* parser(
       // err.code will be changed to BABEL_PARSE_ERROR later.
     }
 
+    const startLine = parserOpts?.startLine;
+    const startColumn = parserOpts?.startColumn;
+
+    if (startLine != null || startColumn != null) {
+      code = "\n".repeat(startLine - 1) + " ".repeat(startColumn) + code;
+    }
+
     const { loc, missingPlugin } = err;
     if (loc) {
       const codeFrame = codeFrameColumns(

--- a/packages/babel-core/test/parse.js
+++ b/packages/babel-core/test/parse.js
@@ -39,4 +39,38 @@ describe("parseSync", function () {
     });
     expect(JSON.parse(JSON.stringify(result))).toEqual(output);
   });
+
+  it("should show correct codeFrame with startLine and startColumn", function () {
+    const input = `const* a = 1;
+
+
+
+
+`;
+    let err;
+    try {
+      parseSync(input, {
+        parserOpts: {
+          startLine: 3,
+          startColumn: 3,
+        },
+        highlightCode: false,
+        configFile: false,
+        babelrc: false,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.message).toMatchInlineSnapshot(`
+      "unknown: Unexpected token (3:8)
+
+        1 |
+        2 |
+      > 3 |    const* a = 1;
+          |         ^
+        4 |
+        5 |
+        6 |"
+    `);
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17069 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
