### PR TITLE
TypeCheck `.d.ts` file with `strict: true`

### DIFF
--- a/packages/babel-parser/src/plugins/jsx/xhtml.ts
+++ b/packages/babel-parser/src/plugins/jsx/xhtml.ts
@@ -1,7 +1,4 @@
-const entities: {
-  __proto__: null;
-  [name: string]: string;
-} = {
+const entities: { [name: string]: string } = {
   __proto__: null,
   quot: "\u0022",
   amp: "&",

--- a/packages/babel-parser/src/types.ts
+++ b/packages/babel-parser/src/types.ts
@@ -201,7 +201,7 @@ export interface Identifier extends PatternBase {
   // @deprecated
   __clone(): Identifier;
   // TypeScript only. Used in case of an optional parameter.
-  optional?: boolean | null;
+  optional?: boolean;
 }
 // | Placeholder<"Identifier">;
 
@@ -1015,7 +1015,7 @@ export interface OptClassDeclaration
     HasDecorators {
   type: "ClassDeclaration";
   // TypeScript only
-  abstract?: boolean | null;
+  abstract?: boolean;
 }
 
 export interface ClassDeclaration extends OptClassDeclaration {
@@ -1502,8 +1502,8 @@ export interface TSParameterProperty extends HasDecorators {
   type: "TSParameterProperty";
   // At least one of `accessibility` or `readonly` must be set.
   accessibility?: Accessibility | null;
-  readonly?: boolean | null;
-  override?: boolean | null;
+  readonly?: boolean;
+  override?: boolean;
   parameter: Identifier | AssignmentPattern;
   // For TS-ESLint
   static?: false;

--- a/packages/babel-traverse/src/hub.ts
+++ b/packages/babel-traverse/src/hub.ts
@@ -5,7 +5,7 @@ export interface HubInterface {
   getCode(): string | void;
   getScope(): Scope | void;
   addHelper(name: string): any;
-  buildError(node: Node, msg: string, Error: new () => Error): Error;
+  buildError(node: Node, msg: string, Error: new (msg: string) => Error): Error;
 }
 
 export default class Hub implements HubInterface {
@@ -17,7 +17,11 @@ export default class Hub implements HubInterface {
     throw new Error("Helpers are not supported by the default hub.");
   }
 
-  buildError(node: Node, msg: string, Error = TypeError): Error {
+  buildError(
+    node: Node,
+    msg: string,
+    Error: new (msg: string) => Error = TypeError,
+  ): Error {
     return new Error(msg);
   }
 }

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -367,10 +367,10 @@ type Trav<
   : never;
 
 type ToNodePath<T> =
-  T extends Array<t.Node | null | undefined>
-    ? Array<NodePath<T[number]>>
-    : T extends t.Node | null | undefined
-      ? NodePath<T>
+  T extends Array<(infer U extends t.Node) | null | undefined>
+    ? Array<NodePath<U> | null | undefined>
+    : T extends (infer U extends t.Node) | null | undefined
+      ? NodePath<U> | null | undefined
       : never;
 
 function get<T extends NodePath, K extends keyof T["node"]>(
@@ -378,10 +378,10 @@ function get<T extends NodePath, K extends keyof T["node"]>(
   key: K,
   context?: boolean | TraversalContext,
 ): T extends any
-  ? T["node"][K] extends Array<t.Node | null | undefined>
-    ? Array<NodePath<T["node"][K][number]>>
-    : T["node"][K] extends t.Node | null | undefined
-      ? NodePath<T["node"][K]>
+  ? T["node"][K] extends Array<(infer U extends t.Node) | null | undefined>
+    ? Array<NodePath<U> | null | undefined>
+    : T["node"][K] extends (infer U extends t.Node) | null | undefined
+      ? NodePath<U> | null | undefined
       : never
   : never;
 

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -63,7 +63,7 @@ const NodePath_Final = class NodePath {
   @bit(SHOULD_SKIP) accessor shouldSkip = false;
 
   skipKeys: Record<string, boolean> | null = null;
-  parentPath: NodePath_Final | null = null;
+  parentPath: NodePath_Final = null;
   container: t.Node | Array<t.Node> | null = null;
   listKey: string | null = null;
   key: string | number | null = null;
@@ -444,10 +444,11 @@ interface NodePath<T extends t.Node>
     NodePathOverwrites {
   type: T["type"] | null;
   node: T;
-  parent: t.ParentMaps[T["type"]];
-  parentPath: t.ParentMaps[T["type"]] extends null
-    ? null
-    : NodePath_Final<t.ParentMaps[T["type"]]> | null;
+  // .parent is only null for File nodes, which are not traversed by @babel/traverse
+  // You can technically create a path that contains one, but it's so rare that
+  // we can ignore it to avoid having non-null assertions everywhere.
+  parent: NonNullable<t.ParentMaps[T["type"]]>;
+  parentPath: NodePath_Final<NonNullable<t.ParentMaps[T["type"]]>>;
 }
 
 // This trick is necessary so that

--- a/scripts/generators/tsconfig.js
+++ b/scripts/generators/tsconfig.js
@@ -352,6 +352,7 @@ maybeWriteFile(
         extends: ["./tsconfig.base.json", "./tsconfig.paths.json"],
         compilerOptions: {
           skipLibCheck: false,
+          strict: true,
         },
         include: ["./lib/libdom-minimal.d.ts", "dts/**/*.d.ts"],
         references: Array.from(new Set(projectsFolders.values()))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "./tsconfig.paths.json"
   ],
   "compilerOptions": {
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "strict": true
   },
   "include": [
     "./lib/libdom-minimal.d.ts",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

We're not ready yet to enable `strict: true` on the monorepo, but we should at least make sure that our `.d.ts` files work with `strict: true` to avoid problems for our consumers.