### PR TITLE
chore(Babel 7): ignore browserslist old data

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,9 @@
 
 const semver = require("semver");
 
+// Disable browserslist old data warning for 7.x branch
+process.env.BROWSERSLIST_IGNORE_OLD_DATA = "1";
+
 const nodeVersion = process.versions.node;
 const supportsESMAndJestLightRunner = semver.satisfies(
   nodeVersion,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Ignore the browserslist old data warning in Babel 7 branch, such that we don't have to bump the compat data while the branch is deemed to receive less frequent updates.

This PR should fix the current failing Babel 7 CI.