### PR TITLE
[Babel 8]: clean up unused preset-env data entries

### DIFF
--- a/packages/babel-plugin-transform-runtime/src/index.ts
+++ b/packages/babel-plugin-transform-runtime/src/index.ts
@@ -4,8 +4,6 @@ import { types as t } from "@babel/core";
 
 import getRuntimePath, { resolveFSPath } from "./get-runtime-path/index.ts";
 
-// TODO(Babel 8): Remove this
-
 export interface Options {
   absoluteRuntime?: boolean;
   corejs?: string | number | { version: string | number; proposals?: boolean };

--- a/packages/babel-preset-env/data/built-in-modules.js
+++ b/packages/babel-preset-env/data/built-in-modules.js
@@ -1,3 +1,0 @@
-// TODO: Remove in Babel 8
-
-module.exports = require("@babel/compat-data/native-modules");

--- a/packages/babel-preset-env/data/built-in-modules.json.js
+++ b/packages/babel-preset-env/data/built-in-modules.json.js
@@ -1,3 +1,0 @@
-// TODO: Remove in Babel 8
-
-module.exports = require("@babel/compat-data/native-modules");

--- a/packages/babel-preset-env/data/built-ins.js
+++ b/packages/babel-preset-env/data/built-ins.js
@@ -1,4 +1,0 @@
-// TODO: Remove in Babel 8
-// https://github.com/vuejs/vue-cli/issues/3671
-
-module.exports = require("./corejs2-built-ins.json");

--- a/packages/babel-preset-env/data/built-ins.json.js
+++ b/packages/babel-preset-env/data/built-ins.json.js
@@ -1,4 +1,0 @@
-// TODO: Remove in Babel 8
-// https://github.com/vuejs/vue-cli/issues/3671
-
-module.exports = require("./corejs2-built-ins.json");

--- a/packages/babel-preset-env/data/core-js-compat.js
+++ b/packages/babel-preset-env/data/core-js-compat.js
@@ -1,3 +1,0 @@
-// TODO: Remove in Babel 8
-
-module.exports = require("core-js-compat/data.json");

--- a/packages/babel-preset-env/data/corejs2-built-ins.js
+++ b/packages/babel-preset-env/data/corejs2-built-ins.js
@@ -1,3 +1,0 @@
-// TODO: Remove in Babel 8
-
-module.exports = require("@babel/compat-data/corejs2-built-ins");

--- a/packages/babel-preset-env/data/corejs2-built-ins.json.js
+++ b/packages/babel-preset-env/data/corejs2-built-ins.json.js
@@ -1,3 +1,0 @@
-// TODO: Remove in Babel 8
-
-module.exports = require("@babel/compat-data/corejs2-built-ins");

--- a/packages/babel-preset-env/data/package.json
+++ b/packages/babel-preset-env/data/package.json
@@ -1,1 +1,0 @@
-{ "type": "commonjs" }

--- a/packages/babel-preset-env/data/plugins.js
+++ b/packages/babel-preset-env/data/plugins.js
@@ -1,3 +1,0 @@
-// TODO: Remove in Babel 8
-
-module.exports = require("@babel/compat-data/plugins");

--- a/packages/babel-preset-env/data/plugins.json.js
+++ b/packages/babel-preset-env/data/plugins.json.js
@@ -1,3 +1,0 @@
-// TODO: Remove in Babel 8
-
-module.exports = require("@babel/compat-data/plugins");

--- a/packages/babel-preset-env/data/shipped-proposals.js
+++ b/packages/babel-preset-env/data/shipped-proposals.js
@@ -1,4 +1,0 @@
-// TODO: Remove in Babel 8
-
-const { pluginSyntaxMap, proposalPlugins, proposalSyntaxPlugins } = require("../lib/shipped-proposals");
-module.exports = { pluginSyntaxMap, proposalPlugins, proposalSyntaxPlugins };

--- a/packages/babel-preset-env/data/unreleased-labels.js
+++ b/packages/babel-preset-env/data/unreleased-labels.js
@@ -1,3 +1,0 @@
-// TODO: Remove in Babel 8
-
-module.exports = require("@babel/helper-compilation-targets").unreleasedLabels;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | https://github.com/babel/website/pull/3152
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
After we specified the `exports` in Babel 8, the `./data` entries in `preset-env` is generally unreachable and therefore they can be removed.