### PR TITLE
Improve integrations of using declaration with other transforms

### DIFF
--- a/eslint/babel-eslint-parser/test/typescript-estree.test.js
+++ b/eslint/babel-eslint-parser/test/typescript-estree.test.js
@@ -338,6 +338,9 @@ function deeplyRemoveProperties(obj, props) {
       );
       const fixtures = getFixtures(parserTestFixtureRoot);
       const FAILURES = new Set([
+        // Todo: Remove when https://github.com/typescript-eslint/typescript-eslint/issues/11244 is resolved
+        "typescript/declare/valid-namespace-var/input.ts",
+
         // ts-eslint/tsc does not support arrow generic in tsx mode
         "typescript/arrow-function/async-await-null/input.ts",
         "typescript/arrow-function/async-generic-after-await/input.ts",

--- a/packages/babel-parser/ast/spec.md
+++ b/packages/babel-parser/ast/spec.md
@@ -572,7 +572,7 @@ A function declaration. Note that unlike in the parent interface `Function`, the
 interface VariableDeclaration <: Declaration {
   type: "VariableDeclaration";
   declarations: [ VariableDeclarator ];
-  kind: "var" | "let" | "const" | "using";
+  kind: "var" | "let" | "const" | "using" | "await using";
 }
 ```
 

--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -2927,7 +2927,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     // parse flow type annotations on variable declarator heads - let foo: string = bar
     parseVarId(
       decl: N.VariableDeclarator,
-      kind: "var" | "let" | "const",
+      kind: "var" | "let" | "const" | "using" | "await using",
     ): void {
       super.parseVarId(decl, kind);
       if (this.match(tt.colon)) {

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -91,11 +91,11 @@ const TSErrors = ParseErrorEnum`typescript`({
     "Initializers are not allowed in ambient contexts.",
   DeclareFunctionHasImplementation:
     "An implementation cannot be declared in ambient contexts.",
-  DuplicateAccessibilityModifier:
-    // `Accessibility modifier already seen: ${modifier}` would be more helpful.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    ({ modifier }: { modifier: N.Accessibility }) =>
-      `Accessibility modifier already seen.`,
+  DuplicateAccessibilityModifier: ({
+    modifier,
+  }: {
+    modifier: N.Accessibility;
+  }) => `Accessibility modifier already seen: '${modifier}'.`,
   DuplicateModifier: ({ modifier }: { modifier: TsModifier }) =>
     `Duplicate modifier: '${modifier}'.`,
   // `token` matches the terminology used by typescript:

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -158,7 +158,7 @@ const TSErrors = ParseErrorEnum`typescript`({
     "'interface' declarations must be followed by an identifier.",
   NonAbstractClassHasAbstractMethod:
     "Abstract methods can only appear within an abstract class.",
-  NonClassMethodPropertyHasAbstractModifer:
+  NonClassMethodPropertyHasAbstractModifier:
     "'abstract' modifier can only appear on a class, method, or property declaration.",
   OptionalTypeBeforeRequired:
     "A required element cannot follow an optional element.",
@@ -4205,7 +4205,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         //   Foo {}
         if (!this.hasFollowingLineBreak()) {
           node.abstract = true;
-          this.raise(TSErrors.NonClassMethodPropertyHasAbstractModifer, node);
+          this.raise(TSErrors.NonClassMethodPropertyHasAbstractModifier, node);
           return this.tsParseInterfaceDeclaration(
             node as N.TsInterfaceDeclaration,
           );

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -3091,7 +3091,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
     parseVarStatement(
       node: N.VariableDeclaration,
-      kind: "var" | "let" | "const" | "using",
+      kind: "var" | "let" | "const" | "using" | "await using",
       allowMissingInitializer: boolean = false,
     ) {
       const { isAmbientContext } = this.state;
@@ -3108,7 +3108,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         if (!init) continue;
 
         // var and let aren't ever allowed initializers.
-        if (kind !== "const" || !!id.typeAnnotation) {
+        if (kind === "var" || kind === "let" || !!id.typeAnnotation) {
           this.raise(TSErrors.InitializerNotAllowedInAmbientContext, init);
         } else if (
           !isValidAmbientConstInitializer(init, this.hasPlugin("estree"))
@@ -3620,7 +3620,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     // `let x: number;`
     parseVarId(
       decl: N.VariableDeclarator,
-      kind: "var" | "let" | "const" | "using",
+      kind: "var" | "let" | "const" | "using" | "await using",
     ): void {
       super.parseVarId(decl, kind);
       if (

--- a/packages/babel-parser/test/fixtures/typescript/class/duplicates-accessibility/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/class/duplicates-accessibility/output.json
@@ -2,12 +2,12 @@
   "type": "File",
   "start":0,"end":127,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":127}},
   "errors": [
-    "SyntaxError: Accessibility modifier already seen. (2:9)",
-    "SyntaxError: Accessibility modifier already seen. (3:10)",
-    "SyntaxError: Accessibility modifier already seen. (4:12)",
-    "SyntaxError: Accessibility modifier already seen. (5:9)",
-    "SyntaxError: Accessibility modifier already seen. (6:9)",
-    "SyntaxError: Accessibility modifier already seen. (6:19)"
+    "SyntaxError: Accessibility modifier already seen: 'public'. (2:9)",
+    "SyntaxError: Accessibility modifier already seen: 'public'. (3:10)",
+    "SyntaxError: Accessibility modifier already seen: 'private'. (4:12)",
+    "SyntaxError: Accessibility modifier already seen: 'protected'. (5:9)",
+    "SyntaxError: Accessibility modifier already seen: 'protected'. (6:9)",
+    "SyntaxError: Accessibility modifier already seen: 'private'. (6:19)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-var/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-var/input.ts
@@ -1,0 +1,8 @@
+declare namespace invalid_namespace_var {
+  var A = 0;
+  var A1: number = 0;
+  let B = 0;
+  let B1: number = 0;
+  const C: number = 0;
+  using D: number = 0;
+}

--- a/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-var/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-var/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["explicitResourceManagement", "typescript"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-var/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-var/output.json
@@ -1,0 +1,223 @@
+{
+  "type": "File",
+  "start":0,"end":159,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":8,"column":1,"index":159}},
+  "errors": [
+    "SyntaxError: Initializers are not allowed in ambient contexts. (2:10)",
+    "SyntaxError: Initializers are not allowed in ambient contexts. (3:19)",
+    "SyntaxError: Initializers are not allowed in ambient contexts. (4:10)",
+    "SyntaxError: Initializers are not allowed in ambient contexts. (5:19)",
+    "SyntaxError: Initializers are not allowed in ambient contexts. (6:20)",
+    "SyntaxError: Initializers are not allowed in ambient contexts. (7:20)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":159,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":8,"column":1,"index":159}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSModuleDeclaration",
+        "start":0,"end":159,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":8,"column":1,"index":159}},
+        "kind": "namespace",
+        "id": {
+          "type": "Identifier",
+          "start":18,"end":39,"loc":{"start":{"line":1,"column":18,"index":18},"end":{"line":1,"column":39,"index":39},"identifierName":"invalid_namespace_var"},
+          "name": "invalid_namespace_var"
+        },
+        "body": {
+          "type": "TSModuleBlock",
+          "start":40,"end":159,"loc":{"start":{"line":1,"column":40,"index":40},"end":{"line":8,"column":1,"index":159}},
+          "body": [
+            {
+              "type": "VariableDeclaration",
+              "start":44,"end":54,"loc":{"start":{"line":2,"column":2,"index":44},"end":{"line":2,"column":12,"index":54}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":48,"end":53,"loc":{"start":{"line":2,"column":6,"index":48},"end":{"line":2,"column":11,"index":53}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":48,"end":49,"loc":{"start":{"line":2,"column":6,"index":48},"end":{"line":2,"column":7,"index":49},"identifierName":"A"},
+                    "name": "A"
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":52,"end":53,"loc":{"start":{"line":2,"column":10,"index":52},"end":{"line":2,"column":11,"index":53}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ],
+              "kind": "var"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":57,"end":76,"loc":{"start":{"line":3,"column":2,"index":57},"end":{"line":3,"column":21,"index":76}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":61,"end":75,"loc":{"start":{"line":3,"column":6,"index":61},"end":{"line":3,"column":20,"index":75}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":61,"end":71,"loc":{"start":{"line":3,"column":6,"index":61},"end":{"line":3,"column":16,"index":71},"identifierName":"A1"},
+                    "name": "A1",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start":63,"end":71,"loc":{"start":{"line":3,"column":8,"index":63},"end":{"line":3,"column":16,"index":71}},
+                      "typeAnnotation": {
+                        "type": "TSNumberKeyword",
+                        "start":65,"end":71,"loc":{"start":{"line":3,"column":10,"index":65},"end":{"line":3,"column":16,"index":71}}
+                      }
+                    }
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":74,"end":75,"loc":{"start":{"line":3,"column":19,"index":74},"end":{"line":3,"column":20,"index":75}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ],
+              "kind": "var"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":79,"end":89,"loc":{"start":{"line":4,"column":2,"index":79},"end":{"line":4,"column":12,"index":89}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":83,"end":88,"loc":{"start":{"line":4,"column":6,"index":83},"end":{"line":4,"column":11,"index":88}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":83,"end":84,"loc":{"start":{"line":4,"column":6,"index":83},"end":{"line":4,"column":7,"index":84},"identifierName":"B"},
+                    "name": "B"
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":87,"end":88,"loc":{"start":{"line":4,"column":10,"index":87},"end":{"line":4,"column":11,"index":88}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ],
+              "kind": "let"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":92,"end":111,"loc":{"start":{"line":5,"column":2,"index":92},"end":{"line":5,"column":21,"index":111}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":96,"end":110,"loc":{"start":{"line":5,"column":6,"index":96},"end":{"line":5,"column":20,"index":110}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":96,"end":106,"loc":{"start":{"line":5,"column":6,"index":96},"end":{"line":5,"column":16,"index":106},"identifierName":"B1"},
+                    "name": "B1",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start":98,"end":106,"loc":{"start":{"line":5,"column":8,"index":98},"end":{"line":5,"column":16,"index":106}},
+                      "typeAnnotation": {
+                        "type": "TSNumberKeyword",
+                        "start":100,"end":106,"loc":{"start":{"line":5,"column":10,"index":100},"end":{"line":5,"column":16,"index":106}}
+                      }
+                    }
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":109,"end":110,"loc":{"start":{"line":5,"column":19,"index":109},"end":{"line":5,"column":20,"index":110}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ],
+              "kind": "let"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":114,"end":134,"loc":{"start":{"line":6,"column":2,"index":114},"end":{"line":6,"column":22,"index":134}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":120,"end":133,"loc":{"start":{"line":6,"column":8,"index":120},"end":{"line":6,"column":21,"index":133}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":120,"end":129,"loc":{"start":{"line":6,"column":8,"index":120},"end":{"line":6,"column":17,"index":129},"identifierName":"C"},
+                    "name": "C",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start":121,"end":129,"loc":{"start":{"line":6,"column":9,"index":121},"end":{"line":6,"column":17,"index":129}},
+                      "typeAnnotation": {
+                        "type": "TSNumberKeyword",
+                        "start":123,"end":129,"loc":{"start":{"line":6,"column":11,"index":123},"end":{"line":6,"column":17,"index":129}}
+                      }
+                    }
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":132,"end":133,"loc":{"start":{"line":6,"column":20,"index":132},"end":{"line":6,"column":21,"index":133}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ],
+              "kind": "const"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":137,"end":157,"loc":{"start":{"line":7,"column":2,"index":137},"end":{"line":7,"column":22,"index":157}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":143,"end":156,"loc":{"start":{"line":7,"column":8,"index":143},"end":{"line":7,"column":21,"index":156}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":143,"end":152,"loc":{"start":{"line":7,"column":8,"index":143},"end":{"line":7,"column":17,"index":152},"identifierName":"D"},
+                    "name": "D",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start":144,"end":152,"loc":{"start":{"line":7,"column":9,"index":144},"end":{"line":7,"column":17,"index":152}},
+                      "typeAnnotation": {
+                        "type": "TSNumberKeyword",
+                        "start":146,"end":152,"loc":{"start":{"line":7,"column":11,"index":146},"end":{"line":7,"column":17,"index":152}}
+                      }
+                    }
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":155,"end":156,"loc":{"start":{"line":7,"column":20,"index":155},"end":{"line":7,"column":21,"index":156}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ],
+              "kind": "using"
+            }
+          ]
+        },
+        "declare": true
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/declare/valid-namespace-var/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/declare/valid-namespace-var/input.ts
@@ -1,0 +1,7 @@
+declare namespace valid_namespace_var {
+  var A;
+  let B;
+  const C;
+  const C1 = 0;
+  using D;
+}

--- a/packages/babel-parser/test/fixtures/typescript/declare/valid-namespace-var/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/valid-namespace-var/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["explicitResourceManagement", "typescript"]
+}

--- a/packages/babel-parser/test/fixtures/typescript/declare/valid-namespace-var/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/valid-namespace-var/output.json
@@ -1,0 +1,126 @@
+{
+  "type": "File",
+  "start":0,"end":97,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":97}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":97,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":97}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSModuleDeclaration",
+        "start":0,"end":97,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":97}},
+        "kind": "namespace",
+        "id": {
+          "type": "Identifier",
+          "start":18,"end":37,"loc":{"start":{"line":1,"column":18,"index":18},"end":{"line":1,"column":37,"index":37},"identifierName":"valid_namespace_var"},
+          "name": "valid_namespace_var"
+        },
+        "body": {
+          "type": "TSModuleBlock",
+          "start":38,"end":97,"loc":{"start":{"line":1,"column":38,"index":38},"end":{"line":7,"column":1,"index":97}},
+          "body": [
+            {
+              "type": "VariableDeclaration",
+              "start":42,"end":48,"loc":{"start":{"line":2,"column":2,"index":42},"end":{"line":2,"column":8,"index":48}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":46,"end":47,"loc":{"start":{"line":2,"column":6,"index":46},"end":{"line":2,"column":7,"index":47}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":46,"end":47,"loc":{"start":{"line":2,"column":6,"index":46},"end":{"line":2,"column":7,"index":47},"identifierName":"A"},
+                    "name": "A"
+                  },
+                  "init": null
+                }
+              ],
+              "kind": "var"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":51,"end":57,"loc":{"start":{"line":3,"column":2,"index":51},"end":{"line":3,"column":8,"index":57}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":55,"end":56,"loc":{"start":{"line":3,"column":6,"index":55},"end":{"line":3,"column":7,"index":56}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":55,"end":56,"loc":{"start":{"line":3,"column":6,"index":55},"end":{"line":3,"column":7,"index":56},"identifierName":"B"},
+                    "name": "B"
+                  },
+                  "init": null
+                }
+              ],
+              "kind": "let"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":60,"end":68,"loc":{"start":{"line":4,"column":2,"index":60},"end":{"line":4,"column":10,"index":68}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":66,"end":67,"loc":{"start":{"line":4,"column":8,"index":66},"end":{"line":4,"column":9,"index":67}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":66,"end":67,"loc":{"start":{"line":4,"column":8,"index":66},"end":{"line":4,"column":9,"index":67},"identifierName":"C"},
+                    "name": "C"
+                  },
+                  "init": null
+                }
+              ],
+              "kind": "const"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":71,"end":84,"loc":{"start":{"line":5,"column":2,"index":71},"end":{"line":5,"column":15,"index":84}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":77,"end":83,"loc":{"start":{"line":5,"column":8,"index":77},"end":{"line":5,"column":14,"index":83}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":77,"end":79,"loc":{"start":{"line":5,"column":8,"index":77},"end":{"line":5,"column":10,"index":79},"identifierName":"C1"},
+                    "name": "C1"
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":82,"end":83,"loc":{"start":{"line":5,"column":13,"index":82},"end":{"line":5,"column":14,"index":83}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ],
+              "kind": "const"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":87,"end":95,"loc":{"start":{"line":6,"column":2,"index":87},"end":{"line":6,"column":10,"index":95}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":93,"end":94,"loc":{"start":{"line":6,"column":8,"index":93},"end":{"line":6,"column":9,"index":94}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":93,"end":94,"loc":{"start":{"line":6,"column":8,"index":93},"end":{"line":6,"column":9,"index":94},"identifierName":"D"},
+                    "name": "D"
+                  },
+                  "init": null
+                }
+              ],
+              "kind": "using"
+            }
+          ]
+        },
+        "declare": true
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/untransformed-await-using-declaration/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/untransformed-await-using-declaration/input.js
@@ -1,0 +1,3 @@
+{
+  await using foo = null;
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/untransformed-await-using-declaration/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/untransformed-await-using-declaration/options.json
@@ -1,0 +1,5 @@
+{
+  "sourceType": "module",
+  "plugins": ["transform-block-scoping", "syntax-explicit-resource-management"],
+  "throws": "The await using declaration should be first transformed by `@babel/plugin-proposal-explicit-resource-management`."
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/untransformed-using-declaration/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/untransformed-using-declaration/input.js
@@ -1,0 +1,3 @@
+{
+  using foo = null;
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/untransformed-using-declaration/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/untransformed-using-declaration/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["transform-block-scoping", "syntax-explicit-resource-management"],
+  "throws": "The using declaration should be first transformed by `@babel/plugin-proposal-explicit-resource-management`."
+}

--- a/packages/babel-plugin-transform-destructuring/src/index.ts
+++ b/packages/babel-plugin-transform-destructuring/src/index.ts
@@ -6,6 +6,7 @@ import {
   convertAssignmentExpression,
   unshiftForXStatementBody,
   type DestructuringTransformerNode,
+  type VariableDeclarationKindAllowsPattern,
 } from "./util.ts";
 export { buildObjectExcludingKeys, unshiftForXStatementBody } from "./util.ts";
 
@@ -113,7 +114,7 @@ export default declare((api, options: Options) => {
         const nodes: DestructuringTransformerNode[] = [];
 
         const destructuring = new DestructuringTransformer({
-          kind: left.kind,
+          kind: left.kind as VariableDeclarationKindAllowsPattern,
           scope: scope,
           nodes: nodes,
           arrayLikeIsIterable,

--- a/packages/babel-traverse/src/scope/binding.ts
+++ b/packages/babel-traverse/src/scope/binding.ts
@@ -5,7 +5,7 @@ import type Scope from "./index.ts";
 export type BindingKind =
   | "var" /* var declarator */
   | "let" /* let declarator, class declaration id, catch clause parameters */
-  | "const" /* const/using declarator */
+  | "const" /* const/using/await using declarator */
   | "module" /* import specifiers */
   | "hoisted" /* function declaration id */
   | "param" /* function declaration parameters */


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Improves the integration of using declaration with typescript / block-scoping transforms
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR is a series of small fixes about the integration of using transform with other transforms. 

If the explicit-resource-management advances to stage 4 in the upcoming meeting, I will open a PR to add it to preset-env and enable the parser flags.