### PR TITLE
fix: improve parentheses rule of conditional

### DIFF
--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -250,13 +250,9 @@ export function TSConditionalType(
     parentType === "TSOptionalType" ||
     parentType === "TSTypeOperator" ||
     // for `infer K extends (L extends M ? M : ...)`
-    parentType === "TSTypeParameter"
-  ) {
-    return true;
-  }
-  if (
-    (parentType === "TSIntersectionType" || parentType === "TSUnionType") &&
-    parent.types[0] === node
+    parentType === "TSTypeParameter" ||
+    parentType === "TSIntersectionType" ||
+    parentType === "TSUnionType"
   ) {
     return true;
   }
@@ -303,10 +299,7 @@ export function TSInferType(node: t.TSInferType, parent: t.Node): boolean {
     return true;
   }
   if (node.typeParameter.constraint) {
-    if (
-      (parentType === "TSIntersectionType" || parentType === "TSUnionType") &&
-      parent.types[0] === node
-    ) {
+    if (parentType === "TSIntersectionType" || parentType === "TSUnionType") {
       return true;
     }
   }

--- a/packages/babel-generator/test/fixtures/parentheses/ts-conditional-type/input.ts
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-conditional-type/input.ts
@@ -12,6 +12,8 @@ type t6<T> = T extends Array<infer K extends (T extends string ? string : never)
 type t7<T> = (T extends string[] ? T : never) extends string[] ? T : never;
 type t8<T> = T extends (T extends string[] ? T : never) ? string[] : never;
 
+type t9<T> = Promise<T> | (T extends any ? Promise<T> : never);
+
 // These parentheses should be stripped
 type s0<T> = [...(T extends string[] ? T : never)];
 type s1<T> = ""[(T extends string[] ? "toString" : "valueOf")];

--- a/packages/babel-generator/test/fixtures/parentheses/ts-conditional-type/output.js
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-conditional-type/output.js
@@ -8,6 +8,7 @@ type t5<T> = keyof (T extends string[] ? T : never);
 type t6<T> = T extends Array<infer K extends (T extends string ? string : never)> ? K : never;
 type t7<T> = (T extends string[] ? T : never) extends string[] ? T : never;
 type t8<T> = T extends (T extends string[] ? T : never) ? string[] : never;
+type t9<T> = Promise<T> | (T extends any ? Promise<T> : never);
 
 // These parentheses should be stripped
 type s0<T> = [...T extends string[] ? T : never];

--- a/packages/babel-generator/test/fixtures/parentheses/ts-infer-type/input.ts
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-infer-type/input.ts
@@ -6,11 +6,15 @@ type t2<T> = T extends Array<[(infer K)?]> ? K : never;
 type t3<T> = T extends Array<(infer K extends string) | boolean> ? K : never;
 type t4<T> = T extends Array<(infer K extends string) & boolean> ? K : never;
 
-// These parentheses should be stripped
+type t5<T> = T extends Array<T extends "N" ? T : never | (infer K extends string)> ? K : never;
+type t6<T> = T extends Array<T extends "N" ? T : never & (infer K extends string)> ? K : never;
+
+// The outer parentheses should be stripped
 type s0<T> = T extends Array<(infer K) | boolean> ? K : never;
 type s1<T> = T extends Array<(infer K) & boolean> ? K : never;
-type s2<T> = T extends Array<boolean | (infer K extends string)> ? K : never;
-type s3<T> = T extends Array<boolean & (infer K extends string)> ? K : never;
+
+type s2<T> = T extends Array<T extends "N" ? T : (never | (infer K extends string))> ? K : never;
+type s3<T> = T extends Array<T extends "N" ? T : (never & (infer K extends string))> ? K : never;
 
 type s4<T> = T extends Array<infer K extends (infer L extends string)> ? K : never;
 

--- a/packages/babel-generator/test/fixtures/parentheses/ts-infer-type/output.js
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-infer-type/output.js
@@ -4,12 +4,14 @@ type t1<T> = T extends Array<(infer K)['valueOf']> ? K : never;
 type t2<T> = T extends Array<[(infer K)?]> ? K : never;
 type t3<T> = T extends Array<(infer K extends string) | boolean> ? K : never;
 type t4<T> = T extends Array<(infer K extends string) & boolean> ? K : never;
+type t5<T> = T extends Array<T extends "N" ? T : never | (infer K extends string)> ? K : never;
+type t6<T> = T extends Array<T extends "N" ? T : never & (infer K extends string)> ? K : never;
 
-// These parentheses should be stripped
+// The outer parentheses should be stripped
 type s0<T> = T extends Array<infer K | boolean> ? K : never;
 type s1<T> = T extends Array<infer K & boolean> ? K : never;
-type s2<T> = T extends Array<boolean | infer K extends string> ? K : never;
-type s3<T> = T extends Array<boolean & infer K extends string> ? K : never;
+type s2<T> = T extends Array<T extends "N" ? T : never | (infer K extends string)> ? K : never;
+type s3<T> = T extends Array<T extends "N" ? T : never & (infer K extends string)> ? K : never;
 type s4<T> = T extends Array<infer K extends infer L extends string> ? K : never;
 type s5<T> = T extends infer Q ? Q : never;
 type s6<T> = T extends Array<T extends string[] ? infer Q : never> ? Q : never;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17715 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
As a follow-up to https://github.com/babel/babel/pull/17131, this PR improves the parentheses rules of `TSConditionalType` and `TSInferType`. The new rules adopt a more conservative approach when removing parentheses, and the test suite has been expanded to cover these changes.