### PR TITLE
Fix: align behaviour to tsc `rewriteRelativeImportExtensions`

### DIFF
--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -1303,6 +1303,18 @@ const helpers: Record<string, Helper> = {
       dependencies: {},
     },
   ),
+  // size: 243, gzip size: 210
+  tsRewriteRelativeImportExtensions: helper(
+    "7.26.8",
+    'function tsRewriteRelativeImportExtensions(t,e){return"string"==typeof t&&/^\\.\\.?\\//.test(t)?t.replace(/\\.(tsx)$|((?:\\.d)?)((?:\\.[^./]+)?)\\.([cm]?)ts$/i,(function(t,s,r,n,o){return s?e?".jsx":".js":!r||n&&o?r+n+"."+o.toLowerCase()+"js":t})):t}',
+    {
+      globals: [],
+      locals: { tsRewriteRelativeImportExtensions: ["body.0.id"] },
+      exportBindingAssignments: [],
+      exportName: "tsRewriteRelativeImportExtensions",
+      dependencies: {},
+    },
+  ),
   // size: 274, gzip size: 157
   typeof: helper(
     "7.0.0-beta.0",

--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -1303,10 +1303,10 @@ const helpers: Record<string, Helper> = {
       dependencies: {},
     },
   ),
-  // size: 243, gzip size: 210
+  // size: 246, gzip size: 211
   tsRewriteRelativeImportExtensions: helper(
     "7.26.8",
-    'function tsRewriteRelativeImportExtensions(t,e){return"string"==typeof t&&/^\\.\\.?\\//.test(t)?t.replace(/\\.(tsx)$|((?:\\.d)?)((?:\\.[^./]+)?)\\.([cm]?)ts$/i,(function(t,s,r,n,o){return s?e?".jsx":".js":!r||n&&o?r+n+"."+o.toLowerCase()+"js":t})):t}',
+    'function tsRewriteRelativeImportExtensions(t,e){return"string"==typeof t&&/^\\.\\.?[\\\\/]/.test(t)?t.replace(/\\.(tsx)$|((?:\\.d)?)((?:\\.[^./]+)?)\\.([cm]?)ts$/i,(function(t,s,r,n,o){return s?e?".jsx":".js":!r||n&&o?r+n+"."+o.toLowerCase()+"js":t})):t}',
     {
       globals: [],
       locals: { tsRewriteRelativeImportExtensions: ["body.0.id"] },

--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -1305,7 +1305,7 @@ const helpers: Record<string, Helper> = {
   ),
   // size: 243, gzip size: 210
   tsRewriteRelativeImportExtensions: helper(
-    "7.26.8",
+    "7.27.0",
     'function tsRewriteRelativeImportExtensions(t,e){return"string"==typeof t&&/^\\.\\.?\\//.test(t)?t.replace(/\\.(tsx)$|((?:\\.d)?)((?:\\.[^./]+)?)\\.([cm]?)ts$/i,(function(t,s,r,n,o){return s?e?".jsx":".js":!r||n&&o?r+n+"."+o.toLowerCase()+"js":t})):t}',
     {
       globals: [],

--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -1303,10 +1303,10 @@ const helpers: Record<string, Helper> = {
       dependencies: {},
     },
   ),
-  // size: 246, gzip size: 211
+  // size: 243, gzip size: 210
   tsRewriteRelativeImportExtensions: helper(
     "7.26.8",
-    'function tsRewriteRelativeImportExtensions(t,e){return"string"==typeof t&&/^\\.\\.?[\\\\/]/.test(t)?t.replace(/\\.(tsx)$|((?:\\.d)?)((?:\\.[^./]+)?)\\.([cm]?)ts$/i,(function(t,s,r,n,o){return s?e?".jsx":".js":!r||n&&o?r+n+"."+o.toLowerCase()+"js":t})):t}',
+    'function tsRewriteRelativeImportExtensions(t,e){return"string"==typeof t&&/^\\.\\.?\\//.test(t)?t.replace(/\\.(tsx)$|((?:\\.d)?)((?:\\.[^./]+)?)\\.([cm]?)ts$/i,(function(t,s,r,n,o){return s?e?".jsx":".js":!r||n&&o?r+n+"."+o.toLowerCase()+"js":t})):t}',
     {
       globals: [],
       locals: { tsRewriteRelativeImportExtensions: ["body.0.id"] },

--- a/packages/babel-helpers/src/helpers/tsRewriteRelativeImportExtensions.ts
+++ b/packages/babel-helpers/src/helpers/tsRewriteRelativeImportExtensions.ts
@@ -5,7 +5,7 @@ export default function tsRewriteRelativeImportExtensions(
   path: unknown,
   preserveJsx?: boolean,
 ) {
-  if (typeof path === "string" && /^\.\.?[\\/]/.test(path)) {
+  if (typeof path === "string" && /^\.\.?\//.test(path)) {
     return path.replace(
       /\.(tsx)$|((?:\.d)?)((?:\.[^./]+)?)\.([cm]?)ts$/i,
       function (m, tsx, d, ext, cm) {

--- a/packages/babel-helpers/src/helpers/tsRewriteRelativeImportExtensions.ts
+++ b/packages/babel-helpers/src/helpers/tsRewriteRelativeImportExtensions.ts
@@ -1,4 +1,4 @@
-/* @minVersion 7.26.8 */
+/* @minVersion 7.27.0 */
 
 // https://github.com/microsoft/TypeScript/blob/71716a2868c87248af5020e33a84a2178d41a2d6/src/compiler/factory/emitHelpers.ts#L1451
 export default function tsRewriteRelativeImportExtensions(

--- a/packages/babel-helpers/src/helpers/tsRewriteRelativeImportExtensions.ts
+++ b/packages/babel-helpers/src/helpers/tsRewriteRelativeImportExtensions.ts
@@ -1,0 +1,23 @@
+/* @minVersion 7.26.8 */
+
+// https://github.com/microsoft/TypeScript/blob/71716a2868c87248af5020e33a84a2178d41a2d6/src/compiler/factory/emitHelpers.ts#L1451
+export default function tsRewriteRelativeImportExtensions(
+  path: unknown,
+  preserveJsx?: boolean,
+) {
+  if (typeof path === "string" && /^\.\.?\//.test(path)) {
+    return path.replace(
+      /\.(tsx)$|((?:\.d)?)((?:\.[^./]+)?)\.([cm]?)ts$/i,
+      function (m, tsx, d, ext, cm) {
+        return tsx
+          ? preserveJsx
+            ? ".jsx"
+            : ".js"
+          : d && (!ext || !cm)
+            ? m
+            : d + ext + "." + cm.toLowerCase() + "js";
+      },
+    );
+  }
+  return path;
+}

--- a/packages/babel-helpers/src/helpers/tsRewriteRelativeImportExtensions.ts
+++ b/packages/babel-helpers/src/helpers/tsRewriteRelativeImportExtensions.ts
@@ -5,7 +5,7 @@ export default function tsRewriteRelativeImportExtensions(
   path: unknown,
   preserveJsx?: boolean,
 ) {
-  if (typeof path === "string" && /^\.\.?\//.test(path)) {
+  if (typeof path === "string" && /^\.\.?[\\/]/.test(path)) {
     return path.replace(
       /\.(tsx)$|((?:\.d)?)((?:\.[^./]+)?)\.([cm]?)ts$/i,
       function (m, tsx, d, ext, cm) {

--- a/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
+++ b/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
@@ -11,6 +11,12 @@ describe("tsRewriteRelativeImportExtensions", () => {
     ["./a.mts", "./a.mjs"],
     ["./a.tsx", "./a.js"],
 
+    // rewrite relative import with windows path separator
+    [".\\a.ts", ".\\a.js"],
+    [".\\a.cts", ".\\a.cjs"],
+    [".\\a.mts", ".\\a.mjs"],
+    [".\\a.tsx", ".\\a.js"],
+
     // rewrite relative import from parent directory
     ["../a.ts", "../a.js"],
     ["../a.cts", "../a.cjs"],

--- a/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
+++ b/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
@@ -1,0 +1,81 @@
+import _tsRewriteRelativeImportExtensions from "../../lib/helpers/tsRewriteRelativeImportExtensions.js";
+const tsRewriteRelativeImportExtensions =
+  _tsRewriteRelativeImportExtensions.default ||
+  _tsRewriteRelativeImportExtensions;
+
+describe("tsRewriteRelativeImportExtensions", () => {
+  it.each([
+    // rewrite relative import
+    ["./a.ts", "./a.js"],
+    ["./a.cts", "./a.cjs"],
+    ["./a.mts", "./a.mjs"],
+    ["./a.tsx", "./a.js"],
+
+    // rewrite relative import from parent directory
+    ["../a.ts", "../a.js"],
+    ["../a.cts", "../a.cjs"],
+    ["../a.mts", "../a.mjs"],
+    ["../a.tsx", "../a.js"],
+
+    // rewrite transforms uppercase to lowercase
+    ["./a.Ts", "./a.js"],
+    ["./a.CTS", "./a.cjs"],
+    ["./a.MTs", "./a.mjs"],
+    ["./a.tSx", "./a.js"],
+
+    // rewrite relative import containing .d
+    ["./.d.a.ts", "./.d.a.ts"], // This is a bug!
+    ["./.d.a.cts", "./.d.a.cjs"],
+    ["./.d.a.mts", "./.d.a.mjs"],
+    ["./.d.a.tsx", "./.d.a.js"],
+
+    // skip d.ts, d.cts, and d.mts
+    ["./a.d.ts", "./a.d.ts"],
+    ["./a.d.cts", "./a.d.cts"],
+    ["./a.d.mts", "./a.d.mts"],
+    // transform d.tsx
+    ["./a.d.tsx", "./a.d.js"],
+
+    // skip absolute
+    ["/a.ts", "/a.ts"],
+    ["/a.cts", "/a.cts"],
+    ["/a.mts", "/a.mts"],
+    ["/a.tsx", "/a.tsx"],
+
+    // skip library
+    ["a.ts", "a.ts"],
+    ["a.cts", "a.cts"],
+    ["a.mts", "a.mts"],
+    ["a.tsx", "a.tsx"],
+
+    // skip non-terminal
+    ["./a.ts.foo", "./a.ts.foo"],
+    ["./a.cts.foo", "./a.cts.foo"],
+    ["./a.mts.foo", "./a.mts.foo"],
+    ["./a.tsx.foo", "./a.tsx.foo"],
+  ])("%p -> %p", (input, result) => {
+    expect(tsRewriteRelativeImportExtensions(input)).toBe(result);
+  });
+
+  it.each([
+    // skip string wrapper object
+    [new String("./a.ts")],
+    [new String("./a.cts")],
+    [new String("./a.mts")],
+    [new String("./a.tsx")],
+
+    // skip toString() transforms
+    [{ [Symbol.toStringTag]: "./a.ts" }],
+    [{ [Symbol.toStringTag]: "./a.cts" }],
+    [{ [Symbol.toStringTag]: "./a.mts" }],
+    [{ [Symbol.toStringTag]: "./a.tsx" }],
+
+    // skip toPrimitive() calls
+    [{ [Symbol.toPrimitive]: () => "./a.ts" }],
+    [{ [Symbol.toPrimitive]: () => "./a.cts" }],
+    [{ [Symbol.toPrimitive]: () => "./a.mts" }],
+    [{ [Symbol.toPrimitive]: () => "./a.tsx" }],
+  ])("should skip %p", input => {
+    expect(tsRewriteRelativeImportExtensions(input)).toBe(input);
+  });
+});

--- a/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
+++ b/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
@@ -11,12 +11,6 @@ describe("tsRewriteRelativeImportExtensions", () => {
     ["./a.mts", "./a.mjs"],
     ["./a.tsx", "./a.js"],
 
-    // rewrite relative import with windows path separator
-    [".\\a.ts", ".\\a.js"],
-    [".\\a.cts", ".\\a.cjs"],
-    [".\\a.mts", ".\\a.mjs"],
-    [".\\a.tsx", ".\\a.js"],
-
     // rewrite relative import from parent directory
     ["../a.ts", "../a.js"],
     ["../a.cts", "../a.cjs"],

--- a/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
+++ b/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
@@ -24,7 +24,7 @@ describe("tsRewriteRelativeImportExtensions", () => {
     ["./a.tSx", "./a.js"],
 
     // rewrite relative import containing .d
-    ["./.d.a.ts", "./.d.a.ts"], // This is a bug!
+    ["./.d.a.ts", "./.d.a.js"],
     ["./.d.a.cts", "./.d.a.cjs"],
     ["./.d.a.mts", "./.d.a.mjs"],
     ["./.d.a.tsx", "./.d.a.js"],
@@ -35,6 +35,13 @@ describe("tsRewriteRelativeImportExtensions", () => {
     ["./a.d.mts", "./a.d.mts"],
     // transform d.tsx
     ["./a.d.tsx", "./a.d.js"],
+
+    // skip bare .d.ts, .d.cts, and .d.mts
+    ["./.d.ts", "./.d.ts"],
+    ["./.d.cts", "./.d.cts"],
+    ["./.d.mts", "./.d.mts"],
+    // transform bare .d.tsx
+    ["./.d.tsx", "./.d.js"],
 
     // skip absolute
     ["/a.ts", "/a.ts"],
@@ -47,6 +54,12 @@ describe("tsRewriteRelativeImportExtensions", () => {
     ["a.cts", "a.cts"],
     ["a.mts", "a.mts"],
     ["a.tsx", "a.tsx"],
+
+    // skip dot-leading library
+    [".a.ts", ".a.ts"],
+    [".a.cts", ".a.cts"],
+    [".a.mts", ".a.mts"],
+    [".a.tsx", ".a.tsx"],
 
     // skip non-terminal
     ["./a.ts.foo", "./a.ts.foo"],

--- a/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
+++ b/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
@@ -23,11 +23,30 @@ describe("tsRewriteRelativeImportExtensions", () => {
     ["./a.MTs", "./a.mjs"],
     ["./a.tSx", "./a.js"],
 
+    // keep .d.css.ts
+    ["./.d.css.ts", "./.d.css.ts"],
     // rewrite relative import containing .d
-    ["./.d.a.ts", "./.d.a.js"],
-    ["./.d.a.cts", "./.d.a.cjs"],
-    ["./.d.a.mts", "./.d.a.mjs"],
-    ["./.d.a.tsx", "./.d.a.js"],
+    ["./.d.css.cts", "./.d.css.cjs"],
+    ["./.d.css.mts", "./.d.css.mjs"],
+    ["./.d.css.tsx", "./.d.css.js"],
+
+    // rewrite relative import starting with .d
+    ["./.dcss.ts", "./.dcss.js"],
+    ["./.dcss.cts", "./.dcss.cjs"],
+    ["./.dcss.mts", "./.dcss.mjs"],
+    ["./.dcss.tsx", "./.dcss.js"],
+
+    // rewrite relative import containing .d and 3 extra extensions
+    ["./.d.a.css.ts", "./.d.a.css.js"],
+    ["./.d.a.css.cts", "./.d.a.css.cjs"],
+    ["./.d.a.css.mts", "./.d.a.css.mjs"],
+    ["./.d.a.css.tsx", "./.d.a.css.js"],
+
+    // rewrite relative import directory containing .d
+    ["./.d/.css.ts", "./.d/.css.js"],
+    ["./.d/.css.cts", "./.d/.css.cjs"],
+    ["./.d/.css.mts", "./.d/.css.mjs"],
+    ["./.d/.css.tsx", "./.d/.css.js"],
 
     // skip d.ts, d.cts, and d.mts
     ["./a.d.ts", "./a.d.ts"],

--- a/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
+++ b/packages/babel-helpers/test/unittests/tsRewriteRelativeImportExtensions.test.js
@@ -85,6 +85,13 @@ describe("tsRewriteRelativeImportExtensions", () => {
     ["./a.cts.foo", "./a.cts.foo"],
     ["./a.mts.foo", "./a.mts.foo"],
     ["./a.tsx.foo", "./a.tsx.foo"],
+
+    // skip import path with windows path separator
+    // Node.js ESM does not support them either
+    [".\\a.ts", ".\\a.ts"],
+    [".\\a.cts", ".\\a.cts"],
+    [".\\a.mts", ".\\a.mts"],
+    [".\\a.tsx", ".\\a.tsx"],
   ])("%p -> %p", (input, result) => {
     expect(tsRewriteRelativeImportExtensions(input)).toBe(result);
   });

--- a/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
+++ b/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
@@ -11,7 +11,7 @@ export default declare(function ({ types: t, template }) {
     // todo: if we want to support `preserveJsx`, we can register a global flag via file.set from transform-react-jsx, and read it here.
     const preserveJsx = false;
     if (t.isStringLiteral(source)) {
-      if (/^\.\.?[\\/]/.test(source.value)) {
+      if (/^\.\.?\//.test(source.value)) {
         // @see packages/babel-helpers/src/helpers/tsRewriteRelativeImportExtensions.ts
         source.value = source.value.replace(
           /\.(tsx)$|((?:\.d)?)((?:\.[^./]+)?)\.([cm]?)ts$/i,

--- a/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
+++ b/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
@@ -1,25 +1,50 @@
 import { declare } from "@babel/helper-plugin-utils";
-import type { types as t, NodePath } from "@babel/core";
+import type { types as t, NodePath, PluginPass } from "@babel/core";
 
 export default declare(function ({ types: t, template }) {
   function maybeReplace(
-    source: t.ArgumentPlaceholder | t.SpreadElement | t.Expression,
+    source: t.ArgumentPlaceholder | t.Expression,
     path: NodePath,
+    state: PluginPass,
   ) {
     if (!source) return;
+    // todo: if we want to support `preserveJsx`, we can register a global flag via file.set from transform-react-jsx, and read it here.
+    const preserveJsx = false;
     if (t.isStringLiteral(source)) {
-      if (/[\\/]/.test(source.value)) {
-        source.value = source.value
-          .replace(/(\.[mc]?)ts$/, "$1js")
-          .replace(/\.tsx$/, ".js");
+      if (/^\.\.?\//.test(source.value)) {
+        // @see packages/babel-helpers/src/helpers/tsRewriteRelativeImportExtensions.ts
+        source.value = source.value.replace(
+          /\.(tsx)$|((?:\.d)?)((?:\.[^./]+)?)\.([cm]?)ts$/i,
+          function (m, tsx, d, ext, cm) {
+            return tsx
+              ? preserveJsx
+                ? ".jsx"
+                : ".js"
+              : d && (!ext || !cm)
+                ? m
+                : d + ext + "." + cm.toLowerCase() + "js";
+          },
+        );
       }
       return;
     }
 
-    path.replaceWith(
-      template.expression
-        .ast`(${source} + "").replace(/([\\/].*\.[mc]?)tsx?$/, "$1js")`,
-    );
+    if (
+      process.env.BABEL_8_BREAKING ||
+      state.availableHelper("tsRewriteRelativeImportExtensions")
+    ) {
+      path.replaceWith(
+        t.callExpression(
+          state.addHelper("tsRewriteRelativeImportExtensions"),
+          preserveJsx ? [source, t.booleanLiteral(true)] : [source],
+        ),
+      );
+    } else {
+      path.replaceWith(
+        template.expression
+          .ast`(${source} + "").replace(/([\\/].*\.[mc]?)tsx?$/, "$1js")`,
+      );
+    }
   }
 
   return {
@@ -31,22 +56,28 @@ export default declare(function ({ types: t, template }) {
           | t.ExportAllDeclaration
           | t.ExportNamedDeclaration
         >,
+        state,
       ) {
         const node = path.node;
         const kind = t.isImportDeclaration(node)
           ? node.importKind
           : node.exportKind;
         if (kind === "value") {
-          maybeReplace(node.source, path.get("source"));
+          maybeReplace(node.source, path.get("source"), state);
         }
       },
-      CallExpression(path) {
+      CallExpression(path, state) {
         if (t.isImport(path.node.callee)) {
-          maybeReplace(path.node.arguments[0], path.get("arguments.0"));
+          maybeReplace(
+            // The argument of import must not be a spread element
+            path.node.arguments[0] as t.ArgumentPlaceholder | t.Expression,
+            path.get("arguments.0"),
+            state,
+          );
         }
       },
-      ImportExpression(path) {
-        maybeReplace(path.node.source, path.get("source"));
+      ImportExpression(path, state) {
+        maybeReplace(path.node.source, path.get("source"), state);
       },
     },
   };

--- a/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
+++ b/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
@@ -67,7 +67,7 @@ export default declare(function ({ types: t, template }) {
         }
       },
       CallExpression(path, state) {
-        if (t.isImport(path.node.callee)) {
+        if (!process.env.BABEL_8_BREAKING && t.isImport(path.node.callee)) {
           maybeReplace(
             // The argument of import must not be a spread element
             path.node.arguments[0] as t.ArgumentPlaceholder | t.Expression,

--- a/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
+++ b/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts
@@ -11,7 +11,7 @@ export default declare(function ({ types: t, template }) {
     // todo: if we want to support `preserveJsx`, we can register a global flag via file.set from transform-react-jsx, and read it here.
     const preserveJsx = false;
     if (t.isStringLiteral(source)) {
-      if (/^\.\.?\//.test(source.value)) {
+      if (/^\.\.?[\\/]/.test(source.value)) {
         // @see packages/babel-helpers/src/helpers/tsRewriteRelativeImportExtensions.ts
         source.value = source.value.replace(
           /\.(tsx)$|((?:\.d)?)((?:\.[^./]+)?)\.([cm]?)ts$/i,

--- a/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions-createImportExpressions/output.mjs
+++ b/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions-createImportExpressions/output.mjs
@@ -1,2 +1,2 @@
 import("./a.js");
-import((a + "").replace(/([\/].*.[mc]?)tsx?$/, "$1js"));
+import(babelHelpers.tsRewriteRelativeImportExtensions(a));

--- a/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/output.mjs
+++ b/packages/babel-preset-typescript/test/fixtures/opts/rewriteImportExtensions/output.mjs
@@ -5,10 +5,10 @@ import "./react.js";
 // .mtsx and .ctsx are not valid and should not be transformed.
 import "./react.mtsx";
 import "./react.ctsx";
-import "a-package/file.js";
+import "a-package/file.ts";
 // Bare import, it's either a node package or remapped by an import map
 import "soundcloud.ts";
 export * from "./a.js";
 export { x } from "./a.mjs";
 import("./a.js");
-import((a + "").replace(/([\/].*.[mc]?)tsx?$/, "$1js"));
+import(babelHelpers.tsRewriteRelativeImportExtensions(a));

--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -756,6 +756,15 @@
       "./helpers/toSetter.js"
     ],
     "./helpers/esm/toSetter": "./helpers/esm/toSetter.js",
+    "./helpers/tsRewriteRelativeImportExtensions": [
+      {
+        "node": "./helpers/tsRewriteRelativeImportExtensions.js",
+        "import": "./helpers/esm/tsRewriteRelativeImportExtensions.js",
+        "default": "./helpers/tsRewriteRelativeImportExtensions.js"
+      },
+      "./helpers/tsRewriteRelativeImportExtensions.js"
+    ],
+    "./helpers/esm/tsRewriteRelativeImportExtensions": "./helpers/esm/tsRewriteRelativeImportExtensions.js",
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof.js",

--- a/packages/babel-runtime-corejs3/helpers/esm/tsRewriteRelativeImportExtensions.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/tsRewriteRelativeImportExtensions.js
@@ -1,0 +1,6 @@
+function tsRewriteRelativeImportExtensions(t, e) {
+  return "string" == typeof t && /^\.\.?\//.test(t) ? t.replace(/\.(tsx)$|((?:\.d)?)((?:\.[^./]+)?)\.([cm]?)ts$/i, function (t, s, r, n, o) {
+    return s ? e ? ".jsx" : ".js" : !r || n && o ? r + n + "." + o.toLowerCase() + "js" : t;
+  }) : t;
+}
+export { tsRewriteRelativeImportExtensions as default };

--- a/packages/babel-runtime-corejs3/helpers/esm/tsRewriteRelativeImportExtensions.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/tsRewriteRelativeImportExtensions.js
@@ -1,5 +1,5 @@
 function tsRewriteRelativeImportExtensions(t, e) {
-  return "string" == typeof t && /^\.\.?\//.test(t) ? t.replace(/\.(tsx)$|((?:\.d)?)((?:\.[^./]+)?)\.([cm]?)ts$/i, function (t, s, r, n, o) {
+  return "string" == typeof t && /^\.\.?[\\/]/.test(t) ? t.replace(/\.(tsx)$|((?:\.d)?)((?:\.[^./]+)?)\.([cm]?)ts$/i, function (t, s, r, n, o) {
     return s ? e ? ".jsx" : ".js" : !r || n && o ? r + n + "." + o.toLowerCase() + "js" : t;
   }) : t;
 }

--- a/packages/babel-runtime-corejs3/helpers/esm/tsRewriteRelativeImportExtensions.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/tsRewriteRelativeImportExtensions.js
@@ -1,5 +1,5 @@
 function tsRewriteRelativeImportExtensions(t, e) {
-  return "string" == typeof t && /^\.\.?[\\/]/.test(t) ? t.replace(/\.(tsx)$|((?:\.d)?)((?:\.[^./]+)?)\.([cm]?)ts$/i, function (t, s, r, n, o) {
+  return "string" == typeof t && /^\.\.?\//.test(t) ? t.replace(/\.(tsx)$|((?:\.d)?)((?:\.[^./]+)?)\.([cm]?)ts$/i, function (t, s, r, n, o) {
     return s ? e ? ".jsx" : ".js" : !r || n && o ? r + n + "." + o.toLowerCase() + "js" : t;
   }) : t;
 }

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -755,6 +755,15 @@
       "./helpers/toSetter.js"
     ],
     "./helpers/esm/toSetter": "./helpers/esm/toSetter.js",
+    "./helpers/tsRewriteRelativeImportExtensions": [
+      {
+        "node": "./helpers/tsRewriteRelativeImportExtensions.js",
+        "import": "./helpers/esm/tsRewriteRelativeImportExtensions.js",
+        "default": "./helpers/tsRewriteRelativeImportExtensions.js"
+      },
+      "./helpers/tsRewriteRelativeImportExtensions.js"
+    ],
+    "./helpers/esm/tsRewriteRelativeImportExtensions": "./helpers/esm/tsRewriteRelativeImportExtensions.js",
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof.js",

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -755,6 +755,15 @@
       "./helpers/toSetter.js"
     ],
     "./helpers/esm/toSetter": "./helpers/esm/toSetter.js",
+    "./helpers/tsRewriteRelativeImportExtensions": [
+      {
+        "node": "./helpers/tsRewriteRelativeImportExtensions.js",
+        "import": "./helpers/esm/tsRewriteRelativeImportExtensions.js",
+        "default": "./helpers/tsRewriteRelativeImportExtensions.js"
+      },
+      "./helpers/tsRewriteRelativeImportExtensions.js"
+    ],
+    "./helpers/esm/tsRewriteRelativeImportExtensions": "./helpers/esm/tsRewriteRelativeImportExtensions.js",
     "./helpers/typeof": [
       {
         "node": "./helpers/typeof.js",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/17114
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/3052
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we introduced a new helper `tsRewriteRelativeImportExtensions` that is almost identical (the regex is slightly improved with the help of eslint-regex) to the TS helper. The new behaviour in this PR should mirror the tsc `rewriteRelativeImportExtensions` option without the tsc JSX output option.