### PR TITLE
Add VoidPattern to FunctionParameter

### DIFF
--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -612,7 +612,17 @@ export interface ObjectProperty extends BaseNode {
 
 export interface RestElement extends BaseNode {
   type: "RestElement";
-  argument: PatternLike;
+  argument:
+    | Identifier
+    | ArrayPattern
+    | ObjectPattern
+    | MemberExpression
+    | TSAsExpression
+    | TSSatisfiesExpression
+    | TSTypeAssertion
+    | TSNonNullExpression
+    | RestElement
+    | AssignmentPattern;
   decorators?: Array<Decorator> | null;
   optional?: boolean | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
@@ -623,7 +633,17 @@ export interface RestElement extends BaseNode {
  */
 export interface RestProperty extends BaseNode {
   type: "RestProperty";
-  argument: PatternLike;
+  argument:
+    | Identifier
+    | ArrayPattern
+    | ObjectPattern
+    | MemberExpression
+    | TSAsExpression
+    | TSSatisfiesExpression
+    | TSTypeAssertion
+    | TSNonNullExpression
+    | RestElement
+    | AssignmentPattern;
   decorators?: Array<Decorator> | null;
   optional?: boolean | null;
   typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null;
@@ -2431,7 +2451,8 @@ export type FunctionParameter =
   | RestElement
   | AssignmentPattern
   | ArrayPattern
-  | ObjectPattern;
+  | ObjectPattern
+  | VoidPattern;
 export type PatternLike =
   | Identifier
   | MemberExpression

--- a/packages/babel-types/src/builders/generated/lowercase.ts
+++ b/packages/babel-types/src/builders/generated/lowercase.ts
@@ -574,7 +574,19 @@ export function objectProperty(
   validate(defs.decorators, node, "decorators", decorators, 1);
   return node;
 }
-export function restElement(argument: t.PatternLike): t.RestElement {
+export function restElement(
+  argument:
+    | t.Identifier
+    | t.ArrayPattern
+    | t.ObjectPattern
+    | t.MemberExpression
+    | t.TSAsExpression
+    | t.TSSatisfiesExpression
+    | t.TSTypeAssertion
+    | t.TSNonNullExpression
+    | t.RestElement
+    | t.AssignmentPattern,
+): t.RestElement {
   const node: t.RestElement = {
     type: "RestElement",
     argument,
@@ -3446,7 +3458,19 @@ function RegexLiteral(pattern: string, flags: string = "") {
 }
 export { RegexLiteral as regexLiteral };
 /** @deprecated */
-function RestProperty(argument: t.PatternLike) {
+function RestProperty(
+  argument:
+    | t.Identifier
+    | t.ArrayPattern
+    | t.ObjectPattern
+    | t.MemberExpression
+    | t.TSAsExpression
+    | t.TSSatisfiesExpression
+    | t.TSTypeAssertion
+    | t.TSNonNullExpression
+    | t.RestElement
+    | t.AssignmentPattern,
+) {
   deprecationWarning("RestProperty", "RestElement", "The node type ");
   return restElement(argument);
 }

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -1009,7 +1009,19 @@ defineType("RestElement", {
     argument: {
       validate:
         !process.env.BABEL_8_BREAKING && !process.env.BABEL_TYPES_8_BREAKING
-          ? assertNodeType("PatternLike")
+          ? assertNodeType(
+              "Identifier",
+              "ArrayPattern",
+              "ObjectPattern",
+              "MemberExpression",
+              "TSAsExpression",
+              "TSSatisfiesExpression",
+              "TSTypeAssertion",
+              "TSNonNullExpression",
+              // These are not valid in RestElement, but we allow them for backwards compatibility.
+              "RestElement",
+              "AssignmentPattern",
+            )
           : assertNodeType(
               "Identifier",
               "ArrayPattern",

--- a/packages/babel-types/src/definitions/experimental.ts
+++ b/packages/babel-types/src/definitions/experimental.ts
@@ -146,5 +146,5 @@ defineType("PipelinePrimaryTopicReference", {
 
 // https://github.com/tc39/proposal-discard-binding
 defineType("VoidPattern", {
-  aliases: ["Pattern", "PatternLike"],
+  aliases: ["Pattern", "PatternLike", "FunctionParameter"],
 });

--- a/packages/babel-types/src/validators/generated/index.ts
+++ b/packages/babel-types/src/validators/generated/index.ts
@@ -3173,6 +3173,7 @@ export function isFunctionParameter(
     case "AssignmentPattern":
     case "ArrayPattern":
     case "ObjectPattern":
+    case "VoidPattern":
       break;
     case "Placeholder":
       if (node.expectedNode === "Identifier") break;

--- a/scripts/integration-tests/e2e-angular-cli.sh
+++ b/scripts/integration-tests/e2e-angular-cli.sh
@@ -29,8 +29,6 @@ node "$dir"/utils/bump-babel-dependencies.js resolutions
 touch yarn.lock
 yarn set version stable
 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
-# Remove this when https://github.com/fb55/css-select/issues/1591 is fixed
-yarn add css-select@5.1.0
 yarn run build
 yarn run ng test --watch=false --browsers ChromeHeadless
 

--- a/scripts/integration-tests/e2e-angular-cli.sh
+++ b/scripts/integration-tests/e2e-angular-cli.sh
@@ -29,6 +29,8 @@ node "$dir"/utils/bump-babel-dependencies.js resolutions
 touch yarn.lock
 yarn set version stable
 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
+# Remove this when https://github.com/fb55/css-select/issues/1591 is fixed
+yarn add css-select@5.1.0
 yarn run build
 yarn run ng test --watch=false --browsers ChromeHeadless
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes failing main
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This pull request updates type definitions in Babel to improve compatibility and ensure correctness. The changes primarily involve expanding the validation rules for `RestElement` and adding a new alias to the `VoidPattern` type.

### Updates to type definitions:

* **`RestElement` validation changes**:
  - Expanded previously `PatternLike` to observe the fact that `VoidPattern` is currently not allowed as a rest argument. (`[packages/babel-types/src/definitions/core.tsL1012-R1024](diffhunk://#diff-370a1305c2f95dacef1c4873c91748e0ec805825841f30265cf58288d245d927L1012-R1024)`)

* **`VoidPattern` alias addition**:
  - Added the `FunctionParameter` alias to the `VoidPattern` type to align with its intended use in function parameter contexts. (`[packages/babel-types/src/definitions/experimental.tsL149-R149](diffhunk://#diff-a5507cb97c51044f6b9030fa3918a9eb867c21cef71977d7ebf124bc74a6454bL149-R149)`)