### PR TITLE
Support ESTree AccessorProperty

### DIFF
--- a/eslint/babel-eslint-parser/src/analyze-scope.cts
+++ b/eslint/babel-eslint-parser/src/analyze-scope.cts
@@ -194,6 +194,10 @@ class Referencer extends OriginalReferencer {
     this._visitClassProperty(node);
   }
 
+  AccessorProperty(node: any) {
+    this._visitClassProperty(node);
+  }
+
   ClassAccessorProperty(node: any) {
     this._visitClassProperty(node);
   }

--- a/eslint/babel-eslint-plugin/src/rules/no-undef.cjs
+++ b/eslint/babel-eslint-plugin/src/rules/no-undef.cjs
@@ -14,10 +14,12 @@ const rule = (
  * @returns {Boolean} Returns true if the node is under a decorator.
  */
 function isAccessorFieldName(node) {
+  const parent = node.parent;
   return (
-    node.parent.type === "ClassAccessorProperty" &&
-    node.parent.key === node &&
-    !node.parent.computed
+    (parent.type === "AccessorProperty" ||
+      parent.type === "ClassAccessorProperty") &&
+    parent.key === node &&
+    !parent.computed
   );
 }
 

--- a/eslint/babel-eslint-plugin/src/rules/no-undef.cjs
+++ b/eslint/babel-eslint-plugin/src/rules/no-undef.cjs
@@ -17,7 +17,8 @@ function isAccessorFieldName(node) {
   const parent = node.parent;
   return (
     (parent.type === "AccessorProperty" ||
-      parent.type === "ClassAccessorProperty") &&
+      (!process.env.BABEL_8_BREAKING &&
+        parent.type === "ClassAccessorProperty")) &&
     parent.key === node &&
     !parent.computed
   );

--- a/packages/babel-parser/data/schema.json
+++ b/packages/babel-parser/data/schema.json
@@ -9,6 +9,13 @@
       },
       "type": "object"
     },
+    "EstreePluginOptions": {
+      "properties": {
+        "classFeatures": {
+          "type": "boolean"
+        }
+      }
+    },
     "FlowPluginOptions": {
       "properties": {
         "all": {
@@ -93,6 +100,19 @@
               },
               {
                 "$ref": "#/definitions/DecoratorsPluginOptions"
+              }
+            ],
+            "additionalItems": false,
+            "type": "array"
+          },
+          {
+            "items": [
+              {
+                "enum": ["estree"],
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/EstreePluginOptions"
               }
             ],
             "additionalItems": false,

--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -349,6 +349,11 @@ export default (superClass: typeof Parser) =>
       node: N.ClassAccessorProperty,
     ): any {
       const accessorPropertyNode = super.parseClassAccessorProperty(node);
+      if (!process.env.BABEL_8_BREAKING) {
+        if (!this.getPluginOption("estree", "classFeatures")) {
+          return accessorPropertyNode;
+        }
+      }
       (accessorPropertyNode as unknown as N.EstreeAccessorProperty).type =
         "AccessorProperty";
       return accessorPropertyNode;

--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -344,6 +344,16 @@ export default (superClass: typeof Parser) =>
       return propertyNode;
     }
 
