### PR TITLE
[babel 7] Make `operator` param in `t.tsTypeOperator` optional

### DIFF
--- a/packages/babel-types/src/builders/generated/lowercase.ts
+++ b/packages/babel-types/src/builders/generated/lowercase.ts
@@ -3040,7 +3040,7 @@ export function tsParenthesizedType(
 export { tsParenthesizedType as tSParenthesizedType };
 export function tsTypeOperator(
   typeAnnotation: t.TSType,
-  operator: string,
+  operator: string = "keyof",
 ): t.TSTypeOperator {
   const node: t.TSTypeOperator = {
     type: "TSTypeOperator",

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -357,6 +357,10 @@ defineType("TSTypeOperator", {
       validate: process.env.BABEL_8_BREAKING
         ? assertOneOf("keyof", "readonly", "unique")
         : assertValueType("string"),
+      // "keyof" is not a good default, but as this field is required better
+      // pick one. We need it for backwards compatibility with older versions
+      // of Babel 7.
+      default: process.env.BABEL_8_BREAKING ? undefined : "keyof",
     },
     typeAnnotation: validateType("TSType"),
   },


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Fixes compatibility with [this code](https://github.com/sanity-io/sanity/blob/fd2aa4c9d25018ba66ada5b13d1e51b0d6f0a0dd/packages/%40sanity/codegen/src/typescript/typeGenerator.ts#L105-L106), which was the only possible way of using `t.tsTypeOperator` before that https://github.com/babel/babel/pull/17009 was released.