### PR TITLE
fix: disable using in ambient context

### DIFF
--- a/eslint/babel-eslint-parser/test/typescript-estree.test.js
+++ b/eslint/babel-eslint-parser/test/typescript-estree.test.js
@@ -338,9 +338,6 @@ function deeplyRemoveProperties(obj, props) {
       );
       const fixtures = getFixtures(parserTestFixtureRoot);
       const FAILURES = new Set([
-        // Todo: Remove when https://github.com/typescript-eslint/typescript-eslint/issues/11244 is resolved
-        "typescript/declare/valid-namespace-var/input.ts",
-
         // ts-eslint/tsc does not support arrow generic in tsx mode
         "typescript/arrow-function/async-await-null/input.ts",
         "typescript/arrow-function/async-generic-after-await/input.ts",

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -221,6 +221,8 @@ const TSErrors = ParseErrorEnum`typescript`({
     "A parameter property may not be declared using a binding pattern.",
   UnsupportedSignatureParameterKind: ({ type }: { type: string }) =>
     `Name in a signature must be an Identifier, ObjectPattern or ArrayPattern, instead got ${type}.`,
+  UsingDeclarationInAmbientContext: (kind: "using" | "await using") =>
+    `'${kind}' declarations are not allowed in ambient contexts.`,
 });
 
 /* eslint-disable sort-keys */
@@ -3130,6 +3132,12 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       );
 
       if (!isAmbientContext) return declaration;
+
+      // If node.declare is true, the error has already been raised in tsTryParseDeclare.
+      if (!node.declare && (kind === "using" || kind === "await using")) {
+        this.raise(TSErrors.UsingDeclarationInAmbientContext, node, kind);
+        return declaration;
+      }
 
       for (const { id, init } of declaration.declarations) {
         // Empty initializer is the easy case that we want.

--- a/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-await-using/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-await-using/input.ts
@@ -1,0 +1,6 @@
+declare namespace invalid_namespace_var {
+  await using A;
+  await using A1 = 0;
+  await using A2: number = 0;
+  await using B, C;
+}

--- a/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-await-using/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-await-using/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": ["explicitResourceManagement", "typescript"],
+  "allowAwaitOutsideFunction": true,
+  "sourceType": "module"
+}

--- a/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-await-using/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-await-using/output.json
@@ -1,0 +1,141 @@
+{
+  "type": "File",
+  "start":0,"end":132,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":6,"column":1,"index":132}},
+  "errors": [
+    "SyntaxError: 'await using' declarations are not allowed in ambient contexts. (2:2)",
+    "SyntaxError: 'await using' declarations are not allowed in ambient contexts. (3:2)",
+    "SyntaxError: 'await using' declarations are not allowed in ambient contexts. (4:2)",
+    "SyntaxError: 'await using' declarations are not allowed in ambient contexts. (5:2)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":132,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":6,"column":1,"index":132}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSModuleDeclaration",
+        "start":0,"end":132,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":6,"column":1,"index":132}},
+        "kind": "namespace",
+        "id": {
+          "type": "Identifier",
+          "start":18,"end":39,"loc":{"start":{"line":1,"column":18,"index":18},"end":{"line":1,"column":39,"index":39},"identifierName":"invalid_namespace_var"},
+          "name": "invalid_namespace_var"
+        },
+        "body": {
+          "type": "TSModuleBlock",
+          "start":40,"end":132,"loc":{"start":{"line":1,"column":40,"index":40},"end":{"line":6,"column":1,"index":132}},
+          "body": [
+            {
+              "type": "VariableDeclaration",
+              "start":44,"end":58,"loc":{"start":{"line":2,"column":2,"index":44},"end":{"line":2,"column":16,"index":58}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":56,"end":57,"loc":{"start":{"line":2,"column":14,"index":56},"end":{"line":2,"column":15,"index":57}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":56,"end":57,"loc":{"start":{"line":2,"column":14,"index":56},"end":{"line":2,"column":15,"index":57},"identifierName":"A"},
+                    "name": "A"
+                  },
+                  "init": null
+                }
+              ],
+              "kind": "await using"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":61,"end":80,"loc":{"start":{"line":3,"column":2,"index":61},"end":{"line":3,"column":21,"index":80}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":73,"end":79,"loc":{"start":{"line":3,"column":14,"index":73},"end":{"line":3,"column":20,"index":79}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":73,"end":75,"loc":{"start":{"line":3,"column":14,"index":73},"end":{"line":3,"column":16,"index":75},"identifierName":"A1"},
+                    "name": "A1"
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":78,"end":79,"loc":{"start":{"line":3,"column":19,"index":78},"end":{"line":3,"column":20,"index":79}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ],
+              "kind": "await using"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":83,"end":110,"loc":{"start":{"line":4,"column":2,"index":83},"end":{"line":4,"column":29,"index":110}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":95,"end":109,"loc":{"start":{"line":4,"column":14,"index":95},"end":{"line":4,"column":28,"index":109}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":95,"end":105,"loc":{"start":{"line":4,"column":14,"index":95},"end":{"line":4,"column":24,"index":105},"identifierName":"A2"},
+                    "name": "A2",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start":97,"end":105,"loc":{"start":{"line":4,"column":16,"index":97},"end":{"line":4,"column":24,"index":105}},
+                      "typeAnnotation": {
+                        "type": "TSNumberKeyword",
+                        "start":99,"end":105,"loc":{"start":{"line":4,"column":18,"index":99},"end":{"line":4,"column":24,"index":105}}
+                      }
+                    }
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":108,"end":109,"loc":{"start":{"line":4,"column":27,"index":108},"end":{"line":4,"column":28,"index":109}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ],
+              "kind": "await using"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":113,"end":130,"loc":{"start":{"line":5,"column":2,"index":113},"end":{"line":5,"column":19,"index":130}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":125,"end":126,"loc":{"start":{"line":5,"column":14,"index":125},"end":{"line":5,"column":15,"index":126}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":125,"end":126,"loc":{"start":{"line":5,"column":14,"index":125},"end":{"line":5,"column":15,"index":126},"identifierName":"B"},
+                    "name": "B"
+                  },
+                  "init": null
+                },
+                {
+                  "type": "VariableDeclarator",
+                  "start":128,"end":129,"loc":{"start":{"line":5,"column":17,"index":128},"end":{"line":5,"column":18,"index":129}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":128,"end":129,"loc":{"start":{"line":5,"column":17,"index":128},"end":{"line":5,"column":18,"index":129},"identifierName":"C"},
+                    "name": "C"
+                  },
+                  "init": null
+                }
+              ],
+              "kind": "await using"
+            }
+          ]
+        },
+        "declare": true
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": true
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-using/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-using/input.ts
@@ -1,0 +1,6 @@
+declare namespace invalid_namespace_var {
+  using A;
+  using A1 = 0;
+  using A2: number = 0;
+  using B, C;
+}