+    parseClassAccessorProperty(
+      this: Parser,
+      node: N.ClassAccessorProperty,
+    ): any {
+      const accessorPropertyNode = super.parseClassAccessorProperty(node);
+      (accessorPropertyNode as unknown as N.EstreeAccessorProperty).type =
+        "AccessorProperty";
+      return accessorPropertyNode;
+    }
+
     parseObjectMethod(
       prop: N.ObjectMethod,
       isGenerator: boolean,

--- a/packages/babel-parser/src/types.ts
+++ b/packages/babel-parser/src/types.ts
@@ -1432,6 +1432,11 @@ export interface EstreePropertyDefinition extends EstreePropertyDefinitionBase {
   value: Expression;
 }
 
+export interface EstreeAccessorProperty extends EstreePropertyDefinitionBase {
+  type: "AccessorProperty";
+  value: Expression;
+}
+
 export interface EstreeChainExpression extends NodeBase {
   type: "ChainExpression";
   expression: Expression;

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-babel-7/input.js
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-babel-7/input.js
@@ -1,0 +1,5 @@
+class A {
+  accessor foo;
+  accessor bar = 0;
+  accessor #qux;
+}

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-babel-7/options.json
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-babel-7/options.json
@@ -1,0 +1,3 @@
+{
+  "BABEL_8_BREAKING": false
+}

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-babel-7/output.json
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-babel-7/output.json
@@ -54,9 +54,13 @@
               "start":48,"end":62,"loc":{"start":{"line":4,"column":2},"end":{"line":4,"column":16}},
               "static": false,
               "key": {
-                "type": "PrivateIdentifier",
+                "type": "PrivateName",
                 "start":57,"end":61,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":15}},
-                "name": "qux"
+                "id": {
+                  "type": "Identifier",
+                  "start":58,"end":61,"loc":{"start":{"line":4,"column":12},"end":{"line":4,"column":15},"identifierName":"qux"},
+                  "name": "qux"
+                }
               },
               "computed": false,
               "value": null

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-class-features-true/input.js
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-class-features-true/input.js
@@ -1,0 +1,5 @@
+class A {
+  accessor foo;
+  accessor bar = 0;
+  accessor #qux;
+}

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-class-features-true/options.json
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-class-features-true/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["decoratorAutoAccessors", ["estree", { "classFeatures": true }]]
+}

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-class-features-true/output.json
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic-class-features-true/output.json
@@ -21,7 +21,7 @@
           "start":8,"end":64,"loc":{"start":{"line":1,"column":8},"end":{"line":5,"column":1}},
           "body": [
             {
-              "type": "ClassAccessorProperty",
+              "type": "AccessorProperty",
               "start":12,"end":25,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":15}},
               "static": false,
               "key": {
@@ -33,7 +33,7 @@
               "value": null
             },
             {
-              "type": "ClassAccessorProperty",
+              "type": "AccessorProperty",
               "start":28,"end":45,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":19}},
               "static": false,
               "key": {
@@ -50,17 +50,13 @@
               }
             },
             {
-              "type": "ClassAccessorProperty",
+              "type": "AccessorProperty",
               "start":48,"end":62,"loc":{"start":{"line":4,"column":2},"end":{"line":4,"column":16}},
               "static": false,
               "key": {
-                "type": "PrivateName",
+                "type": "PrivateIdentifier",
                 "start":57,"end":61,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":15}},
-                "id": {
-                  "type": "Identifier",
-                  "start":58,"end":61,"loc":{"start":{"line":4,"column":12},"end":{"line":4,"column":15},"identifierName":"qux"},
-                  "name": "qux"
-                }
+                "name": "qux"
               },
               "computed": false,
               "value": null

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic/input.js
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic/input.js
@@ -1,0 +1,4 @@
+class A {
+  accessor foo;
+  accessor bar = 0;
+}

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic/input.js
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic/input.js
@@ -1,4 +1,5 @@
 class A {
   accessor foo;
   accessor bar = 0;
+  accessor #qux;
 }

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic/options.json
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic/options.json
@@ -1,0 +1,3 @@
+{
+  "BABEL_8_BREAKING": true
+}

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic/output.json
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic/output.json
@@ -1,0 +1,57 @@
+{
+  "type": "File",
+  "start":0,"end":47,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":47,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":47,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"A"},
+          "name": "A"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":8,"end":47,"loc":{"start":{"line":1,"column":8},"end":{"line":4,"column":1}},
+          "body": [
+            {
+              "type": "AccessorProperty",
+              "start":12,"end":25,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":15}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":21,"end":24,"loc":{"start":{"line":2,"column":11},"end":{"line":2,"column":14},"identifierName":"foo"},
+                "name": "foo"
+              },
+              "computed": false,
+              "value": null
+            },
+            {
+              "type": "AccessorProperty",
+              "start":28,"end":45,"loc":{"start":{"line":3,"column":2},"end":{"line":3,"column":19}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":37,"end":40,"loc":{"start":{"line":3,"column":11},"end":{"line":3,"column":14},"identifierName":"bar"},
+                "name": "bar"
+              },
+              "computed": false,
+              "value": {
+                "type": "Literal",
+                "start":43,"end":44,"loc":{"start":{"line":3,"column":17},"end":{"line":3,"column":18}},
+                "value": 0,
+                "raw": "0"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic/output.json
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/basic/output.json
@@ -1,15 +1,15 @@
 {
   "type": "File",
-  "start":0,"end":47,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+  "start":0,"end":64,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
   "program": {
     "type": "Program",
-    "start":0,"end":47,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+    "start":0,"end":64,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
     "sourceType": "script",
     "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
-        "start":0,"end":47,"loc":{"start":{"line":1,"column":0},"end":{"line":4,"column":1}},
+        "start":0,"end":64,"loc":{"start":{"line":1,"column":0},"end":{"line":5,"column":1}},
         "id": {
           "type": "Identifier",
           "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"A"},
@@ -18,7 +18,7 @@
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start":8,"end":47,"loc":{"start":{"line":1,"column":8},"end":{"line":4,"column":1}},
+          "start":8,"end":64,"loc":{"start":{"line":1,"column":8},"end":{"line":5,"column":1}},
           "body": [
             {
               "type": "AccessorProperty",
@@ -48,6 +48,22 @@
                 "value": 0,
                 "raw": "0"
               }
+            },
+            {
+              "type": "AccessorProperty",
+              "start":48,"end":62,"loc":{"start":{"line":4,"column":2},"end":{"line":4,"column":16}},
+              "static": false,
+              "key": {
+                "type": "PrivateName",
+                "start":57,"end":61,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":15}},
+                "id": {
+                  "type": "Identifier",
+                  "start":58,"end":61,"loc":{"start":{"line":4,"column":12},"end":{"line":4,"column":15},"identifierName":"qux"},
+                  "name": "qux"
+                }
+              },
+              "computed": false,
+              "value": null
             }
           ]
         }

--- a/packages/babel-parser/test/fixtures/estree/class-accessor-property/options.json
+++ b/packages/babel-parser/test/fixtures/estree/class-accessor-property/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["decoratorAutoAccessors", "estree"]
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | (part of #16679), fixes #15188
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The `AccessorProperty` is part of the [stage 3 ESTree decorators spec](https://github.com/estree/estree/blob/master/stage3/decorators.md), which is already supported by typescript-eslint. 