### PR TITLE
allow separate registrations with @babel/register

### DIFF
--- a/packages/babel-register/src/experimental-worker.cts
+++ b/packages/babel-register/src/experimental-worker.cts
@@ -1,5 +1,5 @@
 // TODO: Move this file to index.js in Babel 8
-import type { IClient, Options } from "./types.cts";
+import type { IClient, Options, RegistrationOptions } from "./types.cts";
 
 const [major, minor] = process.versions.node.split(".").map(Number);
 
@@ -13,9 +13,9 @@ import hook = require("./hook.cjs");
 import workerClient = require("./worker-client.cjs");
 
 let client: IClient;
-function register(opts?: Options) {
+function register(opts?: Options, regOpts?: RegistrationOptions) {
   client ||= new workerClient.WorkerClient();
-  hook.register(client, opts);
+  hook.register(client, opts, regOpts);
 }
 
 export = Object.assign(register, {

--- a/packages/babel-register/src/node.cts
+++ b/packages/babel-register/src/node.cts
@@ -6,8 +6,8 @@ const hook = require("./hook.cjs");
 const { LocalClient } = require("./worker-client.cjs");
 
 const client = new LocalClient();
-function register(opts = {}) {
-  return hook.register(client, { ...opts });
+function register(opts = {}, regOpts = {}) {
+  return hook.register(client, { ...opts }, { ...regOpts });
 }
 
 module.exports = Object.assign(register, {

--- a/packages/babel-register/src/types.cts
+++ b/packages/babel-register/src/types.cts
@@ -5,6 +5,10 @@ export const enum ACTIONS {
   TRANSFORM_SYNC = "TRANSFORM_SYNC",
 }
 
+export type RegistrationOptions = {
+  revertPreviousHooks?: boolean;
+};
+
 export type Options = {
   extensions?: string[];
 };


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      |
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Would it be possible to allow several `@babel/register` requires to live side by side, potentially using different settings (a different list of files / plugins / etc...) like what's suggested in the PR?

Currently, each register reverts the previous, making it possible for two different services to conflict when registering "their" files. This can be "worked around" in the following way (notice that `_only` is extended with each call to `config`).
https://github.com/facebook/metro/blob/f3645501bea6ea99bbfc2b2d17b458c176ff2bfa/packages/metro-babel-register/src/babel-register.js#L22

Usage example:
```js
const register = require('@babel/register');

// reverts only the individual hook in question
const revert = register(config1);
revert();

const revert2 = register(config2, {revertPreviousHooks = false});

// reverts all hooks
register.revert()

```
