### PR TITLE
Refine typing for parserOverride in babel plugins

### DIFF
--- a/packages/babel-core/src/config/plugin.ts
+++ b/packages/babel-core/src/config/plugin.ts
@@ -9,7 +9,7 @@ export default class Plugin {
   pre?: PluginObject["pre"];
   visitor: PluginObject["visitor"];
 
-  parserOverride?: Function;
+  parserOverride?: PluginObject["parserOverride"];
   generatorOverride?: Function;
 
   options: object;

--- a/packages/babel-core/src/config/validation/plugins.ts
+++ b/packages/babel-core/src/config/validation/plugins.ts
@@ -11,7 +11,7 @@ import type {
   OptionPath,
   RootPath,
 } from "./option-assertions.ts";
-import type { ParserOptions } from "@babel/parser";
+import type { parse, ParserOptions } from "@babel/parser";
 import type { Visitor } from "@babel/traverse";
 import type { ValidatedOptions } from "./options.ts";
 import type { File, PluginAPI, PluginPass } from "../../index.ts";
@@ -93,7 +93,9 @@ export type PluginObject<S extends PluginPass = PluginPass> = {
     dirname: string,
   ) => PluginObject;
   visitor?: Visitor<S>;
-  parserOverride?: Function;
+  parserOverride?: (
+    ...args: [...Parameters<typeof parse>, typeof parse]
+  ) => ReturnType<typeof parse>;
   generatorOverride?: Function;
 };
 

--- a/packages/babel-core/src/parser/index.ts
+++ b/packages/babel-core/src/parser/index.ts
@@ -29,7 +29,7 @@ export default function* parser(
     } else if (results.length === 1) {
       // If we want to allow async parsers
       yield* [];
-      if (typeof results[0].then === "function") {
+      if (typeof (results[0] as any).then === "function") {
         throw new Error(
           `You appear to be using an async parser plugin, ` +
             `which your current version of Babel does not support. ` +


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`parserOverride` is executed the same way as `parse`, but with the original parse being the last parameter. I was trying to build a babel plugin using this, and had to come to the source code to understand since it was just typed as a general `Function`.

https://github.com/babel/babel/blob/1d4546bcb80009303aab386b59f4df1fd335c1d5/packages/babel-core/src/parser/index.ts#L20
