### PR TITLE
Do not mark OptionalMemberExpresion as LVal

### DIFF
--- a/packages/babel-plugin-proposal-destructuring-private/src/util.ts
+++ b/packages/babel-plugin-proposal-destructuring-private/src/util.ts
@@ -161,6 +161,7 @@ type StackItem = {
     | t.PatternLike
     | t.ObjectProperty
     | t.TSParameterProperty
+    | t.OptionalMemberExpression
     | null;
   index: number;
   depth: number;
@@ -179,9 +180,18 @@ type StackItem = {
  * @param visitor
  */
 export function* traversePattern(
-  root: t.LVal | t.PatternLike | t.TSParameterProperty,
+  root:
+    | t.LVal
+    | t.PatternLike
+    | t.TSParameterProperty
+    | t.OptionalMemberExpression,
   visitor: (
-    node: t.LVal | t.PatternLike | t.TSParameterProperty | t.ObjectProperty,
+    node:
+      | t.LVal
+      | t.PatternLike
+      | t.TSParameterProperty
+      | t.ObjectProperty
+      | t.OptionalMemberExpression,
     index: number,
     depth: number,
   ) => Generator<any, void, any>,
@@ -231,7 +241,9 @@ export function* traversePattern(
   }
 }
 
-export function hasPrivateKeys(pattern: t.LVal | t.PatternLike) {
+export function hasPrivateKeys(
+  pattern: t.LVal | t.PatternLike | t.OptionalMemberExpression,
+) {
   let result = false;
   traversePattern(pattern, function* (node) {
     if (isObjectProperty(node) && isPrivateName(node.key)) {

--- a/packages/babel-plugin-proposal-do-expressions/src/index.ts
+++ b/packages/babel-plugin-proposal-do-expressions/src/index.ts
@@ -453,7 +453,7 @@ export default declare(api => {
     }
 
     function flattenLVal(
-      path: NodePath<t.LVal | t.PatternLike>,
+      path: NodePath<t.LVal | t.PatternLike | t.OptionalMemberExpression>,
       init: t.Expression | null | undefined,
       declare: "var" | "let" | "const" | "using" | "await using" | null,
     ): t.Statement[] {

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -315,7 +315,7 @@ export interface ArrayExpression extends BaseNode {
 export interface AssignmentExpression extends BaseNode {
   type: "AssignmentExpression";
   operator: string;
-  left: LVal;
+  left: LVal | OptionalMemberExpression;
   right: Expression;
 }
 
@@ -2472,7 +2472,6 @@ export type LVal =
   | AssignmentPattern
   | ArrayPattern
   | ObjectPattern
-  | OptionalMemberExpression
   | TSParameterProperty
   | TSAsExpression
   | TSSatisfiesExpression

--- a/packages/babel-types/src/builders/generated/lowercase.ts
+++ b/packages/babel-types/src/builders/generated/lowercase.ts
@@ -39,7 +39,7 @@ export function arrayExpression(
 }
 export function assignmentExpression(
   operator: string,
-  left: t.LVal,
+  left: t.LVal | t.OptionalMemberExpression,
   right: t.Expression,
 ): t.AssignmentExpression {
   const node: t.AssignmentExpression = {

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -72,7 +72,7 @@ defineType("AssignmentExpression", {
     left: {
       validate:
         !process.env.BABEL_8_BREAKING && !process.env.BABEL_TYPES_8_BREAKING
-          ? assertNodeType("LVal")
+          ? assertNodeType("LVal", "OptionalMemberExpression")
           : assertNodeType(
               "Identifier",
               "MemberExpression",
@@ -336,6 +336,7 @@ defineType("ForInStatement", {
               "TSSatisfiesExpression",
               "TSTypeAssertion",
               "TSNonNullExpression",
+              "OptionalMemberExpression",
             ),
     },
     right: {
@@ -2213,7 +2214,8 @@ defineType("ExportNamespaceSpecifier", {
 defineType("OptionalMemberExpression", {
   builder: ["object", "property", "computed", "optional"],
   visitor: ["object", "property"],
-  aliases: ["Expression", "LVal"],
+  // todo: Add OptionalMemberExpression to LVal when optional-chaining-assign reaches stage 4
+  aliases: ["Expression"],
   fields: {
     object: {
       validate: assertNodeType("Expression"),

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -336,7 +336,6 @@ defineType("ForInStatement", {
               "TSSatisfiesExpression",
               "TSTypeAssertion",
               "TSNonNullExpression",
-              "OptionalMemberExpression",
             ),
     },
     right: {

--- a/packages/babel-types/src/validators/generated/index.ts
+++ b/packages/babel-types/src/validators/generated/index.ts
@@ -3230,7 +3230,6 @@ export function isLVal(
     case "AssignmentPattern":
     case "ArrayPattern":
     case "ObjectPattern":
-    case "OptionalMemberExpression":
     case "TSParameterProperty":
     case "TSAsExpression":
     case "TSSatisfiesExpression":


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/17430, fixes #17434
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we remove the `OptionalMemberExpression` from the `LVal` alias. The `left` of the AssignmentExpression still allows `OptionalMemberExpression`, so the builder usage and the internal typings are generally not affected.

This PR partially reverts https://github.com/babel/babel/pull/17391. 