### PR TITLE
chore: cleanup test262 test setup

### DIFF
--- a/scripts/parser-tests/test262/ignored-features.json
+++ b/scripts/parser-tests/test262/ignored-features.json
@@ -95,6 +95,7 @@
   "destructuring-binding",
   "dynamic-import",
   "error-cause",
+  "explicit-resource-management",
   "exponentiation",
   "export-star-as-namespace-from-module",
   "for-in-order",

--- a/scripts/parser-tests/test262/index.js
+++ b/scripts/parser-tests/test262/index.js
@@ -34,17 +34,11 @@ const ignoredTests = ["built-ins/RegExp/", "language/literals/regexp/"];
 
 // @ts-expect-error Map signature is not recognized by TS
 const featuresToPlugins = new Map([
-  ["import-assertions", "importAssertions"],
-  ["import-attributes", "importAttributes"],
   ["import-defer", "deferredImportEvaluation"],
   [
     "decorators",
-    [
-      ["decorators", { version: "2022-03", decoratorsBeforeExport: false }],
-      "decoratorAutoAccessors",
-    ],
+    [["decorators", { version: "2023-11" }], "decoratorAutoAccessors"],
   ],
-  ["explicit-resource-management", "explicitResourceManagement"],
   ["source-phase-imports", "sourcePhaseImports"],
   ["source-phase-imports-module-source", "sourcePhaseImports"],
 ]);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR removes the Stage 4 features / obsolete syntaxes from the plugin map of the test262 parser test setup.