### PR TITLE
[babel 8] Remove legacy `.d.ts` for TypeScript <= 4.0

### DIFF
--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -15,14 +15,6 @@
     "directory": "packages/babel-types"
   },
   "main": "./lib/index.js",
-  "types": "./lib/index-legacy.d.ts",
-  "typesVersions": {
-    ">=4.1": {
-      "lib/index-legacy.d.ts": [
-        "lib/index.d.ts"
-      ]
-    }
-  },
   "dependencies": {
     "@babel/helper-string-parser": "workspace:^",
     "@babel/helper-validator-identifier": "workspace:^"
@@ -43,7 +35,15 @@
         }
       },
       {
-        "exports": null
+        "exports": null,
+        "types": "./lib/index-legacy.d.ts",
+        "typesVersions": {
+          ">=4.1": {
+            "lib/index-legacy.d.ts": [
+              "lib/index.d.ts"
+            ]
+          }
+        }
       }
     ],
     "USE_ESM": [
@@ -55,8 +55,7 @@
   },
   "exports": {
     ".": {
-      "types@>=4.1": "./lib/index.d.ts",
-      "types": "./lib/index-legacy.d.ts",
+      "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/17092
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

