### PR TITLE
Do not enable default plugins in `@babel/standalone`

### DIFF
--- a/packages/babel-standalone/src/transformScriptTags.ts
+++ b/packages/babel-standalone/src/transformScriptTags.ts
@@ -76,7 +76,7 @@ function buildBabelOptions(script: CompilationResult, filename: string) {
   }
 
   let plugins = script.plugins;
-  if (!plugins && process.env.BABEL_8_BREAKING) {
+  if (!process.env.BABEL_8_BREAKING && !plugins) {
     plugins = [
       "transform-class-properties",
       "transform-object-rest-spread",


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      |
| Documentation PR Link    |
| Any Dependency Changes?  |
| License                  | MIT

This is per https://github.com/babel/babel/issues/17419#issuecomment-3023021662, but does not fully fix  that issue.

As suggested I've made it a future change for Babel 8. I did not add any tests (and I wouldn't really know where to start), but I did run the existing tests for babel-standalone and they continue to pass. (I have no idea whether they even attempt to exercise any of this, though.) 

I'm happy to tweak it for any local style things I missed, but I'd just as soon you edit it directly, if it's otherwise suitable.