### PR TITLE
fix: support negative bigint in valueToNode

### DIFF
--- a/packages/babel-types/src/converters/valueToNode.ts
+++ b/packages/babel-types/src/converters/valueToNode.ts
@@ -105,7 +105,11 @@ function valueToNode(value: unknown): t.Expression {
 
   // bigints
   if (typeof value === "bigint") {
-    return bigIntLiteral(value.toString());
+    if (value < 0) {
+      return unaryExpression("-", bigIntLiteral((-value).toString()));
+    } else {
+      return bigIntLiteral(value.toString());
+    }
   }
 
   // regexes

--- a/packages/babel-types/test/builders/core.js
+++ b/packages/babel-types/test/builders/core.js
@@ -20,8 +20,8 @@ describe("builders", function () {
   });
 
   itBabel8("uppercase builders are deprecated", async () => {
-    // Spawn a separate process, because the warnig only happens once for all builders
-    // and it relies on globa state to du the deduplication
+    // Spawn a separate process, because the warning only happens once for all builders
+    // and it relies on global state due to the deduplication
 
     const { stderr } = cp.spawn(process.execPath, [
       "-p",

--- a/packages/babel-types/test/converters.js
+++ b/packages/babel-types/test/converters.js
@@ -41,6 +41,29 @@ describe("converters", function () {
     const nodeGte10 = itGte("10.4.0");
     nodeGte10("bigint", function () {
       expect(t.valueToNode(BigInt(123))).toEqual(t.bigIntLiteral("123"));
+      expect(t.valueToNode(BigInt(-123))).toEqual(
+        t.unaryExpression("-", t.bigIntLiteral("123")),
+      );
+      expect(t.valueToNode(BigInt(0))).toEqual(t.bigIntLiteral("0"));
+      expect(t.valueToNode(BigInt(-0))).toEqual(t.bigIntLiteral("0"));
+      expect(t.valueToNode(BigInt(0x1fffffffffffff))).toEqual(
+        t.bigIntLiteral("9007199254740991"),
+      );
+      expect(t.valueToNode(BigInt("9007199254740992"))).toEqual(
+        t.bigIntLiteral("9007199254740992"),
+      );
+      expect(t.valueToNode(BigInt("-9007199254740992"))).toEqual(
+        t.unaryExpression("-", t.bigIntLiteral("9007199254740992")),
+      );
+      expect(t.valueToNode(BigInt("123456789012345678901234567890"))).toEqual(
+        t.bigIntLiteral("123456789012345678901234567890"),
+      );
+      expect(t.valueToNode(BigInt("-123456789012345678901234567890"))).toEqual(
+        t.unaryExpression(
+          "-",
+          t.bigIntLiteral("123456789012345678901234567890"),
+        ),
+      );
     });
     it("string", function () {
       expect(t.valueToNode('This is a "string"')).toEqual(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `t.valueToNode` returns incorrect AST for negative bigint
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This pull request improves the handling of `bigint` values in the `valueToNode` function and expands the corresponding test coverage. The changes ensure that negative `bigint` values are correctly represented as unary expressions.

Enhancements to `bigint` handling:

* [`packages/babel-types/src/converters/valueToNode.ts`](diffhunk://#diff-769e3b847e5ab3814104c533982e5b6863869d890fb7589a732d107ea663bdeaR108-R113): Updated the `valueToNode` function to handle negative `bigint` values by returning a unary expression with a negative sign instead of directly converting them to literals.

Expanded test coverage:

* [`packages/babel-types/test/converters.js`](diffhunk://#diff-f7a647772cf84aeccfe32b536218d612ff56b822980edd9faf58f3c312fe45ebR44-R66): Added multiple test cases to validate the conversion of positive, negative, zero, and large `bigint` values, ensuring proper handling and representation.