### PR TITLE
Remove unused `regenerator-runtime` dep in `@babel/runtime`

### DIFF
--- a/packages/babel-runtime-corejs2/package.json
+++ b/packages/babel-runtime-corejs2/package.json
@@ -14,8 +14,7 @@
   "homepage": "https://babel.dev/docs/en/next/babel-runtime-corejs2",
   "author": "The Babel Team (https://babel.dev/team)",
   "dependencies": {
-    "core-js": "^2.6.12",
-    "regenerator-runtime": "^0.14.0"
+    "core-js": "^2.6.12"
   },
   "exports": {
     "./helpers/OverloadYield": [

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -13,8 +13,7 @@
   },
   "author": "The Babel Team (https://babel.dev/team)",
   "dependencies": {
-    "core-js-pure": "^3.30.2",
-    "regenerator-runtime": "^0.14.0"
+    "core-js-pure": "^3.30.2"
   },
   "exports": {
     "./helpers/OverloadYield": [

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -13,9 +13,6 @@
   },
   "homepage": "https://babel.dev/docs/en/next/babel-runtime",
   "author": "The Babel Team (https://babel.dev/team)",
-  "dependencies": {
-    "regenerator-runtime": "^0.14.0"
-  },
   "exports": {
     "./helpers/OverloadYield": [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3952,7 +3952,6 @@ __metadata:
   resolution: "@babel/runtime-corejs2@workspace:packages/babel-runtime-corejs2"
   dependencies:
     core-js: "npm:^2.6.12"
-    regenerator-runtime: "npm:^0.14.0"
   languageName: unknown
   linkType: soft
 
@@ -3961,7 +3960,6 @@ __metadata:
   resolution: "@babel/runtime-corejs3@workspace:packages/babel-runtime-corejs3"
   dependencies:
     core-js-pure: "npm:^3.30.2"
-    regenerator-runtime: "npm:^0.14.0"
   languageName: unknown
   linkType: soft
 
@@ -3986,8 +3984,6 @@ __metadata:
 "@babel/runtime@workspace:^, @babel/runtime@workspace:packages/babel-runtime":
   version: 0.0.0-use.local
   resolution: "@babel/runtime@workspace:packages/babel-runtime"
-  dependencies:
-    regenerator-runtime: "npm:^0.14.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This dependency has been unused since when we started bundling `regenerator-runtime`, in https://github.com/babel/babel/pull/14538 :)