### PR TITLE
fix: Private class method not found when TS and estree

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -3555,7 +3555,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       // This happens when using the "estree" plugin.
       if (
         (node as N.Node).type === "MethodDefinition" &&
-        (node as unknown as N.EstreeMethodDefinition).value == null
+        (node as unknown as N.EstreeMethodDefinition).value.body == null
       ) {
         return;
       }

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -3553,7 +3553,10 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     ) {
       if (node.type === "TSDeclareMethod") return;
       // This happens when using the "estree" plugin.
-      if ((node as N.Node).type === "MethodDefinition" && node.body == null) {
+      if (
+        (node as N.Node).type === "MethodDefinition" &&
+        (node as unknown as N.EstreeMethodDefinition).value == null
+      ) {
         return;
       }
 

--- a/packages/babel-parser/test/fixtures/misc/regression/issue-17290/input.js
+++ b/packages/babel-parser/test/fixtures/misc/regression/issue-17290/input.js
@@ -1,0 +1,9 @@
+class Reflection {
+  get attributes() {
+    return this.#parseAttributes()
+  }
+
+  #parseAttributes() {
+    111;
+  }
+}

--- a/packages/babel-parser/test/fixtures/misc/regression/issue-17290/options.json
+++ b/packages/babel-parser/test/fixtures/misc/regression/issue-17290/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    [
+      "estree",
+      {
+        "classFeatures": true
+      }
+    ],
+    "typescript"
+  ]
+}

--- a/packages/babel-parser/test/fixtures/misc/regression/issue-17290/output.json
+++ b/packages/babel-parser/test/fixtures/misc/regression/issue-17290/output.json
@@ -1,0 +1,133 @@
+{
+  "type": "File",
+  "start":0,"end":117,"loc":{"start":{"line":1,"column":0},"end":{"line":9,"column":1}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":117,"loc":{"start":{"line":1,"column":0},"end":{"line":9,"column":1}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":117,"loc":{"start":{"line":1,"column":0},"end":{"line":9,"column":1}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":16,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":16},"identifierName":"Reflection"},
+          "name": "Reflection",
+          "decorators": [],
+          "optional": false
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":17,"end":117,"loc":{"start":{"line":1,"column":17},"end":{"line":9,"column":1}},
+          "body": [
+            {
+              "type": "MethodDefinition",
+              "start":21,"end":78,"loc":{"start":{"line":2,"column":2},"end":{"line":4,"column":3}},
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":25,"end":35,"loc":{"start":{"line":2,"column":6},"end":{"line":2,"column":16},"identifierName":"attributes"},
+                "name": "attributes",
+                "decorators": [],
+                "optional": false
+              },
+              "computed": false,
+              "kind": "get",
+              "value": {
+                "type": "FunctionExpression",
+                "start":35,"end":78,"loc":{"start":{"line":2,"column":16},"end":{"line":4,"column":3}},
+                "id": null,
+                "generator": false,
+                "async": false,
+                "expression": false,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start":38,"end":78,"loc":{"start":{"line":2,"column":19},"end":{"line":4,"column":3}},
+                  "body": [
+                    {
+                      "type": "ReturnStatement",
+                      "start":44,"end":74,"loc":{"start":{"line":3,"column":4},"end":{"line":3,"column":34}},
+                      "argument": {
+                        "type": "CallExpression",
+                        "start":51,"end":74,"loc":{"start":{"line":3,"column":11},"end":{"line":3,"column":34}},
+                        "callee": {
+                          "type": "MemberExpression",
+                          "start":51,"end":72,"loc":{"start":{"line":3,"column":11},"end":{"line":3,"column":32}},
+                          "object": {
+                            "type": "ThisExpression",
+                            "start":51,"end":55,"loc":{"start":{"line":3,"column":11},"end":{"line":3,"column":15}}
+                          },
+                          "computed": false,
+                          "property": {
+                            "type": "PrivateIdentifier",
+                            "start":56,"end":72,"loc":{"start":{"line":3,"column":16},"end":{"line":3,"column":32}},
+                            "name": "parseAttributes"
+                          },
+                          "optional": false
+                        },
+                        "arguments": [],
+                        "optional": false
+                      }
+                    }
+                  ]
+                },
+                "declare": false
+              },
+              "decorators": [],
+              "override": false,
+              "optional": false
+            },
+            {
+              "type": "MethodDefinition",
+              "start":82,"end":115,"loc":{"start":{"line":6,"column":2},"end":{"line":8,"column":3}},
+              "static": false,
+              "key": {
+                "type": "PrivateIdentifier",
+                "start":82,"end":98,"loc":{"start":{"line":6,"column":2},"end":{"line":6,"column":18}},
+                "name": "parseAttributes"
+              },
+              "kind": "method",
+              "value": {
+                "type": "FunctionExpression",
+                "start":98,"end":115,"loc":{"start":{"line":6,"column":18},"end":{"line":8,"column":3}},
+                "id": null,
+                "generator": false,
+                "async": false,
+                "expression": false,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start":101,"end":115,"loc":{"start":{"line":6,"column":21},"end":{"line":8,"column":3}},
+                  "body": [
+                    {
+                      "type": "ExpressionStatement",
+                      "start":107,"end":111,"loc":{"start":{"line":7,"column":4},"end":{"line":7,"column":8}},
+                      "expression": {
+                        "type": "Literal",
+                        "start":107,"end":110,"loc":{"start":{"line":7,"column":4},"end":{"line":7,"column":7}},
+                        "value": 111,
+                        "raw": "111"
+                      }
+                    }
+                  ]
+                },
+                "declare": false
+              },
+              "computed": false,
+              "decorators": [],
+              "override": false,
+              "optional": false
+            }
+          ]
+        },
+        "abstract": false,
+        "declare": false,
+        "decorators": [],
+        "implements": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17290 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Regression from https://github.com/babel/babel/pull/17224