### PR TITLE
fix: `transform-regenerator` correctly handles scope

### DIFF
--- a/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543-2/input.mjs
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543-2/input.mjs
@@ -1,0 +1,7 @@
+import {useLayoutEffect as n} from "react";
+
+function Ki(i, n) {
+  return i(async () => {
+    var n;
+  }, n); // This n is the one from the Ki function, not from the import statement
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543-2/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543-2/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-modules-commonjs", "transform-regenerator"]
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543-2/output.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543-2/output.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var _react = require("react");
+function Ki(i, n) {
+  return i(() => {
+    var n;
+    return babelHelpers.regeneratorAsync(function (_context) {
+      while (1) switch (_context.n) {
+        case 0:
+          return _context.a(2);
+      }
+    }, null, null, null, Promise);
+  }, n); // This n is the one from the Ki function, not from the import statement
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543/input.mjs
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543/input.mjs
@@ -1,0 +1,7 @@
+import {useLayoutEffect as n} from "react";
+
+function Ki(i, n) {
+  return i(async () => {
+    function n() {}
+  }, n); // This n is the one from the Ki function, not from the import statement
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543/options.json
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-modules-commonjs", "transform-regenerator"]
+}

--- a/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543/output.js
+++ b/packages/babel-plugin-transform-regenerator/test/fixtures/scope/17543/output.js
@@ -1,0 +1,16 @@
+"use strict";
+
+var _react = require("react");
+function Ki(i, n) {
+  return i(() => {
+    var n;
+    return babelHelpers.regeneratorAsync(function (_context) {
+      while (1) switch (_context.n) {
+        case 0:
+          n = function _n() {};
+        case 1:
+          return _context.a(2);
+      }
+    }, null, null, null, Promise);
+  }, n); // This n is the one from the Ki function, not from the import statement
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17543 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | √
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | √
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The issue comes from the fact that `.remove` removes the binding, while `replaceWith` does not.