### PR TITLE
Fix: improve object rest handling in array pattern

### DIFF
--- a/packages/babel-plugin-transform-object-rest-spread/package.json
+++ b/packages/babel-plugin-transform-object-rest-spread/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@babel/helper-compilation-targets": "workspace:^",
     "@babel/helper-plugin-utils": "workspace:^",
+    "@babel/plugin-transform-destructuring": "workspace:^",
     "@babel/plugin-transform-parameters": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.ts
@@ -623,7 +623,7 @@ export default declare((api, opts: Options) => {
 
       // [{a, ...b}] = c;
       ArrayPattern(path) {
-        type LhsAndRhs = { left: t.Pattern; right: t.Identifier };
+        type LhsAndRhs = { left: t.ObjectPattern; right: t.Identifier };
         const objectPatterns: LhsAndRhs[] = [];
 
         visitObjectRestElements(path, path => {

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern-rest-only/exec.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern-rest-only/exec.js
@@ -1,0 +1,4 @@
+let a, result;
+for (const [{...a}] of [[{ a: 0}]]) { result = a; }
+
+expect(result).toEqual({ a: 0 });

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern-rest-only/input.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern-rest-only/input.js
@@ -1,0 +1,18 @@
+// ForXStatement
+{
+  let a;
+  for (const [{...a}] of []) {}
+  for ([{...a}] of []) {}
+  async function f() {
+    for await ([{...a}] of []) {}
+  }
+}
+
+// skip
+{
+  for ([...a] in {}) {}
+  for ([...a] of []) {}
+  async function a() {
+    for await ([...a] of []) {}
+  }
+}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern-rest-only/output.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern-rest-only/output.js
@@ -1,0 +1,33 @@
+// ForXStatement
+{
+  let a;
+  for (const _ref of []) {
+    const [_ref2] = _ref,
+      a = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref2), _ref2));
+  }
+  for (var _ref3 of []) {
+    [_ref4] = _ref3;
+    var _ref5 = _ref4;
+    ({} = _ref5);
+    a = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref5), _ref5));
+    _ref5;
+  }
+  async function f() {
+    for await (var _ref6 of []) {
+      [_ref7] = _ref6;
+      var _ref8 = _ref7;
+      ({} = _ref8);
+      a = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref8), _ref8));
+      _ref8;
+    }
+  }
+}
+
+// skip
+{
+  for ([...a] in {}) {}
+  for ([...a] of []) {}
+  async function a() {
+    for await ([...a] of []) {}
+  }
+}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern-rest-only/output.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern-rest-only/output.js
@@ -6,6 +6,7 @@
       a = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref2), _ref2));
   }
   for (var _ref3 of []) {
+    var _ref4;
     [_ref4] = _ref3;
     var _ref5 = _ref4;
     ({} = _ref5);
@@ -14,6 +15,7 @@
   }
   async function f() {
     for await (var _ref6 of []) {
+      var _ref7;
       [_ref7] = _ref6;
       var _ref8 = _ref7;
       ({} = _ref8);

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/input.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/input.js
@@ -1,19 +1,27 @@
 // ForXStatement
-for (const [{a, ...b}] of []) {}
-for ([{a, ...b}] of []) {}
-async function a() {
-  for await ([{a, ...b}] of []) {}
+{
+  let a, b;
+  for (const [{a, ...b}] of []) {}
+  for ([{a, ...b}] of []) {}
+  async function f() {
+    for await ([{a, ...b}] of []) {}
+  }
+
+  for (const { a: [{a, ...b}] } of []) {}
 }
 
 // skip
-for ([{a}] in {}) {}
-for ([{a}] of []) {}
-async function a() {
-  for await ([{a}] of []) {}
+{
+  for ([{a}] in {}) {}
+  for ([{a}] of []) {}
+  async function a() {
+    for await ([{a}] of []) {}
+  }
 }
-
-for ([a, ...b] in {}) {}
-for ([a, ...b] of []) {}
-async function a() {
-  for await ([a, ...b] of []) {}
+{
+  for ([a, ...b] in {}) {}
+  for ([a, ...b] of []) {}
+  async function a() {
+    for await ([a, ...b] of []) {}
+  }
 }

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/output.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/output.js
@@ -1,45 +1,65 @@
 const _excluded = ["a"],
   _excluded2 = ["a"],
-  _excluded3 = ["a"];
+  _excluded3 = ["a"],
+  _excluded4 = ["a"];
 // ForXStatement
-for (const _ref of []) {
-  const [_ref2] = _ref;
-  const {
-      a
-    } = _ref2,
-    b = babelHelpers.objectWithoutProperties(_ref2, _excluded);
-}
-for (var _ref3 of []) {
-  [_ref4] = _ref3;
-  var {
-      a
-    } = _ref4,
-    b = babelHelpers.objectWithoutProperties(_ref4, _excluded2);
-}
-async function a() {
-  for await (var _ref5 of []) {
-    [_ref6] = _ref5;
-    var {
+{
+  let a, b;
+  for (const _ref of []) {
+    const [_ref2] = _ref,
+      {
         a
-      } = _ref6,
-      b = babelHelpers.objectWithoutProperties(_ref6, _excluded3);
+      } = _ref2,
+      b = babelHelpers.objectWithoutProperties(_ref2, _excluded);
+  }
+  for (var _ref3 of []) {
+    [_ref4] = _ref3;
+    var _ref5 = _ref4;
+    ({
+      a
+    } = _ref5);
+    b = babelHelpers.objectWithoutProperties(_ref5, _excluded2);
+    _ref5;
+  }
+  async function f() {
+    for await (var _ref6 of []) {
+      [_ref7] = _ref6;
+      var _ref8 = _ref7;
+      ({
+        a
+      } = _ref8);
+      b = babelHelpers.objectWithoutProperties(_ref8, _excluded3);
+      _ref8;
+    }
+  }
+  for (const _ref9 of []) {
+    const {
+        a: [{
+          a
+        }]
+      } = _ref9,
+      b = babelHelpers.objectWithoutProperties(_ref9.a, _excluded4);
   }
 }
 
 // skip
-for ([{
-  a
-}] in {}) {}
-for ([{
-  a
-}] of []) {}
-async function a() {
-  for await ([{
+{
+  for ([{
+    a
+  }] in {}) {}
+  for ([{
     a
   }] of []) {}
+  async function a() {
+    for await ([{
+      a
+    }] of []) {}
+  }
 }
-for ([a, ...b] in {}) {}
-for ([a, ...b] of []) {}
-async function a() {
-  for await ([a, ...b] of []) {}
+{
+  for ([a, ...b] in {}) {}
+  for ([a, ...b] of []) {}
+  async function a() {
+    for await ([a, ...b] of []) {}
+  }
 }

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/output.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-array-pattern/output.js
@@ -13,6 +13,7 @@ const _excluded = ["a"],
       b = babelHelpers.objectWithoutProperties(_ref2, _excluded);
   }
   for (var _ref3 of []) {
+    var _ref4;
     [_ref4] = _ref3;
     var _ref5 = _ref4;
     ({
@@ -23,6 +24,7 @@ const _excluded = ["a"],
   }
   async function f() {
     for await (var _ref6 of []) {
+      var _ref7;
       [_ref7] = _ref6;
       var _ref8 = _ref7;
       ({

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-assignment-shadowed-block-scoped-bindings/exec.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-assignment-shadowed-block-scoped-bindings/exec.js
@@ -1,0 +1,7 @@
+let a = 0, result, y;
+
+for ({ [a++]: result, ...y} of [["0", "1"]]) {
+  const a = 1;
+}
+
+expect(result).toBe("0");

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-assignment-shadowed-block-scoped-bindings/input.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-assignment-shadowed-block-scoped-bindings/input.js
@@ -1,0 +1,5 @@
+let a = 0, result, y;
+
+for ({ [a++]: result, ...y} of [["0", "1"]]) {
+  const a = 1;
+}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-assignment-shadowed-block-scoped-bindings/output.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-assignment-shadowed-block-scoped-bindings/output.js
@@ -1,0 +1,15 @@
+let a = 0,
+  result,
+  y;
+for (var _ref of [["0", "1"]]) {
+  var _ref2 = _ref;
+  var _a = a++;
+  ({
+    [_a]: result
+  } = _ref2);
+  y = babelHelpers.objectWithoutProperties(_ref2, [_a].map(babelHelpers.toPropertyKey));
+  _ref2;
+  {
+    const a = 1;
+  }
+}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-declaration-shadowed-block-scoped-bindings/exec.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-declaration-shadowed-block-scoped-bindings/exec.js
@@ -1,0 +1,8 @@
+let a = 0, result;
+
+for (const { [a++]: x, ...y} of [["0", "1"]]) {
+  const a = 1;
+  result = x;
+}
+
+expect(result).toBe("0");

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-declaration-shadowed-block-scoped-bindings/input.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-declaration-shadowed-block-scoped-bindings/input.js
@@ -1,0 +1,6 @@
+let a = 0, result;
+
+for (const { [a++]: x, ...y} of [["0", "1"]]) {
+  const a = 1;
+  result = x;
+}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-declaration-shadowed-block-scoped-bindings/output.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/for-x-declaration-shadowed-block-scoped-bindings/output.js
@@ -1,0 +1,13 @@
+let a = 0,
+  result;
+for (const _ref of [["0", "1"]]) {
+  const _a = a++,
+    {
+      [_a]: x
+    } = _ref,
+    y = babelHelpers.objectWithoutProperties(_ref, [_a].map(babelHelpers.toPropertyKey));
+  {
+    const a = 1;
+    result = x;
+  }
+}

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-array-2/output.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-array-2/output.js
@@ -1,7 +1,7 @@
 const [a, [_ref], _ref2, [_ref3, {
-  h: [i, _ref4]
-}]] = x;
-const {
+    h: [i, _ref4]
+  }]] = x,
+  {
     b
   } = _ref,
   c = babelHelpers.objectWithoutProperties(_ref, ["b"]),

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-array/exec.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-array/exec.js
@@ -1,0 +1,16 @@
+const [a, {b, ...c}] = [1, { b: 2, other: 3 }];
+expect(a).toBe(1);
+expect(b).toBe(2);
+expect(c).toStrictEqual({ other: 3 });
+
+let [d, {e, ...f}] = [4, { e: 5, other: 6 }];
+expect(d).toBe(4);
+expect(e).toBe(5);
+expect(f).toStrictEqual({ other: 6 });
+
+let g, h, i;
+
+[g, {h, ...i}] = [7, { h: 8, other: 9 }];
+expect(g).toBe(7);
+expect(h).toBe(8);
+expect(i).toStrictEqual({ other: 9 });

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-array/output.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-array/output.js
@@ -1,3 +1,4 @@
+var _ref3;
 const [a, _ref] = x,
   {
     b

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-array/output.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/nested-array/output.js
@@ -1,15 +1,17 @@
-const [a, _ref] = x;
-const {
+const [a, _ref] = x,
+  {
     b
   } = _ref,
   c = babelHelpers.objectWithoutProperties(_ref, ["b"]);
-let [d, _ref2] = x;
-let {
+let [d, _ref2] = x,
+  {
     e
   } = _ref2,
   f = babelHelpers.objectWithoutProperties(_ref2, ["e"]);
 [g, _ref3] = x;
-var {
-    h
-  } = _ref3,
-  i = babelHelpers.objectWithoutProperties(_ref3, ["h"]);
+var _ref4 = _ref3;
+({
+  h
+} = _ref4);
+i = babelHelpers.objectWithoutProperties(_ref4, ["h"]);
+_ref4;

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/variable-destructuring/output.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/variable-destructuring/output.js
@@ -98,10 +98,10 @@ const {
   x16: []
 } = z();
 const [...[...y17]] = z();
-const [..._ref] = z();
-const y18 = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref), _ref));
-const [..._ref2] = z();
-const {
+const [..._ref] = z(),
+  y18 = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref), _ref));
+const [..._ref2] = z(),
+  {
     a19
   } = _ref2,
   y19 = babelHelpers.objectWithoutProperties(_ref2, ["a19"]);
@@ -116,8 +116,8 @@ const _z12 = z(),
   } = _z12,
   y22 = babelHelpers.objectWithoutProperties(_z12.x22, ["q22"]);
 const [[...y23] = []] = z();
-const [_ref3 = []] = z();
-const y24 = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref3), _ref3));
+const [_ref3 = []] = z(),
+  y24 = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref3), _ref3));
 const {
   x25: [...y25] = []
 } = z();
@@ -136,19 +136,19 @@ const _z14 = z(),
     }]
   } = _z14,
   y29 = babelHelpers.objectWithoutProperties(_z14.x29, ["q29"]);
-const [,, _ref4] = z();
-const {
+const [,, _ref4] = z(),
+  {
     y30
   } = _ref4,
   x30 = babelHelpers.objectWithoutProperties(_ref4, ["y30"]);
-const [,, _ref5] = z();
-const x31 = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref5), _ref5));
+const [,, _ref5] = z(),
+  x31 = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref5), _ref5));
 const _z15 = z(),
   {
     x32: {}
   } = _z15,
   y32 = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_z15.w32), _z15.w32));
-const [,, {}, _ref6] = z();
-const q32 = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref6), _ref6));
+const [,, {}, _ref6] = z(),
+  q32 = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref6), _ref6));
 const _z16 = z(),
   y33 = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_z16), _z16));

--- a/packages/babel-plugin-transform-object-rest-spread/tsconfig.json
+++ b/packages/babel-plugin-transform-object-rest-spread/tsconfig.json
@@ -18,6 +18,9 @@
       "path": "../../packages/babel-helper-plugin-utils"
     },
     {
+      "path": "../../packages/babel-plugin-transform-destructuring"
+    },
+    {
       "path": "../../packages/babel-plugin-transform-parameters"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2973,6 +2973,7 @@ __metadata:
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
     "@babel/parser": "workspace:^"
+    "@babel/plugin-transform-destructuring": "workspace:^"
     "@babel/plugin-transform-parameters": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17271, fixes #17272
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR contains two refactors and the array pattern fix. On https://gist.github.com/nicolo-ribaudo/f8ac7916f89450f2ead77d99855b2098, I plan to implement the object pattern split as we have already done in the `destructuring-private` transform, which is a more ambitious goal. This PR, as a temporary fix, should unblock the discard binding transform PR.