### PR TITLE
Update `Hub#buildError` type

### DIFF
--- a/packages/babel-traverse/src/hub.ts
+++ b/packages/babel-traverse/src/hub.ts
@@ -5,7 +5,7 @@ export interface HubInterface {
   getCode(): string | void;
   getScope(): Scope | void;
   addHelper(name: string): any;
-  buildError(node: Node, msg: string, Error: new () => Error): Error;
+  buildError(node: Node, msg: string, Error: new (msg: string) => Error): Error;
 }
 
 export default class Hub implements HubInterface {
@@ -17,7 +17,11 @@ export default class Hub implements HubInterface {
     throw new Error("Helpers are not supported by the default hub.");
   }
 
-  buildError(node: Node, msg: string, Error = TypeError): Error {
+  buildError(
+    node: Node,
+    msg: string,
+    Error: new (msg: string) => Error = TypeError,
+  ): Error {
     return new Error(msg);
   }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I'm not sure about why TS isn't complaining in our repo, but it generates `.d.ts` file that cause typechecking for Babel consumers to break if whey don't have `skipLibCheck`.

TS playground (Hub is before this PR, Hub2 is after): https://www.typescriptlang.org/play/?#code/JYOwLgpgTgZghgYwgAgBIFcBGBJc15LIDeAUMucgOYRgDCA9gCYQAUAlAFzIDOYUolZAB9kAN3rBGAbjIVqYAMoJ6AB1acxE6bPJxGjVBAA2aqCxBwAthC69+IShrggAnjIrJM6YEcYBRKCh6MxAmG2QAOTCAGmRLbkpbPgFYgKCoLhAIAHdkdmQAXgA+ZDTgjTKoGQBfEmYEIzgoFAa4bm40LGRgSxUjCGtwDowcPFhEFFIPeQZmdi5xSXc5GiVVdQWtZd19QxNoec0lnU9vX0rzMK4o5lj4xJ5kh1TA4IB+LgAVFzVKhhA7OgEGBylxKjUSHUIK1mshWu1OpgAEzdXr9QZgYZYXCQcaEKYrOhhQ6LbTTVbKNQkrYnPQGYymanHDxeHz+V4hK6RGJxBJJeyUF7pD7ILK5Fj3fkCNiFEqVCocmpAA