### PR TITLE
feat(matchesPattern): support super/private/meta

### DIFF
--- a/packages/babel-types/test/misc.js
+++ b/packages/babel-types/test/misc.js
@@ -58,12 +58,32 @@ describe("misc helpers", function () {
       expect(t.matchesPattern(ast, "import.meta")).toBe(false);
       expect(t.matchesPattern(ast, "import.meta.uri")).toBe(false);
       expect(t.matchesPattern(ast, "import.meta.url.toString")).toBe(false);
+      expect(t.matchesPattern(ast, "Import.meta")).toBe(false);
+      expect(t.matchesPattern(ast, "import.wrongProperty")).toBe(false);
+      expect(t.matchesPattern(ast, "import.wrongProperty.url")).toBe(false);
+    });
+
+    it("matches meta properties: import.meta.url, partially", function () {
+      const ast = parseCode("import.meta.url");
+      expect(t.matchesPattern(ast, "import.meta.url", true)).toBeTruthy();
+      expect(t.matchesPattern(ast, "import.meta", true)).toBeTruthy();
+      expect(t.matchesPattern(ast, "meta.url", true)).toBe(false);
+      expect(t.matchesPattern(ast, "import.meta.url.toString", true)).toBe(
+        false,
+      );
     });
 
     it("matches meta properties: import.meta", function () {
       const ast = parseCode("import.meta");
       expect(t.matchesPattern(ast, "import.meta")).toBeTruthy();
       expect(t.matchesPattern(ast, "import.meta.uri")).toBe(false);
+    });
+
+    it("matches meta properties: import.meta, partially", function () {
+      const ast = parseCode("import.meta");
+      expect(t.matchesPattern(ast, "import.meta", true)).toBeTruthy();
+      expect(t.matchesPattern(ast, "import", true)).toBeTruthy();
+      expect(t.matchesPattern(ast, "meta", true)).toBe(false);
     });
 
     it("matches meta properties: new.target", function () {

--- a/packages/babel-types/test/misc.js
+++ b/packages/babel-types/test/misc.js
@@ -1,16 +1,19 @@
 import * as t from "../lib/index.js";
-import { parse } from "@babel/parser";
+import { parseExpression } from "@babel/parser";
 
 function parseCode(string) {
-  return parse(string, {
+  return parseExpression(string, {
+    allowSuperOutsideMethod: true,
+    allowNewTargetOutsideFunction: true,
     allowReturnOutsideFunction: true,
-  }).program.body[0];
+    sourceType: "module",
+  });
 }
 
 describe("misc helpers", function () {
   describe("matchesPattern", function () {
     it("matches explicitly", function () {
-      const ast = parseCode("a.b.c.d").expression;
+      const ast = parseCode("a.b.c.d");
       expect(t.matchesPattern(ast, "a.b.c.d")).toBeTruthy();
       expect(t.matchesPattern(ast, "a.b.c")).toBe(false);
       expect(t.matchesPattern(ast, "b.c.d")).toBe(false);
@@ -18,7 +21,7 @@ describe("misc helpers", function () {
     });
 
     it("matches partially", function () {
-      const ast = parseCode("a.b.c.d").expression;
+      const ast = parseCode("a.b.c.d");
       expect(t.matchesPattern(ast, "a.b.c.d", true)).toBeTruthy();
       expect(t.matchesPattern(ast, "a.b.c", true)).toBeTruthy();
       expect(t.matchesPattern(ast, "b.c.d", true)).toBe(false);
@@ -26,7 +29,7 @@ describe("misc helpers", function () {
     });
 
     it("matches string literal expressions", function () {
-      const ast = parseCode("a['b'].c.d").expression;
+      const ast = parseCode("a['b'].c.d");
       expect(t.matchesPattern(ast, "a.b.c.d")).toBeTruthy();
       expect(t.matchesPattern(ast, "a.b.c")).toBe(false);
       expect(t.matchesPattern(ast, "b.c.d")).toBe(false);
@@ -34,7 +37,7 @@ describe("misc helpers", function () {
     });
 
     it("matches string literal expressions partially", function () {
-      const ast = parseCode("a['b'].c.d").expression;
+      const ast = parseCode("a['b'].c.d");
       expect(t.matchesPattern(ast, "a.b.c.d", true)).toBeTruthy();
       expect(t.matchesPattern(ast, "a.b.c", true)).toBeTruthy();
       expect(t.matchesPattern(ast, "b.c.d", true)).toBe(false);
@@ -42,11 +45,50 @@ describe("misc helpers", function () {
     });
 
     it("matches this expressions", function () {
-      const ast = parseCode("this.a.b.c.d").expression;
+      const ast = parseCode("this.a.b.c.d");
       expect(t.matchesPattern(ast, "this.a.b.c.d")).toBeTruthy();
       expect(t.matchesPattern(ast, "this.a.b.c")).toBe(false);
       expect(t.matchesPattern(ast, "this.b.c.d")).toBe(false);
       expect(t.matchesPattern(ast, "this.a.b.c.d.e")).toBe(false);
+    });
+
+    it("matches meta properties: import.meta.url", function () {
+      const ast = parseCode("import.meta.url");
+      expect(t.matchesPattern(ast, "import.meta.url")).toBeTruthy();
+      expect(t.matchesPattern(ast, "import.meta")).toBe(false);
+      expect(t.matchesPattern(ast, "import.meta.uri")).toBe(false);
+      expect(t.matchesPattern(ast, "import.meta.url.toString")).toBe(false);
+    });
+
+    it("matches meta properties: import.meta", function () {
+      const ast = parseCode("import.meta");
+      expect(t.matchesPattern(ast, "import.meta")).toBeTruthy();
+      expect(t.matchesPattern(ast, "import.meta.uri")).toBe(false);
+    });
+
+    it("matches meta properties: new.target", function () {
+      const ast = parseCode("new.target.name");
+      expect(t.matchesPattern(ast, "new.target.name")).toBeTruthy();
+      expect(t.matchesPattern(ast, "new.target")).toBe(false);
+      expect(t.matchesPattern(ast, "new.target.constructor")).toBe(false);
+      expect(t.matchesPattern(ast, "new.target.name.toString")).toBe(false);
+    });
+
+    it("matches super property access", function () {
+      const ast = parseCode("super.property.name");
+      expect(t.matchesPattern(ast, "super.property.name")).toBeTruthy();
+      expect(t.matchesPattern(ast, "super.property")).toBe(false);
+      expect(t.matchesPattern(ast, "super.property.constructor")).toBe(false);
+      expect(t.matchesPattern(ast, "super.property.name.toString")).toBe(false);
+    });
+
+    it("matches private name", function () {
+      const ast = parseCode("(class { #property = this.#property.name })").body
+        .body[0].value;
+      expect(t.matchesPattern(ast, "this.#property.name")).toBeTruthy();
+      expect(t.matchesPattern(ast, "this.#property")).toBe(false);
+      expect(t.matchesPattern(ast, "this.#property.constructor")).toBe(false);
+      expect(t.matchesPattern(ast, "this.#property.name.toString")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Resolves https://github.com/babel/babel/issues/17225
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we expand the supported syntax in `matchesPattern`: It can match the super property, private property and the meta property now.