### PR TITLE
Fix start of TSParameterProperty

### DIFF
--- a/packages/babel-parser/src/parser/lval.ts
+++ b/packages/babel-parser/src/parser/lval.ts
@@ -483,10 +483,11 @@ export default abstract class LValParser extends NodeUtils {
     ) {
       this.parseFunctionParamType(left);
     }
-    const elt = this.parseMaybeDefault(left.loc.start, left);
     if (decorators.length) {
       left.decorators = decorators;
+      this.resetStartLocationFromNode(left, decorators[0]);
     }
+    const elt = this.parseMaybeDefault(left.loc.start, left);
     return elt;
   }
 

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -2425,8 +2425,10 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       flags: ParseBindingListFlags,
       decorators: N.Decorator[],
     ): N.Pattern | N.TSParameterProperty {
-      // Store original location to include modifiers in range
-      const startLoc = this.state.startLoc;
+      // Store original location to include decorators/modifiers in range
+      const startLoc = decorators.length
+        ? decorators[0].loc.start
+        : this.state.startLoc;
 
       const modified: ModifierBase = {};
       this.tsParseModifiers(

--- a/packages/babel-parser/test/fixtures/experimental/decorators-legacy/class-method-parameter/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-legacy/class-method-parameter/output.json
@@ -37,7 +37,7 @@
               "params": [
                 {
                   "type": "Identifier",
-                  "start":33,"end":34,"loc":{"start":{"line":2,"column":21,"index":33},"end":{"line":2,"column":22,"index":34},"identifierName":"x"},
+                  "start":26,"end":34,"loc":{"start":{"line":2,"column":14,"index":26},"end":{"line":2,"column":22,"index":34},"identifierName":"x"},
                   "name": "x",
                   "decorators": [
                     {
@@ -58,7 +58,7 @@
                 },
                 {
                   "type": "Identifier",
-                  "start":60,"end":61,"loc":{"start":{"line":2,"column":48,"index":60},"end":{"line":2,"column":49,"index":61},"identifierName":"y"},
+                  "start":36,"end":61,"loc":{"start":{"line":2,"column":24,"index":36},"end":{"line":2,"column":49,"index":61},"identifierName":"y"},
                   "name": "y",
                   "decorators": [
                     {

--- a/packages/babel-parser/test/fixtures/experimental/decorators-legacy/export-default-declaration-function-declaration-parameter/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-legacy/export-default-declaration-function-declaration-parameter/output.json
@@ -23,7 +23,7 @@
           "params": [
             {
               "type": "Identifier",
-              "start":36,"end":37,"loc":{"start":{"line":1,"column":36,"index":36},"end":{"line":1,"column":37,"index":37},"identifierName":"x"},
+              "start":29,"end":37,"loc":{"start":{"line":1,"column":29,"index":29},"end":{"line":1,"column":37,"index":37},"identifierName":"x"},
               "name": "x",
               "decorators": [
                 {
@@ -44,7 +44,7 @@
             },
             {
               "type": "Identifier",
-              "start":63,"end":64,"loc":{"start":{"line":1,"column":63,"index":63},"end":{"line":1,"column":64,"index":64},"identifierName":"y"},
+              "start":39,"end":64,"loc":{"start":{"line":1,"column":39,"index":39},"end":{"line":1,"column":64,"index":64},"identifierName":"y"},
               "name": "y",
               "decorators": [
                 {

--- a/packages/babel-parser/test/fixtures/experimental/decorators-legacy/function-declaration-parameter/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-legacy/function-declaration-parameter/output.json
@@ -20,7 +20,7 @@
         "params": [
           {
             "type": "Identifier",
-            "start":21,"end":22,"loc":{"start":{"line":1,"column":21,"index":21},"end":{"line":1,"column":22,"index":22},"identifierName":"x"},
+            "start":14,"end":22,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":22,"index":22},"identifierName":"x"},
             "name": "x",
             "decorators": [
               {
@@ -41,7 +41,7 @@
           },
           {
             "type": "Identifier",
-            "start":48,"end":49,"loc":{"start":{"line":1,"column":48,"index":48},"end":{"line":1,"column":49,"index":49},"identifierName":"y"},
+            "start":24,"end":49,"loc":{"start":{"line":1,"column":24,"index":24},"end":{"line":1,"column":49,"index":49},"identifierName":"y"},
             "name": "y",
             "decorators": [
               {

--- a/packages/babel-parser/test/fixtures/experimental/decorators-legacy/function-expression-parameter/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-legacy/function-expression-parameter/output.json
@@ -28,7 +28,7 @@
               "params": [
                 {
                   "type": "Identifier",
-                  "start":30,"end":31,"loc":{"start":{"line":1,"column":30,"index":30},"end":{"line":1,"column":31,"index":31},"identifierName":"x"},
+                  "start":23,"end":31,"loc":{"start":{"line":1,"column":23,"index":23},"end":{"line":1,"column":31,"index":31},"identifierName":"x"},
                   "name": "x",
                   "decorators": [
                     {
@@ -49,7 +49,7 @@
                 },
                 {
                   "type": "Identifier",
-                  "start":57,"end":58,"loc":{"start":{"line":1,"column":57,"index":57},"end":{"line":1,"column":58,"index":58},"identifierName":"y"},
+                  "start":33,"end":58,"loc":{"start":{"line":1,"column":33,"index":33},"end":{"line":1,"column":58,"index":58},"identifierName":"y"},
                   "name": "y",
                   "decorators": [
                     {

--- a/packages/babel-parser/test/fixtures/experimental/decorators-legacy/object-method-parameter/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators-legacy/object-method-parameter/output.json
@@ -40,7 +40,7 @@
                   "params": [
                     {
                       "type": "Identifier",
-                      "start":28,"end":29,"loc":{"start":{"line":2,"column":16,"index":28},"end":{"line":2,"column":17,"index":29},"identifierName":"x"},
+                      "start":21,"end":29,"loc":{"start":{"line":2,"column":9,"index":21},"end":{"line":2,"column":17,"index":29},"identifierName":"x"},
                       "name": "x",
                       "decorators": [
                         {
@@ -61,7 +61,7 @@
                     },
                     {
                       "type": "Identifier",
-                      "start":55,"end":56,"loc":{"start":{"line":2,"column":43,"index":55},"end":{"line":2,"column":44,"index":56},"identifierName":"y"},
+                      "start":31,"end":56,"loc":{"start":{"line":2,"column":19,"index":31},"end":{"line":2,"column":44,"index":56},"identifierName":"y"},
                       "name": "y",
                       "decorators": [
                         {

--- a/packages/babel-parser/test/fixtures/experimental/decorators/no-class-method-parameter/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/no-class-method-parameter/output.json
@@ -40,7 +40,7 @@
               "params": [
                 {
                   "type": "Identifier",
-                  "start":31,"end":32,"loc":{"start":{"line":2,"column":19,"index":31},"end":{"line":2,"column":20,"index":32},"identifierName":"x"},
+                  "start":26,"end":32,"loc":{"start":{"line":2,"column":14,"index":26},"end":{"line":2,"column":20,"index":32},"identifierName":"x"},
                   "name": "x",
                   "decorators": [
                     {

--- a/packages/babel-parser/test/fixtures/experimental/decorators/no-function-parameters/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/no-function-parameters/output.json
@@ -23,7 +23,7 @@
         "params": [
           {
             "type": "Identifier",
-            "start":19,"end":20,"loc":{"start":{"line":1,"column":19,"index":19},"end":{"line":1,"column":20,"index":20},"identifierName":"x"},
+            "start":14,"end":20,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":20,"index":20},"identifierName":"x"},
             "name": "x",
             "decorators": [
               {

--- a/packages/babel-parser/test/fixtures/experimental/decorators/no-object-method-parameters/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/no-object-method-parameters/output.json
@@ -43,7 +43,7 @@
                   "params": [
                     {
                       "type": "Identifier",
-                      "start":26,"end":27,"loc":{"start":{"line":2,"column":14,"index":26},"end":{"line":2,"column":15,"index":27},"identifierName":"x"},
+                      "start":21,"end":27,"loc":{"start":{"line":2,"column":9,"index":21},"end":{"line":2,"column":15,"index":27},"identifierName":"x"},
                       "name": "x",
                       "decorators": [
                         {

--- a/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-with-decorators/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-with-decorators/output.json
@@ -37,7 +37,7 @@
               "params": [
                 {
                   "type": "TSParameterProperty",
-                  "start":31,"end":49,"loc":{"start":{"line":2,"column":21,"index":31},"end":{"line":2,"column":39,"index":49}},
+                  "start":26,"end":49,"loc":{"start":{"line":2,"column":16,"index":26},"end":{"line":2,"column":39,"index":49}},
                   "decorators": [
                     {
                       "type": "Decorator",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | When a TSParameterProperty is decorated, e.g. `method(@foo param) {}`, the parameter property should start from the first decorator (part of #16679)
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
