### PR TITLE
fix: allow `d` and `v` flag in `regExpLiteral` builder

### DIFF
--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -686,7 +686,7 @@ defineType("RegExpLiteral", {
               assertValueType("string"),
               Object.assign(
                 function (node, key, val) {
-                  const invalid = /[^gimsuy]/.exec(val);
+                  const invalid = /[^dgimsuvy]/.exec(val);
                   if (invalid) {
                     throw new TypeError(
                       `"${invalid[0]}" is not a valid RegExp flag`,

--- a/packages/babel-types/test/builders/core/__snapshots__/classProperty.js.snap
+++ b/packages/babel-types/test/builders/core/__snapshots__/classProperty.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`builders experimental classProperty should validate 1`] = `
+exports[`builders core classProperty should validate 1`] = `
 Object {
   "computed": false,
   "decorators": null,
@@ -18,7 +18,7 @@ Object {
 }
 `;
 
-exports[`builders experimental classProperty should validate 2`] = `
+exports[`builders core classProperty should validate 2`] = `
 Object {
   "computed": false,
   "decorators": null,

--- a/packages/babel-types/test/builders/core/__snapshots__/templateElement.js.snap
+++ b/packages/babel-types/test/builders/core/__snapshots__/templateElement.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`builders es2015 templateElement should validate 1`] = `
+exports[`builders core templateElement should validate 1`] = `
 Object {
   "tail": false,
   "type": "TemplateElement",
@@ -11,7 +11,7 @@ Object {
 }
 `;
 
-exports[`builders es2015 templateElement should validate 2`] = `
+exports[`builders core templateElement should validate 2`] = `
 Object {
   "tail": false,
   "type": "TemplateElement",
@@ -22,22 +22,22 @@ Object {
 }
 `;
 
-exports[`builders es2015 templateElement should validate 3`] = `
+exports[`builders core templateElement should validate 3`] = `
 "Property value of TemplateElement expected to have the following:
 Property raw expected type of string but got number"
 `;
 
-exports[`builders es2015 templateElement should validate 4`] = `
+exports[`builders core templateElement should validate 4`] = `
 "Property value of TemplateElement expected to have the following:
 Property cooked expected type of string but got number"
 `;
 
-exports[`builders es2015 templateElement should validate 5`] = `
+exports[`builders core templateElement should validate 5`] = `
 "Property value of TemplateElement expected to have the following:
 Property raw expected type of string but got undefined"
 `;
 
-exports[`builders es2015 templateElement should validate 6`] = `
+exports[`builders core templateElement should validate 6`] = `
 Object {
   "tail": false,
   "type": "TemplateElement",
@@ -48,7 +48,7 @@ Object {
 }
 `;
 
-exports[`builders es2015 templateElement should validate 7`] = `
+exports[`builders core templateElement should validate 7`] = `
 Object {
   "tail": false,
   "type": "TemplateElement",
@@ -59,7 +59,7 @@ Object {
 }
 `;
 
-exports[`builders es2015 templateElement should validate 8`] = `
+exports[`builders core templateElement should validate 8`] = `
 Object {
   "tail": false,
   "type": "TemplateElement",
@@ -70,11 +70,11 @@ Object {
 }
 `;
 
-exports[`builders es2015 templateElement should validate 9`] = `"Invalid raw"`;
+exports[`builders core templateElement should validate 9`] = `"Invalid raw"`;
 
-exports[`builders es2015 templateElement should validate 10`] = `"Invalid raw"`;
+exports[`builders core templateElement should validate 10`] = `"Invalid raw"`;
 
-exports[`builders es2015 templateLiteral should validate 1`] = `
+exports[`builders core templateLiteral should validate 1`] = `
 Object {
   "expressions": Array [],
   "quasis": Array [
@@ -91,7 +91,7 @@ Object {
 }
 `;
 
-exports[`builders es2015 templateLiteral should validate 2`] = `
+exports[`builders core templateLiteral should validate 2`] = `
 Object {
   "expressions": Array [
     Object {
@@ -121,16 +121,16 @@ Object {
 }
 `;
 
-exports[`builders es2015 templateLiteral should validate 3`] = `
+exports[`builders core templateLiteral should validate 3`] = `
 "Number of TemplateLiteral quasis should be exactly one more than the number of expressions.
 Expected 3 quasis but got 2"
 `;
 
-exports[`builders es2015 templateLiteral should validate 4`] = `
+exports[`builders core templateLiteral should validate 4`] = `
 "Number of TemplateLiteral quasis should be exactly one more than the number of expressions.
 Expected 1 quasis but got 2"
 `;
 
-exports[`builders es2015 templateLiteral should validate 5`] = `"Property quasis expected type of array but got object"`;
+exports[`builders core templateLiteral should validate 5`] = `"Property quasis expected type of array but got object"`;
 
-exports[`builders es2015 templateLiteral should validate 6`] = `"Property expressions expected type of array but got undefined"`;
+exports[`builders core templateLiteral should validate 6`] = `"Property expressions expected type of array but got undefined"`;

--- a/packages/babel-types/test/builders/core/classProperty.js
+++ b/packages/babel-types/test/builders/core/classProperty.js
@@ -1,7 +1,7 @@
 import * as t from "../../../lib/index.js";
 
 describe("builders", function () {
-  describe("experimental", function () {
+  describe("core", function () {
     describe("classProperty", function () {
       it("should validate", function () {
         expect(

--- a/packages/babel-types/test/builders/core/regexLiteral.js
+++ b/packages/babel-types/test/builders/core/regexLiteral.js
@@ -1,0 +1,28 @@
+import { itBabel8 } from "$repo-utils";
+import * as t from "../../../lib/index.js";
+
+describe("builders", function () {
+  describe("core", function () {
+    describe("regexLiteral", function () {
+      it("should set default flags to empty string", function () {
+        expect(t.regExpLiteral("test")).toHaveProperty("flags", "");
+      });
+      it.each(["d", "g", "i", "m", "s", "u", "v", "y"])(
+        "should accept flags: %s",
+        function (flags) {
+          expect(t.regExpLiteral("test", flags)).toHaveProperty("flags", flags);
+        },
+      );
+      itBabel8("should reject invalid flags", function () {
+        expect(() => t.regExpLiteral("test", "a")).toThrow(
+          '"a" is not a valid RegExp flag',
+        );
+      });
+      itBabel8("should print the first invalid flags", function () {
+        expect(() => t.regExpLiteral("test", "def")).toThrow(
+          '"e" is not a valid RegExp flag',
+        );
+      });
+    });
+  });
+});

--- a/packages/babel-types/test/builders/core/templateElement.js
+++ b/packages/babel-types/test/builders/core/templateElement.js
@@ -1,7 +1,7 @@
 import * as t from "../../../lib/index.js";
 
 describe("builders", function () {
-  describe("es2015", function () {
+  describe("core", function () {
     describe("templateElement", function () {
       it("should validate", function () {
         expect(


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Babel 8 rejects `d` and `v` flag in `t.regExpLiteral` builder
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This issue does not affect Babel 7 as Babel 7 does not enforce the `flags` input. Spot this issue when working on https://github.com/babel/babel/pull/17494.