--- a/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-using/options.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-using/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["explicitResourceManagement", "typescript"],
+  "sourceType": "module"
+}

--- a/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-using/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-using/output.json
@@ -1,0 +1,141 @@
+{
+  "type": "File",
+  "start":0,"end":108,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":6,"column":1,"index":108}},
+  "errors": [
+    "SyntaxError: 'using' declarations are not allowed in ambient contexts. (2:2)",
+    "SyntaxError: 'using' declarations are not allowed in ambient contexts. (3:2)",
+    "SyntaxError: 'using' declarations are not allowed in ambient contexts. (4:2)",
+    "SyntaxError: 'using' declarations are not allowed in ambient contexts. (5:2)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":108,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":6,"column":1,"index":108}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSModuleDeclaration",
+        "start":0,"end":108,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":6,"column":1,"index":108}},
+        "kind": "namespace",
+        "id": {
+          "type": "Identifier",
+          "start":18,"end":39,"loc":{"start":{"line":1,"column":18,"index":18},"end":{"line":1,"column":39,"index":39},"identifierName":"invalid_namespace_var"},
+          "name": "invalid_namespace_var"
+        },
+        "body": {
+          "type": "TSModuleBlock",
+          "start":40,"end":108,"loc":{"start":{"line":1,"column":40,"index":40},"end":{"line":6,"column":1,"index":108}},
+          "body": [
+            {
+              "type": "VariableDeclaration",
+              "start":44,"end":52,"loc":{"start":{"line":2,"column":2,"index":44},"end":{"line":2,"column":10,"index":52}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":50,"end":51,"loc":{"start":{"line":2,"column":8,"index":50},"end":{"line":2,"column":9,"index":51}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":50,"end":51,"loc":{"start":{"line":2,"column":8,"index":50},"end":{"line":2,"column":9,"index":51},"identifierName":"A"},
+                    "name": "A"
+                  },
+                  "init": null
+                }
+              ],
+              "kind": "using"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":55,"end":68,"loc":{"start":{"line":3,"column":2,"index":55},"end":{"line":3,"column":15,"index":68}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":61,"end":67,"loc":{"start":{"line":3,"column":8,"index":61},"end":{"line":3,"column":14,"index":67}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":61,"end":63,"loc":{"start":{"line":3,"column":8,"index":61},"end":{"line":3,"column":10,"index":63},"identifierName":"A1"},
+                    "name": "A1"
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":66,"end":67,"loc":{"start":{"line":3,"column":13,"index":66},"end":{"line":3,"column":14,"index":67}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ],
+              "kind": "using"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":71,"end":92,"loc":{"start":{"line":4,"column":2,"index":71},"end":{"line":4,"column":23,"index":92}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":77,"end":91,"loc":{"start":{"line":4,"column":8,"index":77},"end":{"line":4,"column":22,"index":91}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":77,"end":87,"loc":{"start":{"line":4,"column":8,"index":77},"end":{"line":4,"column":18,"index":87},"identifierName":"A2"},
+                    "name": "A2",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start":79,"end":87,"loc":{"start":{"line":4,"column":10,"index":79},"end":{"line":4,"column":18,"index":87}},
+                      "typeAnnotation": {
+                        "type": "TSNumberKeyword",
+                        "start":81,"end":87,"loc":{"start":{"line":4,"column":12,"index":81},"end":{"line":4,"column":18,"index":87}}
+                      }
+                    }
+                  },
+                  "init": {
+                    "type": "NumericLiteral",
+                    "start":90,"end":91,"loc":{"start":{"line":4,"column":21,"index":90},"end":{"line":4,"column":22,"index":91}},
+                    "extra": {
+                      "rawValue": 0,
+                      "raw": "0"
+                    },
+                    "value": 0
+                  }
+                }
+              ],
+              "kind": "using"
+            },
+            {
+              "type": "VariableDeclaration",
+              "start":95,"end":106,"loc":{"start":{"line":5,"column":2,"index":95},"end":{"line":5,"column":13,"index":106}},
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start":101,"end":102,"loc":{"start":{"line":5,"column":8,"index":101},"end":{"line":5,"column":9,"index":102}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":101,"end":102,"loc":{"start":{"line":5,"column":8,"index":101},"end":{"line":5,"column":9,"index":102},"identifierName":"B"},
+                    "name": "B"
+                  },
+                  "init": null
+                },
+                {
+                  "type": "VariableDeclarator",
+                  "start":104,"end":105,"loc":{"start":{"line":5,"column":11,"index":104},"end":{"line":5,"column":12,"index":105}},
+                  "id": {
+                    "type": "Identifier",
+                    "start":104,"end":105,"loc":{"start":{"line":5,"column":11,"index":104},"end":{"line":5,"column":12,"index":105},"identifierName":"C"},
+                    "name": "C"
+                  },
+                  "init": null
+                }
+              ],
+              "kind": "using"
+            }
+          ]
+        },
+        "declare": true
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-var/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-var/input.ts
@@ -4,5 +4,4 @@ declare namespace invalid_namespace_var {
   let B = 0;
   let B1: number = 0;
   const C: number = 0;
-  using D: number = 0;
 }

