### PR TITLE
test: add invalid local use strict test

### DIFF
--- a/packages/babel-parser/test/fixtures/experimental/discard-binding/invalid-function-parameter-local-use-strict/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/discard-binding/invalid-function-parameter-local-use-strict/input.js
@@ -1,0 +1,1 @@
+function f(void) { "use strict"; }

--- a/packages/babel-parser/test/fixtures/experimental/discard-binding/invalid-function-parameter-local-use-strict/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/discard-binding/invalid-function-parameter-local-use-strict/output.json
@@ -1,0 +1,54 @@
+{
+  "type": "File",
+  "start":0,"end":34,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":34,"index":34}},
+  "errors": [
+    "SyntaxError: Illegal 'use strict' directive in function with non-simple parameter list. (1:0)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":34,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":34,"index":34}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start":0,"end":34,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":34,"index":34}},
+        "id": {
+          "type": "Identifier",
+          "start":9,"end":10,"loc":{"start":{"line":1,"column":9,"index":9},"end":{"line":1,"column":10,"index":10},"identifierName":"f"},
+          "name": "f"
+        },
+        "generator": false,
+        "async": false,
+        "params": [
+          {
+            "type": "VoidPattern",
+            "start":11,"end":15,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":15,"index":15}}
+          }
+        ],
+        "body": {
+          "type": "BlockStatement",
+          "start":17,"end":34,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":1,"column":34,"index":34}},
+          "body": [],
+          "directives": [
+            {
+              "type": "Directive",
+              "start":19,"end":32,"loc":{"start":{"line":1,"column":19,"index":19},"end":{"line":1,"column":32,"index":32}},
+              "value": {
+                "type": "DirectiveLiteral",
+                "start":19,"end":31,"loc":{"start":{"line":1,"column":19,"index":19},"end":{"line":1,"column":31,"index":31}},
+                "extra": {
+                  "rawValue": "use strict",
+                  "raw": "\"use strict\"",
+                  "expressionValue": "use strict"
+                },
+                "value": "use strict"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Ref https://github.com/tc39/proposal-discard-binding/issues/16
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

In this PR we add a new behaviour test for local use strict directive within a function with void pattern. The proposal spec has not yet specified the desired behaviour. This PR is to assume that `IsSimpleParameterList` should return `false` for discard binding, which is already the behaviour of the current parser implementation.