### PR TITLE
Improve @babel/traverse typings

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/loop.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/loop.ts
@@ -231,7 +231,7 @@ export function wrapLoopBody(
   // TODO: Consider using a function declaration
   const [varPath] = loopPath.insertBefore(
     t.variableDeclaration("var", [t.variableDeclarator(t.identifier(id), fn)]),
-  ) as [NodePath<t.VariableDeclaration>];
+  );
 
   const bodyStmts: t.Statement[] = [];
 

--- a/packages/babel-plugin-transform-classes/src/inline-callSuper-helpers.ts
+++ b/packages/babel-plugin-transform-classes/src/inline-callSuper-helpers.ts
@@ -73,8 +73,8 @@ export default function addCallSuperHelper(file: File) {
     POSSIBLE_CONSTRUCTOR_RETURN: file.addHelper("possibleConstructorReturn"),
   });
 
-  file.path.unshiftContainer("body", [fn]);
-  file.scope.registerDeclaration(file.path.get("body.0"));
+  const [fnPath] = file.path.unshiftContainer("body", [fn]);
+  file.scope.registerDeclaration(fnPath);
 
   return t.cloneNode(id);
 }

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.ts
@@ -474,7 +474,7 @@ export default declare((api, opts: Options) => {
 
           insertionPath = insertionPath.insertAfter(
             t.variableDeclarator(argument, callExpression),
-          )[0] as NodePath<t.VariableDeclarator>;
+          )[0];
 
           path.scope.registerBinding(kind, insertionPath);
 

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -34,7 +34,22 @@ export const REMOVED = 1 << 0;
 export const SHOULD_STOP = 1 << 1;
 export const SHOULD_SKIP = 1 << 2;
 
-declare const bit: import("../../../../scripts/babel-plugin-bit-decorator/types.d.ts").BitDecorator<any>;
+declare const bit: import("../../../../scripts/babel-plugin-bit-decorator/types.d.ts").BitDecorator<
+  NodePath_Final<t.Node>
+>;
+
+export type NodePaths<T extends t.Node | t.Node[]> = T extends t.Node[]
+  ? { [K in keyof T]: NodePath_Final<Extract<T[K], t.Node>> }
+  : T extends t.Node
+    ? [NodePath_Final<T>]
+    : never;
+
+export type NodeListType<N, K extends keyof N> =
+  N[K] extends Array<infer P extends t.Node> ? P : never;
+
+export type NodeOrNodeList<T extends t.Node> = T | NodeList<T>;
+
+export type NodeList<T extends t.Node> = T[] | [T, ...T[]];
 
 const NodePath_Final = class NodePath {
   constructor(hub: HubInterface, parent: t.Node | null) {
@@ -115,7 +130,7 @@ const NodePath_Final = class NodePath {
     return this.isScope() ? new Scope(this) : scope;
   }
 
-  setData(key: string | symbol, val: any): any {
+  setData<T>(key: string | symbol, val: T): T {
     if (this.data == null) {
       this.data = Object.create(null);
     }

--- a/packages/babel-traverse/src/path/lib/hoister.ts
+++ b/packages/babel-traverse/src/path/lib/hoister.ts
@@ -262,10 +262,8 @@ export default class PathHoister<T extends t.Node = t.Node> {
 
     this.path.replaceWith(cloneNode(uid));
 
-    // TODO: Should we use `attached.isVariableDeclaration()`?
-    return attachTo.isVariableDeclarator()
-      ? // @ts-expect-error TS cannot refine the type of `attached`
-        attached.get("init")
+    return attached.isVariableDeclarator()
+      ? attached.get("init")
       : attached.get("declarations.0.init");
   }
 }

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -23,7 +23,12 @@ import {
 } from "@babel/types";
 import type * as t from "@babel/types";
 import type Scope from "../scope/index.ts";
-import type { NodeList, NodeOrNodeList, NodeListType, NodePaths } from "./index.ts";
+import type {
+  NodeList,
+  NodeOrNodeList,
+  NodeListType,
+  NodePaths,
+} from "./index.ts";
 
 /**
  * Insert the provided nodes before the current one.
@@ -69,8 +74,13 @@ export function insertBefore<Nodes extends NodeOrNodeList<t.Node>>(
       (!this.isExpressionStatement() ||
         (node as t.ExpressionStatement).expression != null);
 
-    const [blockPath] = this.replaceWith(blockStatement(shouldInsertCurrentNode ? [node] : []));
-    return blockPath.unshiftContainer("body", nodes as t.Statement[]) as NodePaths<Nodes>;
+    const [blockPath] = this.replaceWith(
+      blockStatement(shouldInsertCurrentNode ? [node] : []),
+    );
+    return blockPath.unshiftContainer(
+      "body",
+      nodes as t.Statement[],
+    ) as NodePaths<Nodes>;
   } else {
     throw new Error(
       "We don't know what to do with this node type. " +
@@ -118,14 +128,22 @@ export function _containerInsertBefore<Nodes extends NodeList<t.Node>>(
   this: NodePath,
   nodes: Nodes,
 ): NodePaths<Nodes> {
-  return _containerInsert.call(this, this.key as number, nodes) as NodePaths<Nodes>;
+  return _containerInsert.call(
+    this,
+    this.key as number,
+    nodes,
+  ) as NodePaths<Nodes>;
 }
 
 export function _containerInsertAfter<Nodes extends NodeList<t.Node>>(
   this: NodePath,
   nodes: Nodes,
 ): NodePaths<Nodes> {
-  return _containerInsert.call(this, (this.key as number) + 1, nodes) as NodePaths<Nodes>;
+  return _containerInsert.call(
+    this,
+    (this.key as number) + 1,
+    nodes,
+  ) as NodePaths<Nodes>;
 }
 
 const last = <T>(arr: T[]) => arr[arr.length - 1];
@@ -256,8 +274,13 @@ export function insertAfter<Nodes extends NodeOrNodeList<t.Node>>(
       (!this.isExpressionStatement() ||
         (node as t.ExpressionStatement).expression != null);
 
-    const [blockPath] = this.replaceWith(blockStatement(shouldInsertCurrentNode ? [node] : []));
-    return blockPath.pushContainer("body", nodes as t.Statement[]) as NodePaths<Nodes>;
+    const [blockPath] = this.replaceWith(
+      blockStatement(shouldInsertCurrentNode ? [node] : []),
+    );
+    return blockPath.pushContainer(
+      "body",
+      nodes as t.Statement[],
+    ) as NodePaths<Nodes>;
   } else {
     throw new Error(
       "We don't know what to do with this node type. " +
@@ -329,7 +352,7 @@ export function _verifyNodeList<N extends t.Node | null>(
 }
 
 type NodeKeyOfArrays<N extends t.Node> = {
-    [P in string & keyof N]-?: N[P] extends Array<t.Node | null> ? P : never;
+  [P in string & keyof N]-?: N[P] extends Array<t.Node | null> ? P : never;
 }[string & keyof N];
 
 export function unshiftContainer<

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -57,7 +57,7 @@ export function insertBefore<Nodes extends NodeOrNodeList<t.Node>>(
     isExportNamedDeclaration(parent) ||
     (parentPath.isExportDefaultDeclaration() && this.isDeclaration())
   ) {
-    return parentPath.insertBefore(nodes) as NodePaths<Nodes>;
+    return parentPath.insertBefore(nodes as Nodes);
   } else if (
     (this.isNodeType("Expression") && !this.isJSXElement()) ||
     (parentPath.isForStatement() && this.key === "init")
@@ -211,6 +211,7 @@ export function insertAfter<Nodes extends NodeOrNodeList<t.Node>>(
         //     A;        -> A; B // No semicolon! It could break if followed by [!
         return isExpression(node) ? expressionStatement(node) : node;
       }),
+      // todo: this cast is unsound, we wrap some expression nodes in expressionStatement but never unwrap them in the return values.
     ) as NodePaths<Nodes>;
   } else if (
     (this.isNodeType("Expression") &&
@@ -228,6 +229,8 @@ export function insertAfter<Nodes extends NodeOrNodeList<t.Node>>(
 
         self.replaceWith(callExpression(arrowFunctionExpression([], node), []));
         (self.get("callee.body") as NodePath<t.Expression>).insertAfter(nodes);
+        // todo: this cast is unsound, we wrap nodes in the IIFE but never unwrap them in the return values.
+        // consider just returning the insertAfter result.
         return [self] as NodePaths<Nodes>;
       }
 

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -23,15 +23,16 @@ import {
 } from "@babel/types";
 import type * as t from "@babel/types";
 import type Scope from "../scope/index.ts";
+import type { NodeList, NodeOrNodeList, NodeListType, NodePaths } from "./index.ts";
 
 /**
  * Insert the provided nodes before the current one.
  */
 
-export function insertBefore(
+export function insertBefore<Nodes extends NodeOrNodeList<t.Node>>(
   this: NodePath,
-  nodes_: t.Node | t.Node[],
-): NodePath[] {
+  nodes_: Nodes,
+): NodePaths<Nodes> {
   _assertUnremoved.call(this);
 
   const nodes = _verifyNodeList.call(this, nodes_);
@@ -51,7 +52,7 @@ export function insertBefore(
     isExportNamedDeclaration(parent) ||
     (parentPath.isExportDefaultDeclaration() && this.isDeclaration())
   ) {
-    return parentPath.insertBefore(nodes);
+    return parentPath.insertBefore(nodes) as NodePaths<Nodes>;
   } else if (
     (this.isNodeType("Expression") && !this.isJSXElement()) ||
     (parentPath.isForStatement() && this.key === "init")
@@ -60,7 +61,7 @@ export function insertBefore(
     // @ts-expect-error todo(flow->ts): check that nodes is an array of statements
     return this.replaceExpressionWithStatements(nodes);
   } else if (Array.isArray(this.container)) {
-    return _containerInsertBefore.call(this, nodes);
+    return _containerInsertBefore.call(this, nodes) as NodePaths<Nodes>;
   } else if (this.isStatementOrBlock()) {
     const node = this.node as t.Statement;
     const shouldInsertCurrentNode =
@@ -68,12 +69,8 @@ export function insertBefore(
       (!this.isExpressionStatement() ||
         (node as t.ExpressionStatement).expression != null);
 
-    this.replaceWith(blockStatement(shouldInsertCurrentNode ? [node] : []));
-    return (this as NodePath<t.BlockStatement>).unshiftContainer(
-      "body",
-      // @ts-expect-error Fixme: refine nodes to t.BlockStatement["body"] when this is a BlockStatement path
-      nodes,
-    );
+    const [blockPath] = this.replaceWith(blockStatement(shouldInsertCurrentNode ? [node] : []));
+    return blockPath.unshiftContainer("body", nodes as t.Statement[]) as NodePaths<Nodes>;
   } else {
     throw new Error(
       "We don't know what to do with this node type. " +
@@ -82,20 +79,20 @@ export function insertBefore(
   }
 }
 
-export function _containerInsert<N extends t.Node>(
+export function _containerInsert<Nodes extends NodeList<t.Node>>(
   this: NodePath,
   from: number,
-  nodes: N[],
-): NodePath<N>[] {
+  nodes: Nodes,
+): NodePaths<Nodes> {
   updateSiblingKeys.call(this, from, nodes.length);
 
-  const paths: NodePath<N>[] = [];
+  const paths: NodePath[] = [];
 
   // @ts-expect-error todo(flow->ts): this.container could be a NodePath
   this.container.splice(from, 0, ...nodes);
   for (let i = 0; i < nodes.length; i++) {
     const to = from + i;
-    const path = this.getSibling(to) as NodePath<N>;
+    const path = this.getSibling(to);
     paths.push(path);
 
     if (this.context?.queue) {
@@ -114,21 +111,21 @@ export function _containerInsert<N extends t.Node>(
     }
   }
 
-  return paths;
+  return paths as NodePaths<Nodes>;
 }
 
-export function _containerInsertBefore<N extends t.Node>(
+export function _containerInsertBefore<Nodes extends NodeList<t.Node>>(
   this: NodePath,
-  nodes: N[],
-) {
-  return _containerInsert.call(this, this.key as number, nodes);
+  nodes: Nodes,
+): NodePaths<Nodes> {
+  return _containerInsert.call(this, this.key as number, nodes) as NodePaths<Nodes>;
 }
 
-export function _containerInsertAfter<N extends t.Node>(
+export function _containerInsertAfter<Nodes extends NodeList<t.Node>>(
   this: NodePath,
-  nodes: N[],
-) {
-  return _containerInsert.call(this, (this.key as number) + 1, nodes);
+  nodes: Nodes,
+): NodePaths<Nodes> {
+  return _containerInsert.call(this, (this.key as number) + 1, nodes) as NodePaths<Nodes>;
 }
 
 const last = <T>(arr: T[]) => arr[arr.length - 1];
@@ -166,10 +163,10 @@ function isAlmostConstantAssignment(
  * expression, ensure that the completion record is correct by pushing the current node.
  */
 
-export function insertAfter(
+export function insertAfter<Nodes extends NodeOrNodeList<t.Node>>(
   this: NodePath,
-  nodes_: t.Node | t.Node[],
-): NodePath[] {
+  nodes_: Nodes,
+): NodePaths<Nodes> {
   _assertUnremoved.call(this);
 
   if (this.isSequenceExpression()) {
@@ -196,7 +193,7 @@ export function insertAfter(
         //     A;        -> A; B // No semicolon! It could break if followed by [!
         return isExpression(node) ? expressionStatement(node) : node;
       }),
-    );
+    ) as NodePaths<Nodes>;
   } else if (
     (this.isNodeType("Expression") &&
       !this.isJSXElement() &&
@@ -213,7 +210,7 @@ export function insertAfter(
 
         self.replaceWith(callExpression(arrowFunctionExpression([], node), []));
         (self.get("callee.body") as NodePath<t.Expression>).insertAfter(nodes);
-        return [self];
+        return [self] as NodePaths<Nodes>;
       }
 
       if (isHiddenInSequenceExpression(self)) {
@@ -251,7 +248,7 @@ export function insertAfter(
     // @ts-expect-error todo(flow->ts): check that nodes is an array of statements
     return this.replaceExpressionWithStatements(nodes);
   } else if (Array.isArray(this.container)) {
-    return _containerInsertAfter.call(this, nodes);
+    return _containerInsertAfter.call(this, nodes) as NodePaths<Nodes>;
   } else if (this.isStatementOrBlock()) {
     const node = this.node as t.Statement;
     const shouldInsertCurrentNode =
@@ -259,9 +256,8 @@ export function insertAfter(
       (!this.isExpressionStatement() ||
         (node as t.ExpressionStatement).expression != null);
 
-    this.replaceWith(blockStatement(shouldInsertCurrentNode ? [node] : []));
-    // @ts-expect-error Fixme: refine nodes to t.BlockStatement["body"] when this is a BlockStatement path
-    return this.pushContainer("body", nodes);
+    const [blockPath] = this.replaceWith(blockStatement(shouldInsertCurrentNode ? [node] : []));
+    return blockPath.pushContainer("body", nodes as t.Statement[]) as NodePaths<Nodes>;
   } else {
     throw new Error(
       "We don't know what to do with this node type. " +
@@ -295,10 +291,10 @@ export function updateSiblingKeys(
   }
 }
 
-export function _verifyNodeList<N extends t.Node>(
+export function _verifyNodeList<N extends t.Node | null>(
   this: NodePath,
   nodes: N | N[],
-): N[] {
+) {
   if (!nodes) {
     return [];
   }
@@ -332,75 +328,55 @@ export function _verifyNodeList<N extends t.Node>(
   return nodes;
 }
 
-export function unshiftContainer<N extends t.Node, K extends keyof N & string>(
-  this: NodePath<N>,
-  listKey: K,
-  nodes: N[K] extends (infer E)[]
-    ? E | E[]
-    : // todo: refine to t.Node[]
-      //  ? E extends t.Node
-      //    ? E | E[]
-      //    : never
-      never,
-) {
-  // todo: NodePaths<Nodes>
+type NodeKeyOfArrays<N extends t.Node> = {
+    [P in string & keyof N]-?: N[P] extends Array<t.Node | null> ? P : never;
+}[string & keyof N];
+
+export function unshiftContainer<
+  N extends t.Node,
+  K extends NodeKeyOfArrays<N>,
+  Nodes extends NodeOrNodeList<NodeListType<N, K>>,
+>(this: NodePath<N>, listKey: K, nodes: Nodes): NodePaths<Nodes> {
   _assertUnremoved.call(this);
 
-  // @ts-expect-error fixme
-  nodes = _verifyNodeList.call(this, nodes);
+  const verifiedNodes = _verifyNodeList.call(this, nodes);
 
   // get the first path and insert our nodes before it, if it doesn't exist then it
   // doesn't matter, our nodes will be inserted anyway
+  const container = (this.node as N)[listKey] as t.Node[];
   const path = NodePath.get({
     parentPath: this,
     parent: this.node,
-    container: (this.node as N)[listKey] as unknown as t.Node | t.Node[],
+    container,
     listKey,
     key: 0,
   }).setContext(this.context);
 
-  return _containerInsertBefore.call(
-    path,
-    // @ts-expect-error typings needed to narrow down nodes as t.Node[]
-    nodes,
-  );
+  return _containerInsertBefore.call(path, verifiedNodes) as NodePaths<Nodes>;
 }
 
 export function pushContainer<
-  P extends NodePath,
-  K extends string & keyof P["node"],
->(
-  this: P,
-  listKey: K,
-  nodes: P["node"][K] extends (infer E)[]
-    ? E | E[]
-    : // todo: refine to t.Node[]
-      //  ? E extends t.Node
-      //    ? E | E[]
-      //    : never
-      never,
-) {
+  N extends t.Node,
+  K extends NodeKeyOfArrays<N>,
+  Nodes extends NodeOrNodeList<NodeListType<N, K>>,
+>(this: NodePath<N>, listKey: K, nodes: Nodes): NodePaths<Nodes> {
   _assertUnremoved.call(this);
 
-  const verifiedNodes = _verifyNodeList.call(
-    this,
-    // @ts-expect-error refine typings
-    nodes,
-  );
+  const verifiedNodes = _verifyNodeList.call(this, nodes);
 
   // get an invisible path that represents the last node + 1 and replace it with our
   // nodes, effectively inlining it
 
-  const container = (this.node as P["node"])[listKey] as t.Node[];
+  const container = (this.node as N)[listKey] as t.Node[];
   const path = NodePath.get({
     parentPath: this,
     parent: this.node,
-    container: container as unknown as t.Node | t.Node[],
+    container,
     listKey,
     key: container.length,
   }).setContext(this.context);
 
-  return path.replaceWithMultiple(verifiedNodes);
+  return path.replaceWithMultiple(verifiedNodes) as NodePaths<Nodes>;
 }
 
 import PathHoister from "./lib/hoister.ts" with { if: "!process.env.BABEL_8_BREAKING && !USE_ESM" };
@@ -410,11 +386,11 @@ if (!process.env.BABEL_8_BREAKING && !USE_ESM) {
    * referencing it.
    */
   // eslint-disable-next-line no-restricted-globals
-  exports.hoist = function hoist<T extends t.Node>(
-    this: NodePath<T>,
+  exports.hoist = function hoist<N extends t.Node>(
+    this: NodePath<N>,
     scope: Scope = this.scope,
   ) {
-    const hoister = new PathHoister<T>(this, scope);
+    const hoister = new PathHoister<N>(this, scope);
     return hoister.run();
   };
 }

--- a/packages/babel-traverse/src/path/replacement.ts
+++ b/packages/babel-traverse/src/path/replacement.ts
@@ -47,15 +47,17 @@ import { resync, setScope } from "./context.ts";
  *  - Remove the current node.
  */
 
-export function replaceWithMultiple(
+import type { NodeOrNodeList, NodePaths } from "./index.ts";
+
+export function replaceWithMultiple<Nodes extends NodeOrNodeList<t.Node>>(
   this: NodePath,
-  nodes: t.Node | t.Node[],
-): NodePath[] {
+  nodes: Nodes,
+): NodePaths<Nodes> {
   resync.call(this);
 
-  nodes = _verifyNodeList.call(this, nodes);
-  inheritLeadingComments(nodes[0], this.node);
-  inheritTrailingComments(nodes[nodes.length - 1], this.node);
+  const verifiedNodes = _verifyNodeList.call(this, nodes);
+  inheritLeadingComments(verifiedNodes[0], this.node);
+  inheritTrailingComments(verifiedNodes[verifiedNodes.length - 1], this.node);
   getCachedPaths(this)?.delete(this.node);
   this.node =
     // @ts-expect-error this.key must present in this.container


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR improves the typings of `NodePath` modification APIs in `@babel/traverse`: Namely `insertBefore`, `insertAfter`, `unshiftContainer`, `pushContainer` and `replaceWithMultiple`. Previously the return value them were general `NodePath`s, this PR introduced a few typescript mixins such that TS can infer the specific return value from the provided modification nodes. The `listKey` of `unshiftContainer` and `pushContainer` is also narrowed to those key whose value is an array of AST nodes.

Thanks to the improved typings, we can remove a few redundant type casts from their usage.