### PR TITLE
Add missing FunctionParameter docs

### DIFF
--- a/packages/babel-types/scripts/generators/docs.js
+++ b/packages/babel-types/scripts/generators/docs.js
@@ -56,7 +56,11 @@ const APIHistory = {
   ModuleDeclaration: [["v7.21.0", "Deprecated"]],
   TSSatisfiesExpression: [["v7.20.0", "Introduced"]],
   TSTypeParameter: [["v7.21.0", "Supports `const`"]],
-  VariableDeclaration: [["v7.20.0", '`kind` can be "using".']],
+  VariableDeclaration: [
+    ["v7.20.0", '`kind` can be "using".'],
+    ["v7.22.0", '`kind` can be "await using".'],
+  ],
+  VoidPattern: [["v7.28.0", "Introduced"]],
 };
 const aliasDescriptions = {
   Accessor: "Deprecated. Will be removed in Babel 8.",
@@ -93,6 +97,8 @@ const aliasDescriptions = {
     "A cover of functions and [method](#method)s, the must have `body` and `params`. Note: `Function` is different to `FunctionParent`. For example, a `StaticBlock` is a `FunctionParent` but not `Function`.",
   FunctionParent:
     "A cover of AST nodes that start an execution context with new [VariableEnvironment](https://tc39.es/ecma262/#table-additional-state-components-for-ecmascript-code-execution-contexts). In other words, they define the scope of `var` declarations. FunctionParent did not include `Program` since Babel 7.",
+  FunctionParameter:
+    "A cover of function parameters. They the elements of [FormalParameterList](https://tc39.es/ecma262/#prod-FormalParameterList).",
   Immutable:
     "A cover of immutable objects and JSX elements. An object is [immutable](https://tc39.es/ecma262/#immutable-prototype-exotic-object) if no other properties can be defined once created.",
   ImportOrExportDeclaration:

--- a/packages/babel-types/scripts/generators/docs.js
+++ b/packages/babel-types/scripts/generators/docs.js
@@ -98,7 +98,7 @@ const aliasDescriptions = {
   FunctionParent:
     "A cover of AST nodes that start an execution context with new [VariableEnvironment](https://tc39.es/ecma262/#table-additional-state-components-for-ecmascript-code-execution-contexts). In other words, they define the scope of `var` declarations. FunctionParent did not include `Program` since Babel 7.",
   FunctionParameter:
-    "A cover of function parameters. They the elements of [FormalParameterList](https://tc39.es/ecma262/#prod-FormalParameterList).",
+    "A cover of function parameters. They are the elements of [FormalParameterList](https://tc39.es/ecma262/#prod-FormalParameterList).",
   Immutable:
     "A cover of immutable objects and JSX elements. An object is [immutable](https://tc39.es/ecma262/#immutable-prototype-exotic-object) if no other properties can be defined once created.",
   ImportOrExportDeclaration:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Failing babel-types docs update (https://github.com/babel/website/pull/3114) due to missing docs of the `FunctionParameter` alias
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Also added API history info for `await using` and the recently introduced `VoidPattern`.