### PR TITLE
fix: support named evaluation for using declaration

### DIFF
--- a/packages/babel-plugin-proposal-explicit-resource-management/src/index.ts
+++ b/packages/babel-plugin-proposal-explicit-resource-management/src/index.ts
@@ -1,10 +1,34 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { types as t, template, traverse } from "@babel/core";
-import type { NodePath, Visitor, PluginPass } from "@babel/core";
+import type { NodePath, Scope, Visitor, PluginPass } from "@babel/core";
 
 const enum USING_KIND {
   NORMAL,
   AWAIT,
+}
+
+// https://tc39.es/ecma262/#sec-isanonymousfunctiondefinition
+// We don't test anonymous function / arrow function because they must not be disposable
+function isAnonymousFunctionDefinition(
+  node: t.Node,
+): node is t.ClassExpression {
+  return t.isClassExpression(node) && !node.id;
+}
+
+function emitSetFunctionNameCall(
+  state: PluginPass,
+  scope: Scope,
+  expression: t.Expression,
+  name: string,
+) {
+  const memoiserId = scope.generateDeclaredUidIdentifier("m");
+  return t.sequenceExpression([
+    t.assignmentExpression("=", t.cloneNode(memoiserId), expression),
+    t.callExpression(state.addHelper("setFunctionName"), [
+      t.cloneNode(memoiserId),
+      t.stringLiteral(name),
+    ]),
+  ]);
 }
 
 export default declare(api => {
@@ -45,10 +69,11 @@ export default declare(api => {
       if (process.env.BABEL_8_BREAKING || state.availableHelper("usingCtx")) {
         let ctx: t.Identifier | null = null;
         let needsAwait = false;
+        const scope = path.scope;
 
         for (const node of path.node.body) {
           if (!isUsingDeclaration(node)) continue;
-          ctx ??= path.scope.generateUidIdentifier("usingCtx");
+          ctx ??= scope.generateUidIdentifier("usingCtx");
           const isAwaitUsing =
             node.kind === "await using" ||
             TOP_LEVEL_USING.get(node) === USING_KIND.AWAIT;
@@ -58,12 +83,23 @@ export default declare(api => {
             node.kind = "const";
           }
           for (const decl of node.declarations) {
+            const currentInit = decl.init;
             decl.init = t.callExpression(
               t.memberExpression(
                 t.cloneNode(ctx),
                 isAwaitUsing ? t.identifier("a") : t.identifier("u"),
               ),
-              [decl.init],
+              [
+                isAnonymousFunctionDefinition(currentInit) &&
+                t.isIdentifier(decl.id)
+                  ? emitSetFunctionNameCall(
+                      state,
+                      scope,
+                      currentInit,
+                      decl.id.name,
+                    )
+                  : currentInit,
+              ],
             );
           }
         }

--- a/packages/babel-plugin-proposal-explicit-resource-management/src/index.ts
+++ b/packages/babel-plugin-proposal-explicit-resource-management/src/index.ts
@@ -1,6 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 import { types as t, template, traverse } from "@babel/core";
-import type { NodePath, Scope, Visitor, PluginPass } from "@babel/core";
+import type { NodePath, Visitor, PluginPass } from "@babel/core";
 
 const enum USING_KIND {
   NORMAL,
@@ -17,17 +17,12 @@ function isAnonymousFunctionDefinition(
 
 function emitSetFunctionNameCall(
   state: PluginPass,
-  scope: Scope,
   expression: t.Expression,
   name: string,
 ) {
-  const memoiserId = scope.generateDeclaredUidIdentifier("m");
-  return t.sequenceExpression([
-    t.assignmentExpression("=", t.cloneNode(memoiserId), expression),
-    t.callExpression(state.addHelper("setFunctionName"), [
-      t.cloneNode(memoiserId),
-      t.stringLiteral(name),
-    ]),
+  return t.callExpression(state.addHelper("setFunctionName"), [
+    expression,
+    t.stringLiteral(name),
   ]);
 }
 
@@ -92,12 +87,7 @@ export default declare(api => {
               [
                 isAnonymousFunctionDefinition(currentInit) &&
                 t.isIdentifier(decl.id)
-                  ? emitSetFunctionNameCall(
-                      state,
-                      scope,
-                      currentInit,
-                      decl.id.name,
-                    )
+                  ? emitSetFunctionNameCall(state, currentInit, decl.id.name)
                   : currentInit,
               ],
             );

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync-node-12/named-evaluation-tdz.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync-node-12/named-evaluation-tdz.js
@@ -1,0 +1,3 @@
+expect(() => {
+  using fooTDZ = class { static self = fooTDZ }
+}).toThrow("Cannot access 'fooTDZ' before initialization")

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync-node-12/options.json
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync-node-12/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "proposal-explicit-resource-management"
+  ],
+  "minNodeVersion": "12.0.0"
+}

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync/named-evaluation.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync/named-evaluation.js
@@ -1,0 +1,12 @@
+let log = [];
+let Symbol$dispose = Symbol.dispose || Symbol.for("Symbol.dispose");
+{
+  using foo = class { static [Symbol$dispose]() { log.push(`${foo.name} is disposed`) } }
+  log.push(foo.name);
+}
+
+expect(log).toEqual(["foo", "foo is disposed"])
+
+expect(() => {
+  using fooTDZ = class { static p = fooTDZ }
+}).toThrow("Cannot access 'fooTDZ' before initialization")

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync/named-evaluation.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync/named-evaluation.js
@@ -6,7 +6,3 @@ let Symbol$dispose = Symbol.dispose || Symbol.for("Symbol.dispose");
 }
 
 expect(log).toEqual(["foo", "foo is disposed"])
-
-expect(() => {
-  using fooTDZ = class { static p = fooTDZ }
-}).toThrow("Cannot access 'fooTDZ' before initialization")

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/transform-sync/named-evaluation/input.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/transform-sync/named-evaluation/input.js
@@ -1,0 +1,6 @@
+let log = [];
+let Symbol$dispose = Symbol.dispose || Symbol.for("Symbol.dispose");
+{
+  using foo = class { static [Symbol$dispose]() { log.push(`${foo.name} is disposed`) } }
+  log.push(foo.name);
+}

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/transform-sync/named-evaluation/output.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/transform-sync/named-evaluation/output.js
@@ -1,0 +1,16 @@
+let log = [];
+let Symbol$dispose = Symbol.dispose || Symbol.for("Symbol.dispose");
+try {
+  var _m;
+  var _usingCtx = babelHelpers.usingCtx();
+  const foo = _usingCtx.u((_m = class {
+    static [Symbol$dispose]() {
+      log.push(`${foo.name} is disposed`);
+    }
+  }, babelHelpers.setFunctionName(_m, "foo")));
+  log.push(foo.name);
+} catch (_) {
+  _usingCtx.e = _;
+} finally {
+  _usingCtx.d();
+}

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/transform-sync/named-evaluation/output.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/transform-sync/named-evaluation/output.js
@@ -1,13 +1,12 @@
 let log = [];
 let Symbol$dispose = Symbol.dispose || Symbol.for("Symbol.dispose");
 try {
-  var _m;
   var _usingCtx = babelHelpers.usingCtx();
-  const foo = _usingCtx.u((_m = class {
+  const foo = _usingCtx.u(babelHelpers.setFunctionName(class {
     static [Symbol$dispose]() {
       log.push(`${foo.name} is disposed`);
     }
-  }, babelHelpers.setFunctionName(_m, "foo")));
+  }, "foo"));
   log.push(foo.name);
 } catch (_) {
   _usingCtx.e = _;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17270 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Although adding name to class id generally works, in this PR we choose the `setFunctionName` approach because `using ... = class {}` is probably not very popular, I think it is acceptable to trade off output size for spec compliance here.