### PR TITLE
Fix source type detection when parsing TypeScript

### DIFF
--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -611,20 +611,10 @@ export default abstract class StatementParser extends ExpressionParser {
             node as Undone<
               | N.ExportAllDeclaration
               | N.ExportDefaultDeclaration
-              | N.ExportDefaultDeclaration
+              | N.ExportNamedDeclaration
             >,
             decorators,
           );
-
-          if (
-            (result.type === "ExportNamedDeclaration" &&
-              (!result.exportKind || result.exportKind === "value")) ||
-            (result.type === "ExportAllDeclaration" &&
-              (!result.exportKind || result.exportKind === "value")) ||
-            result.type === "ExportDefaultDeclaration"
-          ) {
-            this.sawUnambiguousESM = true;
-          }
         }
 
         this.assertModuleNodeAllowed(result);
@@ -2374,6 +2364,10 @@ export default abstract class StatementParser extends ExpressionParser {
       }
       this.parseExportFrom(node, true);
 
+      if (node.exportKind !== "type") {
+        this.sawUnambiguousESM = true;
+      }
+
       return this.finishNode(node, "ExportAllDeclaration");
     }
 
@@ -2411,6 +2405,9 @@ export default abstract class StatementParser extends ExpressionParser {
       } else if (decorators) {
         throw this.raise(Errors.UnsupportedDecoratorExport, node);
       }
+      if (node2.exportKind !== "type") {
+        this.sawUnambiguousESM = true;
+      }
       return this.finishNode(node2, "ExportNamedDeclaration");
     }
 
@@ -2427,7 +2424,7 @@ export default abstract class StatementParser extends ExpressionParser {
       }
 
       this.checkExport(node2, true, true);
