### PR TITLE
fix: improve duplicate named groups check

### DIFF
--- a/packages/babel-helper-create-regexp-features-plugin/src/util.ts
+++ b/packages/babel-helper-create-regexp-features-plugin/src/util.ts
@@ -23,8 +23,8 @@ export function generateRegexpuOptions(
     const seen = new Set();
     for (
       let match;
-      (match = regex.exec(pattern));
-      match[2] && seen.add(match[1])
+      (match = regex.exec(pattern)) && match[2];
+      seen.add(match[1])
     ) {
       if (seen.has(match[1])) return "transform";
     }

--- a/packages/babel-helper-create-regexp-features-plugin/src/util.ts
+++ b/packages/babel-helper-create-regexp-features-plugin/src/util.ts
@@ -18,9 +18,14 @@ export function generateRegexpuOptions(
     // However, it's such a rare occurrence that it's ok to compile
     // the regexp even if we only need to compile regexps with
     // duplicate named capturing groups.
-    const regex = /\(\?<([^>]+)>/g;
+    // The $ is to exit early for malicious input such as \(?<\(?<\(?<...
+    const regex = /\(\?<([^>]+)(>|$)/g;
     const seen = new Set();
-    for (let match; (match = regex.exec(pattern)); seen.add(match[1])) {
+    for (
+      let match;
+      (match = regex.exec(pattern));
+      match[2] && seen.add(match[1])
+    ) {
       if (seen.has(match[1])) return "transform";
     }
     return false;

--- a/packages/babel-helper-create-regexp-features-plugin/test/util.skip-bundled.js
+++ b/packages/babel-helper-create-regexp-features-plugin/test/util.skip-bundled.js
@@ -7,7 +7,6 @@ describe("generateRegexpuOptions", () => {
       const startTime = Date.now();
       const options = generateRegexpuOptions(pattern, 0);
       const timeTaken = Date.now() - startTime;
-      console.log(timeTaken);
       expect(timeTaken).toBeLessThan(2000);
       expect(options).toHaveProperty("namedGroups", false);
     });

--- a/packages/babel-helper-create-regexp-features-plugin/test/util.skip-bundled.js
+++ b/packages/babel-helper-create-regexp-features-plugin/test/util.skip-bundled.js
@@ -1,0 +1,15 @@
+import { generateRegexpuOptions } from "../lib/util.js";
+
+describe("generateRegexpuOptions", () => {
+  describe("should handle maliciously crafted pattern", () => {
+    it("\\(?<\\(?<...", () => {
+      const pattern = "" + new RegExp("\\(?<".repeat(4e4));
+      const startTime = Date.now();
+      const options = generateRegexpuOptions(pattern, 0);
+      const timeTaken = Date.now() - startTime;
+      console.log(timeTaken);
+      expect(timeTaken).toBeLessThan(2000);
+      expect(options).toHaveProperty("namedGroups", false);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The duplicate named groups check demonstrates quadratic behaviour on some input
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The fix is similar to #17173, here we exit early for unterminated groups.