### PR TITLE
Allow `using of` as lexical declaration within for

### DIFF
--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -351,9 +351,7 @@ export default abstract class StatementParser extends ExpressionParser {
     if (type === tt._of && !containsEsc) {
       // `for( using of` must start either a for-lhs-of statement
       // or a for lexical declaration
-      const nextCharAfterOf = this.input.charCodeAt(
-        this.nextTokenStartSince(end),
-      );
+      const nextCharAfterOf = this.lookaheadCharCodeSince(end);
       if (
         nextCharAfterOf !== charCodes.equalsTo &&
         nextCharAfterOf !== charCodes.colon &&

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -351,8 +351,13 @@ export default abstract class StatementParser extends ExpressionParser {
     if (type === tt._of && !containsEsc) {
       // `for( using of` must start either a for-lhs-of statement
       // or a for lexical declaration
-      const nextAfterOf = this.nextTokenStartSince(start + 2);
-      if (this.input.charCodeAt(nextAfterOf) !== charCodes.equalsTo) {
+      const nextCharAfterOf = this.input.charCodeAt(
+        this.nextTokenStartSince(start + 2),
+      );
+      if (
+        nextCharAfterOf !== charCodes.equalsTo &&
+        nextCharAfterOf !== charCodes.colon
+      ) {
         return false;
       }
     }

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -347,16 +347,18 @@ export default abstract class StatementParser extends ExpressionParser {
   }
 
   allowsForUsing(): boolean {
-    const { type, containsEsc, start } = this.lookahead();
+    const { type, containsEsc, end } = this.lookahead();
     if (type === tt._of && !containsEsc) {
       // `for( using of` must start either a for-lhs-of statement
       // or a for lexical declaration
       const nextCharAfterOf = this.input.charCodeAt(
-        this.nextTokenStartSince(start + 2),
+        this.nextTokenStartSince(end),
       );
       if (
         nextCharAfterOf !== charCodes.equalsTo &&
-        nextCharAfterOf !== charCodes.colon
+        nextCharAfterOf !== charCodes.colon &&
+        // recover from `for(using of;...);`
+        nextCharAfterOf !== charCodes.semicolon
       ) {
         return false;
       }

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -346,15 +346,21 @@ export default abstract class StatementParser extends ExpressionParser {
     );
   }
 
-  startsUsingForOf(): boolean {
-    const { type, containsEsc } = this.lookahead();
+  allowsForUsing(): boolean {
+    const { type, containsEsc, start } = this.lookahead();
     if (type === tt._of && !containsEsc) {
-      // `using of` must start a for-lhs-of statement
-      return false;
-    } else if (tokenIsIdentifier(type) && !this.hasFollowingLineBreak()) {
+      // `for( using of` must start either a for-lhs-of statement
+      // or a for lexical declaration
+      const nextAfterOf = this.nextTokenStartSince(start + 2);
+      if (this.input.charCodeAt(nextAfterOf) !== charCodes.equalsTo) {
+        return false;
+      }
+    }
+    if (tokenIsIdentifier(type) && !this.hasFollowingLineBreak()) {
       this.expectPlugin("explicitResourceManagement");
       return true;
     }
+    return false;
   }
 
   startsAwaitUsing(): boolean {
@@ -942,7 +948,7 @@ export default abstract class StatementParser extends ExpressionParser {
         this.isContextual(tt._await) && this.startsAwaitUsing();
       const starsWithUsingDeclaration =
         startsWithAwaitUsing ||
-        (this.isContextual(tt._using) && this.startsUsingForOf());
+        (this.isContextual(tt._using) && this.allowsForUsing());
       const isLetOrUsing =
         (startsWithLet && this.hasFollowingBindingAtom()) ||
         starsWithUsingDeclaration;

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -194,7 +194,11 @@ export default abstract class Tokenizer extends CommentsParser {
   }
 
   lookaheadCharCode(): number {
-    return this.input.charCodeAt(this.nextTokenStart());
+    return this.lookaheadCharCodeSince(this.state.pos);
+  }
+
+  lookaheadCharCodeSince(pos: number): number {
+    return this.input.charCodeAt(this.nextTokenStartSince(pos));
   }
 
   /**

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/explicit-resource-management-for-variable-declaration/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/explicit-resource-management-for-variable-declaration/input.js
@@ -1,0 +1,1 @@
+for(using of = getReader();;;);

--- a/packages/babel-parser/test/fixtures/experimental/_no-plugin/explicit-resource-management-for-variable-declaration/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/_no-plugin/explicit-resource-management-for-variable-declaration/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "This experimental syntax requires enabling the parser plugin: \"explicitResourceManagement\". (1:4)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-for-using-of-equal-equal/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-for-using-of-equal-equal/input.js
@@ -1,0 +1,1 @@
+for (using of == {};;);

--- a/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-for-using-of-equal-equal/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-for-using-of-equal-equal/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (1:14)"
+}

--- a/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-for-using-of-no-initializer/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-for-using-of-no-initializer/input.js
@@ -1,0 +1,1 @@
+for (using of;of.isValid;);

--- a/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-for-using-of-no-initializer/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/invalid-for-using-of-no-initializer/output.json
@@ -1,0 +1,57 @@
+{
+  "type": "File",
+  "start":0,"end":27,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":27,"index":27}},
+  "errors": [
+    "SyntaxError: Missing initializer in using declaration. (1:13)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":27,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":27,"index":27}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ForStatement",
+        "start":0,"end":27,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":27,"index":27}},
+        "init": {
+          "type": "VariableDeclaration",
+          "start":5,"end":13,"loc":{"start":{"line":1,"column":5,"index":5},"end":{"line":1,"column":13,"index":13}},
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "start":11,"end":13,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":13,"index":13}},
+              "id": {
+                "type": "Identifier",
+                "start":11,"end":13,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":13,"index":13},"identifierName":"of"},
+                "name": "of"
+              },
+              "init": null
+            }
+          ],
+          "kind": "using"
+        },
+        "test": {
+          "type": "MemberExpression",
+          "start":14,"end":24,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":24,"index":24}},
+          "object": {
+            "type": "Identifier",
+            "start":14,"end":16,"loc":{"start":{"line":1,"column":14,"index":14},"end":{"line":1,"column":16,"index":16},"identifierName":"of"},
+            "name": "of"
+          },
+          "computed": false,
+          "property": {
+            "type": "Identifier",
+            "start":17,"end":24,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":1,"column":24,"index":24},"identifierName":"isValid"},
+            "name": "isValid"
+          }
+        },
+        "update": null,
+        "body": {
+          "type": "EmptyStatement",
+          "start":26,"end":27,"loc":{"start":{"line":1,"column":26,"index":26},"end":{"line":1,"column":27,"index":27}}
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/valid-for-using-declaration-binding-of/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/valid-for-using-declaration-binding-of/input.js
@@ -1,0 +1,3 @@
+{
+  for (using of = reader();;);
+}

--- a/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/valid-for-using-declaration-binding-of/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/valid-for-using-declaration-binding-of/output.json
@@ -1,0 +1,56 @@
+{
+  "type": "File",
+  "start":0,"end":34,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":34}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":34,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":34}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "BlockStatement",
+        "start":0,"end":34,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":34}},
+        "body": [
+          {
+            "type": "ForStatement",
+            "start":4,"end":32,"loc":{"start":{"line":2,"column":2,"index":4},"end":{"line":2,"column":30,"index":32}},
+            "init": {
+              "type": "VariableDeclaration",
+              "start":9,"end":28,"loc":{"start":{"line":2,"column":7,"index":9},"end":{"line":2,"column":26,"index":28}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":15,"end":28,"loc":{"start":{"line":2,"column":13,"index":15},"end":{"line":2,"column":26,"index":28}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":15,"end":17,"loc":{"start":{"line":2,"column":13,"index":15},"end":{"line":2,"column":15,"index":17},"identifierName":"of"},
+                    "name": "of"
+                  },
+                  "init": {
+                    "type": "CallExpression",
+                    "start":20,"end":28,"loc":{"start":{"line":2,"column":18,"index":20},"end":{"line":2,"column":26,"index":28}},
+                    "callee": {
+                      "type": "Identifier",
+                      "start":20,"end":26,"loc":{"start":{"line":2,"column":18,"index":20},"end":{"line":2,"column":24,"index":26},"identifierName":"reader"},
+                      "name": "reader"
+                    },
+                    "arguments": []
+                  }
+                }
+              ],
+              "kind": "using"
+            },
+            "test": null,
+            "update": null,
+            "body": {
+              "type": "EmptyStatement",
+              "start":31,"end":32,"loc":{"start":{"line":2,"column":29,"index":31},"end":{"line":2,"column":30,"index":32}}
+            }
+          }
+        ],
+        "directives": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/valid-using-binding-of/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/valid-using-binding-of/input.js
@@ -1,0 +1,3 @@
+{
+  using of = reader();
+}

--- a/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/valid-using-binding-of/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/explicit-resource-management/valid-using-binding-of/output.json
@@ -1,0 +1,46 @@
+{
+  "type": "File",
+  "start":0,"end":26,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":26}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":26,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":26}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "BlockStatement",
+        "start":0,"end":26,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":26}},
+        "body": [
+          {
+            "type": "VariableDeclaration",
+            "start":4,"end":24,"loc":{"start":{"line":2,"column":2,"index":4},"end":{"line":2,"column":22,"index":24}},
+            "declarations": [
+              {
+                "type": "VariableDeclarator",
+                "start":10,"end":23,"loc":{"start":{"line":2,"column":8,"index":10},"end":{"line":2,"column":21,"index":23}},
+                "id": {
+                  "type": "Identifier",
+                  "start":10,"end":12,"loc":{"start":{"line":2,"column":8,"index":10},"end":{"line":2,"column":10,"index":12},"identifierName":"of"},
+                  "name": "of"
+                },
+                "init": {
+                  "type": "CallExpression",
+                  "start":15,"end":23,"loc":{"start":{"line":2,"column":13,"index":15},"end":{"line":2,"column":21,"index":23}},
+                  "callee": {
+                    "type": "Identifier",
+                    "start":15,"end":21,"loc":{"start":{"line":2,"column":13,"index":15},"end":{"line":2,"column":19,"index":21},"identifierName":"reader"},
+                    "name": "reader"
+                  },
+                  "arguments": []
+                }
+              }
+            ],
+            "kind": "using"
+          }
+        ],
+        "directives": []
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/explicit-resource-management/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/explicit-resource-management/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["explicitResourceManagement", "typescript"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/explicit-resource-management/valid-for-using-declaration-binding-of/input.js
+++ b/packages/babel-parser/test/fixtures/typescript/explicit-resource-management/valid-for-using-declaration-binding-of/input.js
@@ -1,0 +1,3 @@
+{
+  for (using of: Reader = reader();;);
+}

--- a/packages/babel-parser/test/fixtures/typescript/explicit-resource-management/valid-for-using-declaration-binding-of/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/explicit-resource-management/valid-for-using-declaration-binding-of/output.json
@@ -1,0 +1,69 @@
+{
+  "type": "File",
+  "start":0,"end":42,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":42}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":42,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":42}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "BlockStatement",
+        "start":0,"end":42,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":1,"index":42}},
+        "body": [
+          {
+            "type": "ForStatement",
+            "start":4,"end":40,"loc":{"start":{"line":2,"column":2,"index":4},"end":{"line":2,"column":38,"index":40}},
+            "init": {
+              "type": "VariableDeclaration",
+              "start":9,"end":36,"loc":{"start":{"line":2,"column":7,"index":9},"end":{"line":2,"column":34,"index":36}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":15,"end":36,"loc":{"start":{"line":2,"column":13,"index":15},"end":{"line":2,"column":34,"index":36}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":15,"end":25,"loc":{"start":{"line":2,"column":13,"index":15},"end":{"line":2,"column":23,"index":25},"identifierName":"of"},
+                    "name": "of",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start":17,"end":25,"loc":{"start":{"line":2,"column":15,"index":17},"end":{"line":2,"column":23,"index":25}},
+                      "typeAnnotation": {
+                        "type": "TSTypeReference",
+                        "start":19,"end":25,"loc":{"start":{"line":2,"column":17,"index":19},"end":{"line":2,"column":23,"index":25}},
+                        "typeName": {
+                          "type": "Identifier",
+                          "start":19,"end":25,"loc":{"start":{"line":2,"column":17,"index":19},"end":{"line":2,"column":23,"index":25},"identifierName":"Reader"},
+                          "name": "Reader"
+                        }
+                      }
+                    }
+                  },
+                  "init": {
+                    "type": "CallExpression",
+                    "start":28,"end":36,"loc":{"start":{"line":2,"column":26,"index":28},"end":{"line":2,"column":34,"index":36}},
+                    "callee": {
+                      "type": "Identifier",
+                      "start":28,"end":34,"loc":{"start":{"line":2,"column":26,"index":28},"end":{"line":2,"column":32,"index":34},"identifierName":"reader"},
+                      "name": "reader"
+                    },
+                    "arguments": []
+                  }
+                }
+              ],
+              "kind": "using"
+            },
+            "test": null,
+            "update": null,
+            "body": {
+              "type": "EmptyStatement",
+              "start":39,"end":40,"loc":{"start":{"line":2,"column":37,"index":39},"end":{"line":2,"column":38,"index":40}}
+            }
+          }
+        ],
+        "directives": []
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Ref https://github.com/tc39/proposal-explicit-resource-management/issues/248
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Quote from https://github.com/tc39/proposal-explicit-resource-management/issues/248:

> TypeScript doesn't recognize the syntax, and
> Babel, esbuild, Chromium, and SpiderMonkey throw syntax error.
> Apparently the negative lookahead is applied also to ForStatement in all of them.

I believe the spec is correct, there should be no restriction for the LexicalDeclaration within ForStatement. It is an implementation bug and the cost is merely another lookahead when we see `using of`, which is presumably pretty rare.