### PR TITLE
[babel 8] Do not replace global `regeneratorRuntime` references in regenerator transform

### DIFF
--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -32,6 +32,7 @@
     "@babel/plugin-transform-modules-commonjs": "workspace:^",
     "@babel/plugin-transform-parameters": "workspace:^",
     "@babel/plugin-transform-runtime": "workspace:^",
+    "babel-plugin-polyfill-regenerator": "^0.6.1",
     "mocha": "^10.0.0",
     "recast": "^0.23.3",
     "uglify-js": "^3.14.0"

--- a/packages/babel-plugin-transform-regenerator/src/index.ts
+++ b/packages/babel-plugin-transform-regenerator/src/index.ts
@@ -8,43 +8,41 @@ export default declare(({ types: t, traverse, assertVersion }) => {
   return {
     name: "transform-regenerator",
 
-    visitor: traverse.visitors.merge([
-      getVisitor(t),
-      {
-        // We visit CallExpression so that we always transform
-        // regeneratorRuntime.*() before babel-plugin-polyfill-regenerator.
-        CallExpression(path) {
-          if (!process.env.BABEL_8_BREAKING) {
-            if (!this.availableHelper?.("regeneratorRuntime")) {
-              // When using an older @babel/helpers version, fallback
-              // to the old behavior.
-              return;
-            }
-          }
-
-          const callee = path.get("callee");
-          if (!callee.isMemberExpression()) return;
-
-          const obj = callee.get("object");
-          if (obj.isIdentifier({ name: "regeneratorRuntime" })) {
-            const helper = this.addHelper("regeneratorRuntime") as
-              | t.Identifier
-              | t.ArrowFunctionExpression;
-
-            if (!process.env.BABEL_8_BREAKING) {
-              if (
-                // It's necessary to avoid the IIFE when using older Babel versions.
-                t.isArrowFunctionExpression(helper)
-              ) {
-                obj.replaceWith(helper.body);
+    visitor: process.env.BABEL_8_BREAKING
+      ? getVisitor(t)
+      : traverse.visitors.merge([
+          getVisitor(t),
+          {
+            // We visit CallExpression so that we always transform
+            // regeneratorRuntime.*() before babel-plugin-polyfill-regenerator.
+            CallExpression(path) {
+              if (!this.availableHelper?.("regeneratorRuntime")) {
+                // When using an older @babel/helpers version, fallback
+                // to the old behavior.
                 return;
               }
-            }
 
-            obj.replaceWith(t.callExpression(helper, []));
-          }
-        },
-      },
-    ]),
+              const callee = path.get("callee");
+              if (!callee.isMemberExpression()) return;
+
+              const obj = callee.get("object");
+              if (obj.isIdentifier({ name: "regeneratorRuntime" })) {
+                const helper = this.addHelper("regeneratorRuntime") as
+                  | t.Identifier
+                  | t.ArrowFunctionExpression;
+
+                if (
+                  // It's necessary to avoid the IIFE when using older Babel versions.
+                  t.isArrowFunctionExpression(helper)
+                ) {
+                  obj.replaceWith(helper.body);
+                  return;
+                }
+
+                obj.replaceWith(t.callExpression(helper, []));
+              }
+            },
+          },
+        ]),
   };
 });

--- a/packages/babel-plugin-transform-regenerator/src/regenerator/emit.ts
+++ b/packages/babel-plugin-transform-regenerator/src/regenerator/emit.ts
@@ -4,7 +4,7 @@ import * as leap from "./leap.ts";
 import * as meta from "./meta.ts";
 import * as util from "./util.ts";
 
-import type { NodePath, Visitor } from "@babel/core";
+import type { NodePath, PluginPass, Visitor } from "@babel/core";
 import { types as t } from "@babel/core";
 
 type AbruptCompletion =
@@ -62,7 +62,11 @@ export class Emitter {
   tryEntries: leap.TryEntry[];
   leapManager: leap.LeapManager;
 
-  constructor(contextId: t.Identifier) {
+  pluginPass: PluginPass;
+
+  constructor(contextId: t.Identifier, pluginPass: PluginPass) {
+    this.pluginPass = pluginPass;
+
     // Used to generate unique temporary names.
     this.nextTempId = 0;
 
@@ -516,7 +520,7 @@ export class Emitter {
         const keyIterNextFn = self.makeTempVar();
         self.emitAssign(
           keyIterNextFn,
-          t.callExpression(util.runtimeProperty("keys"), [
+          t.callExpression(util.runtimeProperty(this.pluginPass, "keys"), [
             self.explodeExpression(path.get("right")),
           ]),
         );

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-babel-7/input.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-babel-7/input.js
@@ -1,0 +1,3 @@
+function* fn() {}
+
+regeneratorRuntime.isGeneratorFunction(fn);

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-babel-7/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-babel-7/options.json
@@ -1,5 +1,5 @@
 {
-  "BABEL_8_BREAKING": true,
+  "BABEL_8_BREAKING": false,
   "plugins": [
     "transform-regenerator"
   ]

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-babel-7/output.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-babel-7/output.js
@@ -8,4 +8,4 @@ function fn() {
     }
   }, _marked);
 }
-regeneratorRuntime.isGeneratorFunction(fn);
+babelHelpers.regeneratorRuntime().isGeneratorFunction(fn);

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-with-polyfill-provider/input.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-with-polyfill-provider/input.js
@@ -1,0 +1,3 @@
+function* fn() {}
+
+regeneratorRuntime.isGeneratorFunction(fn);

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-with-polyfill-provider/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-with-polyfill-provider/options.json
@@ -1,0 +1,7 @@
+{
+  "BABEL_8_BREAKING": true,
+  "plugins": [
+    "transform-regenerator",
+    ["babel-plugin-polyfill-regenerator", { "method": "usage-pure" }]
+  ]
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-with-polyfill-provider/output.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage-with-polyfill-provider/output.js
@@ -1,3 +1,4 @@
+var _regeneratorRuntime = require("regenerator-runtime");
 var _marked = /*#__PURE__*/babelHelpers.regeneratorRuntime().mark(fn);
 function fn() {
   return babelHelpers.regeneratorRuntime().wrap(function fn$(_context) {
@@ -8,4 +9,4 @@ function fn() {
     }
   }, _marked);
 }
-regeneratorRuntime.isGeneratorFunction(fn);
+_regeneratorRuntime.isGeneratorFunction(fn);

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage/input.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage/input.js
@@ -1,0 +1,3 @@
+function* fn() {}
+
+regeneratorRuntime.isGeneratorFunction(fn);

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-regenerator"
+  ]
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage/output.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/misc/existing-regeneratorRuntime-usage/output.js
@@ -1,0 +1,11 @@
+var _marked = /*#__PURE__*/babelHelpers.regeneratorRuntime().mark(fn);
+function fn() {
+  return babelHelpers.regeneratorRuntime().wrap(function fn$(_context) {
+    while (1) switch (_context.prev = _context.next) {
+      case 0:
+      case "end":
+        return _context.stop();
+    }
+  }, _marked);
+}
+babelHelpers.regeneratorRuntime().isGeneratorFunction(fn);

--- a/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/regenerator-runtime-old-runtime-version/options.json
+++ b/packages/babel-plugin-transform-runtime/test/fixtures/runtime-corejs3/regenerator-runtime-old-runtime-version/options.json
@@ -1,5 +1,4 @@
 {
   "BABEL_8_BREAKING": false,
-  "BABEL_8_BREAKING": false,
   "plugins": [["transform-runtime", { "corejs": 3 }], "transform-regenerator"]
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In Babel 7 it's safe to replace `regeneratorRuntime` references not injected by Babel with a call to the helper, because it has the same behavior. To avoid having to provide backwards compatibility _across major versions_, this PR changes the Babel 8 behavior to simply not do that. If somebody has a `regeneratorRuntime` global reference in their code they will have to use `babel-plugin-polyfill-regenerator`, which injects an import to the original (thus, with the semantics that the user expected when they wrote that code) `regenerator-runtime` package.