### PR TITLE
Update firefox bugfix compat data

### DIFF
--- a/packages/babel-compat-data/data/plugin-bugfixes.json
+++ b/packages/babel-compat-data/data/plugin-bugfixes.json
@@ -107,18 +107,6 @@
     "opera_mobile": "64",
     "electron": "13.0"
   },
-  "bugfix/transform-firefox-class-in-computed-class-key": {
-    "chrome": "74",
-    "opera": "62",
-    "edge": "79",
-    "safari": "16",
-    "node": "12",
-    "deno": "1",
-    "ios": "16",
-    "samsung": "11",
-    "opera_mobile": "53",
-    "electron": "6.0"
-  },
   "transform-optional-chaining": {
     "chrome": "80",
     "opera": "67",

--- a/packages/babel-compat-data/data/plugins.json
+++ b/packages/babel-compat-data/data/plugins.json
@@ -46,6 +46,7 @@
     "chrome": "74",
     "opera": "62",
     "edge": "79",
+    "firefox": "126",
     "safari": "16",
     "node": "12",
     "deno": "1",

--- a/packages/babel-compat-data/scripts/data/plugin-features.js
+++ b/packages/babel-compat-data/scripts/data/plugin-features.js
@@ -169,8 +169,8 @@ const es2022 = {
   "bugfix/transform-firefox-class-in-computed-class-key": {
     replaces: "transform-class-properties",
     overwrite: {
-      // TODO: Once Firefox releases the fix, write the correct version here.
-      firefox: undefined,
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1887677
+      firefox: "126",
     },
   },
   "bugfix/transform-safari-class-field-initializer-scope": {

--- a/packages/babel-compat-data/scripts/utils-build-data.js
+++ b/packages/babel-compat-data/scripts/utils-build-data.js
@@ -150,8 +150,7 @@ exports.generateData = (environments, features) => {
     }
   }
 
-  // eslint-disable-next-line prefer-const
-  for (let [key, options] of Object.entries(normalized)) {
+  for (const [key, options] of Object.entries(normalized)) {
     const plugin = {};
 
     environments.forEach(env => {

--- a/packages/babel-preset-env/test/fixtures/bugfixes-always-enabled/class-in-computed-field-firefox-90/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes-always-enabled/class-in-computed-field-firefox-90/stdout.txt
@@ -11,7 +11,7 @@ Using plugins:
   transform-duplicate-named-capturing-groups-regex { firefox < 129 }
   transform-regexp-modifiers { firefox < 132 }
   transform-unicode-sets-regex { firefox < 116 }
-  bugfix/transform-firefox-class-in-computed-class-key { firefox }
+  bugfix/transform-firefox-class-in-computed-class-key { firefox < 126 }
   transform-class-static-block { firefox < 93 }
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/bugfixes-babel-8/_esmodules/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/bugfixes-babel-8/_esmodules/stdout.txt
@@ -19,7 +19,7 @@ Using plugins:
   transform-duplicate-named-capturing-groups-regex { chrome < 126, firefox < 129, ios < 17.4, opera_mobile, samsung }
   transform-regexp-modifiers { chrome < 125, firefox < 132, ios, opera_mobile, safari, samsung }
   transform-unicode-sets-regex { chrome < 112, ios < 17, samsung }
-  bugfix/transform-firefox-class-in-computed-class-key { firefox, ios < 16 }
+  bugfix/transform-firefox-class-in-computed-class-key { ios < 16 }
   bugfix/transform-safari-class-field-initializer-scope { ios < 16 }
   transform-class-static-block { ios < 16.4 }
   transform-export-namespace-from { }

--- a/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/corejs3/usage-browserslist-config-ignore/stdout.txt
@@ -19,7 +19,7 @@ Using plugins:
   transform-duplicate-named-capturing-groups-regex { chrome < 126, firefox < 129, ios < 17.4, opera_mobile, samsung }
   transform-regexp-modifiers { chrome < 125, firefox < 132, ios, opera_mobile, safari, samsung }
   transform-unicode-sets-regex { chrome < 112, ios < 17, samsung }
-  bugfix/transform-firefox-class-in-computed-class-key { firefox, ios < 16 }
+  bugfix/transform-firefox-class-in-computed-class-key { ios < 16 }
   bugfix/transform-safari-class-field-initializer-scope { ios < 16 }
   transform-class-static-block { ios < 16.4 }
   bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios < 16.3 }

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults-not-ie/stdout.txt
@@ -19,7 +19,7 @@ Using plugins:
   transform-duplicate-named-capturing-groups-regex { chrome < 126, firefox < 129, ios < 17.4, opera_mobile, samsung }
   transform-regexp-modifiers { chrome < 125, firefox < 132, ios, opera_mobile, safari, samsung }
   transform-unicode-sets-regex { chrome < 112, ios < 17, samsung }
-  bugfix/transform-firefox-class-in-computed-class-key { firefox, ios < 16 }
+  bugfix/transform-firefox-class-in-computed-class-key { ios < 16 }
   bugfix/transform-safari-class-field-initializer-scope { ios < 16 }
   transform-class-static-block { ios < 16.4 }
   syntax-private-property-in-object

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-defaults/stdout.txt
@@ -19,7 +19,7 @@ Using plugins:
   transform-duplicate-named-capturing-groups-regex { chrome < 126, firefox < 129, ios < 17.4, opera_mobile, samsung }
   transform-regexp-modifiers { chrome < 125, firefox < 132, ios, opera_mobile, safari, samsung }
   transform-unicode-sets-regex { chrome < 112, ios < 17, samsung }
-  bugfix/transform-firefox-class-in-computed-class-key { firefox, ios < 16 }
+  bugfix/transform-firefox-class-in-computed-class-key { ios < 16 }
   bugfix/transform-safari-class-field-initializer-scope { ios < 16 }
   transform-class-static-block { ios < 16.4 }
   syntax-private-property-in-object

--- a/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug-babel-7/browserslists-last-2-versions-not-ie/stdout.txt
@@ -19,7 +19,6 @@ Using plugins:
   transform-duplicate-named-capturing-groups-regex { opera_mobile, samsung }
   transform-regexp-modifiers { ios, opera_mobile, safari, samsung }
   transform-unicode-sets-regex { samsung }
-  bugfix/transform-firefox-class-in-computed-class-key { firefox }
   syntax-class-static-block
   syntax-private-property-in-object
   syntax-class-properties

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults-not-ie/stdout.txt
@@ -19,7 +19,7 @@ Using plugins:
   transform-duplicate-named-capturing-groups-regex { chrome < 126, firefox < 129, ios < 17.4, opera_mobile, samsung }
   transform-regexp-modifiers { chrome < 125, firefox < 132, ios, opera_mobile, safari, samsung }
   transform-unicode-sets-regex { chrome < 112, ios < 17, samsung }
-  bugfix/transform-firefox-class-in-computed-class-key { firefox, ios < 16 }
+  bugfix/transform-firefox-class-in-computed-class-key { ios < 16 }
   bugfix/transform-safari-class-field-initializer-scope { ios < 16 }
   transform-class-static-block { ios < 16.4 }
   transform-export-namespace-from { }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-defaults/stdout.txt
@@ -19,7 +19,7 @@ Using plugins:
   transform-duplicate-named-capturing-groups-regex { chrome < 126, firefox < 129, ios < 17.4, opera_mobile, samsung }
   transform-regexp-modifiers { chrome < 125, firefox < 132, ios, opera_mobile, safari, samsung }
   transform-unicode-sets-regex { chrome < 112, ios < 17, samsung }
-  bugfix/transform-firefox-class-in-computed-class-key { firefox, ios < 16 }
+  bugfix/transform-firefox-class-in-computed-class-key { ios < 16 }
   bugfix/transform-safari-class-field-initializer-scope { ios < 16 }
   transform-class-static-block { ios < 16.4 }
   transform-export-namespace-from { }

--- a/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
+++ b/packages/babel-preset-env/test/fixtures/debug/browserslists-last-2-versions-not-ie/stdout.txt
@@ -19,7 +19,6 @@ Using plugins:
   transform-duplicate-named-capturing-groups-regex { opera_mobile, samsung }
   transform-regexp-modifiers { ios, opera_mobile, safari, samsung }
   transform-unicode-sets-regex { samsung }
-  bugfix/transform-firefox-class-in-computed-class-key { firefox }
   transform-export-namespace-from { }
   transform-modules-commonjs
   transform-dynamic-import


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The `transform-firefox-class-in-computed-class-key` was enabled when targeted to an unaffected firefox version
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The upstream browser bug was fixed in FF 126, hence we update the compat data.