### PR TITLE
Bumped picocolors version to prevent webpack warnings

### DIFF
--- a/packages/babel-code-frame/package.json
+++ b/packages/babel-code-frame/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@babel/helper-validator-identifier": "workspace:^",
     "js-tokens": "condition:BABEL_8_BREAKING ? ^8.0.0 : ^4.0.0",
-    "picocolors": "^1.0.0"
+    "picocolors": "^1.1.1"
   },
   "devDependencies": {
     "import-meta-resolve": "^4.1.0",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | 
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Yes
| License                  | MIT


Latest version of @babel/code-frame depends on picocolors resolving to v1.0.1. That older versions of picocolors produces a warning when used in webpack environments (nextJS)

```
Import trace for requested module:
../../node_modules/picocolors/picocolors.js
../../node_modules/@babel/code-frame/lib/index.js
../../node_modules/next-mdx-remote/dist/format-mdx-error.js
../../node_modules/next-mdx-remote/dist/serialize.js
../../node_modules/next-mdx-remote/dist/rsc.js
../../node_modules/next-mdx-remote/rsc.js
../../packages/ui/src/components/shared/search.tsx
 ⚠ ../../node_modules/picocolors/picocolors.js
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted

Import trace for requested module:
../../node_modules/picocolors/picocolors.js
../../node_modules/@babel/code-frame/lib/index.js
../../node_modules/next-mdx-remote/dist/format-mdx-error.js
../../node_modules/next-mdx-remote/dist/serialize.js
../../node_modules/next-mdx-remote/dist/rsc.js
../../node_modules/next-mdx-remote/rsc.js
../../packages/ui/src/components/shared/search.tsx
```

This was fixed in the latest version 1.1.1 with this pull request https://github.com/alexeyraspopov/picocolors/pull/87, so I just bumped the version to latest so @babel/code-frame doesn't produce this warning 