### PR TITLE
Revert "Switch to the new Prettier VSCode extension"

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -36,4 +36,4 @@ github:
 vscode:
   extensions:
     - dbaeumer.vscode-eslint@2.1.5:9Wg0Glx/TwD8ElFBg+FKcQ==
-    - prettier.prettier-vscode
+    - esbenp.prettier-vscode@5.0.0:qca7d0cHbKkrkb5rvNlpcg==

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -20,7 +20,7 @@
     ]
   },
   "[typescript][javascript]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"


### PR DESCRIPTION
Reverts babel/babel#17700

Unfortunately, it switched back to the old namespace.

https://github.com/prettier/prettier-vscode/pull/3899
https://github.com/prettier/prettier-vscode/issues/3872#issuecomment-3662898646