### PR TITLE
[babel 8] Add `@types/jsesc` as a dep of `@babel/generator`

### DIFF
--- a/packages/babel-generator/package.json
+++ b/packages/babel-generator/package.json
@@ -23,6 +23,7 @@
     "@babel/types": "workspace:^",
     "@jridgewell/gen-mapping": "^0.3.12",
     "@jridgewell/trace-mapping": "^0.3.28",
+    "@types/jsesc": "condition:BABEL_8_BREAKING ? ^2.5.0 :",
     "jsesc": "^3.0.2"
   },
   "devDependencies": {
@@ -30,7 +31,6 @@
     "@babel/helper-fixtures": "workspace:^",
     "@babel/plugin-transform-typescript": "workspace:^",
     "@jridgewell/sourcemap-codec": "^1.5.3",
-    "@types/jsesc": "^2.5.0",
     "charcodes": "^0.2.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,7 +611,7 @@ __metadata:
     "@jridgewell/gen-mapping": "npm:^0.3.12"
     "@jridgewell/sourcemap-codec": "npm:^1.5.3"
     "@jridgewell/trace-mapping": "npm:^0.3.28"
-    "@types/jsesc": "npm:^2.5.0"
+    "@types/jsesc": "condition:BABEL_8_BREAKING ? ^2.5.0 :"
     charcodes: "npm:^0.2.0"
     jsesc: "npm:^3.0.2"
   languageName: unknown
@@ -5896,10 +5896,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsesc@npm:^2.5.0":
+"@types/jsesc-BABEL_8_BREAKING-true@npm:@types/jsesc@^2.5.0":
   version: 2.5.1
   resolution: "@types/jsesc@npm:2.5.1"
   checksum: 10/25407775ed621790d2eec0cc51e194bd0d67a82e39204fd9748899c249ef965e17d9e6560f6c658773714f6d45a259465f3639790bb55750ebb168ee23801596
+  languageName: node
+  linkType: hard
+
+"@types/jsesc@condition:BABEL_8_BREAKING ? ^2.5.0 :":
+  version: 0.0.0-condition-345ae2
+  resolution: "@types/jsesc@condition:BABEL_8_BREAKING?^2.5.0:#345ae2"
+  dependencies:
+    "@types/jsesc-BABEL_8_BREAKING-true": "npm:@types/jsesc@^2.5.0"
+  checksum: 10/dfb6b40a8486458599876d46b3eacfa49a08145369ebac1a9352df73307a9713652af1ea75e1aea7ad7ce43000175e7c967ffc79c983762150f185185470855a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Error found while trying to move Jest to Babel 8. We reference jsesc in the generated files.