### PR TITLE
Allow Babel 8 in compatible Babel 7 plugins

### DIFF
--- a/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/src/index.ts
+++ b/packages/babel-plugin-bugfix-v8-static-class-fields-redefine-readonly/src/index.ts
@@ -32,7 +32,7 @@ function buildFieldsReplacement(
 }
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   const setPublicClassFields = api.assumption("setPublicClassFields");
 

--- a/packages/babel-plugin-proposal-decorators/src/index.ts
+++ b/packages/babel-plugin-proposal-decorators/src/index.ts
@@ -17,7 +17,7 @@ interface Options extends SyntaxOptions {
 export type { Options };
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   // Options are validated in @babel/plugin-syntax-decorators
   if (!process.env.BABEL_8_BREAKING) {
@@ -45,7 +45,7 @@ export default declare((api, options: Options) => {
     version === "2023-05" ||
     version === "2023-11"
   ) {
-    api.assertVersion(REQUIRED_VERSION("^7.0.2"));
+    api.assertVersion(REQUIRED_VERSION("^7.0.2 || ^8.0.0-0"));
     return createClassFeaturePlugin({
       name: "proposal-decorators",
 

--- a/packages/babel-plugin-proposal-import-attributes-to-assertions/src/index.ts
+++ b/packages/babel-plugin-proposal-import-attributes-to-assertions/src/index.ts
@@ -3,7 +3,7 @@ import type { types as t, NodePath } from "@babel/core";
 import syntaxImportAttributes from "@babel/plugin-syntax-import-attributes";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "proposal-import-attributes-to-assertions",

--- a/packages/babel-plugin-proposal-import-wasm-source/src/index.ts
+++ b/packages/babel-plugin-proposal-import-wasm-source/src/index.ts
@@ -11,7 +11,7 @@ import {
 
 export default declare(api => {
   const { types: t, template } = api;
-  api.assertVersion(REQUIRED_VERSION("^7.23.0"));
+  api.assertVersion(REQUIRED_VERSION("^7.23.0 || ^8.0.0-0"));
 
   const targets = api.targets();
 

--- a/packages/babel-plugin-syntax-async-do-expressions/src/index.ts
+++ b/packages/babel-plugin-syntax-async-do-expressions/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-async-do-expressions",

--- a/packages/babel-plugin-syntax-decorators/src/index.ts
+++ b/packages/babel-plugin-syntax-decorators/src/index.ts
@@ -17,7 +17,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   let { version } = options;
 

--- a/packages/babel-plugin-syntax-destructuring-private/src/index.ts
+++ b/packages/babel-plugin-syntax-destructuring-private/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-destructuring-private",

--- a/packages/babel-plugin-syntax-do-expressions/src/index.ts
+++ b/packages/babel-plugin-syntax-do-expressions/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-do-expressions",

--- a/packages/babel-plugin-syntax-explicit-resource-management/src/index.ts
+++ b/packages/babel-plugin-syntax-explicit-resource-management/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-explicit-resource-management",

--- a/packages/babel-plugin-syntax-export-default-from/src/index.ts
+++ b/packages/babel-plugin-syntax-export-default-from/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-export-default-from",

--- a/packages/babel-plugin-syntax-flow/src/index.ts
+++ b/packages/babel-plugin-syntax-flow/src/index.ts
@@ -5,7 +5,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   // When enabled and plugins includes flow, all files should be parsed as if
   // the @flow pragma was provided.

--- a/packages/babel-plugin-syntax-function-bind/src/index.ts
+++ b/packages/babel-plugin-syntax-function-bind/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-function-bind",

--- a/packages/babel-plugin-syntax-function-sent/src/index.ts
+++ b/packages/babel-plugin-syntax-function-sent/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-function-sent",

--- a/packages/babel-plugin-syntax-import-assertions/src/index.ts
+++ b/packages/babel-plugin-syntax-import-assertions/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   const isPlugin = (plugin: string | [string, object], name: string) =>
     name === "plugin" || (Array.isArray(plugin) && plugin[0] === "plugin");

--- a/packages/babel-plugin-syntax-import-attributes/src/index.ts
+++ b/packages/babel-plugin-syntax-import-attributes/src/index.ts
@@ -5,7 +5,7 @@ export interface Options {
 }
 
 export default declare((api, { deprecatedAssertSyntax }: Options) => {
-  api.assertVersion(REQUIRED_VERSION("^7.22.0"));
+  api.assertVersion(REQUIRED_VERSION("^7.22.0 || ^8.0.0-0"));
 
   if (
     deprecatedAssertSyntax != null &&

--- a/packages/babel-plugin-syntax-import-defer/src/index.ts
+++ b/packages/babel-plugin-syntax-import-defer/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-import-defer",

--- a/packages/babel-plugin-syntax-import-source/src/index.ts
+++ b/packages/babel-plugin-syntax-import-source/src/index.ts
@@ -1,6 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION("^7.22.0"));
+  api.assertVersion(REQUIRED_VERSION("^7.22.0 || ^8.0.0-0"));
 
   return {
     name: "syntax-import-source",

--- a/packages/babel-plugin-syntax-jsx/src/index.ts
+++ b/packages/babel-plugin-syntax-jsx/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-jsx",

--- a/packages/babel-plugin-syntax-module-blocks/src/index.ts
+++ b/packages/babel-plugin-syntax-module-blocks/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-module-blocks",

--- a/packages/babel-plugin-syntax-optional-chaining-assign/src/index.ts
+++ b/packages/babel-plugin-syntax-optional-chaining-assign/src/index.ts
@@ -8,7 +8,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION("^7.23.0"));
+  api.assertVersion(REQUIRED_VERSION("^7.23.0 || ^8.0.0-0"));
 
   v.validateTopLevelOptions(options, { version: "version" });
   const { version } = options;

--- a/packages/babel-plugin-syntax-partial-application/src/index.ts
+++ b/packages/babel-plugin-syntax-partial-application/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-partial-application",

--- a/packages/babel-plugin-syntax-pipeline-operator/src/index.ts
+++ b/packages/babel-plugin-syntax-pipeline-operator/src/index.ts
@@ -13,7 +13,7 @@ export interface Options {
 }
 
 export default declare((api, { proposal, topicToken }: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   if (
     typeof proposal !== "string" ||

--- a/packages/babel-plugin-syntax-throw-expressions/src/index.ts
+++ b/packages/babel-plugin-syntax-throw-expressions/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "syntax-throw-expressions",

--- a/packages/babel-plugin-syntax-typescript/src/index.ts
+++ b/packages/babel-plugin-syntax-typescript/src/index.ts
@@ -25,7 +25,7 @@ export interface Options {
 }
 
 export default declare((api, opts: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   const { disallowAmbiguousJSXLike, dts } = opts;
 

--- a/packages/babel-plugin-transform-async-generator-functions/src/index.ts
+++ b/packages/babel-plugin-transform-async-generator-functions/src/index.ts
@@ -6,7 +6,7 @@ import { visitors } from "@babel/traverse";
 import rewriteForAwait from "./for-await.ts";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   const yieldStarVisitor = visitors.environmentVisitor<PluginPass>({
     ArrowFunctionExpression(path) {

--- a/packages/babel-plugin-transform-async-to-generator/src/index.ts
+++ b/packages/babel-plugin-transform-async-to-generator/src/index.ts
@@ -13,7 +13,7 @@ type State = {
 };
 
 export default declare<State>((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   const { method, module } = options;
   // Todo(BABEL 8): Consider default it to false

--- a/packages/babel-plugin-transform-class-properties/src/index.ts
+++ b/packages/babel-plugin-transform-class-properties/src/index.ts
@@ -11,7 +11,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return createClassFeaturePlugin({
     name: "transform-class-properties",

--- a/packages/babel-plugin-transform-class-static-block/src/index.ts
+++ b/packages/babel-plugin-transform-class-static-block/src/index.ts
@@ -32,7 +32,7 @@ function mapLast<T>(arr: T[], fn: (value: T) => T): T[] {
 }
 
 export default declare(({ types: t, template, traverse, assertVersion }) => {
-  assertVersion(REQUIRED_VERSION("^7.12.0"));
+  assertVersion(REQUIRED_VERSION("^7.12.0 || ^8.0.0-0"));
 
   const rawNamedEvaluationVisitor = buildNamedEvaluationVisitor(
     (path: NodePath) => {

--- a/packages/babel-plugin-transform-dotall-regex/src/index.ts
+++ b/packages/babel-plugin-transform-dotall-regex/src/index.ts
@@ -3,7 +3,7 @@ import { createRegExpFeaturePlugin } from "@babel/helper-create-regexp-features-
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return createRegExpFeaturePlugin({
     name: "transform-dotall-regex",

--- a/packages/babel-plugin-transform-duplicate-named-capturing-groups-regex/src/index.ts
+++ b/packages/babel-plugin-transform-duplicate-named-capturing-groups-regex/src/index.ts
@@ -7,7 +7,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION("^7.19.0"));
+  api.assertVersion(REQUIRED_VERSION("^7.19.0 || ^8.0.0-0"));
 
   const { runtime } = options;
   if (runtime !== undefined && typeof runtime !== "boolean") {

--- a/packages/babel-plugin-transform-explicit-resource-management/src/index.ts
+++ b/packages/babel-plugin-transform-explicit-resource-management/src/index.ts
@@ -34,7 +34,7 @@ function emitSetFunctionNameCall(
 
 export default declare(api => {
   // The first Babel 7 version with usingCtx helper support.
-  api.assertVersion(REQUIRED_VERSION("^7.23.9"));
+  api.assertVersion(REQUIRED_VERSION("^7.23.9 || ^8.0.0-0"));
 
   const TOP_LEVEL_USING = new Map<t.Node, USING_KIND>();
 

--- a/packages/babel-plugin-transform-exponentiation-operator/src/index.ts
+++ b/packages/babel-plugin-transform-exponentiation-operator/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import type { types as t, Scope } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   const { types: t, template } = api;
 

--- a/packages/babel-plugin-transform-json-strings/src/index.ts
+++ b/packages/babel-plugin-transform-json-strings/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import type { NodePath, types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
   const regex = /(\\*)([\u2028\u2029])/g;
   function replace(match: string, escapes: string, separator: string) {
     // If there's an odd number, that means the separator itself was escaped.

--- a/packages/babel-plugin-transform-logical-assignment-operators/src/index.ts
+++ b/packages/babel-plugin-transform-logical-assignment-operators/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "transform-logical-assignment-operators",

--- a/packages/babel-plugin-transform-nullish-coalescing-operator/src/index.ts
+++ b/packages/babel-plugin-transform-nullish-coalescing-operator/src/index.ts
@@ -6,7 +6,7 @@ export interface Options {
 }
 
 export default declare((api, { loose = false }: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
   const noDocumentAll = api.assumption("noDocumentAll") ?? loose;
   const pureGetters = api.assumption("pureGetters") ?? false;
 

--- a/packages/babel-plugin-transform-numeric-separator/src/index.ts
+++ b/packages/babel-plugin-transform-numeric-separator/src/index.ts
@@ -17,7 +17,7 @@ function remover({ node }: NodePath<t.BigIntLiteral | t.NumericLiteral>) {
 }
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "transform-numeric-separator",

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.ts
@@ -24,7 +24,7 @@ export interface Options {
 }
 
 export default declare((api, opts: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   const targets = api.targets();
   const supportsObjectAssign = !isRequired("Object.assign", targets, {

--- a/packages/babel-plugin-transform-optional-catch-binding/src/index.ts
+++ b/packages/babel-plugin-transform-optional-catch-binding/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return {
     name: "transform-optional-catch-binding",

--- a/packages/babel-plugin-transform-optional-chaining/src/index.ts
+++ b/packages/babel-plugin-transform-optional-chaining/src/index.ts
@@ -6,7 +6,7 @@ export interface Options {
   loose?: boolean;
 }
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   const { loose = false } = options;
   const noDocumentAll = api.assumption("noDocumentAll") ?? loose;

--- a/packages/babel-plugin-transform-private-methods/src/index.ts
+++ b/packages/babel-plugin-transform-private-methods/src/index.ts
@@ -11,7 +11,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return createClassFeaturePlugin({
     name: "transform-private-methods",

--- a/packages/babel-plugin-transform-private-property-in-object/src/index.ts
+++ b/packages/babel-plugin-transform-private-property-in-object/src/index.ts
@@ -12,7 +12,7 @@ export interface Options {
   loose?: boolean;
 }
 export default declare((api, opt: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
   const { types: t, template } = api;
   const { loose } = opt;
 

--- a/packages/babel-plugin-transform-regexp-modifiers/src/index.ts
+++ b/packages/babel-plugin-transform-regexp-modifiers/src/index.ts
@@ -3,7 +3,7 @@ import { createRegExpFeaturePlugin } from "@babel/helper-create-regexp-features-
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION("^7.19.0"));
+  api.assertVersion(REQUIRED_VERSION("^7.19.0 || ^8.0.0-0"));
 
   return createRegExpFeaturePlugin({
     name: "transform-regexp-modifiers",

--- a/packages/babel-plugin-transform-unicode-property-regex/src/index.ts
+++ b/packages/babel-plugin-transform-unicode-property-regex/src/index.ts
@@ -7,7 +7,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   const { useUnicodeFlag = true } = options;
   if (typeof useUnicodeFlag !== "boolean") {

--- a/packages/babel-plugin-transform-unicode-sets-regex/src/index.ts
+++ b/packages/babel-plugin-transform-unicode-sets-regex/src/index.ts
@@ -3,7 +3,7 @@ import { createRegExpFeaturePlugin } from "@babel/helper-create-regexp-features-
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0-0"));
 
   return createRegExpFeaturePlugin({
     name: "transform-unicode-sets-regex",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

This is the list of plugins from https://github.com/babel/babel/blob/main/test/babel-7-8-compat/data.json, for which we are testing Babel 8 compatibility, as well as all the syntax plugins.

This PR only affects Babel 7 plugins. Babel 8 plugins still require a Babel 8 version.