### PR TITLE
fix invalid gulp watch usage

### DIFF
--- a/Gulpfile.mjs
+++ b/Gulpfile.mjs
@@ -881,7 +881,7 @@ gulp.task(
 );
 
 function watch() {
-  gulp.watch(defaultSourcesGlob, "build-no-bundle-watch");
+  gulp.watch(defaultSourcesGlob, gulp.task("build-no-bundle-watch"));
   gulp.watch(babelStandalonePluginConfigGlob, gulp.task("generate-standalone"));
   gulp.watch(buildTypingsWatchGlob, gulp.task("generate-type-helpers"));
   gulp.watch(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `make watch` throws "watch task has to be a function" error
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Fixed incorrect `gulp.watch` usage, this was introduced in https://github.com/babel/babel/pull/17265.