### PR TITLE
[Babel 8] Use `t.traverseFast` to replace some `path.traverse`

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -87,11 +87,19 @@ function createPrivateUidGeneratorForClass(
   const currentPrivateId: number[] = [];
   const privateNames = new Set<string>();
 
-  classPath.traverse({
-    PrivateName(path) {
-      privateNames.add(path.node.id.name);
-    },
-  });
+  if (process.env.BABEL_8_BREAKING) {
+    t.traverseFast(classPath.node, node => {
+      if (t.isPrivateName(node)) {
+        privateNames.add(node.id.name);
+      }
+    });
+  } else {
+    classPath.traverse({
+      PrivateName(path) {
+        privateNames.add(path.node.id.name);
+      },
+    });
+  }
 
   return (): t.PrivateName => {
     let reifiedId;

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -87,19 +87,11 @@ function createPrivateUidGeneratorForClass(
   const currentPrivateId: number[] = [];
   const privateNames = new Set<string>();
 
-  if (process.env.BABEL_8_BREAKING) {
-    t.traverseFast(classPath.node, node => {
-      if (t.isPrivateName(node)) {
-        privateNames.add(node.id.name);
-      }
-    });
-  } else {
-    classPath.traverse({
-      PrivateName(path) {
-        privateNames.add(path.node.id.name);
-      },
-    });
-  }
+  t.traverseFast(classPath.node, node => {
+    if (t.isPrivateName(node)) {
+      privateNames.add(node.id.name);
+    }
+  });
 
   return (): t.PrivateName => {
     let reifiedId;

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -817,12 +817,22 @@ export default declare((api, opts: Options) => {
 
     // "React" or the JSX pragma is referenced as a value if there are any JSX elements/fragments in the code.
     let sourceFileHasJsx = false;
-    programPath.traverse({
-      "JSXElement|JSXFragment"(path) {
-        sourceFileHasJsx = true;
-        path.stop();
-      },
-    });
+    if (process.env.BABEL_8_BREAKING) {
+      t.traverseFast(programPath.node, node => {
+        if (t.isJSXElement(node) || t.isJSXFragment(node)) {
+          sourceFileHasJsx = true;
+          return t.traverseFast.stop;
+        }
+      });
+    } else {
+      programPath.traverse({
+        "JSXElement|JSXFragment"(path) {
+          sourceFileHasJsx = true;
+          path.stop();
+        },
+      });
+    }
+
     return !sourceFileHasJsx;
   }
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
