### PR TITLE
Include Babel 8 in coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
           BABEL_ENV: test
           BABEL_COVERAGE: true
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
 
   test:
     name: Test on Node.js # GitHub will add ${{ matrix.node-version }} to this title
@@ -403,7 +403,7 @@ jobs:
           BABEL_COVERAGE: true
           BABEL_8_BREAKING: true
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
 
   test-babel8-windows-mac:
     name: Test Babel 8 changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,26 +59,6 @@ jobs:
           yarn
           yarn release-tool check-cycles
 
-  test-coverage:
-    name: Test on Node.js Latest
-    needs: prepare-yarn-cache
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Use Node.js latest
-        uses: actions/setup-node@v4
-        with:
-          node-version: latest
-          check-latest: true
-          cache: "yarn"
-      - name: Generate coverage report
-        run: |
-          make -j test-ci-coverage
-          yarn test:esm
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v3
-
   test-esm:
     name: Test ESM version
     needs: prepare-yarn-cache
@@ -206,6 +186,37 @@ jobs:
         run: |
           node ./scripts/assert-dir-git-clean.js "lint-ci check-compat-data"
 
+  test-coverage:
+    name: Test on Node.js Latest (with coverage)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js latest
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          check-latest: true
+          cache: "yarn"
+      - name: Install
+        run: |
+          yarn install
+      - uses: actions/download-artifact@v4
+        with:
+          name: babel-artifact
+      - name: Extract artifacts
+        run: tar -xf babel-artifact.tar; rm babel-artifact.tar
+      - name: Run tests
+        run: |
+          yarn c8 jest --ci
+          yarn c8 yarn test:esm
+        env:
+          BABEL_ENV: test
+          BABEL_COVERAGE: true
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3
+
   test:
     name: Test on Node.js # GitHub will add ${{ matrix.node-version }} to this title
     needs: build
@@ -271,6 +282,35 @@ jobs:
         with:
           node-version: latest
 
+  test-windows-mac:
+    name: Test on
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js latest
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          check-latest: true
+          cache: "yarn"
+      - name: Install
+        run: yarn install
+      - uses: actions/download-artifact@v4
+        with:
+          name: babel-artifact
+      - name: Extract artifacts
+        run: tar -xf babel-artifact.tar; rm babel-artifact.tar
+      - name: Test
+        run: yarn jest --ci
+        env:
+          BABEL_ENV: test
+
   build-babel8:
     name: Build Babel 8 Artifacts
     needs: prepare-yarn-cache
@@ -310,13 +350,47 @@ jobs:
           path: babel-artifact.tar
           retention-days: 5
 
-  test-babel-8-breaking:
-    name: Test Babel 8 breaking changes on
+  test-babel8-coverage:
+    name: Test Babel 8 changes (with coverage)
+    needs: build-babel8
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js latest
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          check-latest: true
+          cache: "yarn"
+      - name: Install
+        run: |
+          yarn install
+      - uses: actions/download-artifact@v4
+        with:
+          name: babel8-artifact
+      - name: Extract artifacts
+        run: tar -xf babel-artifact.tar; rm babel-artifact.tar
+      - name: Use ESM
+        run: node scripts/set-module-type.js module
+      - name: Run tests
+        run: |
+          yarn c8 jest --ci
+          yarn c8 yarn test:esm
+        env:
+          BABEL_ENV: test
+          BABEL_COVERAGE: true
+          BABEL_8_BREAKING: true
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3
+
+  test-babel8-windows-mac:
+    name: Test Babel 8 changes
     needs: build-babel8
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -345,35 +419,6 @@ jobs:
         env:
           BABEL_ENV: test
           BABEL_8_BREAKING: true
-
-  test-windows-mac:
-    name: Test on
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Use Node.js latest
-        uses: actions/setup-node@v4
-        with:
-          node-version: latest
-          check-latest: true
-          cache: "yarn"
-      - name: Install
-        run: yarn install
-      - uses: actions/download-artifact@v4
-        with:
-          name: babel-artifact
-      - name: Extract artifacts
-        run: tar -xf babel-artifact.tar; rm babel-artifact.tar
-      - name: Test
-        run: yarn jest --ci
-        env:
-          BABEL_ENV: test
 
   external-parser-tests:
     name: Third-party Parser Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,12 +210,15 @@ jobs:
       - name: Run tests
         run: |
           yarn c8 jest --ci
-          yarn c8 yarn test:esm
+          yarn test:esm
         env:
           BABEL_ENV: test
           BABEL_COVERAGE: true
       - name: Upload coverage report
         uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: babel-7
 
   test:
     name: Test on Node.js # GitHub will add ${{ matrix.node-version }} to this title
@@ -397,13 +400,16 @@ jobs:
       - name: Run tests
         run: |
           yarn c8 jest --ci
-          yarn c8 yarn test:esm
+          yarn test:esm
         env:
           BABEL_ENV: test
           BABEL_COVERAGE: true
           BABEL_8_BREAKING: true
       - name: Upload coverage report
         uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: babel-8
 
   test-babel8-windows-mac:
     name: Test Babel 8 changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,11 +336,6 @@ jobs:
           BABEL_ENV: test-legacy
           BABEL_8_BREAKING: true
           STRIP_BABEL_8_FLAG: true
-      - name: Lint
-        run: make -j lint-ci check-compat-data
-        env:
-          BABEL_ENV: test
-          BABEL_8_BREAKING: true
       - name: Prepare artifacts
         run: |
           ./scripts/get-artifact-files.sh | tar --null -cvf babel-artifact.tar --files-from=-
@@ -349,6 +344,32 @@ jobs:
           name: babel8-artifact
           path: babel-artifact.tar
           retention-days: 5
+
+  lint-babel8:
+    name: Lint (Babel 8)
+    needs: build-babel8
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js latest
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          check-latest: true
+          cache: "yarn"
+      - name: Install
+        run: yarn install
+      - uses: actions/download-artifact@v4
+        with:
+          name: babel8-artifact
+      - name: Extract artifacts
+        run: tar -xf babel-artifact.tar; rm babel-artifact.tar
+      - name: Lint
+        run: make -j lint-ci check-compat-data
+        env:
+          BABEL_ENV: test
+          BABEL_8_BREAKING: true
 
   test-babel8-coverage:
     name: Test Babel 8 changes (with coverage)

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     project:
       default:
-        target: "90%"
+        target: "92.5%"
     patch:
       enabled: false
 ignore:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This also changes how the Babel 8 pipeline works, so that linting runs in parallel to tests rather than before.

You can see at https://app.codecov.io/github/babel/babel/pull/17260/indirect-changes that this PR "increases coverage" by 3%, and Babel-8-specific code is now marked as covered rather than uncovered.