### PR TITLE
fix: handle shadowed binding in `for using of` body

### DIFF
--- a/packages/babel-plugin-proposal-explicit-resource-management/package.json
+++ b/packages/babel-plugin-proposal-explicit-resource-management/package.json
@@ -17,7 +17,8 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "@babel/helper-plugin-utils": "workspace:^"
+    "@babel/helper-plugin-utils": "workspace:^",
+    "@babel/plugin-transform-destructuring": "workspace:^"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-plugin-proposal-explicit-resource-management/src/index.ts
+++ b/packages/babel-plugin-proposal-explicit-resource-management/src/index.ts
@@ -1,4 +1,5 @@
 import { declare } from "@babel/helper-plugin-utils";
+import { unshiftForXStatementBody } from "@babel/plugin-transform-destructuring";
 import { types as t, template, traverse } from "@babel/core";
 import type { NodePath, Visitor, PluginPass } from "@babel/core";
 
@@ -32,11 +33,11 @@ export default declare(api => {
       left.kind = "const";
 
       path.ensureBlock();
-      path.node.body.body.unshift(
+      unshiftForXStatementBody(path, [
         t.variableDeclaration("using", [
           t.variableDeclarator(id, t.cloneNode(tmpId)),
         ]),
-      );
+      ]);
     },
     "BlockStatement|StaticBlock"(
       path: NodePath<t.BlockStatement | t.StaticBlock>,

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync/for-head-shadow.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/exec-sync/for-head-shadow.js
@@ -1,0 +1,9 @@
+let log = [];
+{
+  for (using x of [null]) {
+    const x = undefined;
+    log.push(x);
+  }
+}
+
+expect(log).toEqual([undefined]);

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/transform-sync/for-head-shadow/input.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/transform-sync/for-head-shadow/input.js
@@ -1,0 +1,7 @@
+let log = [];
+{
+  for (using x of [null]) {
+    const x = undefined;
+    log.push(x);
+  }
+}

--- a/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/transform-sync/for-head-shadow/output.js
+++ b/packages/babel-plugin-proposal-explicit-resource-management/test/fixtures/transform-sync/for-head-shadow/output.js
@@ -1,0 +1,15 @@
+let log = [];
+{
+  for (const _x of [null]) try {
+    var _usingCtx = babelHelpers.usingCtx();
+    const x = _usingCtx.u(_x);
+    {
+      const x = undefined;
+      log.push(x);
+    }
+  } catch (_) {
+    _usingCtx.e = _;
+  } finally {
+    _usingCtx.d();
+  }
+}

--- a/packages/babel-plugin-proposal-explicit-resource-management/tsconfig.json
+++ b/packages/babel-plugin-proposal-explicit-resource-management/tsconfig.json
@@ -15,6 +15,9 @@
       "path": "../../packages/babel-helper-plugin-utils"
     },
     {
+      "path": "../../packages/babel-plugin-transform-destructuring"
+    },
+    {
       "path": "../../packages/babel-core"
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,6 +1470,7 @@ __metadata:
     "@babel/core": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
+    "@babel/plugin-transform-destructuring": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17318 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we imported `unshiftForXStatementBody` from the destructuring transform to handle the shadowed bindings within the for loop body.