### PR TITLE
Replace `picocolors` with `node:util.styleText()` in dev dependencies

### DIFF
--- a/Gulpfile.mts
+++ b/Gulpfile.mts
@@ -5,7 +5,7 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { Transform as TransformStream } from "node:stream";
 import { callbackify } from "node:util";
-import colors from "node-style-text";
+import { styleText } from "node:util";
 // @ts-expect-error no types
 import gulp from "gulp";
 import { rollup } from "rollup";
@@ -109,7 +109,7 @@ async function generateHelpers(
     path.join(dest, filename)
   );
   fs.writeFileSync(path.join(dest, filename), result, { mode: 0o644 });
-  log(`${colors.green("✔")} Generated ${message}`);
+  log(`${styleText("green", "✔")} Generated ${message}`);
 }
 
 type TypesHelperKind =
@@ -362,7 +362,7 @@ function buildRollup(packages: PackageInfo[], buildStandalone?: boolean) {
           /@babel\/preset-modules\/.*/,
         ];
 
-        log(`Compiling '${colors.cyan(input)}' with rollup ...`);
+        log(`Compiling '${styleText("cyan", input)}' with rollup ...`);
         const bundle = await rollup({
           input,
           external: buildStandalone ? [] : external,
@@ -589,15 +589,17 @@ function buildRollup(packages: PackageInfo[], buildStandalone?: boolean) {
 
         if (!process.env.IS_PUBLISH) {
           log(
-            colors.yellow(
-              `Skipped minification of '${colors.cyan(
+            styleText(
+              "yellow",
+              `Skipped minification of '${styleText(
+                "cyan",
                 outputFile
               )}' because not publishing`
             )
           );
           return undefined;
         }
-        log(`Minifying '${colors.cyan(outputFile)}'...`);
+        log(`Minifying '${styleText("cyan", outputFile)}'...`);
 
         await bundle.write({
           file: outputFile.replace(/\.js$/, ".min.js"),
@@ -629,7 +631,7 @@ function buildRollupDts(packages: string[]) {
     banner: string,
     packageName: string
   ) {
-    log(`Bundling '${colors.cyan(output)}' with rollup ...`);
+    log(`Bundling '${styleText("cyan", output)}' with rollup ...`);
 
     let external;
     if (packageName) {

--- a/Gulpfile.mts
+++ b/Gulpfile.mts
@@ -5,7 +5,7 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { Transform as TransformStream } from "node:stream";
 import { callbackify } from "node:util";
-import colors from "picocolors";
+import colors from "node-style-text";
 // @ts-expect-error no types
 import gulp from "gulp";
 import { rollup } from "rollup";

--- a/babel-worker.mjs
+++ b/babel-worker.mjs
@@ -3,8 +3,8 @@
 import { transformAsync } from "@babel/core";
 import { mkdirSync, statSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { styleText } from "node:util";
 import { log } from "./scripts/utils/logger.js";
-import colors from "node-style-text";
 
 /** * Check if the source file needs to be compiled based on its modification time
  * compared to the destination file.
@@ -34,7 +34,7 @@ export async function transform(src, dest, opts = {}) {
   if (!needCompile(src, dest)) {
     return;
   }
-  log(`Compiling '${colors.cyan(src)}'...`);
+  log(`Compiling '${styleText("cyan", src)}'...`);
   const content = readFileSync(src, { encoding: "utf8" });
   const { code, map } = await transformAsync(content, {
     filename: src,

--- a/babel-worker.mjs
+++ b/babel-worker.mjs
@@ -4,7 +4,7 @@ import { transformAsync } from "@babel/core";
 import { mkdirSync, statSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { log } from "./scripts/utils/logger.js";
-import colors from "picocolors";
+import colors from "node-style-text";
 
 /** * Check if the source file needs to be compiled based on its modification time
  * compared to the destination file.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "lint-staged": "^15.2.7",
     "mergeiterator": "^1.4.4",
     "minimatch": "npm:is-odd@*",
-    "node-style-text": "^2.1.2",
     "pkg-pr-new": "^0.0.54",
     "prettier": "^3.5.2",
     "rollup": "^4.18.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "lint-staged": "^15.2.7",
     "mergeiterator": "^1.4.4",
     "minimatch": "npm:is-odd@*",
-    "picocolors": "^1.0.0",
+    "node-style-text": "^2.1.2",
     "pkg-pr-new": "^0.0.54",
     "prettier": "^3.5.2",
     "rollup": "^4.18.0",

--- a/scripts/parser-tests/utils/parser-test-runner.js
+++ b/scripts/parser-tests/utils/parser-test-runner.js
@@ -1,10 +1,10 @@
 // @ts-check
 
 import fs from "node:fs/promises";
-import colors from "node-style-text";
+import { styleText } from "node:util";
 import { parse as parser } from "../../../packages/babel-parser/lib/index.js";
 
-const dot = colors.gray(".");
+const dot = styleText("gray", ".");
 
 /**
  * @typedef {Object} Summary
@@ -294,11 +294,11 @@ class TestRunner {
 
     console.log(`Testing complete (${summary.count} tests).`);
     console.log("Summary:");
-    console.log(colors.green(goodnews.join("\n").replace(/^/gm, " ✔ ")));
+    console.log(styleText("green", goodnews.join("\n").replace(/^/gm, " ✔ ")));
 
     if (!summary.passed) {
       console.log("");
-      console.log(colors.red(badnews.join("\n").replace(/^/gm, " ✘ ")));
+      console.log(styleText("red", badnews.join("\n").replace(/^/gm, " ✘ ")));
       console.log("");
       console.log("Details:");
       console.log(badnewsDetails.join("\n").replace(/^/gm, "   "));

--- a/scripts/parser-tests/utils/parser-test-runner.js
+++ b/scripts/parser-tests/utils/parser-test-runner.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import fs from "node:fs/promises";
-import colors from "picocolors";
+import colors from "node-style-text";
 import { parse as parser } from "../../../packages/babel-parser/lib/index.js";
 
 const dot = colors.gray(".");

--- a/test/esm/package.json
+++ b/test/esm/package.json
@@ -5,7 +5,6 @@
   "exports": "./index.js",
   "devDependencies": {
     "@babel/runtime": "workspace:^",
-    "@babel/runtime-corejs3": "workspace:^",
-    "node-style-text": "^2.1.2"
+    "@babel/runtime-corejs3": "workspace:^"
   }
 }

--- a/test/esm/package.json
+++ b/test/esm/package.json
@@ -6,6 +6,6 @@
   "devDependencies": {
     "@babel/runtime": "workspace:^",
     "@babel/runtime-corejs3": "workspace:^",
-    "picocolors": "^1.0.0"
+    "node-style-text": "^2.1.2"
   }
 }

--- a/test/esm/test-runner.js
+++ b/test/esm/test-runner.js
@@ -1,4 +1,4 @@
-import colors from "node-style-text";
+import { styleText } from "node:util";
 
 export default async function testRunner({ title, testcases }) {
   console.log(title);
@@ -6,9 +6,9 @@ export default async function testRunner({ title, testcases }) {
   for (const [subtitle, testcase] of testcases) {
     try {
       await testcase();
-      console.log(colors.green(indent + "✓ " + subtitle));
+      console.log(styleText("green", indent + "✓ " + subtitle));
     } catch (e) {
-      console.log(colors.red(indent + "✗ " + subtitle));
+      console.log(styleText("red", indent + "✗ " + subtitle));
       console.error(e);
       process.exitCode = 1;
     }

--- a/test/esm/test-runner.js
+++ b/test/esm/test-runner.js
@@ -1,4 +1,4 @@
-import colors from "picocolors";
+import colors from "node-style-text";
 
 export default async function testRunner({ title, testcases }) {
   console.log(title);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4177,7 +4177,6 @@ __metadata:
   dependencies:
     "@babel/runtime": "workspace:^"
     "@babel/runtime-corejs3": "workspace:^"
-    node-style-text: "npm:^2.1.2"
   languageName: unknown
   linkType: soft
 
@@ -7535,7 +7534,6 @@ __metadata:
     lint-staged: "npm:^15.2.7"
     mergeiterator: "npm:^1.4.4"
     minimatch: "npm:is-odd@*"
-    node-style-text: "npm:^2.1.2"
     pkg-pr-new: "npm:^0.0.54"
     prettier: "npm:^3.5.2"
     rollup: "npm:^4.18.0"
@@ -14078,13 +14076,6 @@ __metadata:
   version: 2.0.27
   resolution: "node-releases@npm:2.0.27"
   checksum: 10/f6c78ddb392ae500719644afcbe68a9ea533242c02312eb6a34e8478506eb7482a3fb709c70235b01c32fe65625b68dfa9665113f816d87f163bc3819b62b106
-  languageName: node
-  linkType: hard
-
-"node-style-text@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "node-style-text@npm:2.1.2"
-  checksum: 10/aea4c31e8a01eadebc5c98d36e1eb985c85979784c7fa31d49805e0517dab23068e3a9e37c91fc070b3ea92cc0478d03cbc1f5e31b4caa1cdd2b938cbe559a2d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4177,7 +4177,7 @@ __metadata:
   dependencies:
     "@babel/runtime": "workspace:^"
     "@babel/runtime-corejs3": "workspace:^"
-    picocolors: "npm:^1.0.0"
+    node-style-text: "npm:^2.1.2"
   languageName: unknown
   linkType: soft
 
@@ -7535,7 +7535,7 @@ __metadata:
     lint-staged: "npm:^15.2.7"
     mergeiterator: "npm:^1.4.4"
     minimatch: "npm:is-odd@*"
-    picocolors: "npm:^1.0.0"
+    node-style-text: "npm:^2.1.2"
     pkg-pr-new: "npm:^0.0.54"
     prettier: "npm:^3.5.2"
     rollup: "npm:^4.18.0"
@@ -14078,6 +14078,13 @@ __metadata:
   version: 2.0.27
   resolution: "node-releases@npm:2.0.27"
   checksum: 10/f6c78ddb392ae500719644afcbe68a9ea533242c02312eb6a34e8478506eb7482a3fb709c70235b01c32fe65625b68dfa9665113f816d87f163bc3819b62b106
+  languageName: node
+  linkType: hard
+
+"node-style-text@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "node-style-text@npm:2.1.2"
+  checksum: 10/aea4c31e8a01eadebc5c98d36e1eb985c85979784c7fa31d49805e0517dab23068e3a9e37c91fc070b3ea92cc0478d03cbc1f5e31b4caa1cdd2b938cbe559a2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

~I built [`node-style-text`](https://github.com/fisker/node-style-text) when I use `node:util.styleText` in Prettier, it's a tiny wrapper on `styleText`, I can switch to use `styleText` directly if you prefer.~
