### PR TITLE
breaking(preset-env): remove `isPluginRequired` export

### DIFF
--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -20,15 +20,11 @@ import {
 
 import type { CallerMetadata, PluginItem, PresetAPI } from "@babel/core";
 
-import _pluginCoreJS3 from "babel-plugin-polyfill-corejs3";
-// TODO(Babel 8): Just use the default import
-const pluginCoreJS3 = (_pluginCoreJS3.default ||
-  _pluginCoreJS3) as typeof _pluginCoreJS3.default;
+import pluginCoreJS3 from "babel-plugin-polyfill-corejs3";
 
 import getTargets, {
   prettifyTargets,
   filterItems,
-  isRequired,
 } from "@babel/helper-compilation-targets";
 import type { Targets, InputTargets } from "@babel/helper-compilation-targets";
 import availablePlugins from "./available-plugins.ts";
@@ -37,11 +33,14 @@ import { declarePreset } from "@babel/helper-plugin-utils";
 import type { BuiltInsOption, ModuleOption, Options } from "./types.d.ts";
 export type { Options };
 
-// TODO: Remove in Babel 8
+/**
+ * @deprecated Use `isRequired` from `@babel/helper-compilation-targets` instead.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function isPluginRequired(targets: Targets, support: Targets) {
-  return isRequired("fake-name", targets, {
-    compatData: { "fake-name": support },
-  });
+  throw new Error(
+    "`isPluginRequired` has been removed in Babel 8. Please use `isRequired` from `@babel/helper-compilation-targets` instead.",
+  );
 }
 
 function filterStageFromList(
@@ -179,17 +178,17 @@ function getLocalTargets(
 }
 
 function supportsStaticESM(caller: CallerMetadata | undefined) {
-  // TODO(Babel 8): Fallback to true
+  // TODO(Babel 9): Fallback to true
   return !!caller?.supportsStaticESM;
 }
 
 function supportsDynamicImport(caller: CallerMetadata | undefined) {
-  // TODO(Babel 8): Fallback to true
+  // TODO(Babel 9): Fallback to true
   return !!caller?.supportsDynamicImport;
 }
 
 function supportsExportNamespaceFrom(caller: CallerMetadata | undefined) {
-  // TODO(Babel 8): Fallback to null
+  // TODO(Babel 9): Fallback to null
   return !!caller?.supportsExportNamespaceFrom;
 }
 
@@ -264,7 +263,7 @@ export default declarePreset((api, opts: Options) => {
 
   // If the caller does not support export-namespace-from, we forcefully add
   // the plugin to `includes`.
-  // TODO(Babel 8): stop doing this, similarly to how we don't do this for any
+  // TODO(Babel 9): stop doing this, similarly to how we don't do this for any
   // other plugin. We can consider adding bundlers as targets in the future,
   // but we should not have a one-off special case for this plugin.
   if (

--- a/packages/babel-preset-env/src/shipped-proposals.ts
+++ b/packages/babel-preset-env/src/shipped-proposals.ts
@@ -1,4 +1,3 @@
-// TODO(Babel 8): Remove this file
 /* eslint sort-keys: "error" */
 // These mappings represent the transform plugins that have been
 // shipped by browsers, and are enabled by the `shippedProposals` option.

--- a/packages/babel-preset-env/src/targets-parser.ts
+++ b/packages/babel-preset-env/src/targets-parser.ts
@@ -1,6 +1,0 @@
-// TODO: Remove in Babel 8
-
-export {
-  default,
-  isBrowsersQueryValid,
-} from "@babel/helper-compilation-targets";

--- a/packages/babel-preset-env/src/types.d.ts
+++ b/packages/babel-preset-env/src/types.d.ts
@@ -33,7 +33,6 @@ export type Options = {
   modules: ModuleOption;
   shippedProposals: boolean;
   targets: {
-    uglify?: boolean;
     esmodules?: boolean;
   } & InputTargets;
   useBuiltIns: BuiltInsOption;

--- a/packages/babel-preset-typescript/package.json
+++ b/packages/babel-preset-typescript/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@babel/helper-plugin-utils": "workspace:^",
     "@babel/helper-validator-option": "workspace:^",
-    "@babel/plugin-syntax-jsx": "workspace:^",
     "@babel/plugin-transform-modules-commonjs": "workspace:^",
     "@babel/plugin-transform-typescript": "workspace:^"
   },

--- a/packages/babel-preset-typescript/src/normalize-options.ts
+++ b/packages/babel-preset-typescript/src/normalize-options.ts
@@ -11,10 +11,6 @@ export interface Options {
   onlyRemoveTypeImports?: boolean;
   optimizeConstEnums?: boolean;
   rewriteImportExtensions?: boolean;
-
-  // TODO: Remove in Babel 8
-  allExtensions?: boolean;
-  isTSX?: boolean;
 }
 
 export default function normalizeOptions(options: Options = {}) {
@@ -31,10 +27,6 @@ export default function normalizeOptions(options: Options = {}) {
     onlyRemoveTypeImports: "onlyRemoveTypeImports",
     optimizeConstEnums: "optimizeConstEnums",
     rewriteImportExtensions: "rewriteImportExtensions",
-
-    // TODO: Remove in Babel 8
-    allExtensions: "allExtensions",
-    isTSX: "isTSX",
   };
 
   v.invariant(

--- a/packages/babel-preset-typescript/tsconfig.json
+++ b/packages/babel-preset-typescript/tsconfig.json
@@ -18,9 +18,6 @@
       "path": "../../packages/babel-helper-validator-option"
     },
     {
-      "path": "../../packages/babel-plugin-syntax-jsx"
-    },
-    {
       "path": "../../packages/babel-plugin-transform-modules-commonjs"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3980,7 +3980,6 @@ __metadata:
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
     "@babel/helper-validator-option": "workspace:^"
-    "@babel/plugin-syntax-jsx": "workspace:^"
     "@babel/plugin-transform-modules-commonjs": "workspace:^"
     "@babel/plugin-transform-typescript": "workspace:^"
   peerDependencies:


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/3148
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we removed the `isPluginRequired` API from `preset-env`. The API has been moved to `isRequired` export from `@babel/helper-compilation-targets`.

Also cleaned up all `Babel 8` todo comments in `preset*` packages.