-
+      this.sawUnambiguousESM = true;
       return this.finishNode(node2, "ExportDefaultDeclaration");
     }
 

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-type-only/input.ts
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-type-only/input.ts
@@ -1,0 +1,3 @@
+import type { Foo } from "bar";
+export type { Foo };
+export type * from "bar";

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-type-only/options.json
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-type-only/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "unambiguous",
+  "plugins": ["typescript"]
+}

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-type-only/output.json
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-type-only/output.json
@@ -1,0 +1,87 @@
+{
+  "type": "File",
+  "start":0,"end":78,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":25,"index":78}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":78,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":25,"index":78}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start":0,"end":31,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":31,"index":31}},
+        "importKind": "type",
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start":14,"end":17,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":17,"index":17}},
+            "imported": {
+              "type": "Identifier",
+              "start":14,"end":17,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":17,"index":17},"identifierName":"Foo"},
+              "name": "Foo"
+            },
+            "importKind": "value",
+            "local": {
+              "type": "Identifier",
+              "start":14,"end":17,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":17,"index":17},"identifierName":"Foo"},
+              "name": "Foo"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start":25,"end":30,"loc":{"start":{"line":1,"column":25,"index":25},"end":{"line":1,"column":30,"index":30}},
+          "extra": {
+            "rawValue": "bar",
+            "raw": "\"bar\""
+          },
+          "value": "bar"
+        },
+        "attributes": []
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start":32,"end":52,"loc":{"start":{"line":2,"column":0,"index":32},"end":{"line":2,"column":20,"index":52}},
+        "exportKind": "type",
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start":46,"end":49,"loc":{"start":{"line":2,"column":14,"index":46},"end":{"line":2,"column":17,"index":49}},
+            "local": {
+              "type": "Identifier",
+              "start":46,"end":49,"loc":{"start":{"line":2,"column":14,"index":46},"end":{"line":2,"column":17,"index":49},"identifierName":"Foo"},
+              "name": "Foo"
+            },
+            "exportKind": "value",
+            "exported": {
+              "type": "Identifier",
+              "start":46,"end":49,"loc":{"start":{"line":2,"column":14,"index":46},"end":{"line":2,"column":17,"index":49},"identifierName":"Foo"},
+              "name": "Foo"
+            }
+          }
+        ],
+        "source": null,
+        "declaration": null
+      },
+      {
+        "type": "ExportAllDeclaration",
+        "start":53,"end":78,"loc":{"start":{"line":3,"column":0,"index":53},"end":{"line":3,"column":25,"index":78}},
+        "exportKind": "type",
+        "source": {
+          "type": "StringLiteral",
+          "start":72,"end":77,"loc":{"start":{"line":3,"column":19,"index":72},"end":{"line":3,"column":24,"index":77}},
+          "extra": {
+            "rawValue": "bar",
+            "raw": "\"bar\""
+          },
+          "value": "bar"
+        },
+        "attributes": []
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-all/input.ts
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-all/input.ts
@@ -1,0 +1,1 @@
+export * from "bar";

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-all/options.json
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-all/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "unambiguous",
+  "plugins": ["typescript"]
+}

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-all/output.json
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-all/output.json
@@ -1,0 +1,31 @@
+{
+  "type": "File",
+  "start":0,"end":20,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":20,"index":20}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":20,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":20,"index":20}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportAllDeclaration",
+        "start":0,"end":20,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":20,"index":20}},
+        "exportKind": "value",
+        "source": {
+          "type": "StringLiteral",
+          "start":14,"end":19,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":19,"index":19}},
+          "extra": {
+            "rawValue": "bar",
+            "raw": "\"bar\""
+          },
+          "value": "bar"
+        },
+        "attributes": []
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-named/input.ts
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-named/input.ts
@@ -1,0 +1,1 @@
+export { Foo } from "bar";

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-named/options.json
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-named/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "unambiguous",
+  "plugins": ["typescript"]
+}

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-named/output.json
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-export-named/output.json
@@ -1,0 +1,49 @@
+{
+  "type": "File",
+  "start":0,"end":26,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":26,"index":26}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":26,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":26,"index":26}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start":0,"end":26,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":26,"index":26}},
+        "exportKind": "value",
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start":9,"end":12,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":12,"index":12}},
+            "local": {
+              "type": "Identifier",
+              "start":9,"end":12,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":12,"index":12},"identifierName":"Foo"},
+              "name": "Foo"
+            },
+            "exportKind": "value",
+            "exported": {
+              "type": "Identifier",
+              "start":9,"end":12,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":12,"index":12},"identifierName":"Foo"},
+              "name": "Foo"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start":20,"end":25,"loc":{"start":{"line":1,"column":20,"index":20},"end":{"line":1,"column":25,"index":25}},
+          "extra": {
+            "rawValue": "bar",
+            "raw": "\"bar\""
+          },
+          "value": "bar"
+        },
+        "declaration": null,
+        "attributes": []
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-import/input.ts
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-import/input.ts
@@ -1,0 +1,1 @@
+import { Foo } from "bar";

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-import/options.json
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-import/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "unambiguous",
+  "plugins": ["typescript"]
+}

--- a/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-import/output.json
+++ b/packages/babel-parser/test/fixtures/core/sourcetype-unambiguous/typescript-value-import/output.json
@@ -1,0 +1,48 @@
+{
+  "type": "File",
+  "start":0,"end":26,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":26,"index":26}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":26,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":26,"index":26}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start":0,"end":26,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":26,"index":26}},
+        "importKind": "value",
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start":9,"end":12,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":12,"index":12}},
+            "imported": {
+              "type": "Identifier",
+              "start":9,"end":12,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":12,"index":12},"identifierName":"Foo"},
+              "name": "Foo"
+            },
+            "importKind": "value",
+            "local": {
+              "type": "Identifier",
+              "start":9,"end":12,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":12,"index":12},"identifierName":"Foo"},
+              "name": "Foo"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start":20,"end":25,"loc":{"start":{"line":1,"column":20,"index":20},"end":{"line":1,"column":25,"index":25}},
+          "extra": {
+            "rawValue": "bar",
+            "raw": "\"bar\""
+          },
+          "value": "bar"
+        },
+        "attributes": []
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | parsing `export { a }` with `typescript` plugin and `unambiguous` source type does not set program sourceType to `module`
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This issue surfaces when we are aligning to the typescript-eslint AST. The typescript parser plugin called `super.parseExport` without handling the `sawUnambiguousESM` state, here we moved the state handling into `parseExport` so it should work for both JS and TS.