### PR TITLE
[Babel 8] Remove `BLOCK_SCOPED_SYMBOL` and `NOT_LOCAL_BINDING`

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/index.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/index.ts
@@ -254,12 +254,6 @@ function isInLoop(path: NodePath<t.Node>): boolean {
 
 function isBlockScoped(node: t.Node): node is t.VariableDeclaration {
   if (!t.isVariableDeclaration(node)) return false;
-  if (
-    // @ts-expect-error Fixme: document symbol properties
-    node[t.BLOCK_SCOPED_SYMBOL]
-  ) {
-    return true;
-  }
 
   if (!isLetOrConst(node.kind) && node.kind !== "using") {
     return false;

--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -5,7 +5,6 @@ import Binding from "./binding.ts";
 import type { BindingKind } from "./binding.ts";
 import globals from "globals";
 import {
-  NOT_LOCAL_BINDING,
   assignmentExpression,
   callExpression,
   cloneNode,
@@ -234,6 +233,13 @@ interface CollectVisitorState {
   constantViolations: NodePath[];
 }
 
+if (!process.env.BABEL_8_BREAKING) {
+  // eslint-disable-next-line no-var
+  var NOT_LOCAL_BINDING = Symbol.for(
+    "should not be considered a local binding",
+  );
+}
+
 const collectorVisitor: Visitor<CollectVisitorState> = {
   ForStatement(path) {
     const declar = path.get("init");
@@ -368,8 +374,9 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
     if (
       path.isFunctionExpression() &&
       path.node.id &&
-      // @ts-expect-error Fixme: document symbol ast properties
-      !path.node.id[NOT_LOCAL_BINDING]
+      (process.env.BABEL_8_BREAKING ||
+        // @ts-expect-error Fixme: document symbol ast properties
+        !path.node.id[NOT_LOCAL_BINDING])
     ) {
       path.scope.registerBinding("local", path.get("id"), path);
     }
@@ -378,8 +385,9 @@ const collectorVisitor: Visitor<CollectVisitorState> = {
   ClassExpression(path) {
     if (
       path.node.id &&
-      // @ts-expect-error Fixme: document symbol ast properties
-      !path.node.id[NOT_LOCAL_BINDING]
+      (process.env.BABEL_8_BREAKING ||
+        // @ts-expect-error Fixme: document symbol ast properties
+        !path.node.id[NOT_LOCAL_BINDING])
     ) {
       path.scope.registerBinding("local", path.get("id"), path);
     }

--- a/packages/babel-types/src/constants/index.ts
+++ b/packages/babel-types/src/constants/index.ts
@@ -64,7 +64,10 @@ export const INHERIT_KEYS = {
   force: ["start", "loc", "end"],
 } as const;
 
-export const BLOCK_SCOPED_SYMBOL = Symbol.for("var used to be block scoped");
+if (!process.env.BABEL_8_BREAKING && !USE_ESM) {
+  // eslint-disable-next-line no-restricted-globals
+  exports.BLOCK_SCOPED_SYMBOL = Symbol.for("var used to be block scoped");
+}
 export const NOT_LOCAL_BINDING = Symbol.for(
   "should not be considered a local binding",
 );

--- a/packages/babel-types/src/constants/index.ts
+++ b/packages/babel-types/src/constants/index.ts
@@ -67,7 +67,8 @@ export const INHERIT_KEYS = {
 if (!process.env.BABEL_8_BREAKING && !USE_ESM) {
   // eslint-disable-next-line no-restricted-globals
   exports.BLOCK_SCOPED_SYMBOL = Symbol.for("var used to be block scoped");
+  // eslint-disable-next-line no-restricted-globals
+  exports.NOT_LOCAL_BINDING = Symbol.for(
+    "should not be considered a local binding",
+  );
 }
-export const NOT_LOCAL_BINDING = Symbol.for(
-  "should not be considered a local binding",
-);

--- a/packages/babel-types/src/validators/isLet.ts
+++ b/packages/babel-types/src/validators/isLet.ts
@@ -1,15 +1,23 @@
 import { isVariableDeclaration } from "./generated/index.ts";
-import { BLOCK_SCOPED_SYMBOL } from "../constants/index.ts";
 import type * as t from "../index.ts";
+
+if (!process.env.BABEL_8_BREAKING) {
+  // eslint-disable-next-line no-var
+  var BLOCK_SCOPED_SYMBOL = Symbol.for("var used to be block scoped");
+}
 
 /**
  * Check if the input `node` is a `let` variable declaration.
  */
 export default function isLet(node: t.Node): boolean {
-  return (
-    isVariableDeclaration(node) &&
-    (node.kind !== "var" ||
-      // @ts-expect-error Fixme: document private properties
-      node[BLOCK_SCOPED_SYMBOL])
-  );
+  if (process.env.BABEL_8_BREAKING) {
+    return isVariableDeclaration(node) && node.kind !== "var";
+  } else {
+    return (
+      isVariableDeclaration(node) &&
+      (node.kind !== "var" ||
+        // @ts-expect-error Fixme: document private properties
+        node[BLOCK_SCOPED_SYMBOL])
+    );
+  }
 }

--- a/packages/babel-types/src/validators/isVar.ts
+++ b/packages/babel-types/src/validators/isVar.ts
@@ -1,16 +1,24 @@
 import { isVariableDeclaration } from "./generated/index.ts";
-import { BLOCK_SCOPED_SYMBOL } from "../constants/index.ts";
 import type * as t from "../index.ts";
+
+if (!process.env.BABEL_8_BREAKING) {
+  // eslint-disable-next-line no-var
+  var BLOCK_SCOPED_SYMBOL = Symbol.for("var used to be block scoped");
+}
 
 /**
  * Check if the input `node` is a variable declaration.
  */
 export default function isVar(node: t.Node): boolean {
-  return (
-    isVariableDeclaration(node, { kind: "var" }) &&
-    !(
-      // @ts-expect-error document private properties
-      node[BLOCK_SCOPED_SYMBOL]
-    )
-  );
+  if (process.env.BABEL_8_BREAKING) {
+    return isVariableDeclaration(node) && node.kind === "var";
+  } else {
+    return (
+      isVariableDeclaration(node, { kind: "var" }) &&
+      !(
+        // @ts-expect-error document private properties
+        node[BLOCK_SCOPED_SYMBOL]
+      )
+    );
+  }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Thanks to https://github.com/babel/babel/pull/15200, we no longer use `BLOCK_SCOPED_SYMBOL`, so we can now safely remove it.
Although this is exported, we have broken its usage in https://github.com/babel/babel/pull/15200, so documentation should not be needed.