### PR TITLE
fix: Makefile: crash when no condition

### DIFF
--- a/Makefile.source.mjs
+++ b/Makefile.source.mjs
@@ -567,7 +567,7 @@ function bumpVersionsToBabel8Pre() {
         if (babel8Condition?.peerDependencies?.["@babel/core"]) {
           babel8Condition.peerDependencies["@babel/core"] = `^${nextVersion}`;
         }
-        if (name === "babel-eslint-plugin") {
+        if (name === "babel-eslint-plugin" && babel8Condition) {
           babel8Condition.peerDependencies["@babel/eslint-parser"] =
             `^${nextVersion}`;
         }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

[`babe-eslint-plugin`](https://github.com/babel/babel/blob/main/eslint/babel-eslint-plugin/package.json) has no condition, so:

```
node Makefile.source.mjs new-babel-8-version-create-commit-ci
```

throws:

```js
file:///Users/coderaiser/babel-babel/Makefile.source.mjs:571
          babel8Condition.peerDependencies["@babel/eslint-parser"] =
                          ^

TypeError: Cannot read properties of undefined (reading 'peerDependencies')
    at file:///Users/coderaiser/babel-babel/Makefile.source.mjs:571:27
    at Array.forEach (<anonymous>)
    at file:///Users/coderaiser/babel-babel/Makefile.source.mjs:559:25
    at Array.forEach (<anonymous>)
    at bumpVersionsToBabel8Pre (file:///Users/coderaiser/babel-babel/Makefile.source.mjs:558:11)
    at target.new-babel-8-version-create-commit-ci (file:///Users/coderaiser/babel-babel/Makefile.source.mjs:587:23)
    at global.target.<computed> [as new-babel-8-version-create-commit-ci] (/Users/coderaiser/babel-babel/node_modules/shelljs/make.js:36:40)
    at /Users/coderaiser/babel-babel/node_modules/shelljs/make.js:48:27
    at Array.forEach (<anonymous>)
    at Timeout._onTimeout (/Users/coderaiser/babel-babel/node_modules/shelljs/make.js:46:10)

Node.js v25.2.1
```
