### PR TITLE
initial support for ESLint sourceType: commonjs

### DIFF
--- a/eslint/babel-eslint-parser/src/configuration.cts
+++ b/eslint/babel-eslint-parser/src/configuration.cts
@@ -13,7 +13,9 @@ export = function normalizeESLintConfig(options: any) {
   return {
     babelOptions: { cwd: process.cwd(), ...babelOptions },
     ecmaVersion: ecmaVersion === "latest" ? 1e8 : ecmaVersion,
-    sourceType,
+    // https://eslint.org/docs/latest/use/configure/language-options#specifying-javascript-options
+    // ESLint supports "commonjs" but Babel parser does not.
+    sourceType: sourceType === "commonjs" ? "script" : sourceType,
     requireConfigFile,
     ...otherOptions,
   } as Options;

--- a/eslint/babel-eslint-tests/test/integration/eslint/config.js
+++ b/eslint/babel-eslint-tests/test/integration/eslint/config.js
@@ -20,4 +20,19 @@ describe("ESLint config", () => {
       },
     );
   });
+
+  it('should allow sourceType to be "commonjs"', () => {
+    // sourceType "commonjs" allows require() calls.
+    verifyAndAssertMessages(
+      'require("greetings").hello',
+      {},
+      undefined,
+      undefined,
+      {
+        parserOptions: {
+          sourceType: "commonjs",
+        },
+      },
+    );
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/17347
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we support the `sourceType: "commonjs"` option introduced in ESLint 9. Since Babel parser does not have a `commonjs` source type, here we change the `commonjs` to the `script` source type.