### PR TITLE
Feat/destructuring private split explicit and rest

### DIFF
--- a/packages/babel-plugin-proposal-destructuring-private/src/util.ts
+++ b/packages/babel-plugin-proposal-destructuring-private/src/util.ts
@@ -66,7 +66,19 @@ function growRestExcludingKeys(
       property.key = assignmentExpression("=", tempId, propertyKey);
       excludingKeys.push({ key: tempId, computed: true });
     } else if (propertyKey.type !== "PrivateName") {
-      excludingKeys.push(property);
+      const isDuplicate = excludingKeys.some(existing => {
+        if (existing.computed || property.computed) return false;
+        if (
+          existing.key.type === "Identifier" &&
+          propertyKey.type === "Identifier"
+        ) {
+          return existing.key.name === propertyKey.name;
+        }
+        return false;
+      });
+      if (!isDuplicate) {
+        excludingKeys.push(property);
+      }
     }
   }
 }

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration/duplicate-keys-with-rest/exec.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration/duplicate-keys-with-rest/exec.js
@@ -1,0 +1,15 @@
+let result;
+class C {
+  static #p = "#p";
+  static a = "a";
+  static {
+    var { a, #p: p, a: x, ...r } = C;
+    result = { a, p, x, r };
+  }
+}
+expect(result).toStrictEqual({
+  a: "a",
+  p: "#p", 
+  x: "a",
+  r: {}
+});

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration/duplicate-keys-with-rest/input.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration/duplicate-keys-with-rest/input.js
@@ -1,0 +1,8 @@
+class C {
+  static #p = "#p";
+  static a = "a";
+  static {
+    var { a, #p: p, a: x, ...r } = C;
+    console.log(x);
+  }
+}

--- a/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration/duplicate-keys-with-rest/output.js
+++ b/packages/babel-plugin-proposal-destructuring-private/test/fixtures/variable-declaration/duplicate-keys-with-rest/output.js
@@ -1,0 +1,16 @@
+const _excluded = ["a"];
+class C {
+  static #p = "#p";
+  static a = "a";
+  static {
+    var {
+        a
+      } = C,
+      p = C.#p,
+      {
+        a: x
+      } = C,
+      r = babelHelpers.objectWithoutProperties(C, _excluded);
+    console.log(x);
+  }
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17282 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

### Summary

This PR fixes a bug in @babel/plugin-proposal-destructuring-private where explicit properties after a private key were destructured from an already-excluded object, causing values to become undefined.

---
### What changed

- Split post-private segment into two declarators:

  - bind explicit props (e.g. { a: x }; In Issue example) from the original RHS (C)

  - bind only the rest identifier from objectWithoutProperties(RHS, excluded)

- Grow excludingKeys before emitting explicit props so rest properly excludes them.

- Memoize non-static computed keys during excludingKeys growth (e.g. [_m = a()]) so the same key is reused by both explicit and rest parts (single evaluation).

- Dedupe non-computed Identifier keys when growing excludingKeys (PrivateName still ignored).