### PR TITLE
fix(babel-traverse): check variable shadowing for global object callees

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -471,7 +471,8 @@ function _evaluate(path: NodePath, state: State): any {
         object.isIdentifier() &&
         property.isIdentifier() &&
         isValidObjectCallee(object.node.name) &&
-        !isInvalidMethod(property.node.name)
+        !isInvalidMethod(property.node.name) &&
+        !path.scope.getBinding(object.node.name)
       ) {
         context = global[object.node.name];
         const key = property.node.name;

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -452,6 +452,23 @@ describe("evaluation", function () {
     expect(evalResult.confident).toBe(false);
   });
 
+  it("should not evaluate Math.method when Math is shadowed by local variable", function () {
+    const path = getPath(`
+      function test(Math) {
+        Math.min(1, 2);
+      }
+    `);
+    const evalResult = path.get("body.0.body.body.0.expression").evaluate();
+    expect(evalResult.confident).toBe(false);
+  });
+
+  it("should evaluate standard global objects when not shadowed", function () {
+    const path = getPath("Math.min(1, 2);");
+    const evalResult = path.get("body.0.expression").evaluate();
+    expect(evalResult.confident).toBe(true);
+    expect(evalResult.value).toBe(1);
+  });
+
   addDeoptTest("({a:{b}})", "ObjectExpression", "Identifier");
   addDeoptTest("({[a + 'b']: 1})", "ObjectExpression", "Identifier");
   addDeoptTest("[{a}]", "ArrayExpression", "Identifier");


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixed #17698   <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Currently, `path.evaluate()` attempts to evaluate methods on global objects (like `Math.min`, `String.raw`, etc.) even when the global object identifier is shadowed by a local variable. This can lead to incorrect constant folding (evaluating code that shouldn't be evaluated).

**Example of the bug:**
```js
const Math = { min: () => 999 };
// Before fix: evaluates to 1 (incorrectly uses global Math.min)
// After fix: confident = false (bails out correctly)
Math.min(1, 2);