### PR TITLE
fix(babel-generator): add named export of generate function

### DIFF
--- a/packages/babel-generator/src/index.ts
+++ b/packages/babel-generator/src/index.ts
@@ -287,7 +287,7 @@ if (!process.env.BABEL_8_BREAKING && !USE_ESM) {
  * @param code - the original source code, used for source maps.
  * @returns - an object containing the output code and source map.
  */
-export default function generate(
+export function generate(
   ast: t.Node,
   opts: GeneratorOptions = {},
   code?: string | { [filename: string]: string },
@@ -304,3 +304,5 @@ export default function generate(
 
   return printer.generate(ast);
 }
+
+export default generate;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #15269
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Not applicable
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This should fix #15269. Import of CJS built @babel/generator module from esm node.js scripts. Now one can use named import.

