### PR TITLE
Replace `picocolors` with `node-style-text` in dev dependencies

### DIFF
--- a/Gulpfile.mts
+++ b/Gulpfile.mts
@@ -5,7 +5,7 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { Transform as TransformStream } from "node:stream";
 import { callbackify } from "node:util";
-import colors from "picocolors";
+import colors from "node-style-text";
 // @ts-expect-error no types
 import gulp from "gulp";
 import { rollup } from "rollup";

--- a/babel-worker.cjs
+++ b/babel-worker.cjs
@@ -5,7 +5,7 @@ const { transformAsync } = require("@babel/core");
 const { mkdirSync, statSync, readFileSync, writeFileSync } = require("node:fs");
 const path = require("node:path");
 const { log } = require("./scripts/utils/logger.cjs");
-const colors = require("picocolors");
+const colors = require("node-style-text");
 
 /** * Check if the source file needs to be compiled based on its modification time
  * compared to the destination file.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "lint-staged": "^15.2.7",
     "mergeiterator": "^1.4.4",
     "minimatch": "npm:is-odd@*",
-    "picocolors": "^1.0.0",
+    "node-style-text": "^2.1.2",
     "pkg-pr-new": "^0.0.54",
     "prettier": "^3.5.2",
     "rollup": "^4.18.0",

--- a/scripts/parser-tests/utils/parser-test-runner.js
+++ b/scripts/parser-tests/utils/parser-test-runner.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import fs from "node:fs/promises";
-import colors from "picocolors";
+import colors from "node-style-text";
 import { parse as parser } from "../../../packages/babel-parser/lib/index.js";
 
 const dot = colors.gray(".");

--- a/test/esm/package.json
+++ b/test/esm/package.json
@@ -6,6 +6,6 @@
   "devDependencies": {
     "@babel/runtime": "workspace:^",
     "@babel/runtime-corejs3": "workspace:^",
-    "picocolors": "^1.0.0"
+    "node-style-text": "^2.1.2"
   }
 }

--- a/test/esm/test-runner.js
+++ b/test/esm/test-runner.js
@@ -1,4 +1,4 @@
-import colors from "picocolors";
+import colors from "node-style-text";
 
 export default async function testRunner({ title, testcases }) {
   console.log(title);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4188,7 +4188,7 @@ __metadata:
   dependencies:
     "@babel/runtime": "workspace:^"
     "@babel/runtime-corejs3": "workspace:^"
-    picocolors: "npm:^1.0.0"
+    node-style-text: "npm:^2.1.2"
   languageName: unknown
   linkType: soft
 
@@ -7509,7 +7509,7 @@ __metadata:
     lint-staged: "npm:^15.2.7"
     mergeiterator: "npm:^1.4.4"
     minimatch: "npm:is-odd@*"
-    picocolors: "npm:^1.0.0"
+    node-style-text: "npm:^2.1.2"
     pkg-pr-new: "npm:^0.0.54"
     prettier: "npm:^3.5.2"
     rollup: "npm:^4.18.0"
@@ -14035,6 +14035,13 @@ __metadata:
   version: 2.0.19
   resolution: "node-releases@npm:2.0.19"
   checksum: 10/c2b33b4f0c40445aee56141f13ca692fa6805db88510e5bbb3baadb2da13e1293b738e638e15e4a8eb668bb9e97debb08e7a35409b477b5cc18f171d35a83045
+  languageName: node
+  linkType: hard
+
+"node-style-text@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "node-style-text@npm:2.1.2"
+  checksum: 10/aea4c31e8a01eadebc5c98d36e1eb985c85979784c7fa31d49805e0517dab23068e3a9e37c91fc070b3ea92cc0478d03cbc1f5e31b4caa1cdd2b938cbe559a2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I built [`node-style-text`](https://github.com/fisker/node-style-text) when I use `node:util.styleText` in Prettier, it's a tiny wrapper on `styleText`, I can switch to use `styleText` directly if you prefer.
