### PR TITLE
fix bundle-dts error in feat-discard-binding

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -1378,8 +1378,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
             if (nextToken.type !== tt.num && nextToken.type !== tt.bigint) {
               this.unexpected();
             }
-            // @ts-expect-error: parseMaybeUnary must returns unary expression
-            node.literal = this.parseMaybeUnary();
+            node.literal = this.parseMaybeUnary() as N.UnaryExpression;
             return this.finishNode(node, "TSLiteralType");
           }
           break;

--- a/packages/babel-parser/src/types.ts
+++ b/packages/babel-parser/src/types.ts
@@ -1825,7 +1825,12 @@ export interface TsTemplateLiteralType extends TsTypeBase {
 
 export interface TsLiteralType extends TsTypeBase {
   type: "TSLiteralType";
-  literal: NumericLiteral | StringLiteral | BooleanLiteral | TemplateLiteral;
+  literal:
+    | NumericLiteral
+    | StringLiteral
+    | BooleanLiteral
+    | TemplateLiteral
+    | UnaryExpression;
 }
 
 export interface TsImportType extends TsTypeBase {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The lint error is very suspicious: 
https://github.com/babel/babel/actions/runs/14754257110/job/41418717342?pr=17276#step:7:58

It seems that a comment in `tsParseNonArrayType` from `plugins/typescript` is somehow smuggled into the signature of `errorBuilder` from `parse-error`, which might be a rollup-plugin-dts bug. Unfortunately I don't have the bandwidth to investigate and instead I remove the very specific `@ts-expect-error` comment. 