### PR TITLE
[babel 8] Use `@babel/types` for parser's return type

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -621,6 +621,7 @@ function buildRollupDts(packages) {
       "packages/babel-parser/typings/babel-parser.source.d.ts",
       "packages/babel-parser/typings/babel-parser.d.ts",
       "// This file is auto-generated! Do not modify it directly.\n" +
+        "// Run `yarn gulp bundle-dts` to re-generate it.\n" +
         // @typescript-eslint/no-redundant-type-constituents can be removed once we drop the IF_BABEL_7 type
         "/* eslint-disable @typescript-eslint/consistent-type-imports, @typescript-eslint/no-redundant-type-constituents */",
       "packages/babel-parser"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,6 +56,7 @@ export default [
       "packages/babel-standalone/babel.min.js",
       "packages/babel-parser/test/expressions",
       "packages/babel-core/src/vendor",
+      "packages/babel-parser/typings/**/*",
       "eslint/*/lib",
       "eslint/*/node_modules",
       "eslint/*/test/fixtures",

--- a/packages/babel-core/src/parser/index.ts
+++ b/packages/babel-core/src/parser/index.ts
@@ -1,5 +1,5 @@
 import type { Handler } from "gensync";
-import { parse, type File as ParseResult } from "@babel/parser";
+import { parse, type ParseResult } from "@babel/parser";
 import { codeFrameColumns } from "@babel/code-frame";
 import generateMissingPluginMessage from "./util/missing-plugin-helper.ts";
 import type { PluginPasses } from "../config/index.ts";

--- a/packages/babel-core/src/transformation/normalize-file.ts
+++ b/packages/babel-core/src/transformation/normalize-file.ts
@@ -46,7 +46,6 @@ export default function* normalizeFile(
       ast = cloneDeep(ast);
     }
   } else {
-    // @ts-expect-error todo: use babel-types ast typings in Babel parser
     ast = yield* parser(pluginPasses, options, code);
   }
 
@@ -101,7 +100,7 @@ export default function* normalizeFile(
 
   return new File(options, {
     code,
-    ast: ast as t.File,
+    ast: ast,
     inputMap,
   });
 }

--- a/packages/babel-helpers/src/helpers/asyncIterator.ts
+++ b/packages/babel-helpers/src/helpers/asyncIterator.ts
@@ -56,7 +56,6 @@ declare class AsyncFromSyncIterator<T = any, TReturn = any, TNext = undefined>
 // This makes ESLint and TypeScript complain a lot, but it's the only way
 function AsyncFromSyncIterator<T, TReturn = any, TNext = undefined>(s: any) {
   // @ts-expect-error - Intentionally overriding the constructor.
-  // eslint-disable-next-line no-class-assign
   AsyncFromSyncIterator = function (
     this: AsyncFromSyncIterator,
     s: Iterator<T>,

--- a/packages/babel-helpers/src/helpers/isNativeFunction.ts
+++ b/packages/babel-helpers/src/helpers/isNativeFunction.ts
@@ -3,7 +3,6 @@
 export default function _isNativeFunction(fn: unknown): fn is Function {
   // Note: This function returns "true" for core-js functions.
   try {
-    // eslint-disable-next-line @typescript-eslint/prefer-includes
     return Function.toString.call(fn).indexOf("[native code]") !== -1;
   } catch (_e) {
     // Firefox 31 throws when "toString" is applied to an HTMLElement

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -49,6 +49,7 @@
   "conditions": {
     "BABEL_8_BREAKING": [
       {
+        "types": null,
         "engines": {
           "node": "^18.20.0 || ^20.17.0 || >=22.8.0"
         }

--- a/packages/babel-parser/src/options.ts
+++ b/packages/babel-parser/src/options.ts
@@ -1,4 +1,4 @@
-import type { PluginList } from "./plugin-utils.ts";
+import type { Plugin } from "./plugin-utils.ts";
 
 // A second optional argument can be given to further configure
 // the parser process. These options are recognized:
@@ -6,26 +6,133 @@ import type { PluginList } from "./plugin-utils.ts";
 export type SourceType = "script" | "module" | "unambiguous";
 
 export interface Options {
-  sourceType?: SourceType;
-  sourceFilename?: string;
-  startIndex?: number;
-  startColumn?: number;
-  startLine?: number;
-  allowAwaitOutsideFunction?: boolean;
-  allowReturnOutsideFunction?: boolean;
-  allowNewTargetOutsideFunction?: boolean;
+  /**
+   * By default, import and export declarations can only appear at a program's top level.
+   * Setting this option to true allows them anywhere where a statement is allowed.
+   */
   allowImportExportEverywhere?: boolean;
+
+  /**
+   * By default, await use is not allowed outside of an async function.
+   * Set this to true to accept such code.
+   */
+  allowAwaitOutsideFunction?: boolean;
+
+  /**
+   * By default, a return statement at the top level raises an error.
+   * Set this to true to accept such code.
+   */
+  allowReturnOutsideFunction?: boolean;
+
+  /**
+   * By default, new.target use is not allowed outside of a function or class.
+   * Set this to true to accept such code.
+   */
+  allowNewTargetOutsideFunction?: boolean;
+
   allowSuperOutsideMethod?: boolean;
+
+  /**
+   * By default, exported identifiers must refer to a declared variable.
+   * Set this to true to allow export statements to reference undeclared variables.
+   */
   allowUndeclaredExports?: boolean;
-  plugins?: PluginList;
-  strictMode?: boolean | undefined | null;
-  ranges?: boolean;
-  tokens?: boolean;
-  createImportExpressions?: boolean;
-  createParenthesizedExpressions?: boolean;
-  errorRecovery?: boolean;
-  attachComment?: boolean;
+
+  /**
+   * By default, Babel parser JavaScript code according to Annex B syntax.
+   * Set this to `false` to disable such behavior.
+   */
   annexB?: boolean;
+
+  /**
+   * By default, Babel attaches comments to adjacent AST nodes.
+   * When this option is set to false, comments are not attached.
+   * It can provide up to 30% performance improvement when the input code has many comments.
+   * @babel/eslint-parser will set it for you.
+   * It is not recommended to use attachComment: false with Babel transform,
+   * as doing so removes all the comments in output code, and renders annotations such as
+   * /* istanbul ignore next *\/ nonfunctional.
+   */
+  attachComment?: boolean;
+
+  /**
+   * By default, Babel always throws an error when it finds some invalid code.
+   * When this option is set to true, it will store the parsing error and
+   * try to continue parsing the invalid input file.
+   */
+  errorRecovery?: boolean;
+
+  /**
+   * Indicate the mode the code should be parsed in.
+   * Can be one of "script", "module", or "unambiguous". Defaults to "script".
+   * "unambiguous" will make @babel/parser attempt to guess, based on the presence
+   * of ES6 import or export statements.
+   * Files with ES6 imports and exports are considered "module" and are otherwise "script".
+   */
+  sourceType?: "script" | "module" | "unambiguous";
+
+  /**
+   * Correlate output AST nodes with their source filename.
+   * Useful when generating code and source maps from the ASTs of multiple input files.
+   */
+  sourceFilename?: string;
+
+  /**
+   * By default, all source indexes start from 0.
+   * You can provide a start index to alternatively start with.
+   * Useful for integration with other source tools.
+   */
+  startIndex?: number;
+
+  /**
+   * By default, the first line of code parsed is treated as line 1.
+   * You can provide a line number to alternatively start with.
+   * Useful for integration with other source tools.
+   */
+  startLine?: number;
+
+  /**
+   * By default, the parsed code is treated as if it starts from line 1, column 0.
+   * You can provide a column number to alternatively start with.
+   * Useful for integration with other source tools.
+   */
+  startColumn?: number;
+
+  /**
+   * Array containing the plugins that you want to enable.
+   */
+  plugins?: Plugin[];
+
+  /**
+   * Should the parser work in strict mode.
+   * Defaults to true if sourceType === 'module'. Otherwise, false.
+   */
+  strictMode?: boolean;
+
+  /**
+   * Adds a ranges property to each node: [node.start, node.end]
+   */
+  ranges?: boolean;
+
+  /**
+   * Adds all parsed tokens to a tokens property on the File node.
+   */
+  tokens?: boolean;
+
+  /**
+   * By default, the parser adds information about parentheses by setting
+   * `extra.parenthesized` to `true` as needed.
+   * When this option is `true` the parser creates `ParenthesizedExpression`
+   * AST nodes instead of using the `extra` property.
+   */
+  createParenthesizedExpressions?: boolean;
+
+  /**
+   * The default is false in Babel 7 and true in Babel 8
+   * Set this to true to parse it as an `ImportExpression` node.
+   * Otherwise `import(foo)` is parsed as `CallExpression(Import, [Identifier(foo)])`.
+   */
+  createImportExpressions?: boolean;
 }
 
 export const enum OptionFlags {

--- a/packages/babel-parser/src/plugin-utils.ts
+++ b/packages/babel-parser/src/plugin-utils.ts
@@ -3,8 +3,6 @@ import type { PluginConfig } from "./typings.ts";
 
 export type Plugin = PluginConfig;
 
-export type PluginList = PluginConfig[];
-
 export type MixinPlugin = (
   superClass: new (...args: any) => Parser,
 ) => new (...args: any) => Parser;

--- a/packages/babel-parser/tsconfig.json
+++ b/packages/babel-parser/tsconfig.json
@@ -8,8 +8,7 @@
     "./src/**/*.ts",
     "./src/**/*.cts",
     "../../lib/globals.d.ts",
-    "../../scripts/repo-utils/*.d.ts",
-    "../../packages/babel-parser/typings/*.d.ts"
+    "../../scripts/repo-utils/*.d.ts"
   ],
   "references": [
     {

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -1,11 +1,12 @@
 // This file is auto-generated! Do not modify it directly.
+// Run `yarn gulp bundle-dts` to re-generate it.
 /* eslint-disable @typescript-eslint/consistent-type-imports, @typescript-eslint/no-redundant-type-constituents */
-import * as _babel_types from '@babel/types';
+import { File, Expression } from '@babel/types';
 
 type BABEL_8_BREAKING = false;
 type IF_BABEL_7<V> = false extends BABEL_8_BREAKING ? V : never;
 
-type Plugin =
+type Plugin$1 =
   | "asyncDoExpressions"
   | IF_BABEL_7<"asyncGenerators">
   | IF_BABEL_7<"bigInt">
@@ -62,7 +63,7 @@ type ParserPluginWithOptions =
   | ["flow", FlowPluginOptions]
   | ["typescript", TypeScriptPluginOptions];
 
-type PluginConfig = Plugin | ParserPluginWithOptions;
+type PluginConfig = Plugin$1 | ParserPluginWithOptions;
 
 interface DecoratorsPluginOptions {
   decoratorsBeforeExport?: boolean;
@@ -94,174 +95,136 @@ interface TypeScriptPluginOptions {
   disallowAmbiguousJSXLike?: boolean;
 }
 
-// Type definitions for @babel/parser
-// Project: https://github.com/babel/babel/tree/main/packages/babel-parser
-// Definitions by: Troy Gerwien <https://github.com/yortus>
-//                 Marvin Hagemeister <https://github.com/marvinhagemeister>
-//                 Avi Vahl <https://github.com/AviVahl>
-// TypeScript Version: 2.9
+type Plugin = PluginConfig;
 
+interface Options {
+    /**
+     * By default, import and export declarations can only appear at a program's top level.
+     * Setting this option to true allows them anywhere where a statement is allowed.
+     */
+    allowImportExportEverywhere?: boolean;
+    /**
+     * By default, await use is not allowed outside of an async function.
+     * Set this to true to accept such code.
+     */
+    allowAwaitOutsideFunction?: boolean;
+    /**
+     * By default, a return statement at the top level raises an error.
+     * Set this to true to accept such code.
+     */
+    allowReturnOutsideFunction?: boolean;
+    /**
+     * By default, new.target use is not allowed outside of a function or class.
+     * Set this to true to accept such code.
+     */
+    allowNewTargetOutsideFunction?: boolean;
+    allowSuperOutsideMethod?: boolean;
+    /**
+     * By default, exported identifiers must refer to a declared variable.
+     * Set this to true to allow export statements to reference undeclared variables.
+     */
+    allowUndeclaredExports?: boolean;
+    /**
+     * By default, Babel parser JavaScript code according to Annex B syntax.
+     * Set this to `false` to disable such behavior.
+     */
+    annexB?: boolean;
+    /**
+     * By default, Babel attaches comments to adjacent AST nodes.
+     * When this option is set to false, comments are not attached.
+     * It can provide up to 30% performance improvement when the input code has many comments.
+     * @babel/eslint-parser will set it for you.
+     * It is not recommended to use attachComment: false with Babel transform,
+     * as doing so removes all the comments in output code, and renders annotations such as
+     * /* istanbul ignore next *\/ nonfunctional.
+     */
+    attachComment?: boolean;
+    /**
+     * By default, Babel always throws an error when it finds some invalid code.
+     * When this option is set to true, it will store the parsing error and
+     * try to continue parsing the invalid input file.
+     */
+    errorRecovery?: boolean;
+    /**
+     * Indicate the mode the code should be parsed in.
+     * Can be one of "script", "module", or "unambiguous". Defaults to "script".
+     * "unambiguous" will make @babel/parser attempt to guess, based on the presence
+     * of ES6 import or export statements.
+     * Files with ES6 imports and exports are considered "module" and are otherwise "script".
+     */
+    sourceType?: "script" | "module" | "unambiguous";
+    /**
+     * Correlate output AST nodes with their source filename.
+     * Useful when generating code and source maps from the ASTs of multiple input files.
+     */
+    sourceFilename?: string;
+    /**
+     * By default, all source indexes start from 0.
+     * You can provide a start index to alternatively start with.
+     * Useful for integration with other source tools.
+     */
+    startIndex?: number;
+    /**
+     * By default, the first line of code parsed is treated as line 1.
+     * You can provide a line number to alternatively start with.
+     * Useful for integration with other source tools.
+     */
+    startLine?: number;
+    /**
+     * By default, the parsed code is treated as if it starts from line 1, column 0.
+     * You can provide a column number to alternatively start with.
+     * Useful for integration with other source tools.
+     */
+    startColumn?: number;
+    /**
+     * Array containing the plugins that you want to enable.
+     */
+    plugins?: Plugin[];
+    /**
+     * Should the parser work in strict mode.
+     * Defaults to true if sourceType === 'module'. Otherwise, false.
+     */
+    strictMode?: boolean;
+    /**
+     * Adds a ranges property to each node: [node.start, node.end]
+     */
+    ranges?: boolean;
+    /**
+     * Adds all parsed tokens to a tokens property on the File node.
+     */
+    tokens?: boolean;
+    /**
+     * By default, the parser adds information about parentheses by setting
+     * `extra.parenthesized` to `true` as needed.
+     * When this option is `true` the parser creates `ParenthesizedExpression`
+     * AST nodes instead of using the `extra` property.
+     */
+    createParenthesizedExpressions?: boolean;
+    /**
+     * The default is false in Babel 7 and true in Babel 8
+     * Set this to true to parse it as an `ImportExpression` node.
+     * Otherwise `import(foo)` is parsed as `CallExpression(Import, [Identifier(foo)])`.
+     */
+    createImportExpressions?: boolean;
+}
+
+type ParserOptions = Partial<Options>;
+interface ParseError {
+    code: string;
+    reasonCode: string;
+}
+type ParseResult<Result extends File | Expression = File> = Result & {
+    errors: null | ParseError[];
+};
 /**
  * Parse the provided code as an entire ECMAScript program.
  */
-declare function parse(
-  input: string,
-  options?: ParserOptions
-): ParseResult<_babel_types.File>;
-
-/**
- * Parse the provided code as a single expression.
- */
-declare function parseExpression(
-  input: string,
-  options?: ParserOptions
-): ParseResult<_babel_types.Expression>;
-
-interface ParserOptions {
-  /**
-   * By default, import and export declarations can only appear at a program's top level.
-   * Setting this option to true allows them anywhere where a statement is allowed.
-   */
-  allowImportExportEverywhere?: boolean;
-
-  /**
-   * By default, await use is not allowed outside of an async function.
-   * Set this to true to accept such code.
-   */
-  allowAwaitOutsideFunction?: boolean;
-
-  /**
-   * By default, a return statement at the top level raises an error.
-   * Set this to true to accept such code.
-   */
-  allowReturnOutsideFunction?: boolean;
-
-  /**
-   * By default, new.target use is not allowed outside of a function or class.
-   * Set this to true to accept such code.
-   */
-  allowNewTargetOutsideFunction?: boolean;
-
-  allowSuperOutsideMethod?: boolean;
-
-  /**
-   * By default, exported identifiers must refer to a declared variable.
-   * Set this to true to allow export statements to reference undeclared variables.
-   */
-  allowUndeclaredExports?: boolean;
-
-  /**
-   * By default, Babel parser JavaScript code according to Annex B syntax.
-   * Set this to `false` to disable such behavior.
-   */
-  annexB?: boolean;
-
-  /**
-   * By default, Babel attaches comments to adjacent AST nodes.
-   * When this option is set to false, comments are not attached.
-   * It can provide up to 30% performance improvement when the input code has many comments.
-   * @babel/eslint-parser will set it for you.
-   * It is not recommended to use attachComment: false with Babel transform,
-   * as doing so removes all the comments in output code, and renders annotations such as
-   * /* istanbul ignore next *\/ nonfunctional.
-   */
-  attachComment?: boolean;
-
-  /**
-   * By default, Babel always throws an error when it finds some invalid code.
-   * When this option is set to true, it will store the parsing error and
-   * try to continue parsing the invalid input file.
-   */
-  errorRecovery?: boolean;
-
-  /**
-   * Indicate the mode the code should be parsed in.
-   * Can be one of "script", "module", or "unambiguous". Defaults to "script".
-   * "unambiguous" will make @babel/parser attempt to guess, based on the presence
-   * of ES6 import or export statements.
-   * Files with ES6 imports and exports are considered "module" and are otherwise "script".
-   */
-  sourceType?: "script" | "module" | "unambiguous";
-
-  /**
-   * Correlate output AST nodes with their source filename.
-   * Useful when generating code and source maps from the ASTs of multiple input files.
-   */
-  sourceFilename?: string;
-
-  /**
-   * By default, all source indexes start from 0.
-   * You can provide a start index to alternatively start with.
-   * Useful for integration with other source tools.
-   */
-  startIndex?: number;
-
-  /**
-   * By default, the first line of code parsed is treated as line 1.
-   * You can provide a line number to alternatively start with.
-   * Useful for integration with other source tools.
-   */
-  startLine?: number;
-
-  /**
-   * By default, the parsed code is treated as if it starts from line 1, column 0.
-   * You can provide a column number to alternatively start with.
-   * Useful for integration with other source tools.
-   */
-  startColumn?: number;
-
-  /**
-   * Array containing the plugins that you want to enable.
-   */
-  plugins?: ParserPlugin[];
-
-  /**
-   * Should the parser work in strict mode.
-   * Defaults to true if sourceType === 'module'. Otherwise, false.
-   */
-  strictMode?: boolean;
-
-  /**
-   * Adds a ranges property to each node: [node.start, node.end]
-   */
-  ranges?: boolean;
-
-  /**
-   * Adds all parsed tokens to a tokens property on the File node.
-   */
-  tokens?: boolean;
-
-  /**
-   * By default, the parser adds information about parentheses by setting
-   * `extra.parenthesized` to `true` as needed.
-   * When this option is `true` the parser creates `ParenthesizedExpression`
-   * AST nodes instead of using the `extra` property.
-   */
-  createParenthesizedExpressions?: boolean;
-
-  /**
-   * The default is false in Babel 7 and true in Babel 8
-   * Set this to true to parse it as an `ImportExpression` node.
-   * Otherwise `import(foo)` is parsed as `CallExpression(Import, [Identifier(foo)])`.
-   */
-  createImportExpressions?: boolean;
-}
-
-type ParserPlugin = PluginConfig;
-
+declare function parse(input: string, options?: ParserOptions): ParseResult<File>;
+declare function parseExpression(input: string, options?: ParserOptions): ParseResult<Expression>;
 
 declare const tokTypes: {
   // todo(flow->ts) real token type
   [name: string]: any;
 };
 
-interface ParseError {
-  code: string;
-  reasonCode: string;
-}
-
-type ParseResult<Result> = Result & {
-  errors: ParseError[];
-};
-
-export { DecoratorsPluginOptions, FlowPluginOptions, ParseError, ParseResult, ParserOptions, ParserPlugin, ParserPluginWithOptions, PipelineOperatorPluginOptions, RecordAndTuplePluginOptions, TypeScriptPluginOptions, parse, parseExpression, tokTypes };
+export { DecoratorsPluginOptions, FlowPluginOptions, ParseError, ParseResult, ParserOptions, PluginConfig as ParserPlugin, ParserPluginWithOptions, PipelineOperatorPluginOptions, RecordAndTuplePluginOptions, TypeScriptPluginOptions, parse, parseExpression, tokTypes };

--- a/packages/babel-parser/typings/babel-parser.source.d.ts
+++ b/packages/babel-parser/typings/babel-parser.source.d.ts
@@ -1,177 +1,24 @@
-// Type definitions for @babel/parser
-// Project: https://github.com/babel/babel/tree/main/packages/babel-parser
-// Definitions by: Troy Gerwien <https://github.com/yortus>
-//                 Marvin Hagemeister <https://github.com/marvinhagemeister>
-//                 Avi Vahl <https://github.com/AviVahl>
-// TypeScript Version: 2.9
-
-/**
- * Parse the provided code as an entire ECMAScript program.
- */
-export function parse(
-  input: string,
-  options?: ParserOptions
-): ParseResult<import("@babel/types").File>;
-
-/**
- * Parse the provided code as a single expression.
- */
-export function parseExpression(
-  input: string,
-  options?: ParserOptions
-): ParseResult<import("@babel/types").Expression>;
-
-export interface ParserOptions {
-  /**
-   * By default, import and export declarations can only appear at a program's top level.
-   * Setting this option to true allows them anywhere where a statement is allowed.
-   */
-  allowImportExportEverywhere?: boolean;
-
-  /**
-   * By default, await use is not allowed outside of an async function.
-   * Set this to true to accept such code.
-   */
-  allowAwaitOutsideFunction?: boolean;
-
-  /**
-   * By default, a return statement at the top level raises an error.
-   * Set this to true to accept such code.
-   */
-  allowReturnOutsideFunction?: boolean;
-
-  /**
-   * By default, new.target use is not allowed outside of a function or class.
-   * Set this to true to accept such code.
-   */
-  allowNewTargetOutsideFunction?: boolean;
-
-  allowSuperOutsideMethod?: boolean;
-
-  /**
-   * By default, exported identifiers must refer to a declared variable.
-   * Set this to true to allow export statements to reference undeclared variables.
-   */
-  allowUndeclaredExports?: boolean;
-
-  /**
-   * By default, Babel parser JavaScript code according to Annex B syntax.
-   * Set this to `false` to disable such behavior.
-   */
-  annexB?: boolean;
-
-  /**
-   * By default, Babel attaches comments to adjacent AST nodes.
-   * When this option is set to false, comments are not attached.
-   * It can provide up to 30% performance improvement when the input code has many comments.
-   * @babel/eslint-parser will set it for you.
-   * It is not recommended to use attachComment: false with Babel transform,
-   * as doing so removes all the comments in output code, and renders annotations such as
-   * /* istanbul ignore next *\/ nonfunctional.
-   */
-  attachComment?: boolean;
-
-  /**
-   * By default, Babel always throws an error when it finds some invalid code.
-   * When this option is set to true, it will store the parsing error and
-   * try to continue parsing the invalid input file.
-   */
-  errorRecovery?: boolean;
-
-  /**
-   * Indicate the mode the code should be parsed in.
-   * Can be one of "script", "module", or "unambiguous". Defaults to "script".
-   * "unambiguous" will make @babel/parser attempt to guess, based on the presence
-   * of ES6 import or export statements.
-   * Files with ES6 imports and exports are considered "module" and are otherwise "script".
-   */
-  sourceType?: "script" | "module" | "unambiguous";
-
-  /**
-   * Correlate output AST nodes with their source filename.
-   * Useful when generating code and source maps from the ASTs of multiple input files.
-   */
-  sourceFilename?: string;
-
-  /**
-   * By default, all source indexes start from 0.
-   * You can provide a start index to alternatively start with.
-   * Useful for integration with other source tools.
-   */
-  startIndex?: number;
-
-  /**
-   * By default, the first line of code parsed is treated as line 1.
-   * You can provide a line number to alternatively start with.
-   * Useful for integration with other source tools.
-   */
-  startLine?: number;
-
-  /**
-   * By default, the parsed code is treated as if it starts from line 1, column 0.
-   * You can provide a column number to alternatively start with.
-   * Useful for integration with other source tools.
-   */
-  startColumn?: number;
-
-  /**
-   * Array containing the plugins that you want to enable.
-   */
-  plugins?: ParserPlugin[];
-
-  /**
-   * Should the parser work in strict mode.
-   * Defaults to true if sourceType === 'module'. Otherwise, false.
-   */
-  strictMode?: boolean;
-
-  /**
-   * Adds a ranges property to each node: [node.start, node.end]
-   */
-  ranges?: boolean;
-
-  /**
-   * Adds all parsed tokens to a tokens property on the File node.
-   */
-  tokens?: boolean;
-
-  /**
-   * By default, the parser adds information about parentheses by setting
-   * `extra.parenthesized` to `true` as needed.
-   * When this option is `true` the parser creates `ParenthesizedExpression`
-   * AST nodes instead of using the `extra` property.
-   */
-  createParenthesizedExpressions?: boolean;
-
-  /**
-   * The default is false in Babel 7 and true in Babel 8
-   * Set this to true to parse it as an `ImportExpression` node.
-   * Otherwise `import(foo)` is parsed as `CallExpression(Import, [Identifier(foo)])`.
-   */
-  createImportExpressions?: boolean;
-}
-
-export type ParserPlugin = import("../src/typings").PluginConfig;
+export type {
+  parse,
+  parseExpression,
+} from "../../../dts/packages/babel-parser/src/index.d.ts";
 
 export type {
-  ParserPluginWithOptions,
+  ParserOptions,
+  ParserPlugin,
   DecoratorsPluginOptions,
   PipelineOperatorPluginOptions,
   RecordAndTuplePluginOptions,
   FlowPluginOptions,
   TypeScriptPluginOptions,
-} from "../src/typings";
+  ParseError,
+  ParseResult,
+} from "../../../dts/packages/babel-parser/src/index.d.ts";
+
+/** @deprecated Will be removed in Babel 8 */
+export type { ParserPluginWithOptions } from "../../../dts/packages/babel-parser/src/typings.d.ts";
 
 export const tokTypes: {
   // todo(flow->ts) real token type
   [name: string]: any;
-};
-
-export interface ParseError {
-  code: string;
-  reasonCode: string;
-}
-
-export type ParseResult<Result> = Result & {
-  errors: ParseError[];
 };

--- a/packages/babel-template/src/parse.ts
+++ b/packages/babel-template/src/parse.ts
@@ -208,7 +208,6 @@ function parseWithCodeFrame(
   };
 
   try {
-    // @ts-expect-error todo: use babel-types ast typings in Babel parser
     return parse(code, parserOpts);
   } catch (err) {
     const loc = err.loc;

--- a/packages/babel-traverse/src/path/replacement.ts
+++ b/packages/babel-traverse/src/path/replacement.ts
@@ -84,7 +84,6 @@ export function replaceWithSourceString(this: NodePath, replacement: string) {
 
   try {
     replacement = `(${replacement})`;
-    // @ts-expect-error todo: use babel-types ast typings in Babel parser
     ast = parse(replacement);
   } catch (err) {
     const loc = err.loc;

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -316,11 +316,7 @@ maybeWriteFile(
         compilerOptions: {
           skipLibCheck: false,
         },
-        include: [
-          "./lib/libdom-minimal.d.ts",
-          "packages/babel-parser/typings/*.d.ts",
-          "dts/**/*.d.ts",
-        ],
+        include: ["./lib/libdom-minimal.d.ts", "dts/**/*.d.ts"],
         references: Array.from(new Set(projectsFolders.values()))
           .sort()
           .map(path => ({ path })),

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -257,9 +257,6 @@ function buildTSConfig(pkgs, allDeps, hasOverrides) {
       "./src/**/*.cts",
       "../../lib/globals.d.ts",
       "../../scripts/repo-utils/*.d.ts",
-      pkgs.some(p => p.name === "@babel/parser")
-        ? "../../packages/babel-parser/typings/*.d.ts"
-        : null,
     ].filter(Boolean),
     references: Array.from(referencePaths, path => ({ path })),
   };

--- a/tsconfig.dts-bundles.json
+++ b/tsconfig.dts-bundles.json
@@ -8,7 +8,6 @@
   },
   "include": [
     "./lib/libdom-minimal.d.ts",
-    "packages/babel-parser/typings/*.d.ts",
     "packages/*/lib/*.d.ts",
     "eslint/*/lib/*.d.ts",
     "codemods/*/lib/*.d.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
   },
   "include": [
     "./lib/libdom-minimal.d.ts",
-    "packages/babel-parser/typings/*.d.ts",
     "dts/**/*.d.ts"
   ],
   "references": [


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/17093
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In Babel 7 we are already using `@babel/types` in `@babel/parser/typings/babel-parser.ts`. However, Babel 8 uses `package.json#exports` thus that file is ignored.

By casting the type to the proper AST types in the `parse()` function itself, we can also use the `@babel/types` definitions in:
- Babel 8
- Local development

One day we can actually de-duplicate the definitions, but it's a lot of work and it can wait :)