### PR TITLE
Use `NodePath#splitExportDeclaration` in destructuring transforms

### DIFF
--- a/packages/babel-plugin-transform-destructuring/package.json
+++ b/packages/babel-plugin-transform-destructuring/package.json
@@ -17,15 +17,15 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "@babel/helper-plugin-utils": "workspace:^"
+    "@babel/helper-plugin-utils": "workspace:^",
+    "@babel/traverse": "workspace:^"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"
   },
   "devDependencies": {
     "@babel/core": "workspace:^",
-    "@babel/helper-plugin-test-runner": "workspace:^",
-    "@babel/traverse": "workspace:^"
+    "@babel/helper-plugin-test-runner": "workspace:^"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/packages/babel-plugin-transform-destructuring/tsconfig.json
+++ b/packages/babel-plugin-transform-destructuring/tsconfig.json
@@ -15,6 +15,9 @@
       "path": "../../packages/babel-helper-plugin-utils"
     },
     {
+      "path": "../../packages/babel-traverse"
+    },
+    {
       "path": "../../packages/babel-core"
     }
   ]

--- a/packages/babel-plugin-transform-object-rest-spread/package.json
+++ b/packages/babel-plugin-transform-object-rest-spread/package.json
@@ -20,7 +20,8 @@
     "@babel/helper-compilation-targets": "workspace:^",
     "@babel/helper-plugin-utils": "workspace:^",
     "@babel/plugin-transform-destructuring": "workspace:^",
-    "@babel/plugin-transform-parameters": "workspace:^"
+    "@babel/plugin-transform-parameters": "workspace:^",
+    "@babel/traverse": "workspace:^"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0"

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.ts
@@ -497,19 +497,16 @@ export default declare((api, opts: Options) => {
           .some(path => hasObjectRestElement(path.get("id")));
         if (!hasRest) return;
 
-        const specifiers = [];
-
-        for (const name of Object.keys(path.getOuterBindingIdentifiers(true))) {
-          specifiers.push(
-            t.exportSpecifier(t.identifier(name), t.identifier(name)),
-          );
-        }
-
         // Split the declaration and export list into two declarations so that the variable
         // declaration can be split up later without needing to worry about not being a
         // top-level statement.
-        path.replaceWith(declaration.node);
-        path.insertAfter(t.exportNamedDeclaration(null, specifiers));
+        if (!process.env.BABEL_8_BREAKING && !USE_ESM && !IS_STANDALONE) {
+          // polyfill when being run by an older Babel version
+          path.splitExportDeclaration ??=
+            // eslint-disable-next-line no-restricted-globals
+            require("@babel/traverse").NodePath.prototype.splitExportDeclaration;
+        }
+        path.splitExportDeclaration();
       },
 
       // try {} catch ({a, ...b}) {}

--- a/packages/babel-plugin-transform-object-rest-spread/tsconfig.json
+++ b/packages/babel-plugin-transform-object-rest-spread/tsconfig.json
@@ -24,6 +24,9 @@
       "path": "../../packages/babel-plugin-transform-parameters"
     },
     {
+      "path": "../../packages/babel-traverse"
+    },
+    {
       "path": "../../packages/babel-core"
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3064,6 +3064,7 @@ __metadata:
     "@babel/parser": "workspace:^"
     "@babel/plugin-transform-destructuring": "workspace:^"
     "@babel/plugin-transform-parameters": "workspace:^"
+    "@babel/traverse": "workspace:^"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   languageName: unknown


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As a follow up to https://github.com/babel/babel/pull/16645, this pull request introduces changes to simplify the handling of export declarations in Babel plugins. It modifies dependencies and refactors code to use the `splitExportDeclaration` method, including a polyfill for older Babel versions.

### Dependency Updates:

* Added `@babel/traverse` as a dependency in `packages/babel-plugin-transform-destructuring/package.json` and `packages/babel-plugin-transform-object-rest-spread/package.json` to support the use of `splitExportDeclaration`. [[1]](diffhunk://#diff-49dc17bf32c8d09a5cb15baf280f94c03d5e39c085c1161ca33eb56e0aa9f8b3L20-R28) [[2]](diffhunk://#diff-85b897c3060329ef698bd7ef5895d6b4cb16652e0528bae70eb4cc715bcf751eL23-R24)

### Code Refactoring:

* Refactored `packages/babel-plugin-transform-object-rest-spread/src/index.ts` and `packages/babel-plugin-transform-destructuring/src/index.ts` to replace manual export declaration splitting with the `splitExportDeclaration` method. A polyfill is included to ensure compatibility with older Babel versions.