### PR TITLE
Make "object without properties" helpers ES6-compatible

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -351,6 +351,7 @@ export default [
       "prefer-spread": "off",
       "import/no-extraneous-dependencies": "off",
       "import/no-unresolved": "off",
+      "@typescript-eslint/prefer-includes": "off",
       "@typescript-eslint/prefer-optional-chain": "off",
       "unicorn/prefer-includes": "off",
     },

--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -959,10 +959,10 @@ const helpers: Record<string, Helper> = {
       },
     },
   ),
-  // size: 275, gzip size: 198
+  // size: 279, gzip size: 205
   objectWithoutProperties: helper(
     "7.0.0-beta.0",
-    "function _objectWithoutProperties(e,t){if(null==e)return{};var o,r,i=objectWithoutPropertiesLoose(e,t);if(Object.getOwnPropertySymbols){var s=Object.getOwnPropertySymbols(e);for(r=0;r<s.length;r++)o=s[r],t.includes(o)||{}.propertyIsEnumerable.call(e,o)&&(i[o]=e[o])}return i}",
+    "function _objectWithoutProperties(e,t){if(null==e)return{};var o,r,i=objectWithoutPropertiesLoose(e,t);if(Object.getOwnPropertySymbols){var n=Object.getOwnPropertySymbols(e);for(r=0;r<n.length;r++)o=n[r],-1===t.indexOf(o)&&{}.propertyIsEnumerable.call(e,o)&&(i[o]=e[o])}return i}",
     {
       globals: ["Object"],
       locals: { _objectWithoutProperties: ["body.0.id"] },
@@ -975,10 +975,10 @@ const helpers: Record<string, Helper> = {
       },
     },
   ),
