### PR TITLE
fix: only rename conflicting functions in strict mode

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/annex-B_3_3.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/annex-B_3_3.ts
@@ -76,7 +76,7 @@ export function isVarScope(scope: Scope) {
   return scope.path.isFunctionParent() || scope.path.isProgram();
 }
 
-function isStrict(path: NodePath) {
+export function isStrict(path: NodePath) {
   return !!path.find(({ node }) => {
     if (t.isProgram(node)) {
       if (node.sourceType === "module") return true;

--- a/packages/babel-plugin-transform-block-scoping/src/index.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/index.ts
@@ -9,7 +9,11 @@ import {
   wrapLoopBody,
 } from "./loop.ts";
 import { validateUsage } from "./validation.ts";
-import { annexB33FunctionsVisitor, isVarScope } from "./annex-B_3_3.ts";
+import {
+  annexB33FunctionsVisitor,
+  isVarScope,
+  isStrict,
+} from "./annex-B_3_3.ts";
 
 export interface Options {
   tdz?: boolean;
@@ -165,10 +169,12 @@ export default declare((api, opts: Options) => {
 
 const conflictingFunctionsVisitor: Visitor<{ names: string[] }> = {
   Scope(path, { names }) {
-    for (const name of names) {
-      const binding = path.scope.getOwnBinding(name);
-      if (binding?.kind === "hoisted") {
-        path.scope.rename(name);
+    if (isStrict(path)) {
+      for (const name of names) {
+        const binding = path.scope.getOwnBinding(name);
+        if (binding?.kind === "hoisted") {
+          path.scope.rename(name);
+        }
       }
     }
   },

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/annex-B_3_3-strict/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/annex-B_3_3-strict/input.js
@@ -1,0 +1,41 @@
+function testStrict() {
+    "use strict";
+    if (true) {
+        function inner() {
+            console.log('inner true');
+        }
+    } else {
+        function inner() {
+            console.log('inner false');
+        }
+    }
+    inner();
+}
+
+class Test {
+    test() {
+        if (true) {
+            function inner() {
+                console.log('inner true');
+            }
+        } else {
+            function inner() {
+                console.log('inner false');
+            }
+        }
+        inner();
+    }
+}
+
+function testNonStrict() {
+    if (true) {
+        function inner() {
+            console.log('inner true');
+        }
+    } else {
+        function inner() {
+            console.log('inner false');
+        }
+    }
+    inner();
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/annex-B_3_3-strict/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/annex-B_3_3-strict/output.js
@@ -1,0 +1,40 @@
+function testStrict() {
+  "use strict";
+
+  if (true) {
+    var _inner = function () {
+      console.log('inner true');
+    };
+  } else {
+    var _inner2 = function () {
+      console.log('inner false');
+    };
+  }
+  inner();
+}
+class Test {
+  test() {
+    if (true) {
+      var _inner3 = function () {
+        console.log('inner true');
+      };
+    } else {
+      var _inner4 = function () {
+        console.log('inner false');
+      };
+    }
+    inner();
+  }
+}
+function testNonStrict() {
+  if (true) {
+    function inner() {
+      console.log('inner true');
+    }
+  } else {
+    function inner() {
+      console.log('inner false');
+    }
+  }
+  inner();
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17688 
| Patch: Bug Fix?          | 👍
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
According to Annex B.3.3, block-scoped function declarations should be hoisted to function scope in non-strict mode, so they should not be renamed. This change adds a strict mode check to `conflictingFunctionsVisitor` to only rename functions in strict mode.
