### PR TITLE
Improve `@babel/core` types

### DIFF
--- a/packages/babel-core/src/config/cache-contexts.ts
+++ b/packages/babel-core/src/config/cache-contexts.ts
@@ -1,12 +1,13 @@
-import type { Targets } from "@babel/helper-compilation-targets";
-
 import type { ConfigContext } from "./config-chain.ts";
-import type { CallerMetadata } from "./validation/options.ts";
+import type {
+  CallerMetadata,
+  TargetsListOrObject,
+} from "./validation/options.ts";
 
 export type { ConfigContext as FullConfig };
 
 export type FullPreset = {
-  targets: Targets;
+  targets: TargetsListOrObject;
 } & ConfigContext;
 export type FullPlugin = {
   assumptions: { [name: string]: boolean };
@@ -19,7 +20,7 @@ export type SimpleConfig = {
   caller: CallerMetadata | undefined;
 };
 export type SimplePreset = {
-  targets: Targets;
+  targets: TargetsListOrObject;
 } & SimpleConfig;
 export type SimplePlugin = {
   assumptions: {

--- a/packages/babel-core/src/config/config-descriptors.ts
+++ b/packages/babel-core/src/config/config-descriptors.ts
@@ -13,9 +13,9 @@ import {
 import type { CacheConfigurator } from "./caching.ts";
 
 import type {
-  ValidatedOptions,
-  PluginList,
   PluginItem,
+  InputOptions,
+  PresetItem,
 } from "./validation/options.ts";
 
 import { resolveBrowserslistConfigFile } from "./resolve-targets.ts";
@@ -25,7 +25,7 @@ import type { PluginAPI, PresetAPI } from "./helpers/config-api.ts";
 // for the plugins and presets so we don't load the plugins/presets unless
 // the options object actually ends up being applicable.
 export type OptionsAndDescriptors = {
-  options: ValidatedOptions;
+  options: InputOptions;
   plugins: () => Handler<Array<UnloadedDescriptor<PluginAPI>>>;
   presets: () => Handler<Array<UnloadedDescriptor<PresetAPI>>>;
 };
@@ -33,9 +33,9 @@ export type OptionsAndDescriptors = {
 // Represents a plugin or presets at a given location in a config object.
 // At this point these have been resolved to a specific object or function,
 // but have not yet been executed to call functions with options.
-export interface UnloadedDescriptor<API, Options = object | undefined | false> {
+export interface UnloadedDescriptor<API, Options = object | undefined> {
   name: string | undefined;
-  value: object | ((api: API, options: Options, dirname: string) => unknown);
+  value: (api: API, options: Options, dirname: string) => unknown;
   options: Options;
   dirname: string;
   alias: string;
@@ -65,7 +65,7 @@ function isEqualDescriptor<API>(
 export type ValidatedFile = {
   filepath: string;
   dirname: string;
-  options: ValidatedOptions;
+  options: InputOptions;
 };
 
 // eslint-disable-next-line require-yield
@@ -74,9 +74,9 @@ function* handlerOf<T>(value: T): Handler<T> {
 }
 
 function optionsWithResolvedBrowserslistConfigFile(
-  options: ValidatedOptions,
+  options: InputOptions,
   dirname: string,
-): ValidatedOptions {
+): InputOptions {
   if (typeof options.browserslistConfigFile === "string") {
     options.browserslistConfigFile = resolveBrowserslistConfigFile(
       options.browserslistConfigFile,
@@ -93,7 +93,7 @@ function optionsWithResolvedBrowserslistConfigFile(
  */
 export function createCachedDescriptors(
   dirname: string,
-  options: ValidatedOptions,
+  options: InputOptions,
   alias: string,
 ): OptionsAndDescriptors {
   const { plugins, presets, passPerPreset } = options;
@@ -122,7 +122,7 @@ export function createCachedDescriptors(
  */
 export function createUncachedDescriptors(
   dirname: string,
-  options: ValidatedOptions,
+  options: InputOptions,
   alias: string,
 ): OptionsAndDescriptors {
   return {
@@ -146,7 +146,7 @@ export function createUncachedDescriptors(
 
 const PRESET_DESCRIPTOR_CACHE = new WeakMap();
 const createCachedPresetDescriptors = makeWeakCacheSync(
-  (items: PluginList, cache: CacheConfigurator<string>) => {
+  (items: PluginItem[], cache: CacheConfigurator<string>) => {
     const dirname = cache.using(dir => dir);
     return makeStrongCacheSync((alias: string) =>
       makeStrongCache(function* (
@@ -171,7 +171,7 @@ const createCachedPresetDescriptors = makeWeakCacheSync(
 
 const PLUGIN_DESCRIPTOR_CACHE = new WeakMap();
 const createCachedPluginDescriptors = makeWeakCacheSync(
-  (items: PluginList, cache: CacheConfigurator<string>) => {
+  (items: PluginItem[], cache: CacheConfigurator<string>) => {
     const dirname = cache.using(dir => dir);
     return makeStrongCache(function* (
       alias: string,
@@ -235,7 +235,7 @@ function loadCachedDescriptor<API>(
 }
 
 function* createPresetDescriptors(
-  items: PluginList,
+  items: PluginItem[],
   dirname: string,
   alias: string,
   passPerPreset: boolean,
@@ -250,7 +250,7 @@ function* createPresetDescriptors(
 }
 
 function* createPluginDescriptors(
-  items: PluginList,
+  items: PluginItem[],
   dirname: string,
   alias: string,
 ): Handler<Array<UnloadedDescriptor<PluginAPI>>> {
@@ -259,7 +259,7 @@ function* createPluginDescriptors(
 
 function* createDescriptors<API>(
   type: "plugin" | "preset",
-  items: PluginList,
+  items: PluginItem[] | PresetItem[],
   dirname: string,
   alias: string,
   ownPass?: boolean,
@@ -283,7 +283,7 @@ function* createDescriptors<API>(
  * Given a plugin/preset item, resolve it into a standard format.
  */
 export function* createDescriptor<API>(
-  pair: PluginItem,
+  pair: PluginItem | PresetItem,
   dirname: string,
   {
     type,

--- a/packages/babel-core/src/config/full.ts
+++ b/packages/babel-core/src/config/full.ts
@@ -113,6 +113,7 @@ export default gensync(function* loadFullConfig(
 
       for (let i = 0; i < rawPresets.length; i++) {
         const descriptor = rawPresets[i];
+        // @ts-expect-error TODO: disallow false
         if (descriptor.options !== false) {
           try {
             // eslint-disable-next-line no-var
@@ -185,6 +186,7 @@ export default gensync(function* loadFullConfig(
 
       for (let i = 0; i < descs.length; i++) {
         const descriptor = descs[i];
+        // @ts-expect-error TODO: disallow false
         if (descriptor.options !== false) {
           try {
             // eslint-disable-next-line no-var
@@ -250,6 +252,7 @@ const makeDescriptorLoader = <Context, API>(
     cache: CacheConfigurator<Context>,
   ): Handler<LoadedDescriptor> {
     // Disabled presets should already have been filtered out
+    // @ts-expect-error expected
     if (options === false) throw new Error("Assertion failure");
 
     options = options || {};
@@ -415,7 +418,7 @@ function* loadPluginDescriptor(
 const needsFilename = (val: unknown) => val && typeof val !== "function";
 
 const validateIfOptionNeedsFilename = (
-  options: ValidatedOptions,
+  options: InputOptions,
   descriptor: UnloadedDescriptor<PresetAPI>,
 ): void => {
   if (

--- a/packages/babel-core/src/config/index.ts
+++ b/packages/babel-core/src/config/index.ts
@@ -17,11 +17,7 @@ export type { PluginObject } from "./validation/plugins.ts";
 type PluginAPI = basePluginAPI & typeof import("..");
 type PresetAPI = basePresetAPI & typeof import("..");
 export type { PluginAPI, PresetAPI };
-// todo: may need to refine PresetObject to be a subset of ValidatedOptions
-export type {
-  CallerMetadata,
-  ValidatedOptions as PresetObject,
-} from "./validation/options.ts";
+export type { CallerMetadata } from "./validation/options.ts";
 
 import loadFullConfig, { type ResolvedConfig } from "./full.ts";
 import {

--- a/packages/babel-core/src/config/item.ts
+++ b/packages/babel-core/src/config/item.ts
@@ -1,5 +1,5 @@
 import type { Handler } from "gensync";
-import type { PluginTarget, PluginOptions } from "./validation/options.ts";
+import type { PluginItem, PresetItem } from "./validation/options.ts";
 
 import path from "node:path";
 import { createDescriptor } from "./config-descriptors.ts";
@@ -19,10 +19,7 @@ export function createItemFromDescriptor<API>(
  * and re-evaluating the plugin/preset function.
  */
 export function* createConfigItem<API>(
-  value:
-    | PluginTarget
-    | [PluginTarget, PluginOptions]
-    | [PluginTarget, PluginOptions, string | void],
+  value: PluginItem | PresetItem,
   {
     dirname = ".",
     type,

--- a/packages/babel-core/src/config/partial.ts
+++ b/packages/babel-core/src/config/partial.ts
@@ -8,12 +8,7 @@ import type { ConfigContext, FileHandling } from "./config-chain.ts";
 import { getEnv } from "./helpers/environment.ts";
 import { validate } from "./validation/options.ts";
 
-import type {
-  ValidatedOptions,
-  NormalizedOptions,
-  RootMode,
-  InputOptions,
-} from "./validation/options.ts";
+import type { RootMode, InputOptions } from "./validation/options.ts";
 
 import {
   findConfigUpwards,
@@ -57,7 +52,7 @@ function resolveRootMode(rootDir: string, rootMode: RootMode): string {
 
 export type PrivPartialConfig = {
   showIgnoredFiles?: boolean;
-  options: NormalizedOptions;
+  options: InputOptions;
   context: ConfigContext;
   babelrc: ConfigFile | void;
   config: ConfigFile | void;
@@ -111,14 +106,14 @@ export default function* loadPrivatePartialConfig(
   const configChain = yield* buildRootChain(args, context);
   if (!configChain) return null;
 
-  const merged: ValidatedOptions = {
+  const merged: InputOptions = {
     assumptions: {},
   };
   configChain.options.forEach(opts => {
     mergeOptions(merged as any, opts);
   });
 
-  const options: NormalizedOptions = {
+  const options: InputOptions = {
     ...merged,
     targets: resolveTargets(merged, absoluteRootDir),
 
@@ -203,7 +198,7 @@ class PartialConfig {
    * These properties are public, so any changes to them should be considered
    * a breaking change to Babel's API.
    */
-  options: NormalizedOptions;
+  options: InputOptions;
   babelrc: string | void;
   babelignore: string | void;
   config: string | void;
@@ -211,7 +206,7 @@ class PartialConfig {
   files: Set<string>;
 
   constructor(
-    options: NormalizedOptions,
+    options: InputOptions,
     babelrc: string | void,
     ignore: string | void,
     config: string | void,

--- a/packages/babel-core/src/config/printer.ts
+++ b/packages/babel-core/src/config/printer.ts
@@ -70,8 +70,8 @@ const Formatter = {
 
 function descriptorToConfig<API>(
   d: UnloadedDescriptor<API>,
-): object | string | [string, unknown] | [string, unknown, string] {
-  let name: object | string = d.file?.request;
+): string | [string, object] | [string, object, string] {
+  let name: string = d.file?.request;
   if (name == null) {
     if (typeof d.value === "object") {
       name = d.value;

--- a/packages/babel-core/src/config/resolve-targets-browser.ts
+++ b/packages/babel-core/src/config/resolve-targets-browser.ts
@@ -1,6 +1,6 @@
 /* c8 ignore start */
 
-import type { ValidatedOptions } from "./validation/options.ts";
+import type { InputOptions } from "./validation/options.ts";
 import getTargets, {
   type InputTargets,
 } from "@babel/helper-compilation-targets";
@@ -17,7 +17,7 @@ export function resolveBrowserslistConfigFile(
 }
 
 export function resolveTargets(
-  options: ValidatedOptions,
+  options: InputOptions,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   root: string,
 ): Targets {

--- a/packages/babel-core/src/config/resolve-targets.ts
+++ b/packages/babel-core/src/config/resolve-targets.ts
@@ -5,7 +5,7 @@ type nodeType = typeof import("./resolve-targets");
 // exports of index-browser, since this file may be replaced at bundle time with index-browser.
 ({}) as any as browserType as nodeType;
 
-import type { ValidatedOptions } from "./validation/options.ts";
+import type { InputOptions } from "./validation/options.ts";
 import path from "node:path";
 import getTargets, {
   type InputTargets,
@@ -20,10 +20,7 @@ export function resolveBrowserslistConfigFile(
   return path.resolve(configFileDir, browserslistConfigFile);
 }
 
-export function resolveTargets(
-  options: ValidatedOptions,
-  root: string,
-): Targets {
+export function resolveTargets(options: InputOptions, root: string): Targets {
   const optTargets = options.targets;
   let targets: InputTargets;
 

--- a/packages/babel-core/src/config/util.ts
+++ b/packages/babel-core/src/config/util.ts
@@ -1,11 +1,8 @@
-import type {
-  ValidatedOptions,
-  NormalizedOptions,
-} from "./validation/options.ts";
+import type { InputOptions, ValidatedOptions } from "./validation/options.ts";
 
 export function mergeOptions(
-  target: ValidatedOptions,
-  source: ValidatedOptions | NormalizedOptions,
+  target: InputOptions | ValidatedOptions,
+  source: InputOptions,
 ): void {
   for (const k of Object.keys(source)) {
     if (

--- a/packages/babel-core/src/config/validation/option-assertions.ts
+++ b/packages/babel-core/src/config/validation/option-assertions.ts
@@ -6,9 +6,7 @@ import {
 import type {
   ConfigFileSearch,
   BabelrcSearch,
-  IgnoreList,
-  IgnoreItem,
-  PluginList,
+  MatchItem,
   PluginItem,
   PluginTarget,
   ConfigApplicableTest,
@@ -233,7 +231,7 @@ export function assertObject(
 export function assertArray<T>(
   loc: GeneralPath,
   value: Array<T> | undefined | null,
-): ReadonlyArray<T> | undefined | null {
+): Array<T> | undefined | null {
   if (value != null && !Array.isArray(value)) {
     throw new Error(`${msg(loc)} must be an array, or undefined`);
   }
@@ -243,13 +241,13 @@ export function assertArray<T>(
 export function assertIgnoreList(
   loc: OptionPath,
   value: unknown[] | undefined,
-): IgnoreList | void {
+): MatchItem[] | void {
   const arr = assertArray(loc, value);
   arr?.forEach((item, i) => assertIgnoreItem(access(loc, i), item));
   // @ts-expect-error todo(flow->ts)
   return arr;
 }
-function assertIgnoreItem(loc: GeneralPath, value: unknown): IgnoreItem {
+function assertIgnoreItem(loc: GeneralPath, value: unknown): MatchItem {
   if (
     typeof value !== "string" &&
     typeof value !== "function" &&
@@ -261,7 +259,7 @@ function assertIgnoreItem(loc: GeneralPath, value: unknown): IgnoreItem {
       )} must be an array of string/Function/RegExp values, or undefined`,
     );
   }
-  return value as IgnoreItem;
+  return value as MatchItem;
 }
 
 export function assertConfigApplicableTest(
@@ -344,14 +342,14 @@ export function assertBabelrcSearch(
 export function assertPluginList(
   loc: OptionPath,
   value: unknown[] | null | undefined,
-): PluginList | void {
+): PluginItem[] {
   const arr = assertArray(loc, value);
   if (arr) {
     // Loop instead of using `.map` in order to preserve object identity
     // for plugin array for use during config chain processing.
     arr.forEach((item, i) => assertPluginItem(access(loc, i), item));
   }
-  return arr as any;
+  return arr as PluginItem[];
 }
 function assertPluginItem(loc: GeneralPath, value: unknown): PluginItem {
   if (Array.isArray(value)) {
@@ -400,7 +398,7 @@ function assertPluginTarget(loc: GeneralPath, value: unknown): PluginTarget {
   ) {
     throw new Error(`${msg(loc)} must be a string, object, function`);
   }
-  return value;
+  return value as PluginTarget;
 }
 
 export function assertTargets(

--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -1,7 +1,6 @@
 import type { InputTargets, Targets } from "@babel/helper-compilation-targets";
 
 import type { ConfigItem } from "../item.ts";
-import type Plugin from "../plugin.ts";
 
 import removed from "./removed.ts";
 import {
@@ -36,6 +35,9 @@ import type { PluginAPI } from "../helpers/config-api.ts";
 import type { ParserOptions } from "@babel/parser";
 import type { GeneratorOptions } from "@babel/generator";
 import ConfigError from "../../errors/config-error.ts";
+import type { PluginObject } from "./plugins.ts";
+import type Plugin from "../plugin.ts";
+import type { PresetAPI } from "../index.ts";
 
 const ROOT_VALIDATORS: ValidatorSet = {
   cwd: assertString as Validator<ValidatedOptions["cwd"]>,
@@ -86,45 +88,45 @@ const COMMON_VALIDATORS: ValidatorSet = {
   inputSourceMap: assertInputSourceMap as Validator<
     ValidatedOptions["inputSourceMap"]
   >,
-  presets: assertPluginList as Validator<ValidatedOptions["presets"]>,
-  plugins: assertPluginList as Validator<ValidatedOptions["plugins"]>,
-  passPerPreset: assertBoolean as Validator<ValidatedOptions["passPerPreset"]>,
-  assumptions: assertAssumptions as Validator<ValidatedOptions["assumptions"]>,
+  presets: assertPluginList as Validator<InputOptions["presets"]>,
+  plugins: assertPluginList as Validator<InputOptions["plugins"]>,
+  passPerPreset: assertBoolean as Validator<InputOptions["passPerPreset"]>,
+  assumptions: assertAssumptions as Validator<InputOptions["assumptions"]>,
 
-  env: assertEnvSet as Validator<ValidatedOptions["env"]>,
-  overrides: assertOverridesList as Validator<ValidatedOptions["overrides"]>,
+  env: assertEnvSet as Validator<InputOptions["env"]>,
+  overrides: assertOverridesList as Validator<InputOptions["overrides"]>,
 
   // We could limit these to 'overrides' blocks, but it's not clear why we'd
   // bother, when the ability to limit a config to a specific set of files
   // is a fairly general useful feature.
-  test: assertConfigApplicableTest as Validator<ValidatedOptions["test"]>,
-  include: assertConfigApplicableTest as Validator<ValidatedOptions["include"]>,
-  exclude: assertConfigApplicableTest as Validator<ValidatedOptions["exclude"]>,
+  test: assertConfigApplicableTest as Validator<InputOptions["test"]>,
+  include: assertConfigApplicableTest as Validator<InputOptions["include"]>,
+  exclude: assertConfigApplicableTest as Validator<InputOptions["exclude"]>,
 
-  retainLines: assertBoolean as Validator<ValidatedOptions["retainLines"]>,
-  comments: assertBoolean as Validator<ValidatedOptions["comments"]>,
+  retainLines: assertBoolean as Validator<InputOptions["retainLines"]>,
+  comments: assertBoolean as Validator<InputOptions["comments"]>,
   shouldPrintComment: assertFunction as Validator<
-    ValidatedOptions["shouldPrintComment"]
+    InputOptions["shouldPrintComment"]
   >,
-  compact: assertCompact as Validator<ValidatedOptions["compact"]>,
-  minified: assertBoolean as Validator<ValidatedOptions["minified"]>,
+  compact: assertCompact as Validator<InputOptions["compact"]>,
+  minified: assertBoolean as Validator<InputOptions["minified"]>,
   auxiliaryCommentBefore: assertString as Validator<
-    ValidatedOptions["auxiliaryCommentBefore"]
+    InputOptions["auxiliaryCommentBefore"]
   >,
   auxiliaryCommentAfter: assertString as Validator<
-    ValidatedOptions["auxiliaryCommentAfter"]
+    InputOptions["auxiliaryCommentAfter"]
   >,
-  sourceType: assertSourceType as Validator<ValidatedOptions["sourceType"]>,
+  sourceType: assertSourceType as Validator<InputOptions["sourceType"]>,
   wrapPluginVisitorMethod: assertFunction as Validator<
-    ValidatedOptions["wrapPluginVisitorMethod"]
+    InputOptions["wrapPluginVisitorMethod"]
   >,
-  highlightCode: assertBoolean as Validator<ValidatedOptions["highlightCode"]>,
-  sourceMaps: assertSourceMaps as Validator<ValidatedOptions["sourceMaps"]>,
-  sourceMap: assertSourceMaps as Validator<ValidatedOptions["sourceMap"]>,
-  sourceFileName: assertString as Validator<ValidatedOptions["sourceFileName"]>,
-  sourceRoot: assertString as Validator<ValidatedOptions["sourceRoot"]>,
-  parserOpts: assertObject as Validator<ValidatedOptions["parserOpts"]>,
-  generatorOpts: assertObject as Validator<ValidatedOptions["generatorOpts"]>,
+  highlightCode: assertBoolean as Validator<InputOptions["highlightCode"]>,
+  sourceMaps: assertSourceMaps as Validator<InputOptions["sourceMaps"]>,
+  sourceMap: assertSourceMaps as Validator<InputOptions["sourceMap"]>,
+  sourceFileName: assertString as Validator<InputOptions["sourceFileName"]>,
+  sourceRoot: assertString as Validator<InputOptions["sourceRoot"]>,
+  parserOpts: assertObject as Validator<InputOptions["parserOpts"]>,
+  generatorOpts: assertObject as Validator<InputOptions["generatorOpts"]>,
 };
 if (!process.env.BABEL_8_BREAKING) {
   Object.assign(COMMON_VALIDATORS, {
@@ -135,9 +137,35 @@ if (!process.env.BABEL_8_BREAKING) {
   });
 }
 
-export type InputOptions = ValidatedOptions;
+type Assumptions = {
+  arrayLikeIsIterable?: boolean;
+  constantReexports?: boolean;
+  constantSuper?: boolean;
+  enumerableModuleMeta?: boolean;
+  ignoreFunctionLength?: boolean;
+  ignoreToPrimitiveHint?: boolean;
+  iterableIsArray?: boolean;
+  mutableTemplateObject?: boolean;
+  noClassCalls?: boolean;
+  noDocumentAll?: boolean;
+  noIncompleteNsImportDetection?: boolean;
+  noNewArrows?: boolean;
+  noUninitializedPrivateFieldAccess?: boolean;
+  objectRestNoSymbols?: boolean;
+  privateFieldsAsProperties?: boolean;
+  privateFieldsAsSymbols?: boolean;
+  pureGetters?: boolean;
+  setClassMethods?: boolean;
+  setComputedProperties?: boolean;
+  setPublicClassFields?: boolean;
+  setSpreadProperties?: boolean;
+  skipForOfIteratorClosing?: boolean;
+  superIsCallableConstructor?: boolean;
+};
 
-export type ValidatedOptions = {
+export type AssumptionName = keyof Assumptions;
+
+export type BaseOptions = {
   cwd?: string;
   filename?: string;
   filenameRelative?: string;
@@ -153,21 +181,17 @@ export type ValidatedOptions = {
   envName?: string;
   caller?: CallerMetadata;
   extends?: string;
-  env?: EnvSet<ValidatedOptions>;
-  ignore?: IgnoreList;
-  only?: IgnoreList;
-  overrides?: OverridesList;
+  env?: EnvSet<InputOptions>;
+  ignore?: MatchItem[];
+  only?: MatchItem[];
+  overrides?: InputOptions[];
   showIgnoredFiles?: boolean;
   // Generally verify if a given config object should be applied to the given file.
   test?: ConfigApplicableTest;
   include?: ConfigApplicableTest;
   exclude?: ConfigApplicableTest;
-  presets?: PluginList;
-  plugins?: PluginList;
   passPerPreset?: boolean;
-  assumptions?: {
-    [name: string]: boolean;
-  };
+  assumptions?: Assumptions;
   // browserslists-related options
   targets?: TargetsListOrObject;
   browserslistConfigFile?: ConfigFileSearch;
@@ -195,9 +219,19 @@ export type ValidatedOptions = {
   generatorOpts?: GeneratorOptions;
 };
 
+export type InputOptions = BaseOptions & {
+  presets?: PluginItem[];
+  plugins?: PluginItem[];
+};
+
+export type ValidatedOptions = BaseOptions & {
+  presets?: { plugins: Plugin[] }[];
+  plugins?: Plugin[];
+};
+
 export type NormalizedOptions = {
   readonly targets: Targets;
-} & Omit<ValidatedOptions, "targets">;
+} & Omit<InputOptions, "targets">;
 
 export type CallerMetadata = {
   // If 'caller' is specified, require that the name is given for debugging
@@ -207,30 +241,36 @@ export type CallerMetadata = {
 export type EnvSet<T> = {
   [x: string]: T;
 };
-export type IgnoreItem =
+export type MatchItem =
   | string
   | RegExp
   | ((
       path: string | undefined,
       context: { dirname: string; caller: CallerMetadata; envName: string },
     ) => unknown);
-export type IgnoreList = ReadonlyArray<IgnoreItem>;
 
-export type PluginOptions = object | void | false;
-export type PluginTarget = string | object | Function;
+export type PluginTarget =
+  | string
+  | ((api: PluginAPI, options?: object, dirname?: string) => PluginObject);
 export type PluginItem =
   | ConfigItem<PluginAPI>
-  | Plugin
   | PluginTarget
-  | [PluginTarget, PluginOptions]
-  | [PluginTarget, PluginOptions, string | void];
-export type PluginList = ReadonlyArray<PluginItem>;
+  | [PluginTarget, object]
+  | [PluginTarget, object, string];
 
-export type OverridesList = Array<ValidatedOptions>;
-export type ConfigApplicableTest = IgnoreItem | Array<IgnoreItem>;
+export type PresetTarget =
+  | string
+  | ((api: PresetAPI, options?: object, dirname?: string) => PluginObject);
+export type PresetItem =
+  | ConfigItem<PresetAPI>
+  | PresetTarget
+  | [PresetTarget, object]
+  | [PresetTarget, object, string];
+
+export type ConfigApplicableTest = MatchItem | Array<MatchItem>;
 
 export type ConfigFileSearch = string | boolean;
-export type BabelrcSearch = boolean | IgnoreItem | IgnoreList;
+export type BabelrcSearch = boolean | MatchItem | MatchItem[];
 export type SourceMapsOption = boolean | "inline" | "both";
 export type SourceTypeOption = "module" | "script" | "unambiguous";
 export type CompactOption = boolean | "auto";
@@ -294,7 +334,6 @@ const knownAssumptions = [
   "skipForOfIteratorClosing",
   "superIsCallableConstructor",
 ] as const;
-export type AssumptionName = (typeof knownAssumptions)[number];
 export const assumptionsNames = new Set(knownAssumptions);
 
 function getSource(loc: NestingPath): OptionsSource {
@@ -305,7 +344,7 @@ export function validate(
   type: OptionsSource,
   opts: any,
   filename?: string,
-): ValidatedOptions {
+): InputOptions {
   try {
     return validateNested(
       {
@@ -324,7 +363,6 @@ export function validate(
 
 function validateNested(loc: NestingPath, opts: { [key: string]: unknown }) {
   const type = getSource(loc);
-
   assertNoDuplicateSourcemap(opts);
 
   Object.keys(opts).forEach((key: string) => {
@@ -407,7 +445,7 @@ function assertNoDuplicateSourcemap(opts: any): void {
 function assertEnvSet(
   loc: OptionPath,
   value: unknown,
-): void | EnvSet<ValidatedOptions> {
+): void | EnvSet<InputOptions> {
   if (loc.parent.type === "env") {
     throw new Error(`${msg(loc)} is not allowed inside of another .env block`);
   }
@@ -435,7 +473,7 @@ function assertEnvSet(
 function assertOverridesList(
   loc: OptionPath,
   value: unknown[],
-): undefined | OverridesList {
+): undefined | InputOptions[] {
   if (loc.parent.type === "env") {
     throw new Error(`${msg(loc)} is not allowed inside an .env block`);
   }
@@ -459,7 +497,7 @@ function assertOverridesList(
       validateNested(overridesLoc, env);
     }
   }
-  return arr as OverridesList;
+  return arr;
 }
 
 export function checkNoUnwrappedItemOptionPairs<API>(

--- a/packages/babel-core/src/index.ts
+++ b/packages/babel-core/src/index.ts
@@ -49,7 +49,17 @@ export {
   loadPartialConfigSync,
 } from "./config/index.ts";
 import { loadOptionsSync } from "./config/index.ts";
+import type {
+  PluginItem,
+  ConfigApplicableTest,
+} from "./config/validation/options.ts";
 export { loadOptionsSync };
+
+export type PresetObject = {
+  overrides?: PresetObject[];
+  test?: ConfigApplicableTest;
+  plugins?: (PluginItem[] | PluginItem)[];
+};
 
 export type {
   CallerMetadata,
@@ -58,7 +68,6 @@ export type {
   PluginAPI,
   PluginObject,
   PresetAPI,
-  PresetObject,
 } from "./config/index.ts";
 
 export {

--- a/packages/babel-core/src/parse.ts
+++ b/packages/babel-core/src/parse.ts
@@ -3,7 +3,6 @@ import gensync, { type Handler } from "gensync";
 import loadConfig, { type InputOptions } from "./config/index.ts";
 import parser, { type ParseResult } from "./parser/index.ts";
 import normalizeOptions from "./transformation/normalize-opts.ts";
-import type { ValidatedOptions } from "./config/validation/options.ts";
 
 import { beginHiddenCallStack } from "./errors/rewrite-stack-trace.ts";
 
@@ -42,7 +41,7 @@ export const parse: Parse = function parse(
 ) {
   if (typeof opts === "function") {
     callback = opts;
-    opts = undefined as ValidatedOptions;
+    opts = undefined as InputOptions;
   }
 
   if (callback === undefined) {

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -577,12 +577,10 @@ export default function (
             if (dynamicOpts) dynamicOpts(task.options, task);
 
             if (task.externalHelpers) {
-              (task.options.plugins ??= [])
-                // @ts-expect-error manipulating input options
-                .push([
-                  "external-helpers",
-                  { helperVersion: EXTERNAL_HELPERS_VERSION },
-                ]);
+              (task.options.plugins ??= []).push([
+                "external-helpers",
+                { helperVersion: EXTERNAL_HELPERS_VERSION },
+              ]);
             }
 
             const throwMsg = task.options.throws;

--- a/packages/babel-preset-react/src/index.ts
+++ b/packages/babel-preset-react/src/index.ts
@@ -4,6 +4,7 @@ import transformReactJSXDevelopment from "@babel/plugin-transform-react-jsx-deve
 import transformReactDisplayName from "@babel/plugin-transform-react-display-name";
 import transformReactPure from "@babel/plugin-transform-react-pure-annotations";
 import normalizeOptions from "./normalize-options.ts";
+import type { PluginItem } from "../../babel-core/src/config/validation/options.ts";
 
 export interface Options {
   development?: boolean;
@@ -55,7 +56,7 @@ export default declarePreset((api, opts: Options) => {
               useBuiltIns: !!opts.useBuiltIns,
               useSpread: opts.useSpread,
             },
-      ],
+      ] satisfies PluginItem,
       transformReactDisplayName,
       pure !== false && transformReactPure,
     ].filter(Boolean),

--- a/packages/babel-preset-typescript/src/index.ts
+++ b/packages/babel-preset-typescript/src/index.ts
@@ -5,6 +5,7 @@ import transformModulesCommonJS from "@babel/plugin-transform-modules-commonjs";
 import normalizeOptions from "./normalize-options.ts";
 import type { Options } from "./normalize-options.ts";
 import pluginRewriteTSImports from "./plugin-rewrite-ts-imports.ts";
+import type { PluginItem } from "../../babel-core/src/config/validation/options.ts";
 
 export default declarePreset((api, opts: Options) => {
   api.assertVersion(REQUIRED_VERSION(7));
@@ -43,7 +44,7 @@ export default declarePreset((api, opts: Options) => {
 
   const getPlugins = (isTSX: boolean, disallowAmbiguousJSXLike: boolean) => {
     if (process.env.BABEL_8_BREAKING) {
-      const tsPlugin = [
+      const tsPlugin: PluginItem = [
         transformTypeScript,
         pluginOptions(disallowAmbiguousJSXLike),
       ];
@@ -53,7 +54,7 @@ export default declarePreset((api, opts: Options) => {
         [
           transformTypeScript,
           { isTSX, ...pluginOptions(disallowAmbiguousJSXLike) },
-        ],
+        ] satisfies PluginItem,
       ];
     }
   };


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The main change is to distinguish `InputOptions` from `ValidatedOptions`, because they have two different fields.

To be honest, I don't want to expose some internal types such as `Plugin` or even `ValidatedOptions` details.
But I didn't think of a good way.