### PR TITLE
perf: remove redundant set in jsx meta visit

### DIFF
--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
@@ -322,14 +322,12 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
                   }`;
               }
 
-              const set = new Set();
               t.traverse(path.node, {
                 enter(node, parents) {
                   if (!t.isJSXOpeningElement(node)) {
                     return;
                   }
-                  set.add(node);
-                  const attributes = [];
+                  const attributes = node.attributes;
                   if (isThisAllowed(parents)) {
                     attributes.push(
                       t.jsxAttribute(
@@ -344,7 +342,6 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
                       t.jsxExpressionContainer(makeSource(node)),
                     ),
                   );
-                  node.attributes.push(...attributes);
                 },
               });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/pull/17555/files#r2546500665
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The `set` check was not implemented before #17555. Since that PR has not yet been released, I think it is okay to keep the previous logic, since the meta property visit was executed in a dedicated `Program` pass, it is highly unlikely that it will re-enter the modified node, unless people deliberately use JSX nested within module expressions.