--- a/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-var/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/invalid-namespace-var/output.json
@@ -1,23 +1,22 @@
 {
   "type": "File",
-  "start":0,"end":159,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":8,"column":1,"index":159}},
+  "start":0,"end":136,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":136}},
   "errors": [
     "SyntaxError: Initializers are not allowed in ambient contexts. (2:10)",
     "SyntaxError: Initializers are not allowed in ambient contexts. (3:19)",
     "SyntaxError: Initializers are not allowed in ambient contexts. (4:10)",
     "SyntaxError: Initializers are not allowed in ambient contexts. (5:19)",
-    "SyntaxError: Initializers are not allowed in ambient contexts. (6:20)",
-    "SyntaxError: Initializers are not allowed in ambient contexts. (7:20)"
+    "SyntaxError: Initializers are not allowed in ambient contexts. (6:20)"
   ],
   "program": {
     "type": "Program",
-    "start":0,"end":159,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":8,"column":1,"index":159}},
+    "start":0,"end":136,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":136}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "TSModuleDeclaration",
-        "start":0,"end":159,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":8,"column":1,"index":159}},
+        "start":0,"end":136,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":136}},
         "kind": "namespace",
         "id": {
           "type": "Identifier",
@@ -26,7 +25,7 @@
         },
         "body": {
           "type": "TSModuleBlock",
-          "start":40,"end":159,"loc":{"start":{"line":1,"column":40,"index":40},"end":{"line":8,"column":1,"index":159}},
+          "start":40,"end":136,"loc":{"start":{"line":1,"column":40,"index":40},"end":{"line":7,"column":1,"index":136}},
           "body": [
             {
               "type": "VariableDeclaration",
@@ -176,39 +175,6 @@
                 }
               ],
               "kind": "const"
-            },
-            {
-              "type": "VariableDeclaration",
-              "start":137,"end":157,"loc":{"start":{"line":7,"column":2,"index":137},"end":{"line":7,"column":22,"index":157}},
-              "declarations": [
-                {
-                  "type": "VariableDeclarator",
-                  "start":143,"end":156,"loc":{"start":{"line":7,"column":8,"index":143},"end":{"line":7,"column":21,"index":156}},
-                  "id": {
-                    "type": "Identifier",
-                    "start":143,"end":152,"loc":{"start":{"line":7,"column":8,"index":143},"end":{"line":7,"column":17,"index":152},"identifierName":"D"},
-                    "name": "D",
-                    "typeAnnotation": {
-                      "type": "TSTypeAnnotation",
-                      "start":144,"end":152,"loc":{"start":{"line":7,"column":9,"index":144},"end":{"line":7,"column":17,"index":152}},
-                      "typeAnnotation": {
-                        "type": "TSNumberKeyword",
-                        "start":146,"end":152,"loc":{"start":{"line":7,"column":11,"index":146},"end":{"line":7,"column":17,"index":152}}
-                      }
-                    }
-                  },
-                  "init": {
-                    "type": "NumericLiteral",
-                    "start":155,"end":156,"loc":{"start":{"line":7,"column":20,"index":155},"end":{"line":7,"column":21,"index":156}},
-                    "extra": {
-                      "rawValue": 0,
-                      "raw": "0"
-                    },
-                    "value": 0
-                  }
-                }
-              ],
-              "kind": "using"
             }
           ]
         },

