### PR TITLE
Improve multiline comments handling in yield/await expression

### DIFF
--- a/packages/babel-generator/src/generators/expressions.ts
+++ b/packages/babel-generator/src/generators/expressions.ts
@@ -236,20 +236,20 @@ export function AwaitExpression(this: Printer, node: t.AwaitExpression) {
 }
 
 export function YieldExpression(this: Printer, node: t.YieldExpression) {
-  this.word("yield", true);
-
   if (node.delegate) {
+    this.word("yield", true);
     this.token("*");
     if (node.argument) {
       this.space();
       // line terminators are allowed after yield*
       this.print(node.argument);
     }
+  } else if (node.argument) {
+    this.word("yield", true);
+    this.space();
+    this.print(node.argument);
   } else {
-    if (node.argument) {
-      this.space();
-      this.printTerminatorless(node.argument);
-    }
+    this.word("yield");
   }
 }
 

--- a/packages/babel-generator/src/generators/expressions.ts
+++ b/packages/babel-generator/src/generators/expressions.ts
@@ -228,11 +228,8 @@ export function Import(this: Printer) {
 
 export function AwaitExpression(this: Printer, node: t.AwaitExpression) {
   this.word("await");
-
-  if (node.argument) {
-    this.space();
-    this.printTerminatorless(node.argument);
-  }
+  this.space();
+  this.print(node.argument);
 }
 
 export function YieldExpression(this: Printer, node: t.YieldExpression) {

--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -40,7 +40,7 @@ export function TSTypeParameterInstantiation(
     printTrailingSeparator &&= !!this.tokenMap.find(node, t =>
       this.tokenMap.matchesOriginal(t, ","),
     );
-    // Preseve the trailing comma if it was there before
+    // Preserve the trailing comma if it was there before
     printTrailingSeparator ||= this.shouldPrintTrailingComma(">");
   }
 

--- a/packages/babel-generator/test/fixtures/edgecase/await-with-retainlines-option/input.js
+++ b/packages/babel-generator/test/fixtures/edgecase/await-with-retainlines-option/input.js
@@ -1,0 +1,4 @@
+async function foo(l) {
+  await/* comment
+  */l;
+}

--- a/packages/babel-generator/test/fixtures/edgecase/await-with-retainlines-option/options.json
+++ b/packages/babel-generator/test/fixtures/edgecase/await-with-retainlines-option/options.json
@@ -1,0 +1,3 @@
+{
+  "retainLines": true
+}

--- a/packages/babel-generator/test/fixtures/edgecase/await-with-retainlines-option/output.js
+++ b/packages/babel-generator/test/fixtures/edgecase/await-with-retainlines-option/output.js
@@ -1,0 +1,4 @@
+async function foo(l) {
+  await /* comment
+  */l;
+}

--- a/packages/babel-generator/test/fixtures/edgecase/throw-with-retainlines-option/input.js
+++ b/packages/babel-generator/test/fixtures/edgecase/throw-with-retainlines-option/input.js
@@ -1,0 +1,11 @@
+function foo(l) {
+  throw (
+    l
+  );
+}
+
+function foo2() {
+  throw (
+    1 && 2
+  ) || 3;
+}

--- a/packages/babel-generator/test/fixtures/edgecase/throw-with-retainlines-option/options.json
+++ b/packages/babel-generator/test/fixtures/edgecase/throw-with-retainlines-option/options.json
@@ -1,0 +1,3 @@
+{
+  "retainLines": true
+}

--- a/packages/babel-generator/test/fixtures/edgecase/throw-with-retainlines-option/output.js
+++ b/packages/babel-generator/test/fixtures/edgecase/throw-with-retainlines-option/output.js
@@ -1,0 +1,11 @@
+function foo(l) {
+  throw (
+    l);
+
+}
+
+function foo2() {
+  throw (
+    1 && 2) ||
+  3;
+}

--- a/packages/babel-generator/test/fixtures/edgecase/yield-star-with-retainlines-option/input.js
+++ b/packages/babel-generator/test/fixtures/edgecase/yield-star-with-retainlines-option/input.js
@@ -1,0 +1,11 @@
+function* foo(l) {
+  yield* (
+    l()
+  );
+}
+
+function* foo2() {
+  yield* (
+    l() && m()
+  ) || n();
+}

--- a/packages/babel-generator/test/fixtures/edgecase/yield-star-with-retainlines-option/options.json
+++ b/packages/babel-generator/test/fixtures/edgecase/yield-star-with-retainlines-option/options.json
@@ -1,0 +1,3 @@
+{
+  "retainLines": true
+}

--- a/packages/babel-generator/test/fixtures/edgecase/yield-star-with-retainlines-option/output.js
+++ b/packages/babel-generator/test/fixtures/edgecase/yield-star-with-retainlines-option/output.js
@@ -1,0 +1,11 @@
+function* foo(l) {
+  yield*
+  l();
+
+}
+
+function* foo2() {
+  yield*
+  l() && m() ||
+  n();
+}

--- a/packages/babel-generator/test/fixtures/edgecase/yield-with-retainlines-option/input.js
+++ b/packages/babel-generator/test/fixtures/edgecase/yield-with-retainlines-option/input.js
@@ -1,0 +1,16 @@
+function* foo(l) {
+  yield (
+    l
+  );
+}
+
+function* foo2() {
+  yield (
+    1 && 2
+  ) || 3;
+}
+
+function* foo3() {
+  (yield/* comment
+  */) + ""
+}

--- a/packages/babel-generator/test/fixtures/edgecase/yield-with-retainlines-option/options.json
+++ b/packages/babel-generator/test/fixtures/edgecase/yield-with-retainlines-option/options.json
@@ -1,0 +1,3 @@
+{
+  "retainLines": true
+}

--- a/packages/babel-generator/test/fixtures/edgecase/yield-with-retainlines-option/output.js
+++ b/packages/babel-generator/test/fixtures/edgecase/yield-with-retainlines-option/output.js
@@ -1,0 +1,16 @@
+function* foo(l) {
+  yield (
+    l);
+
+}
+
+function* foo2() {
+  yield (
+    1 && 2) ||
+  3;
+}
+
+function* foo3() {
+  (yield /* comment
+  */) + "";
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Comments are missing when Babel prints an empty yield expression with multi-line comments ([REPL](https://babel.dev/repl#?browsers=chrome%20102&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=GYVwdgxgLglg9mABAKmACgJSIN4ChGJoCeMApgDYAmA9MvohHALZOlhQrUa4C-QA&forceAllTransforms=false&modules=false&shippedProposals=false&evaluate=false&fileSize=false&timeTravel=false&sourceType=script&lineWrap=true&presets=env&prettier=false&targets=&version=7.27.2&externalPlugins=%40babel%2Fplugin-syntax-explicit-resource-management%407.27.1&assumptions=%7B%7D))
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we improved the line terminator handling when printing lone yield expression and await expression. The spec does not forbid line terminator after `await`, so we relax the await expression requirements. New tested are added such that they are failing on the main but passing on this PR.