### PR TITLE
chore: simplify parseArrayLike

### DIFF
--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -1173,7 +1173,6 @@ export default abstract class ExpressionParser extends LValParser {
       case tt.bracketL: {
         return this.parseArrayLike(
           tt.bracketR,
-          /* canBePattern */ true,
           /* isTuple */ false,
           refExpressionErrors,
         );
@@ -1283,7 +1282,6 @@ export default abstract class ExpressionParser extends LValParser {
           } else if (type === tt.bracketBarL || type === tt.bracketHashL) {
             return this.parseArrayLike(
               this.state.type === tt.bracketBarL ? tt.bracketBarR : tt.bracketR,
-              /* canBePattern */ false,
               /* isTuple */ true,
             );
           } else if (type === tt.braceBarL || type === tt.braceHashL) {
@@ -2505,7 +2503,6 @@ export default abstract class ExpressionParser extends LValParser {
   parseArrayLike(
     this: Parser,
     close: TokenType,
-    canBePattern: boolean,
     isTuple: boolean,
     refExpressionErrors?: ExpressionErrors | null,
   ): N.ArrayExpression | N.TupleExpression {
@@ -2520,7 +2517,6 @@ export default abstract class ExpressionParser extends LValParser {
       close,
       /* allowEmpty */ !isTuple,
       refExpressionErrors,
-      // @ts-expect-error todo(flow->ts)
       node,
     );
     this.state.inFSharpPipelineDirectBody = oldInFSharpPipelineDirectBody;
@@ -2723,7 +2719,7 @@ export default abstract class ExpressionParser extends LValParser {
     close: TokenType,
     allowEmpty?: boolean,
     refExpressionErrors?: ExpressionErrors | null,
-    nodeForExtra?: N.Node | null,
+    nodeForExtra?: Undone<N.Node> | null,
   ): (N.Expression | null)[] {
     const elts: (N.Expression | null)[] = [];
     let first = true;

--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -2492,23 +2492,17 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
     parseArrayLike(
       close: TokenType,
-      canBePattern: boolean,
       isTuple: boolean,
       refExpressionErrors?: ExpressionErrors | null,
     ): N.ArrayExpression | N.TupleExpression {
-      const node = super.parseArrayLike(
-        close,
-        canBePattern,
-        isTuple,
-        refExpressionErrors,
-      );
+      const node = super.parseArrayLike(close, isTuple, refExpressionErrors);
 
       // This could be an array pattern:
       //   ([a: string, b: string]) => {}
       // In this case, we don't have to call toReferencedList. We will
       // call it, if needed, when we are sure that it is a parenthesized
       // expression by calling toReferencedListDeep.
-      if (canBePattern && !this.state.maybeInArrowParameters) {
+      if (refExpressionErrors != null && !this.state.maybeInArrowParameters) {
         this.toReferencedList(node.elements);
       }
 

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -2640,16 +2640,10 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
     parseArrayLike(
       close: TokenType,
-      canBePattern: boolean,
       isTuple: boolean,
       refExpressionErrors?: ExpressionErrors | null,
     ): N.ArrayExpression | N.TupleExpression {
-      const node = super.parseArrayLike(
-        close,
-        canBePattern,
-        isTuple,
-        refExpressionErrors,
-      );
+      const node = super.parseArrayLike(close, isTuple, refExpressionErrors);
 
       if (node.type === "ArrayExpression") {
         this.tsCheckForInvalidTypeCasts(node.elements);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
`canBePattern` is true if and only if `refExpressionErrors` are defined when we are parsing ambiguous patterns.

This is a small cleanup of the `parseArrayLike` method. This PR is sprung off from a WIP PR that removes RecordExpression and TupleExpression support in Babel parser.