--- a/packages/babel-parser/test/fixtures/typescript/declare/valid-namespace-var/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/declare/valid-namespace-var/input.ts
@@ -3,5 +3,4 @@ declare namespace valid_namespace_var {
   let B;
   const C;
   const C1 = 0;
-  using D;
 }

--- a/packages/babel-parser/test/fixtures/typescript/declare/valid-namespace-var/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/declare/valid-namespace-var/output.json
@@ -1,15 +1,15 @@
 {
   "type": "File",
-  "start":0,"end":97,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":97}},
+  "start":0,"end":86,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":6,"column":1,"index":86}},
   "program": {
     "type": "Program",
-    "start":0,"end":97,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":97}},
+    "start":0,"end":86,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":6,"column":1,"index":86}},
     "sourceType": "module",
     "interpreter": null,
     "body": [
       {
         "type": "TSModuleDeclaration",
-        "start":0,"end":97,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":1,"index":97}},
+        "start":0,"end":86,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":6,"column":1,"index":86}},
         "kind": "namespace",
         "id": {
           "type": "Identifier",
@@ -18,7 +18,7 @@
         },
         "body": {
           "type": "TSModuleBlock",
-          "start":38,"end":97,"loc":{"start":{"line":1,"column":38,"index":38},"end":{"line":7,"column":1,"index":97}},
+          "start":38,"end":86,"loc":{"start":{"line":1,"column":38,"index":38},"end":{"line":6,"column":1,"index":86}},
           "body": [
             {
               "type": "VariableDeclaration",
@@ -95,23 +95,6 @@
                 }
               ],
               "kind": "const"
-            },
-            {
-              "type": "VariableDeclaration",
-              "start":87,"end":95,"loc":{"start":{"line":6,"column":2,"index":87},"end":{"line":6,"column":10,"index":95}},
-              "declarations": [
-                {
-                  "type": "VariableDeclarator",
-                  "start":93,"end":94,"loc":{"start":{"line":6,"column":8,"index":93},"end":{"line":6,"column":9,"index":94}},
-                  "id": {
-                    "type": "Identifier",
-                    "start":93,"end":94,"loc":{"start":{"line":6,"column":8,"index":93},"end":{"line":6,"column":9,"index":94},"identifierName":"D"},
-                    "name": "D"
-                  },
-                  "init": null
-                }
-              ],
-              "kind": "using"
             }
           ]
         },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Implements https://github.com/microsoft/TypeScript/pull/61781
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we disallow `using` and `await using` declarations within an ambient context, aligned with the upstream tsc behaviour.