### PR TITLE
test: add basic typescript-eslint integration tests

### DIFF
--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -49,7 +49,8 @@
     "@types/estree": "^1.0.5",
     "@typescript-eslint/scope-manager": "^6.19.0",
     "dedent": "^1.5.3",
-    "eslint": "^9.21.0"
+    "eslint": "^9.21.0",
+    "typescript-eslint": "8.26.1"
   },
   "conditions": {
     "BABEL_8_BREAKING": [

--- a/eslint/babel-eslint-parser/test/typescript-estree.test.js
+++ b/eslint/babel-eslint-parser/test/typescript-estree.test.js
@@ -1,0 +1,136 @@
+import path from "node:path";
+import { parseForESLint } from "../lib/index.cjs";
+import { ESLint } from "eslint";
+import { itDummy, commonJS } from "$repo-utils";
+
+const ESLINT_VERSION = ESLint.version;
+const isESLint9 = ESLINT_VERSION.startsWith("9.");
+const { require } = commonJS(import.meta.url);
+
+const PROPS_TO_REMOVE = [
+  // typescript-eslint generates start/end in the loc object, while Babel generate both start/end and loc
+  { key: "start", type: "Node" },
+  { key: "end", type: "Node" },
+
+  { key: "importKind", type: "Node" },
+  { key: "exportKind", type: "Node" },
+  { key: "variance", type: "Node" },
+  { key: "typeArguments", type: "Node" },
+  { key: "filename", type: null },
+  { key: "identifierName", type: null },
+  // For legacy estree AST
+  { key: "attributes", type: "ImportExpression" },
+];
+
+function deeplyRemoveProperties(obj, props) {
+  for (const [k, v] of Object.entries(obj)) {
+    if (
+      props.some(
+        ({ key, type }) =>
+          key === k &&
+          ((type === "Node" && obj.type) || type === obj.type || type == null),
+      )
+    ) {
+      delete obj[k];
+      continue;
+    }
+
+    if (typeof v === "object") {
+      if (Array.isArray(v)) {
+        for (const el of v) {
+          if (el != null) {
+            deeplyRemoveProperties(el, props);
+          }
+        }
+      }
+
+      if (v != null) {
+        deeplyRemoveProperties(v, props);
+      }
+    }
+  }
+}
+
+(isESLint9 ? describe : describe.skip)(
+  "Babel should output the same AST as TypeScript-Estree",
+  () => {
+    /**
+     * @type {import("@typescript-eslint/typescript-estree")}
+     */
+    let tsEstree;
+
+    /**
+     * @type {import("@typescript-eslint/typescript-estree").TSESTreeOptions}
+     */
+    const tsEstreeOptions = {
+      filePath: "typescript-estree.test.js-test-input.tsx",
+      jsx: true,
+      tokens: true,
+      loc: true,
+      range: true,
+      comment: true,
+      sourceType: "module",
+    };
+
+    function parseAndAssertSame(code, babelEcmaFeatures = null) {
+      if (isESLint9) {
+        // ESLint 9
+        const tsEstreeAST = tsEstree.parse(code, tsEstreeOptions);
+        const babelAST = parseForESLint(code, {
+          eslintVisitorKeys: true,
+          eslintScopeManager: true,
+          ecmaFeatures: babelEcmaFeatures,
+          requireConfigFile: false,
+          babelOptions: {
+            configFile: false,
+            parserOpts: {
+              plugins: ["jsx", "typescript"],
+            },
+          },
+        }).ast;
+
+        deeplyRemoveProperties(babelAST, PROPS_TO_REMOVE);
+        expect(babelAST).toEqual(tsEstreeAST);
+      }
+    }
+
+    beforeAll(() => {
+      // Use the version of TS-Espree that is a dependency of
+      // the version of typescript-eslint we are testing against.
+      const tsEstreePath = require.resolve(
+        "@typescript-eslint/typescript-estree",
+        {
+          paths: [path.dirname(require.resolve("typescript-eslint"))],
+        },
+      );
+
+      tsEstree = require(tsEstreePath);
+    });
+
+    it.each([
+      ["empty", ""],
+
+      ["boolean", "true"],
+      ["boolean", "false"],
+
+      ["numeric", "0"],
+      // ["bigint", "0n"],
+
+      ["regexp without flag", `/foo/;`],
+      ["regexp u flag", `/foo/dgimsuy;`],
+      ["regexp v flag", `/foo/dgimsvy;`],
+
+      ["logical NOT", `!0`],
+      ["bitwise NOT", `~0`],
+    ])("%s: %s", (_, input) => {
+      parseAndAssertSame(input);
+    });
+  },
+);
+
+(isESLint9 ? describe.skip : describe)(
+  "typescript-estree test for older ESLint versions",
+  () => {
+    itDummy("is skipped", () => {});
+  },
+);

--- a/eslint/babel-eslint-parser/test/typescript-estree.test.js
+++ b/eslint/babel-eslint-parser/test/typescript-estree.test.js
@@ -51,6 +51,7 @@ function deeplyRemoveProperties(obj, props) {
   }
 }
 
+// Only ESLint 9 or above will be tested
 (isESLint9 ? describe : describe.skip)(
   "Babel should output the same AST as TypeScript-Estree",
   () => {
@@ -73,25 +74,22 @@ function deeplyRemoveProperties(obj, props) {
     };
 
     function parseAndAssertSame(code, babelEcmaFeatures = null) {
-      if (isESLint9) {
-        // ESLint 9
-        const tsEstreeAST = tsEstree.parse(code, tsEstreeOptions);
-        const babelAST = parseForESLint(code, {
-          eslintVisitorKeys: true,
-          eslintScopeManager: true,
-          ecmaFeatures: babelEcmaFeatures,
-          requireConfigFile: false,
-          babelOptions: {
-            configFile: false,
-            parserOpts: {
-              plugins: ["jsx", "typescript"],
-            },
+      const tsEstreeAST = tsEstree.parse(code, tsEstreeOptions);
+      const babelAST = parseForESLint(code, {
+        eslintVisitorKeys: true,
+        eslintScopeManager: true,
+        ecmaFeatures: babelEcmaFeatures,
+        requireConfigFile: false,
+        babelOptions: {
+          configFile: false,
+          parserOpts: {
+            plugins: ["jsx", "typescript"],
           },
-        }).ast;
+        },
+      }).ast;
 
-        deeplyRemoveProperties(babelAST, PROPS_TO_REMOVE);
-        expect(babelAST).toEqual(tsEstreeAST);
-      }
+      deeplyRemoveProperties(babelAST, PROPS_TO_REMOVE);
+      expect(babelAST).toEqual(tsEstreeAST);
     }
 
     beforeAll(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -419,6 +419,7 @@ __metadata:
     eslint-scope: "condition:BABEL_8_BREAKING ? ^7.1.1 : "
     eslint-visitor-keys: "condition:BABEL_8_BREAKING ? ^3.3.0 : ^2.1.0"
     semver: "condition:BABEL_8_BREAKING ? ^7.3.4 : ^6.3.1"
+    typescript-eslint: "npm:8.26.1"
   peerDependencies:
     "@babel/core": ^7.11.0
     eslint: ^7.5.0 || ^8.0.0 || ^9.0.0


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Ref https://github.com/babel/babel/issues/16679
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR introduces a minimal integration test with typescript-eslint. The AST equality check is very strict so currently there are still a few gaps between the two AST due to optional AST properties: TS-ESLint always define them while Babel optionally define them.