### PR TITLE
Respect `ranges` option in estree method value

### DIFF
--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -270,8 +270,7 @@ export default (superClass: typeof Parser) =>
       if (typeParameters) {
         delete node.typeParameters;
         funcNode.typeParameters = typeParameters;
-        funcNode.start = typeParameters.start;
-        funcNode.loc.start = typeParameters.loc.start;
+        this.resetStartLocationFromNode(funcNode, typeParameters);
       }
       if (type === "ClassPrivateMethod") {
         node.computed = false;

--- a/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true-babel-7/input.js
+++ b/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true-babel-7/input.js
@@ -1,0 +1,4 @@
+class Class {
+  method
+<T>() {}
+}

--- a/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true-babel-7/options.json
+++ b/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true-babel-7/options.json
@@ -4,5 +4,5 @@
     "estree"
   ],
   "ranges": true,
-  "BABEL_8_BREAKING": true
+  "BABEL_8_BREAKING": false
 }

--- a/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true-babel-7/output.json
+++ b/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true-babel-7/output.json
@@ -95,15 +95,7 @@
                         24,
                         25
                       ],
-                      "name": {
-                        "type": "Identifier",
-                        "start":24,"end":25,"loc":{"start":{"line":3,"column":1},"end":{"line":3,"column":2},"identifierName":"T"},
-                        "range": [
-                          24,
-                          25
-                        ],
-                        "name": "T"
-                      }
+                      "name": "T"
                     }
                   ]
                 }

--- a/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true/input.js
+++ b/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true/input.js
@@ -1,0 +1,4 @@
+class Class {
+  method
+<T>() {}
+}

--- a/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true/options.json
+++ b/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["typescript", "estree"],
+  "ranges": true
+}

--- a/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true/output.json
+++ b/packages/babel-parser/test/fixtures/estree/class-method/typescript-type-params-ranges-true/output.json
@@ -1,0 +1,109 @@
+{
+  "type": "File",
+  "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "range": [
+    0,
+    33
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "range": [
+      0,
+      33
+    ],
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":33,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "range": [
+          0,
+          33
+        ],
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":11,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":11},"identifierName":"Class"},
+          "range": [
+            6,
+            11
+          ],
+          "name": "Class"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":12,"end":33,"loc":{"start":{"line":1,"column":12},"end":{"line":4,"column":1}},
+          "range": [
+            12,
+            33
+          ],
+          "body": [
+            {
+              "type": "MethodDefinition",
+              "start":16,"end":31,"loc":{"start":{"line":2,"column":2},"end":{"line":3,"column":8}},
+              "range": [
+                16,
+                31
+              ],
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":16,"end":22,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":8},"identifierName":"method"},
+                "range": [
+                  16,
+                  22
+                ],
+                "name": "method"
+              },
+              "computed": false,
+              "kind": "method",
+              "value": {
+                "type": "FunctionExpression",
+                "start":23,"end":31,"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":8}},
+                "range": [
+                  23,
+                  31
+                ],
+                "id": null,
+                "generator": false,
+                "async": false,
+                "expression": false,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start":29,"end":31,"loc":{"start":{"line":3,"column":6},"end":{"line":3,"column":8}},
+                  "range": [
+                    29,
+                    31
+                  ],
+                  "body": []
+                },
+                "typeParameters": {
+                  "type": "TSTypeParameterDeclaration",
+                  "start":23,"end":26,"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":3}},
+                  "range": [
+                    23,
+                    26
+                  ],
+                  "params": [
+                    {
+                      "type": "TSTypeParameter",
+                      "start":24,"end":25,"loc":{"start":{"line":3,"column":1},"end":{"line":3,"column":2}},
+                      "range": [
+                        24,
+                        25
+                      ],
+                      "name": "T"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Incorrect `ranges` of the method value node in estree mode.
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we call the `resetStartLocationFromNode` method which respects the `ranges` option. Added a new test since this was not covered in our test suites.