### PR TITLE
fix: add typings for eslint-plugin-development

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -9,9 +9,7 @@ import pluginN from "eslint-plugin-n";
 import configPrettier from "eslint-config-prettier";
 import pluginRegexp from "eslint-plugin-regexp";
 import pluginUnicorn from "eslint-plugin-unicorn";
-// @ts-expect-error no types
 import pluginBabelDevelopment from "@babel/eslint-plugin-development";
-// @ts-expect-error no types
 import pluginBabelDevelopmentInternal from "@babel/eslint-plugin-development-internal";
 import typescriptEslint from "typescript-eslint";
 import { commonJS } from "$repo-utils";
@@ -143,8 +141,7 @@ export default defineConfig([
             "packages/babel-helpers/src/helpers/applyDecs2305.ts",
             "scripts/repo-utils/index.d.cts",
             "scripts/babel-plugin-bit-decorator/types.d.ts",
-            "eslint/babel-eslint-plugin/types.d.cts",
-            "eslint/babel-eslint-parser/types.d.cts",
+            "eslint/*/types.d.cts",
           ],
         },
       },

--- a/eslint/babel-eslint-plugin-development-internal/package.json
+++ b/eslint/babel-eslint-plugin-development-internal/package.json
@@ -22,5 +22,12 @@
   "devDependencies": {
     "eslint": "^9.21.0"
   },
-  "type": "module"
+  "type": "module",
+  "exports": {
+    ".": {
+      "default": "./lib/index.cjs",
+      "types": "./types.d.cts"
+    },
+    "./package.json": "./package.json"
+  }
 }

--- a/eslint/babel-eslint-plugin-development-internal/types.d.cts
+++ b/eslint/babel-eslint-plugin-development-internal/types.d.cts
@@ -1,0 +1,7 @@
+import type { ESLint, Rule } from "eslint";
+
+type Rules = "report-error-message-format" | "require-default-import-fallback";
+
+export declare const meta: ESLint.ObjectMetaProperties["meta"];
+export declare const rules: Record<Rules, Rule.RuleModule>;
+export declare const rulesConfig: Record<Rules, string>;

--- a/eslint/babel-eslint-plugin-development/package.json
+++ b/eslint/babel-eslint-plugin-development/package.json
@@ -11,7 +11,10 @@
   "main": "./lib/index.cjs",
   "type": "module",
   "exports": {
-    ".": "./lib/index.cjs",
+    ".": {
+      "default": "./lib/index.cjs",
+      "types": "./types.d.cts"
+    },
     "./package.json": "./package.json"
   },
   "engines": {

--- a/eslint/babel-eslint-plugin-development/types.d.cts
+++ b/eslint/babel-eslint-plugin-development/types.d.cts
@@ -1,0 +1,7 @@
+import type { ESLint, Rule } from "eslint";
+
+type Rules = "no-deprecated-clone" | "no-undefined-identifier" | "plugin-name";
+
+export declare const meta: ESLint.ObjectMetaProperties["meta"];
+export declare const rules: Record<Rules, Rule.RuleModule>;
+export declare const rulesConfig: Record<Rules, string>;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we add typings for two internal eslint plugins. The typings are mostly copied and adapted from the `babel-eslint-plugin` package.