### PR TITLE
Add `BABEL_7_TO_8_DANGEROUSLY_DISABLE_VERSION_CHECK`

### DIFF
--- a/packages/babel-core/src/config/helpers/config-api.ts
+++ b/packages/babel-core/src/config/helpers/config-api.ts
@@ -131,17 +131,27 @@ function assertVersion(range: string | number): void {
     throw new Error("Expected string or integer value.");
   }
 
-  if (
-    typeof process !== "undefined" &&
-    process.env.BABEL_ALLOW_VERSION_MISMATCH
-  ) {
-    return;
-  }
-
   // We want "*" to also allow any pre-release, but we do not pass
   // the includePrerelease option to semver.satisfies because we
   // do not want ^7.0.0 to match 8.0.0-alpha.1.
   if (range === "*" || semver.satisfies(coreVersion, range)) return;
+
+  const message =
+    `Requires Babel "${range}", but was loaded with "${coreVersion}". ` +
+    `If you are sure you have a compatible version of @babel/core, ` +
+    `it is likely that something in your build process is loading the ` +
+    `wrong version. Inspect the stack trace of this error to look for ` +
+    `the first entry that doesn't mention "@babel/core" or "babel-core" ` +
+    `to see what is calling Babel.`;
+
+  if (
+    typeof process !== "undefined" &&
+    process.env.BABEL_8_BREAKING &&
+    process.env.BABEL_7_TO_8_DANGEROUSLY_DISABLE_VERSION_CHECK
+  ) {
+    console.warn(message);
+    return;
+  }
 
   const limit = Error.stackTraceLimit;
 
@@ -151,14 +161,7 @@ function assertVersion(range: string | number): void {
     Error.stackTraceLimit = 25;
   }
 
-  const err = new Error(
-    `Requires Babel "${range}", but was loaded with "${coreVersion}". ` +
-      `If you are sure you have a compatible version of @babel/core, ` +
-      `it is likely that something in your build process is loading the ` +
-      `wrong version. Inspect the stack trace of this error to look for ` +
-      `the first entry that doesn't mention "@babel/core" or "babel-core" ` +
-      `to see what is calling Babel.`,
-  );
+  const err = new Error(message);
 
   if (typeof limit === "number") {
     Error.stackTraceLimit = limit;

--- a/packages/babel-helper-plugin-utils/src/index.ts
+++ b/packages/babel-helper-plugin-utils/src/index.ts
@@ -106,13 +106,6 @@ function throwVersionError(range: string | number, version: string) {
     throw new Error("Expected string or integer value.");
   }
 
-  if (
-    typeof process !== "undefined" &&
-    process.env.BABEL_ALLOW_VERSION_MISMATCH
-  ) {
-    return;
-  }
-
   const limit = Error.stackTraceLimit;
 
   if (typeof limit === "number" && limit < 25) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

It seems like there are many plugins that would support Babel 8 if not for the `assertVersion` check. Ideally all of their maintainers would actually verify that it works with Babel 8 and adjust the check, but let's provide this workaround to help with the migration.

It seems like we have no tests for `assertVersion`.