### PR TITLE
fix: ensure scope.push register in anonymous fn

### DIFF
--- a/packages/babel-traverse/src/scope/index.ts
+++ b/packages/babel-traverse/src/scope/index.ts
@@ -242,6 +242,15 @@ function resetScope(scope: Scope) {
   scope.globals = Object.create(null);
 }
 
+function isAnonymousFunctionExpression(
+  path: NodePath,
+): path is NodePath<t.FunctionExpression | t.ArrowFunctionExpression> {
+  return (
+    (path.isFunctionExpression() && !path.node.id) ||
+    path.isArrowFunctionExpression()
+  );
+}
+
 interface CollectVisitorState {
   assignments: NodePath<t.AssignmentExpression>[];
   references: NodePath<t.Identifier | t.JSXIdentifier>[];
@@ -1104,9 +1113,7 @@ class Scope {
       !init &&
       !unique &&
       (kind === "var" || kind === "let") &&
-      path.isFunction() &&
-      // @ts-expect-error ArrowFunctionExpression never has a name
-      !path.node.name &&
+      isAnonymousFunctionExpression(path) &&
       isCallExpression(path.parent, { callee: path.node }) &&
       path.parent.arguments.length <= path.node.params.length &&
       isIdentifier(id)

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -1039,6 +1039,85 @@ describe("scope", () => {
       `);
       expect(program.scope.hasOwnBinding("ref")).toBe(true);
     });
+    it("registers the new binding within IIFunctionExpression when it has no arguments", () => {
+      const program = getPath("(function(a, b) {})()");
+      const functionBody = program.get("body.0.expression.callee.body");
+      functionBody.scope.push({ id: t.identifier("ref") });
+      expect(program.toString()).toMatchInlineSnapshot(
+        `"(function (a, b, ref) {})();"`,
+      );
+      expect(functionBody.scope.hasOwnBinding("ref")).toBe(true);
+      expect(program.scope.hasOwnBinding("ref")).toBe(false);
+    });
+    it("registers the new binding within IIFunctionExpression when it has same arguments with parameters", () => {
+      const program = getPath("(function(a, b) {})(0, 0)");
+      const functionBody = program.get("body.0.expression.callee.body");
+      functionBody.scope.push({ id: t.identifier("ref") });
+      expect(program.toString()).toMatchInlineSnapshot(
+        `"(function (a, b, ref) {})(0, 0);"`,
+      );
+      expect(functionBody.scope.hasOwnBinding("ref")).toBe(true);
+      expect(program.scope.hasOwnBinding("ref")).toBe(false);
+    });
+    it("registers the new binding within IIArrowFunctionExpression when it has no arguments", () => {
+      const program = getPath("((a, b) => {})()");
+      const functionBody = program.get("body.0.expression.callee.body");
+      functionBody.scope.push({ id: t.identifier("ref") });
+      expect(program.toString()).toMatchInlineSnapshot(
+        `"((a, b, ref) => {})();"`,
+      );
+      expect(functionBody.scope.hasOwnBinding("ref")).toBe(true);
+      expect(program.scope.hasOwnBinding("ref")).toBe(false);
+    });
+    it("registers the new binding within IIArrowFunctionExpression when it has same arguments with parameters", () => {
+      const program = getPath("((a, b) => {})(0, 0)");
+      const functionBody = program.get("body.0.expression.callee.body");
+      functionBody.scope.push({ id: t.identifier("ref") });
+      expect(program.toString()).toMatchInlineSnapshot(
+        `"((a, b, ref) => {})(0, 0);"`,
+      );
+      expect(functionBody.scope.hasOwnBinding("ref")).toBe(true);
+      expect(program.scope.hasOwnBinding("ref")).toBe(false);
+    });
+
+    it("should not register the new binding within IIFunctionExpression when it has a function name", () => {
+      const program = getPath("(function f(a, b = f.length) {})()");
+      const functionBody = program.get("body.0.expression.callee.body");
+      functionBody.scope.push({ id: t.identifier("ref") });
+      expect(program.toString()).toMatchInlineSnapshot(`
+        "(function f(a, b = f.length) {
+          var ref;
+        })();"
+      `);
+      expect(functionBody.scope.hasOwnBinding("ref")).toBe(true);
+      expect(program.scope.hasOwnBinding("ref")).toBe(false);
+    });
+    it("should not register the new binding within IIFunctionExpression when it has more arguments than parameters", () => {
+      const program = getPath("(function() { arguments.length })(0)");
+      const functionBody = program.get("body.0.expression.callee.body");
+      functionBody.scope.push({ id: t.identifier("ref") });
+      expect(program.toString()).toMatchInlineSnapshot(`
+        "(function () {
+          var ref;
+          arguments.length;
+        })(0);"
+      `);
+      expect(functionBody.scope.hasOwnBinding("ref")).toBe(true);
+      expect(program.scope.hasOwnBinding("ref")).toBe(false);
+    });
+    it("should not register the new binding within IIArrowFunctionExpression when it has more arguments than parameters", () => {
+      const program = getPath("(() => { arguments.length })(0)");
+      const functionBody = program.get("body.0.expression.callee.body");
+      functionBody.scope.push({ id: t.identifier("ref") });
+      expect(program.toString()).toMatchInlineSnapshot(`
+        "(() => {
+          var ref;
+          arguments.length;
+        })(0);"
+      `);
+      expect(functionBody.scope.hasOwnBinding("ref")).toBe(true);
+      expect(program.scope.hasOwnBinding("ref")).toBe(false);
+    });
   });
 
   describe("rename", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `scope.push` may register binding to parameter when the function is a named function expression.
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Spot this issue when working on https://github.com/babel/babel/pull/17503. Previously we checked `.name` property, which should have been `.id`.