### PR TITLE
chore: fix various typos across codebase

### DIFF
--- a/benchmark/babel-parser/real-case-ts/ts-parser.txt
+++ b/benchmark/babel-parser/real-case-ts/ts-parser.txt
@@ -2334,7 +2334,7 @@ namespace Parser {
 
     /**
      * Provides a better error message than the generic "';' expected" if possible for
-     * known common variants of a missing semicolon, such as from a mispelled names.
+     * known common variants of a missing semicolon, such as from a misspelled names.
      *
      * @param node Node preceding the expected semicolon location.
      */

--- a/packages/babel-generator/src/index.ts
+++ b/packages/babel-generator/src/index.ts
@@ -49,7 +49,7 @@ function normalizeOptions(
     }
     if (!Array.isArray((ast as any).tokens)) {
       throw new Error(
-        "`experimental_preserveFormat` requires the AST to have attatched the token of the input code. Make sure to enable the `tokens: true` parser option.",
+        "`experimental_preserveFormat` requires the AST to have attached the token of the input code. Make sure to enable the `tokens: true` parser option.",
       );
     }
   }

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -1013,17 +1013,17 @@ describe("generation", function () {
 describe("programmatic generation", function () {
   it("should add parenthesis when NullishCoalescing is used along with ||", function () {
     // https://github.com/babel/babel/issues/10260
-    const nullishCoalesc = t.logicalExpression(
+    const nullishCoalesce = t.logicalExpression(
       "??",
       t.logicalExpression("||", t.identifier("a"), t.identifier("b")),
       t.identifier("c"),
     );
-    const output = generate(nullishCoalesc).code;
+    const output = generate(nullishCoalesce).code;
     expect(output).toBe(`(a || b) ?? c`);
   });
 
   it("should add parenthesis when NullishCoalesing is used with &&", function () {
-    const nullishCoalesc = t.logicalExpression(
+    const nullishCoalesce = t.logicalExpression(
       "??",
       t.identifier("a"),
       t.logicalExpression(
@@ -1032,7 +1032,7 @@ describe("programmatic generation", function () {
         t.logicalExpression("&&", t.identifier("c"), t.identifier("d")),
       ),
     );
-    const output = generate(nullishCoalesc).code;
+    const output = generate(nullishCoalesce).code;
     expect(output).toBe(`a ?? (b && c && d)`);
   });
 

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1292,14 +1292,14 @@ function transformClass(
       ? elemDecsUseFnContext
       : elemDecsUseFnContext || version !== "2023-11");
 
-  let needsDeclaraionForClassBinding = false;
+  let needsDeclarationForClassBinding = false;
   let classDecorationsFlag = 0;
   let classDecorations: t.Expression[] = [];
   let classDecorationsId: t.Identifier;
   let computedKeyAssignments: t.AssignmentExpression[] = [];
   if (classDecorators) {
     classInitLocal = generateLetUidIdentifier(scopeParent, "initClass");
-    needsDeclaraionForClassBinding = path.isClassDeclaration();
+    needsDeclarationForClassBinding = path.isClassDeclaration();
     ({ id: classIdLocal, path } = replaceClassWithVar(path, className));
 
     path.node.decorators = null;
@@ -1996,7 +1996,7 @@ function transformClass(
     } else {
       // When there is no public class elements, we inject a temporary computed
       // field whose key will host the decorator evaluations. The field will be
-      // deleted immediately after it is defiend.
+      // deleted immediately after it is defined.
       originalClass.body.body.unshift(
         t.classProperty(
           t.sequenceExpression([
@@ -2055,7 +2055,7 @@ function transformClass(
   // into a SequenceExpression
   path.insertBefore(classAssignments.map(expr => t.expressionStatement(expr)));
 
-  if (needsDeclaraionForClassBinding) {
+  if (needsDeclarationForClassBinding) {
     const classBindingInfo = scopeParent.getBinding(classIdLocal.name);
     if (!classBindingInfo.constantViolations.length) {
       // optimization: reuse the inner class binding if the outer class binding is not mutated
@@ -2078,7 +2078,7 @@ function transformClass(
           t.variableDeclaration("let", [
             t.variableDeclarator(t.cloneNode(classIdLocal)),
           ]),
-          // needsDeclaraionForClassBinding is true ↔ node is a class declaration
+          // needsDeclarationForClassBinding is true ↔ node is a class declaration
           path.node as t.ClassDeclaration,
           t.expressionStatement(
             t.assignmentExpression(

--- a/packages/babel-helper-wrap-function/src/index.ts
+++ b/packages/babel-helper-wrap-function/src/index.ts
@@ -75,9 +75,9 @@ function classOrObjectMethod(
   let params: Array<t.Identifier | t.Pattern | t.RestElement> = [];
 
   // Errors thrown during argument evaluation must reject the resulting promise
-  const shoudlForwardParams = node.params.some(p => isPattern(p));
+  const shouldForwardParams = node.params.some(p => isPattern(p));
 
-  if (shoudlForwardParams) {
+  if (shouldForwardParams) {
     params = node.params as typeof params;
     node.params = [];
     if (!ignoreFunctionLength) {
@@ -97,7 +97,7 @@ function classOrObjectMethod(
     true,
   );
 
-  if (shoudlForwardParams) {
+  if (shouldForwardParams) {
     // return asyncToGenerator(function*() { ... }).apply(this, arguments);
     body.body = [
       returnStatement(

--- a/packages/babel-helpers/src/helpers/asyncIterator.ts
+++ b/packages/babel-helpers/src/helpers/asyncIterator.ts
@@ -70,7 +70,7 @@ function AsyncFromSyncIterator<T, TReturn = any, TNext = undefined>(s: any) {
     next: function () {
       return AsyncFromSyncIteratorContinuation<T, TReturn>(
         // Use "arguments" here for better compatibility and smaller bundle size
-        // Itentionally casting "arguments" to an array for the type of func.apply
+        // Intentionally casting "arguments" to an array for the type of func.apply
         this.n.apply(this.s, arguments as any as [] | [undefined]),
       );
     },
@@ -88,7 +88,7 @@ function AsyncFromSyncIterator<T, TReturn = any, TNext = undefined>(s: any) {
         ret.apply(
           this.s,
           // Use "arguments" here for better compatibility and smaller bundle size
-          // Itentionally casting "arguments" to an array for the type of func.apply
+          // Intentionally casting "arguments" to an array for the type of func.apply
           arguments as any as [] | [TReturn | PromiseLike<TReturn>],
         ),
       );
@@ -101,7 +101,7 @@ function AsyncFromSyncIterator<T, TReturn = any, TNext = undefined>(s: any) {
       }
       return AsyncFromSyncIteratorContinuation<T, TReturn>(
         // Use "arguments" here for better compatibility and smaller bundle size
-        // Itentionally casting "arguments" to an array for the type of func.apply
+        // Intentionally casting "arguments" to an array for the type of func.apply
         thr.apply(this.s, arguments as any as [any]),
       );
     },

--- a/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/src/util.ts
+++ b/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/src/util.ts
@@ -106,7 +106,7 @@ type ClassElementWithComputedKeySupport = Extract<
  * To avoid unconditionally compiling every public static field, we track how
  * the class is referenced during definition & static evaluation: any side
  * effect after a reference to the class can potentially define a non-writable
- * conficting property, so subsequent public static fields must be compiled.
+ * conflicting property, so subsequent public static fields must be compiled.
  * The class could be referenced using the class name in computed keys, which
  * run before static fields, or using either the class name or 'this' in static
  * fields (both public and private) and static blocks.

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/exec.js
@@ -16,6 +16,6 @@ const obj = new Obj();
 expect(() => {
   obj.call();
 
-  // Asser that this throws, but that it's not
+  // Assert that this throws, but that it's not
   // Obj.p.test's error that is thrown
 }).toThrow(TypeError)

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/input.js
@@ -16,6 +16,6 @@ const obj = new Obj();
 expect(() => {
   obj.call();
 
-  // Asser that this throws, but that it's not
+  // Assert that this throws, but that it's not
   // Obj.p.test's error that is thrown
 }).toThrow(TypeError)

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-not-defined-on-parent/output.js
@@ -19,6 +19,6 @@ const obj = new Obj();
 expect(() => {
   obj.call();
 
-  // Asser that this throws, but that it's not
+  // Assert that this throws, but that it's not
   // Obj.p.test's error that is thrown
 }).toThrow(TypeError);

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/exec.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/exec.js
@@ -22,6 +22,6 @@ const obj = new Obj();
 expect(() => {
   obj.call();
 
-  // Asser that this throws, but that it's not
+  // Assert that this throws, but that it's not
   // a gobbledygook error that is thrown
 }).toThrow(TypeError)

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/input.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/input.js
@@ -19,6 +19,6 @@ const obj = new Obj();
 expect(() => {
   obj.call();
 
-  // Asser that this throws, but that it's not
+  // Assert that this throws, but that it's not
   // a gobbledygook error that is thrown
 }).toThrow(TypeError)

--- a/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/output.js
+++ b/packages/babel-plugin-transform-classes/test/fixtures/get-set-loose/call-semantics-setter-defined-on-parent/output.js
@@ -27,6 +27,6 @@ const obj = new Obj();
 expect(() => {
   obj.call();
 
-  // Asser that this throws, but that it's not
+  // Assert that this throws, but that it's not
   // a gobbledygook error that is thrown
 }).toThrow(TypeError);

--- a/packages/babel-register/src/worker/index.cts
+++ b/packages/babel-register/src/worker/index.cts
@@ -4,9 +4,9 @@ import type { ACTIONS } from "../types.cts";
 const babel = require("./babel-core.cjs");
 import handleMessage = require("./handle-message.cjs");
 
-import workerTheads = require("worker_threads");
+import workerThreads = require("worker_threads");
 
-workerTheads.parentPort.addListener(
+workerThreads.parentPort.addListener(
   "message",
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   async ({

--- a/packages/babel-traverse/test/replacement.js
+++ b/packages/babel-traverse/test/replacement.js
@@ -306,7 +306,7 @@ describe("path/replacement", function () {
       expect(path.get("expressions.1").toString()).toBe("true");
     });
     describe("return", function () {
-      // TODO: These tests veryfy wrong behavior. It's not possible to
+      // TODO: These tests verify wrong behavior. It's not possible to
       // replace an expression with `return`, as wrapping it in a IIFE changes
       // semantics.
       // They are here because it's how @babel/traverse currently behaves, but


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  |
| License                  | MIT

## Summary

Apply consistent typographical fixes throughout the codebase, correcting misspellings in code, comments, error messages, and tests.

Tests:
- Update test code and fixtures to correct variable names (`nullishCoalesc` to `nullishCoalesce`) and spelling in comments ("Asser" → "Assert")

Chores:
- Fix misspelled identifiers and variable names (`needsDeclarationForClassBinding`, `shouldForwardParams`)
- Correct typos in comments, error messages, and string literals across various packages