-  // size: 165, gzip size: 151
+  // size: 169, gzip size: 156
   objectWithoutPropertiesLoose: helper(
     "7.0.0-beta.0",
-    "function _objectWithoutPropertiesLoose(r,e){if(null==r)return{};var t={};for(var n in r)if({}.hasOwnProperty.call(r,n)){if(e.includes(n))continue;t[n]=r[n]}return t}",
+    "function _objectWithoutPropertiesLoose(r,e){if(null==r)return{};var t={};for(var n in r)if({}.hasOwnProperty.call(r,n)){if(-1!==e.indexOf(n))continue;t[n]=r[n]}return t}",
     {
       globals: [],
       locals: { _objectWithoutPropertiesLoose: ["body.0.id"] },

--- a/packages/babel-helpers/src/helpers/objectWithoutProperties.ts
+++ b/packages/babel-helpers/src/helpers/objectWithoutProperties.ts
@@ -29,7 +29,8 @@ export default function _objectWithoutProperties<
     var sourceSymbolKeys = Object.getOwnPropertySymbols(source);
     for (i = 0; i < sourceSymbolKeys.length; i++) {
       key = sourceSymbolKeys[i] as keyof typeof source & keyof typeof target;
-      if (excluded.includes(key)) continue;
+      // eslint-disable-next-line @typescript-eslint/prefer-includes
+      if (excluded.indexOf(key) !== -1) continue;
       if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
       target[key] = source[key];
     }

--- a/packages/babel-helpers/src/helpers/objectWithoutProperties.ts
+++ b/packages/babel-helpers/src/helpers/objectWithoutProperties.ts
@@ -29,7 +29,6 @@ export default function _objectWithoutProperties<
     var sourceSymbolKeys = Object.getOwnPropertySymbols(source);
     for (i = 0; i < sourceSymbolKeys.length; i++) {
       key = sourceSymbolKeys[i] as keyof typeof source & keyof typeof target;
-      // eslint-disable-next-line @typescript-eslint/prefer-includes
       if (excluded.indexOf(key) !== -1) continue;
       if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
       target[key] = source[key];

--- a/packages/babel-helpers/src/helpers/objectWithoutPropertiesLoose.ts
+++ b/packages/babel-helpers/src/helpers/objectWithoutPropertiesLoose.ts
@@ -21,7 +21,6 @@ export default function _objectWithoutPropertiesLoose<T extends object>(
 
   for (var key in source) {
     if (Object.prototype.hasOwnProperty.call(source, key)) {
-      // eslint-disable-next-line @typescript-eslint/prefer-includes
       if (excluded.indexOf(key) !== -1) continue;
       target[key] = source[key];
     }

--- a/packages/babel-helpers/src/helpers/objectWithoutPropertiesLoose.ts
+++ b/packages/babel-helpers/src/helpers/objectWithoutPropertiesLoose.ts
@@ -21,7 +21,8 @@ export default function _objectWithoutPropertiesLoose<T extends object>(
 
   for (var key in source) {
     if (Object.prototype.hasOwnProperty.call(source, key)) {
-      if (excluded.includes(key)) continue;
+      // eslint-disable-next-line @typescript-eslint/prefer-includes
+      if (excluded.indexOf(key) !== -1) continue;
       target[key] = source[key];
     }
   }

--- a/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-shippedProposals/output.js
+++ b/packages/babel-preset-env/test/fixtures/corejs2-babel-7/usage-shippedProposals/output.js
@@ -1,8 +1,7 @@
 "use strict";
 
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
-require("core-js/modules/es6.string.includes.js");
-require("core-js/modules/es7.array.includes.js");
+require("core-js/modules/es6.array.index-of.js");
 require("core-js/modules/es6.number.constructor.js");
 require("core-js/modules/es6.object.define-property.js");
 require("core-js/modules/es6.object.keys.js");
@@ -29,8 +28,8 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
 function _defineProperty(e, r, t) { return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, { value: t, enumerable: !0, configurable: !0, writable: !0 }) : e[r] = t, e; }
 function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
 function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
-function _objectWithoutProperties(e, t) { if (null == e) return {}; var o, r, i = _objectWithoutPropertiesLoose(e, t); if (Object.getOwnPropertySymbols) { var s = Object.getOwnPropertySymbols(e); for (r = 0; r < s.length; r++) o = s[r], t.includes(o) || {}.propertyIsEnumerable.call(e, o) && (i[o] = e[o]); } return i; }
-function _objectWithoutPropertiesLoose(r, e) { if (null == r) return {}; var t = {}; for (var n in r) if ({}.hasOwnProperty.call(r, n)) { if (e.includes(n)) continue; t[n] = r[n]; } return t; }
+function _objectWithoutProperties(e, t) { if (null == e) return {}; var o, r, i = _objectWithoutPropertiesLoose(e, t); if (Object.getOwnPropertySymbols) { var n = Object.getOwnPropertySymbols(e); for (r = 0; r < n.length; r++) o = n[r], -1 === t.indexOf(o) && {}.propertyIsEnumerable.call(e, o) && (i[o] = e[o]); } return i; }
+function _objectWithoutPropertiesLoose(r, e) { if (null == r) return {}; var t = {}; for (var n in r) if ({}.hasOwnProperty.call(r, n)) { if (-1 !== e.indexOf(n)) continue; t[n] = r[n]; } return t; }
 function _awaitAsyncGenerator(e) { return new _OverloadYield(e, 0); }
 function _wrapAsyncGenerator(e) { return function () { return new AsyncGenerator(e.apply(this, arguments)); }; }
 function AsyncGenerator(e) { var r, t; function resume(r, t) { try { var n = e[r](t), o = n.value, u = o instanceof _OverloadYield; Promise.resolve(u ? o.v : o).then(function (t) { if (u) { var i = "return" === r ? "return" : "next"; if (!o.k || t.done) return resume(i, t); t = e[i](t).value; } settle(n.done ? "return" : "normal", t); }, function (e) { resume("throw", e); }); } catch (e) { settle("throw", e); } } function settle(e, n) { switch (e) { case "return": r.resolve({ value: n, done: !0 }); break; case "throw": r.reject(n); break; default: r.resolve({ value: n, done: !1 }); } (r = r.next) ? resume(r.key, r.arg) : t = null; } this._invoke = function (e, n) { return new Promise(function (o, u) { var i = { key: e, arg: n, resolve: o, reject: u, next: null }; t ? t = t.next = i : (r = t = i, resume(e, n)); }); }, "function" != typeof e["return"] && (this["return"] = void 0); }

--- a/packages/babel-runtime-corejs3/helpers/esm/objectWithoutProperties.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/objectWithoutProperties.js
@@ -1,5 +1,5 @@
 import _Object$getOwnPropertySymbols from "core-js-pure/features/object/get-own-property-symbols.js";
-import _includesInstanceProperty from "core-js-pure/features/instance/includes.js";
+import _indexOfInstanceProperty from "core-js-pure/features/instance/index-of.js";
 import objectWithoutPropertiesLoose from "./objectWithoutPropertiesLoose.js";
 function _objectWithoutProperties(e, t) {
   if (null == e) return {};
@@ -7,8 +7,8 @@ function _objectWithoutProperties(e, t) {
     r,
     i = objectWithoutPropertiesLoose(e, t);
   if (_Object$getOwnPropertySymbols) {
-    var s = _Object$getOwnPropertySymbols(e);
-    for (r = 0; r < s.length; r++) o = s[r], _includesInstanceProperty(t).call(t, o) || {}.propertyIsEnumerable.call(e, o) && (i[o] = e[o]);
+    var n = _Object$getOwnPropertySymbols(e);
+    for (r = 0; r < n.length; r++) o = n[r], -1 === _indexOfInstanceProperty(t).call(t, o) && {}.propertyIsEnumerable.call(e, o) && (i[o] = e[o]);
   }
   return i;
 }

--- a/packages/babel-runtime-corejs3/helpers/esm/objectWithoutPropertiesLoose.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/objectWithoutPropertiesLoose.js
@@ -1,9 +1,9 @@
-import _includesInstanceProperty from "core-js-pure/features/instance/includes.js";
+import _indexOfInstanceProperty from "core-js-pure/features/instance/index-of.js";
 function _objectWithoutPropertiesLoose(r, e) {
   if (null == r) return {};
   var t = {};
   for (var n in r) if ({}.hasOwnProperty.call(r, n)) {
-    if (_includesInstanceProperty(e).call(e, n)) continue;
+    if (-1 !== _indexOfInstanceProperty(e).call(e, n)) continue;
     t[n] = r[n];
   }
   return t;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17084
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes (none added, but existing passed)
| Documentation PR Link    |
| Any Dependency Changes?  | No
| License                  | MIT

Updating the `objectWithoutProperties` / `objectWithoutPropertiesLoose` helpers to use `.indexOf()` checks instead of `.includes()`, and disable the lint rule that was enforcing an auto-fix in those files.
