### PR TITLE
Add attributes to import/export builder

### DIFF
--- a/packages/babel-types/scripts/generators/docs.js
+++ b/packages/babel-types/scripts/generators/docs.js
@@ -51,7 +51,12 @@ const customTypes = {
 };
 const APIHistory = {
   ClassProperty: [["v7.6.0", "Supports `static`"]],
-  ImportDeclaration: [["v7.20.0", "Supports `module`"]],
+  ExportAllDeclaration: [["v7.29.0", "Supports `attributes`"]],
+  ExportNamedDeclaration: [["v7.29.0", "Supports `attributes`"]],
+  ImportDeclaration: [
+    ["v7.20.0", "Supports `module`"],
+    ["v7.29.0", "Supports `attributes`"],
+  ],
   ImportOrExportDeclaration: [["v7.21.0", "Introduced"]],
   ModuleDeclaration: [["v7.21.0", "Deprecated"]],
   TSSatisfiesExpression: [["v7.20.0", "Introduced"]],

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -830,9 +830,9 @@ export interface ClassDeclaration extends BaseNode {
 export interface ExportAllDeclaration extends BaseNode {
   type: "ExportAllDeclaration";
   source: StringLiteral;
+  attributes: Array<ImportAttribute>;
   /** @deprecated */
   assertions?: Array<ImportAttribute> | null;
-  attributes?: Array<ImportAttribute> | null;
   exportKind?: "type" | "value" | null;
 }
 
@@ -853,9 +853,9 @@ export interface ExportNamedDeclaration extends BaseNode {
     ExportSpecifier | ExportDefaultSpecifier | ExportNamespaceSpecifier
   >;
   source?: StringLiteral | null;
+  attributes: Array<ImportAttribute>;
   /** @deprecated */
   assertions?: Array<ImportAttribute> | null;
-  attributes?: Array<ImportAttribute> | null;
   exportKind?: "type" | "value" | null;
 }
 
@@ -880,9 +880,9 @@ export interface ImportDeclaration extends BaseNode {
     ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier
   >;
   source: StringLiteral;
+  attributes: Array<ImportAttribute>;
   /** @deprecated */
   assertions?: Array<ImportAttribute> | null;
-  attributes?: Array<ImportAttribute> | null;
   importKind?: "type" | "typeof" | "value" | null;
   module?: boolean | null;
   phase?: "source" | "defer" | null;
@@ -1215,7 +1215,7 @@ export interface DeclareExportDeclaration extends BaseNode {
   declaration?: Flow | null;
   specifiers?: Array<ExportSpecifier | ExportNamespaceSpecifier> | null;
   source?: StringLiteral | null;
-  attributes?: Array<ImportAttribute> | null;
+  attributes: Array<ImportAttribute>;
   /** @deprecated */
   assertions?: Array<ImportAttribute> | null;
   default?: boolean | null;
@@ -1224,7 +1224,7 @@ export interface DeclareExportDeclaration extends BaseNode {
 export interface DeclareExportAllDeclaration extends BaseNode {
   type: "DeclareExportAllDeclaration";
   source: StringLiteral;
-  attributes?: Array<ImportAttribute> | null;
+  attributes: Array<ImportAttribute>;
   /** @deprecated */
   assertions?: Array<ImportAttribute> | null;
   exportKind?: "type" | "value" | null;

--- a/packages/babel-types/src/builders/generated/lowercase.ts
+++ b/packages/babel-types/src/builders/generated/lowercase.ts
@@ -890,13 +890,16 @@ export function classDeclaration(
 }
 export function exportAllDeclaration(
   source: t.StringLiteral,
+  attributes: Array<t.ImportAttribute> = [],
 ): t.ExportAllDeclaration {
   const node: t.ExportAllDeclaration = {
     type: "ExportAllDeclaration",
     source,
+    attributes,
   };
   const defs = NODE_FIELDS.ExportAllDeclaration;
   validate(defs.source, node, "source", source, 1);
+  validate(defs.attributes, node, "attributes", attributes, 1);
   return node;
 }
 export function exportDefaultDeclaration(
@@ -920,17 +923,20 @@ export function exportNamedDeclaration(
     t.ExportSpecifier | t.ExportDefaultSpecifier | t.ExportNamespaceSpecifier
   > = [],
   source: t.StringLiteral | null = null,
+  attributes: Array<t.ImportAttribute> = [],
 ): t.ExportNamedDeclaration {
   const node: t.ExportNamedDeclaration = {
     type: "ExportNamedDeclaration",
     declaration,
     specifiers,
     source,
+    attributes,
   };
   const defs = NODE_FIELDS.ExportNamedDeclaration;
   validate(defs.declaration, node, "declaration", declaration, 1);
   validate(defs.specifiers, node, "specifiers", specifiers, 1);
   validate(defs.source, node, "source", source, 1);
+  validate(defs.attributes, node, "attributes", attributes, 1);
   return node;
 }
 export function exportSpecifier(
@@ -972,15 +978,18 @@ export function importDeclaration(
     t.ImportSpecifier | t.ImportDefaultSpecifier | t.ImportNamespaceSpecifier
   >,
   source: t.StringLiteral,
+  attributes: Array<t.ImportAttribute> = [],
 ): t.ImportDeclaration {
   const node: t.ImportDeclaration = {
     type: "ImportDeclaration",
     specifiers,
     source,
+    attributes,
   };
   const defs = NODE_FIELDS.ImportDeclaration;
   validate(defs.specifiers, node, "specifiers", specifiers, 1);
   validate(defs.source, node, "source", source, 1);
+  validate(defs.attributes, node, "attributes", attributes, 1);
   return node;
 }
 export function importDefaultSpecifier(
@@ -1544,7 +1553,7 @@ export function declareExportDeclaration(
     t.ExportSpecifier | t.ExportNamespaceSpecifier
   > | null = null,
   source: t.StringLiteral | null = null,
-  attributes: Array<t.ImportAttribute> | null = null,
+  attributes: Array<t.ImportAttribute> = [],
 ): t.DeclareExportDeclaration {
   const node: t.DeclareExportDeclaration = {
     type: "DeclareExportDeclaration",
@@ -1562,7 +1571,7 @@ export function declareExportDeclaration(
 }
 export function declareExportAllDeclaration(
   source: t.StringLiteral,
-  attributes: Array<t.ImportAttribute> | null = null,
+  attributes: Array<t.ImportAttribute> = [],
 ): t.DeclareExportAllDeclaration {
   const node: t.DeclareExportAllDeclaration = {
     type: "DeclareExportAllDeclaration",

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -1551,7 +1551,7 @@ defineType("ClassDeclaration", {
 
 export const importAttributes = {
   attributes: {
-    optional: true,
+    default: [] as [],
     validate: arrayOfType("ImportAttribute"),
   },
   assertions: {
@@ -1562,7 +1562,7 @@ export const importAttributes = {
 };
 
 defineType("ExportAllDeclaration", {
-  builder: ["source"],
+  builder: ["source", "attributes"],
   visitor: ["source", "attributes", "assertions"],
   aliases: [
     "Statement",
@@ -1599,7 +1599,7 @@ defineType("ExportDefaultDeclaration", {
 });
 
 defineType("ExportNamedDeclaration", {
-  builder: ["declaration", "specifiers", "source"],
+  builder: ["declaration", "specifiers", "source", "attributes"],
   visitor: process.env.BABEL_8_BREAKING
     ? ["declaration", "specifiers", "source", "attributes"]
     : ["declaration", "specifiers", "source", "attributes", "assertions"],
@@ -1771,7 +1771,7 @@ defineType("ForOfStatement", {
 });
 
 defineType("ImportDeclaration", {
-  builder: ["specifiers", "source"],
+  builder: ["specifiers", "source", "attributes"],
   visitor: process.env.BABEL_8_BREAKING
     ? ["specifiers", "source", "attributes"]
     : ["specifiers", "source", "attributes", "assertions"],


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Added `attributes` to the builder signature of `importDeclaration`, `exportAllDeclaration` and `exportNamedDeclaration`
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we add `attributes` to the builder signature of `importDeclaration`, `exportAllDeclaration` and `exportNamedDeclaration` as the import attributes are part of ES2025 and most modern engines have already migrated from `assertions` to `attributes`.