### PR TITLE
fix apply()/call() annotated as pure

### DIFF
--- a/packages/babel-helper-remap-async-to-generator/src/index.ts
+++ b/packages/babel-helper-remap-async-to-generator/src/index.ts
@@ -1,5 +1,3 @@
-/* @noflow */
-
 import type { NodePath } from "@babel/core";
 import wrapFunction from "@babel/helper-wrap-function";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
@@ -72,37 +70,25 @@ export default function (
     }
 
     // try to catch calls to Function#bind, as emitted by arrowFunctionToExpression in spec mode
-    // this may also catch .bind(this)/.call()/.apply() written by users, but does it matter? 🤔
+    // this may also catch .bind(this) written by users, but does it matter? 🤔
     const { parentPath } = path;
+    if (parentPath.isMemberExpression()) {
+      if (isIdentifier(parentPath.node.property, { name: "bind" })) {
+        const { parentPath: bindCall } = parentPath;
 
-    if (
-      parentPath.isMemberExpression() &&
-      isIdentifier(parentPath.node.property)
-    ) {
-      const { parentPath: methodCall } = parentPath;
-      const { name: methodName } = parentPath.node.property;
-
-      if (["call", "apply"].includes(methodName)) {
-        // (function () { ... }).apply(...)
-        // (function () { ... }).call(...)
-
-        // check if the result of '.call()' or '.apply()' is immediately invoked
-        return methodCall.isCallExpression({ callee: parentPath.node });
-      }
-
-      if (methodName === "bind") {
         // (function () { ... }).bind(this)()
 
         return (
           // first, check if the .bind is actually being called
-          methodCall.isCallExpression() &&
+          bindCall.isCallExpression() &&
           // and whether its sole argument is 'this'
-          methodCall.node.arguments.length === 1 &&
-          isThisExpression(methodCall.node.arguments[0]) &&
+          bindCall.node.arguments.length === 1 &&
+          isThisExpression(bindCall.node.arguments[0]) &&
           // and whether the result of the .bind(this) is being called
-          methodCall.parentPath.isCallExpression({ callee: methodCall.node })
+          bindCall.parentPath.isCallExpression({ callee: bindCall.node })
         );
       }
+      return true;
     }
 
     return false;

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-apply-call-no-pure/input.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-apply-call-no-pure/input.js
@@ -9,3 +9,6 @@
 
 (async function() {
 }).apply();
+
+(async function() {
+}).test();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-apply-call-no-pure/input.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-apply-call-no-pure/input.js
@@ -1,0 +1,11 @@
+(async function() {
+})();
+
+(async function() {
+}).bind(this)();
+
+(async function() {
+}).call();
+
+(async function() {
+}).apply();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-apply-call-no-pure/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-apply-call-no-pure/output.js
@@ -1,0 +1,4 @@
+babelHelpers.asyncToGenerator(function* () {})();
+babelHelpers.asyncToGenerator(function* () {}).bind(this)();
+babelHelpers.asyncToGenerator(function* () {}).call();
+babelHelpers.asyncToGenerator(function* () {}).apply();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-apply-call-no-pure/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/async-to-generator/async-iife-apply-call-no-pure/output.js
@@ -2,3 +2,4 @@ babelHelpers.asyncToGenerator(function* () {})();
 babelHelpers.asyncToGenerator(function* () {}).bind(this)();
 babelHelpers.asyncToGenerator(function* () {}).call();
 babelHelpers.asyncToGenerator(function* () {}).apply();
+babelHelpers.asyncToGenerator(function* () {}).test();

--- a/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7194/output.js
+++ b/packages/babel-plugin-transform-async-to-generator/test/fixtures/regression/T7194/output.js
@@ -6,7 +6,7 @@ function f() {
     });
   }));
 }
-/*#__PURE__*/babelHelpers.asyncToGenerator(function* () {
+babelHelpers.asyncToGenerator(function* () {
   var _this2 = this;
   console.log('async wrapper:', this === 'foo');
   (function () {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17227 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Handle check `apply` and `call` avoid `#__PURE__` annotation in `transform-async-to-generator`
