### PR TITLE
LVal coverage updates (Part 2)

### DIFF
--- a/packages/babel-plugin-proposal-destructuring-private/src/index.ts
+++ b/packages/babel-plugin-proposal-destructuring-private/src/index.ts
@@ -165,7 +165,7 @@ export default declare(function ({ assertVersion, assumption, types: t }) {
         (!isExpressionStatement(parent) && !isSequenceExpression(parent)) ||
         path.isCompletionRecord();
       for (const { left, right } of transformPrivateKeyDestructuring(
-        // @ts-expect-error The left of an assignment expression must not be a RestElement
+        // @ts-ignore(Babel 7 vs Babel 8) The left of an assignment expression must not be a RestElement
         node.left,
         node.right,
         scope,

--- a/packages/babel-plugin-proposal-destructuring-private/src/util.ts
+++ b/packages/babel-plugin-proposal-destructuring-private/src/util.ts
@@ -156,12 +156,7 @@ function buildAssignmentsFromPatternList(
 }
 
 type StackItem = {
-  node:
-    | t.LVal
-    | t.PatternLike
-    | t.OptionalMemberExpression
-    | t.ObjectProperty
-    | null;
+  node: t.LVal | t.PatternLike | t.ObjectProperty | null;
   index: number;
   depth: number;
 };
@@ -179,13 +174,9 @@ type StackItem = {
  * @param visitor
  */
 export function* traversePattern(
-  root: t.LVal | t.PatternLike | t.OptionalMemberExpression,
+  root: t.LVal | t.PatternLike,
   visitor: (
-    node:
-      | t.LVal
-      | t.PatternLike
-      | t.OptionalMemberExpression
-      | t.ObjectProperty,
+    node: t.LVal | t.PatternLike | t.ObjectProperty,
     index: number,
     depth: number,
   ) => Generator<any, void, any>,
@@ -235,9 +226,7 @@ export function* traversePattern(
   }
 }
 
-export function hasPrivateKeys(
-  pattern: t.LVal | t.PatternLike | t.OptionalMemberExpression,
-) {
+export function hasPrivateKeys(pattern: t.LVal | t.PatternLike) {
   let result = false;
   traversePattern(pattern, function* (node) {
     if (isObjectProperty(node) && isPrivateName(node.key)) {

--- a/packages/babel-plugin-proposal-destructuring-private/src/util.ts
+++ b/packages/babel-plugin-proposal-destructuring-private/src/util.ts
@@ -114,7 +114,7 @@ interface Transformed {
 }
 
 function buildAssignmentsFromPatternList(
-  elements: (t.LVal | t.PatternLike | null)[],
+  elements: (t.LVal | t.PatternLike | t.TSParameterProperty | null)[],
   scope: Scope,
   isAssignment: boolean,
 ): {
@@ -156,7 +156,12 @@ function buildAssignmentsFromPatternList(
 }
 
 type StackItem = {
-  node: t.LVal | t.PatternLike | t.ObjectProperty | null;
+  node:
+    | t.LVal
+    | t.PatternLike
+    | t.ObjectProperty
+    | t.TSParameterProperty
+    | null;
   index: number;
   depth: number;
 };
@@ -174,9 +179,9 @@ type StackItem = {
  * @param visitor
  */
 export function* traversePattern(
-  root: t.LVal | t.PatternLike,
+  root: t.LVal | t.PatternLike | t.TSParameterProperty,
   visitor: (
-    node: t.LVal | t.PatternLike | t.ObjectProperty,
+    node: t.LVal | t.PatternLike | t.TSParameterProperty | t.ObjectProperty,
     index: number,
     depth: number,
   ) => Generator<any, void, any>,

--- a/packages/babel-plugin-proposal-do-expressions/src/index.ts
+++ b/packages/babel-plugin-proposal-do-expressions/src/index.ts
@@ -44,7 +44,7 @@ export default declare(api => {
 
         // Do expression within function parameter lists
         let foundDoExpression = false;
-        const deferredPatterns: (t.LVal | t.PatternLike)[] = [];
+        const deferredPatterns: t.PatternLike[] = [];
         const deferredTemps: t.Identifier[] = [];
         for (const param of path.get("params")) {
           const actualParam = param.isRestElement()
@@ -451,7 +451,7 @@ export default declare(api => {
     }
 
     function flattenLVal(
-      path: NodePath<t.LVal | t.PatternLike | t.OptionalMemberExpression>,
+      path: NodePath<t.LVal | t.PatternLike>,
       init: t.Expression | null | undefined,
       declare: "var" | "let" | "const" | "using" | "await using" | null,
     ): t.Statement[] {

--- a/packages/babel-plugin-proposal-do-expressions/src/index.ts
+++ b/packages/babel-plugin-proposal-do-expressions/src/index.ts
@@ -49,7 +49,9 @@ export default declare(api => {
         for (const param of path.get("params")) {
           const actualParam = param.isRestElement()
             ? param.get("argument")
-            : param;
+            : param.isTSParameterProperty()
+              ? param.get("parameter")
+              : param;
           foundDoExpression ||= doAncestors.has(actualParam.node);
           if (foundDoExpression && !isLValSideEffectFree(actualParam)) {
             const pattern = actualParam.node;

--- a/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/inside-ts-parameter-property/exec.ts
+++ b/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/inside-ts-parameter-property/exec.ts
@@ -1,0 +1,8 @@
+class C {
+  constructor(readonly arg = do { effects.push(1); value }) {}
+}
+
+var value = { key: 1 }
+var effects = [];
+new C();
+expect(effects).toEqual([1]);

--- a/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/inside-ts-parameter-property/input.ts
+++ b/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/inside-ts-parameter-property/input.ts
@@ -1,0 +1,3 @@
+class C {
+  constructor(readonly arg = do { effects.push(1); value }) {}
+}

--- a/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/inside-ts-parameter-property/options.json
+++ b/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/inside-ts-parameter-property/options.json
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "typescript"
+  ]
+}

--- a/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/inside-ts-parameter-property/output.js
+++ b/packages/babel-plugin-proposal-do-expressions/test/fixtures/do-expressions/inside-ts-parameter-property/output.js
@@ -1,0 +1,17 @@
+class C {
+  constructor(_do) {
+    var _do2, _do3;
+    [_do2] = [_do];
+    _do3 = _do2;
+    if (_do3 === void 0) {
+      {
+        var _do4;
+        effects.push(1);
+        _do4 = value;
+      }
+      _do3 = _do4;
+    }
+    var arg = _do3;
+    this.arg = arg;
+  }
+}

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.ts
@@ -51,7 +51,7 @@ export default declare((api, opts: Options) => {
   }
 
   function* iterateObjectRestElement(
-    path: NodePath<t.LVal | t.PatternLike>,
+    path: NodePath<t.LVal | t.PatternLike | t.TSParameterProperty>,
   ): Generator<NodePath<t.RestElement>> {
     switch (path.type) {
       case "ArrayPattern":
@@ -83,7 +83,7 @@ export default declare((api, opts: Options) => {
   }
 
   function hasObjectRestElement(
-    path: NodePath<t.LVal | t.PatternLike>,
+    path: NodePath<t.LVal | t.PatternLike | t.TSParameterProperty>,
   ): boolean {
     const objectRestPatternIterator = iterateObjectRestElement(path);
     return !objectRestPatternIterator.next().done;

--- a/packages/babel-traverse/src/generated/visitor-types.d.ts
+++ b/packages/babel-traverse/src/generated/visitor-types.d.ts
@@ -567,6 +567,7 @@ export interface VisitorBaseAliases<S> {
   For?: VisitNode<S, t.For>;
   ForXStatement?: VisitNode<S, t.ForXStatement>;
   Function?: VisitNode<S, t.Function>;
+  FunctionParameter?: VisitNode<S, t.FunctionParameter>;
   FunctionParent?: VisitNode<S, t.FunctionParent>;
   Immutable?: VisitNode<S, t.Immutable>;
   ImportOrExportDeclaration?: VisitNode<S, t.ImportOrExportDeclaration>;

--- a/packages/babel-traverse/src/path/generated/asserts.d.ts
+++ b/packages/babel-traverse/src/path/generated/asserts.d.ts
@@ -276,6 +276,9 @@ export interface NodePathAssertions {
   assertFunctionExpression(
     opts?: Opts<t.FunctionExpression>,
   ): asserts this is NodePath<t.FunctionExpression>;
+  assertFunctionParameter(
+    opts?: Opts<t.FunctionParameter>,
+  ): asserts this is NodePath<t.FunctionParameter>;
   assertFunctionParent(
     opts?: Opts<t.FunctionParent>,
   ): asserts this is NodePath<t.FunctionParent>;

--- a/packages/babel-traverse/src/path/generated/validators.d.ts
+++ b/packages/babel-traverse/src/path/generated/validators.d.ts
@@ -373,6 +373,10 @@ interface BaseNodePathValidators {
     this: NodePath,
     opts?: Opts<t.FunctionExpression>,
   ): this is NodePath<t.FunctionExpression>;
+  isFunctionParameter(
+    this: NodePath,
+    opts?: Opts<t.FunctionParameter>,
+  ): this is NodePath<t.FunctionParameter>;
   isFunctionParent(
     this: NodePath,
     opts?: Opts<t.FunctionParent>,

--- a/packages/babel-types/src/asserts/generated/index.ts
+++ b/packages/babel-types/src/asserts/generated/index.ts
@@ -1641,6 +1641,12 @@ export function assertDeclaration(
 ): asserts node is t.Declaration {
   assert("Declaration", node, opts);
 }
+export function assertFunctionParameter(
+  node: object | null | undefined,
+  opts?: object | null,
+): asserts node is t.FunctionParameter {
+  assert("FunctionParameter", node, opts);
+}
 export function assertPatternLike(
   node: object | null | undefined,
   opts?: object | null,

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -314,7 +314,7 @@ export interface ArrayExpression extends BaseNode {
 export interface AssignmentExpression extends BaseNode {
   type: "AssignmentExpression";
   operator: string;
-  left: LVal | OptionalMemberExpression;
+  left: LVal;
   right: Expression;
 }
 
@@ -611,7 +611,7 @@ export interface ObjectProperty extends BaseNode {
 
 export interface RestElement extends BaseNode {
   type: "RestElement";
-  argument: LVal;
+  argument: PatternLike;
   decorators?: Array<Decorator> | null;
   optional?: boolean | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
@@ -622,7 +622,7 @@ export interface RestElement extends BaseNode {
  */
 export interface RestProperty extends BaseNode {
   type: "RestProperty";
-  argument: LVal;
+  argument: PatternLike;
   decorators?: Array<Decorator> | null;
   optional?: boolean | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
@@ -730,7 +730,7 @@ export interface AssignmentPattern extends BaseNode {
 
 export interface ArrayPattern extends BaseNode {
   type: "ArrayPattern";
-  elements: Array<null | PatternLike | LVal>;
+  elements: Array<null | PatternLike>;
   decorators?: Array<Decorator> | null;
   optional?: boolean | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
@@ -2423,6 +2423,7 @@ export type Declaration =
   | TSImportEqualsDeclaration;
 export type PatternLike =
   | Identifier
+  | MemberExpression
   | RestElement
   | AssignmentPattern
   | ArrayPattern
@@ -2438,6 +2439,7 @@ export type LVal =
   | AssignmentPattern
   | ArrayPattern
   | ObjectPattern
+  | OptionalMemberExpression
   | TSParameterProperty
   | TSAsExpression
   | TSSatisfiesExpression
@@ -7501,13 +7503,11 @@ export interface ParentMaps {
     | TSUnionType
     | TemplateLiteral;
   TSParameterProperty:
-    | ArrayPattern
     | AssignmentExpression
     | ClassMethod
     | ClassPrivateMethod
     | ForInStatement
     | ForOfStatement
-    | RestElement
     | TSDeclareMethod
     | VariableDeclarator;
   TSParenthesizedType:

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -445,7 +445,7 @@ export interface ForStatement extends BaseNode {
 export interface FunctionDeclaration extends BaseNode {
   type: "FunctionDeclaration";
   id?: Identifier | null;
-  params: Array<Identifier | Pattern | RestElement>;
+  params: Array<FunctionParameter>;
   body: BlockStatement;
   generator: boolean;
   async: boolean;
@@ -462,7 +462,7 @@ export interface FunctionDeclaration extends BaseNode {
 export interface FunctionExpression extends BaseNode {
   type: "FunctionExpression";
   id?: Identifier | null;
-  params: Array<Identifier | Pattern | RestElement>;
+  params: Array<FunctionParameter>;
   body: BlockStatement;
   generator: boolean;
   async: boolean;
@@ -579,7 +579,7 @@ export interface ObjectMethod extends BaseNode {
   type: "ObjectMethod";
   kind: "method" | "get" | "set";
   key: Expression | Identifier | StringLiteral | NumericLiteral | BigIntLiteral;
-  params: Array<Identifier | Pattern | RestElement>;
+  params: Array<FunctionParameter>;
   body: BlockStatement;
   computed: boolean;
   generator: boolean;
@@ -738,7 +738,7 @@ export interface ArrayPattern extends BaseNode {
 
 export interface ArrowFunctionExpression extends BaseNode {
   type: "ArrowFunctionExpression";
-  params: Array<Identifier | Pattern | RestElement>;
+  params: Array<FunctionParameter>;
   body: BlockStatement | Expression;
   async: boolean;
   expression: boolean;
@@ -901,7 +901,7 @@ export interface ClassMethod extends BaseNode {
   type: "ClassMethod";
   kind: "get" | "set" | "method" | "constructor";
   key: Identifier | StringLiteral | NumericLiteral | BigIntLiteral | Expression;
-  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>;
+  params: Array<FunctionParameter | TSParameterProperty>;
   body: BlockStatement;
   computed: boolean;
   static: boolean;
@@ -1069,7 +1069,7 @@ export interface ClassPrivateMethod extends BaseNode {
   type: "ClassPrivateMethod";
   kind: "get" | "set" | "method";
   key: PrivateName;
-  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>;
+  params: Array<FunctionParameter | TSParameterProperty>;
   body: BlockStatement;
   static: boolean;
   abstract?: boolean | null;
@@ -1698,7 +1698,7 @@ export interface TSDeclareFunction extends BaseNode {
   type: "TSDeclareFunction";
   id?: Identifier | null;
   typeParameters?: TSTypeParameterDeclaration | Noop | null;
-  params: Array<Identifier | Pattern | RestElement>;
+  params: Array<FunctionParameter>;
   returnType?: TSTypeAnnotation | Noop | null;
   async?: boolean;
   declare?: boolean | null;
@@ -1710,7 +1710,7 @@ export interface TSDeclareMethod extends BaseNode {
   decorators?: Array<Decorator> | null;
   key: Identifier | StringLiteral | NumericLiteral | BigIntLiteral | Expression;
   typeParameters?: TSTypeParameterDeclaration | Noop | null;
-  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>;
+  params: Array<FunctionParameter | TSParameterProperty>;
   returnType?: TSTypeAnnotation | Noop | null;
   abstract?: boolean | null;
   access?: "public" | "private" | "protected" | null;
@@ -2421,6 +2421,12 @@ export type Declaration =
   | TSEnumDeclaration
   | TSModuleDeclaration
   | TSImportEqualsDeclaration;
+export type FunctionParameter =
+  | Identifier
+  | RestElement
+  | AssignmentPattern
+  | ArrayPattern
+  | ObjectPattern;
 export type PatternLike =
   | Identifier
   | MemberExpression
@@ -2808,6 +2814,7 @@ export interface Aliases {
   FunctionParent: FunctionParent;
   Pureish: Pureish;
   Declaration: Declaration;
+  FunctionParameter: FunctionParameter;
   PatternLike: PatternLike;
   LVal: LVal;
   TSEntityName: TSEntityName;

--- a/packages/babel-types/src/builders/generated/lowercase.ts
+++ b/packages/babel-types/src/builders/generated/lowercase.ts
@@ -23,7 +23,7 @@ export function arrayExpression(
 }
 export function assignmentExpression(
   operator: string,
-  left: t.LVal | t.OptionalMemberExpression,
+  left: t.LVal,
   right: t.Expression,
 ): t.AssignmentExpression {
   const node: t.AssignmentExpression = {
@@ -558,7 +558,7 @@ export function objectProperty(
   validate(defs.decorators, node, "decorators", decorators, 1);
   return node;
 }
-export function restElement(argument: t.LVal): t.RestElement {
+export function restElement(argument: t.PatternLike): t.RestElement {
   const node: t.RestElement = {
     type: "RestElement",
     argument,
@@ -772,7 +772,7 @@ export function assignmentPattern(
   return node;
 }
 export function arrayPattern(
-  elements: Array<null | t.PatternLike | t.LVal>,
+  elements: Array<null | t.PatternLike>,
 ): t.ArrayPattern {
   const node: t.ArrayPattern = {
     type: "ArrayPattern",
@@ -3436,7 +3436,7 @@ function RegexLiteral(pattern: string, flags: string = "") {
 }
 export { RegexLiteral as regexLiteral };
 /** @deprecated */
-function RestProperty(argument: t.LVal) {
+function RestProperty(argument: t.PatternLike) {
   deprecationWarning("RestProperty", "RestElement", "The node type ");
   return restElement(argument);
 }

--- a/packages/babel-types/src/builders/generated/lowercase.ts
+++ b/packages/babel-types/src/builders/generated/lowercase.ts
@@ -282,7 +282,7 @@ export function forStatement(
 }
 export function functionDeclaration(
   id: t.Identifier | null | undefined = null,
-  params: Array<t.Identifier | t.Pattern | t.RestElement>,
+  params: Array<t.FunctionParameter>,
   body: t.BlockStatement,
   generator: boolean = false,
   async: boolean = false,
@@ -305,7 +305,7 @@ export function functionDeclaration(
 }
 export function functionExpression(
   id: t.Identifier | null | undefined = null,
-  params: Array<t.Identifier | t.Pattern | t.RestElement>,
+  params: Array<t.FunctionParameter>,
   body: t.BlockStatement,
   generator: boolean = false,
   async: boolean = false,
@@ -502,7 +502,7 @@ export function objectMethod(
     | t.StringLiteral
     | t.NumericLiteral
     | t.BigIntLiteral,
-  params: Array<t.Identifier | t.Pattern | t.RestElement>,
+  params: Array<t.FunctionParameter>,
   body: t.BlockStatement,
   computed: boolean = false,
   generator: boolean = false,
@@ -783,7 +783,7 @@ export function arrayPattern(
   return node;
 }
 export function arrowFunctionExpression(
-  params: Array<t.Identifier | t.Pattern | t.RestElement>,
+  params: Array<t.FunctionParameter>,
   body: t.BlockStatement | t.Expression,
   async: boolean = false,
 ): t.ArrowFunctionExpression {
@@ -1027,9 +1027,7 @@ export function classMethod(
     | t.NumericLiteral
     | t.BigIntLiteral
     | t.Expression,
-  params: Array<
-    t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
-  >,
+  params: Array<t.FunctionParameter | t.TSParameterProperty>,
   body: t.BlockStatement,
   computed: boolean = false,
   _static: boolean = false,
@@ -1298,9 +1296,7 @@ export function classPrivateProperty(
 export function classPrivateMethod(
   kind: "get" | "set" | "method" | undefined = "method",
   key: t.PrivateName,
-  params: Array<
-    t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
-  >,
+  params: Array<t.FunctionParameter | t.TSParameterProperty>,
   body: t.BlockStatement,
   _static: boolean = false,
 ): t.ClassPrivateMethod {
@@ -2549,7 +2545,7 @@ export function tsDeclareFunction(
     | t.Noop
     | null
     | undefined = null,
-  params: Array<t.Identifier | t.Pattern | t.RestElement>,
+  params: Array<t.FunctionParameter>,
   returnType: t.TSTypeAnnotation | t.Noop | null = null,
 ): t.TSDeclareFunction {
   const node: t.TSDeclareFunction = {
@@ -2580,9 +2576,7 @@ export function tsDeclareMethod(
     | t.Noop
     | null
     | undefined = null,
-  params: Array<
-    t.Identifier | t.Pattern | t.RestElement | t.TSParameterProperty
-  >,
+  params: Array<t.FunctionParameter | t.TSParameterProperty>,
   returnType: t.TSTypeAnnotation | t.Noop | null = null,
 ): t.TSDeclareMethod {
   const node: t.TSDeclareMethod = {

--- a/packages/babel-types/src/constants/generated/index.ts
+++ b/packages/babel-types/src/constants/generated/index.ts
@@ -24,6 +24,7 @@ export const FUNCTION_TYPES = FLIPPED_ALIAS_KEYS["Function"];
 export const FUNCTIONPARENT_TYPES = FLIPPED_ALIAS_KEYS["FunctionParent"];
 export const PUREISH_TYPES = FLIPPED_ALIAS_KEYS["Pureish"];
 export const DECLARATION_TYPES = FLIPPED_ALIAS_KEYS["Declaration"];
+export const FUNCTIONPARAMETER_TYPES = FLIPPED_ALIAS_KEYS["FunctionParameter"];
 export const PATTERNLIKE_TYPES = FLIPPED_ALIAS_KEYS["PatternLike"];
 export const LVAL_TYPES = FLIPPED_ALIAS_KEYS["LVal"];
 export const TSENTITYNAME_TYPES = FLIPPED_ALIAS_KEYS["TSEntityName"];

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -72,7 +72,7 @@ defineType("AssignmentExpression", {
     left: {
       validate:
         !process.env.BABEL_8_BREAKING && !process.env.BABEL_TYPES_8_BREAKING
-          ? assertNodeType("LVal", "OptionalMemberExpression")
+          ? assertNodeType("LVal")
           : assertNodeType(
               "Identifier",
               "MemberExpression",
@@ -731,7 +731,7 @@ defineType("MemberExpression", {
       : []),
   ],
   visitor: ["object", "property"],
-  aliases: ["Expression", "LVal"],
+  aliases: ["Expression", "LVal", "PatternLike"],
   fields: {
     object: {
       validate: assertNodeType("Expression", "Super"),
@@ -1011,7 +1011,7 @@ defineType("RestElement", {
     argument: {
       validate:
         !process.env.BABEL_8_BREAKING && !process.env.BABEL_TYPES_8_BREAKING
-          ? assertNodeType("LVal")
+          ? assertNodeType("PatternLike")
           : assertNodeType(
               "Identifier",
               "ArrayPattern",
@@ -1331,7 +1331,7 @@ defineType("ArrayPattern", {
     elements: {
       validate: chain(
         assertValueType("array"),
-        assertEach(assertNodeOrValueType("null", "PatternLike", "LVal")),
+        assertEach(assertNodeOrValueType("null", "PatternLike")),
       ),
     },
   },
@@ -2197,7 +2197,7 @@ defineType("ExportNamespaceSpecifier", {
 defineType("OptionalMemberExpression", {
   builder: ["object", "property", "computed", "optional"],
   visitor: ["object", "property"],
-  aliases: ["Expression"],
+  aliases: ["Expression", "LVal"],
   fields: {
     object: {
       validate: assertNodeType("Expression"),

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -378,7 +378,7 @@ defineType("ForStatement", {
 });
 
 export const functionCommon = () => ({
-  params: validateArrayOfType("Identifier", "Pattern", "RestElement"),
+  params: validateArrayOfType("FunctionParameter"),
   generator: {
     default: false,
   },
@@ -520,7 +520,13 @@ export const patternLikeCommon = () => ({
 defineType("Identifier", {
   builder: ["name"],
   visitor: ["typeAnnotation", "decorators" /* for legacy param decorators */],
-  aliases: ["Expression", "PatternLike", "LVal", "TSEntityName"],
+  aliases: [
+    "Expression",
+    "FunctionParameter",
+    "PatternLike",
+    "LVal",
+    "TSEntityName",
+  ],
   fields: {
     ...patternLikeCommon(),
     name: {
@@ -1003,8 +1009,8 @@ defineType("RestElement", {
   visitor: ["argument", "typeAnnotation"],
   builder: ["argument"],
   aliases: process.env.BABEL_8_BREAKING
-    ? ["PatternLike"]
-    : ["PatternLike", "LVal"],
+    ? ["FunctionParameter", "PatternLike"]
+    : ["FunctionParameter", "PatternLike", "LVal"],
   deprecatedAlias: "RestProperty",
   fields: {
     ...patternLikeCommon(),
@@ -1295,8 +1301,8 @@ defineType("AssignmentPattern", {
   visitor: ["left", "right", "decorators" /* for legacy param decorators */],
   builder: ["left", "right"],
   aliases: process.env.BABEL_8_BREAKING
-    ? ["Pattern", "PatternLike"]
-    : ["Pattern", "PatternLike", "LVal"],
+    ? ["FunctionParameter", "Pattern", "PatternLike"]
+    : ["FunctionParameter", "Pattern", "PatternLike", "LVal"],
   fields: {
     ...patternLikeCommon(),
     left: {
@@ -1325,7 +1331,7 @@ defineType("AssignmentPattern", {
 defineType("ArrayPattern", {
   visitor: ["elements", "typeAnnotation"],
   builder: ["elements"],
-  aliases: ["Pattern", "PatternLike", "LVal"],
+  aliases: ["FunctionParameter", "Pattern", "PatternLike", "LVal"],
   fields: {
     ...patternLikeCommon(),
     elements: {
@@ -1932,12 +1938,7 @@ export const classMethodOrPropertyCommon = () => ({
 export const classMethodOrDeclareMethodCommon = () => ({
   ...functionCommon(),
   ...classMethodOrPropertyCommon(),
-  params: validateArrayOfType(
-    "Identifier",
-    "Pattern",
-    "RestElement",
-    "TSParameterProperty",
-  ),
+  params: validateArrayOfType("FunctionParameter", "TSParameterProperty"),
   kind: {
     validate: assertOneOf("get", "set", "method", "constructor"),
     default: "method",
@@ -1991,7 +1992,7 @@ defineType("ObjectPattern", {
     "typeAnnotation",
   ],
   builder: ["properties"],
-  aliases: ["Pattern", "PatternLike", "LVal"],
+  aliases: ["FunctionParameter", "Pattern", "PatternLike", "LVal"],
   fields: {
     ...patternLikeCommon(),
     properties: validateArrayOfType("RestElement", "ObjectProperty"),

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -42,7 +42,7 @@ const tSFunctionTypeAnnotationCommon = () => ({
 });
 
 defineType("TSParameterProperty", {
-  aliases: ["LVal"], // TODO: This isn't usable in general as an LVal. Should have a "Parameter" alias.
+  aliases: process.env.BABEL_8_BREAKING ? [] : ["LVal"],
   visitor: ["parameter"],
   fields: {
     accessibility: {

--- a/packages/babel-types/src/validators/generated/index.ts
+++ b/packages/babel-types/src/validators/generated/index.ts
@@ -3159,6 +3159,7 @@ export function isPatternLike(
 
   switch (node.type) {
     case "Identifier":
+    case "MemberExpression":
     case "RestElement":
     case "AssignmentPattern":
     case "ArrayPattern":
@@ -3196,6 +3197,7 @@ export function isLVal(
     case "AssignmentPattern":
     case "ArrayPattern":
     case "ObjectPattern":
+    case "OptionalMemberExpression":
     case "TSParameterProperty":
     case "TSAsExpression":
     case "TSSatisfiesExpression":

--- a/packages/babel-types/src/validators/generated/index.ts
+++ b/packages/babel-types/src/validators/generated/index.ts
@@ -3151,6 +3151,27 @@ export function isDeclaration(
 
   return opts == null || shallowEqual(node, opts);
 }
+export function isFunctionParameter(
+  node: t.Node | null | undefined,
+  opts?: Opts<t.FunctionParameter> | null,
+): node is t.FunctionParameter {
+  if (!node) return false;
+
+  switch (node.type) {
+    case "Identifier":
+    case "RestElement":
+    case "AssignmentPattern":
+    case "ArrayPattern":
+    case "ObjectPattern":
+      break;
+    case "Placeholder":
+      if (node.expectedNode === "Identifier") break;
+    default:
+      return false;
+  }
+
+  return opts == null || shallowEqual(node, opts);
+}
 export function isPatternLike(
   node: t.Node | null | undefined,
   opts?: Opts<t.PatternLike> | null,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/17384
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/3107
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This pull request includes several `LVal` and `PatternLike` changes:

- Add `OptionalMemberExpression` to `LVal` because of the stage 1 proposal `a?.b = 1`
- Add `MemberExpression` to `PatternLike` because of it is allowed in the destructuring assignment `[a.b] = []`
- The `argument` of `RestElement` and the elements of `ArrayPattern` must be a `PatternLike` instead of `LVal`, because `[a?.b] = 1` is invalid though `a?.b = 1` is allowed
- Breaking change: Remove `TSParameterProperty` from `LVal`
- Add `FunctionParameter` alias to cover function parameters: `Pattern`, `Identifier` and `RestElement`. The `TSParameterProperty` is currently excluded from `FunctionParameter` because it is only valid in class constructors

The new typing reveals a bug in the do-expression-transform. It is fixed in this PR and new tests are added.