### PR TITLE
Bump sha.js to 2.4.12 to fix cve

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "caniuse-lite": "1.0.30001766",
     "core-js-compat": "3.48.0",
     "electron-to-chromium": "1.5.278",
+    "sha.js": "2.4.12",
     "@types/babel__core": "link:./nope",
     "@types/babel__traverse": "link:./nope",
     "@babel/parser/@babel/types": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "caniuse-lite": "1.0.30001766",
     "core-js-compat": "3.48.0",
     "electron-to-chromium": "1.5.278",
-    "sha.js": "2.4.12",
     "@types/babel__core": "link:./nope",
     "@types/babel__traverse": "link:./nope",
     "@babel/parser/@babel/types": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16052,7 +16052,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sha.js@npm:2.4.12":
+"sha.js@npm:^2.4.0, sha.js@npm:^2.4.8, sha.js@npm:~2.4.4":
   version: 2.4.12
   resolution: "sha.js@npm:2.4.12"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -16052,15 +16052,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sha.js@npm:^2.4.0, sha.js@npm:^2.4.8, sha.js@npm:~2.4.4":
-  version: 2.4.11
-  resolution: "sha.js@npm:2.4.11"
+"sha.js@npm:2.4.12":
+  version: 2.4.12
+  resolution: "sha.js@npm:2.4.12"
   dependencies:
-    inherits: "npm:^2.0.1"
-    safe-buffer: "npm:^5.0.1"
+    inherits: "npm:^2.0.4"
+    safe-buffer: "npm:^5.2.1"
+    to-buffer: "npm:^1.2.0"
   bin:
-    sha.js: ./bin.js
-  checksum: 10/d833bfa3e0a67579a6ce6e1bc95571f05246e0a441dd8c76e3057972f2a3e098465687a4369b07e83a0375a88703577f71b5b2e966809e67ebc340dbedb478c7
+    sha.js: bin.js
+  checksum: 10/39c0993592c2ab34eb2daae2199a2a1d502713765aecb611fd97c0c4ab7cd53e902d628e1962aaf384bafd28f55951fef46dcc78799069ce41d74b03aa13b5a7
   languageName: node
   linkType: hard
 
@@ -17117,6 +17118,17 @@ __metadata:
   version: 1.0.1
   resolution: "to-arraybuffer@npm:1.0.1"
   checksum: 10/31433c10b388722729f5da04c6b2a06f40dc84f797bb802a5a171ced1e599454099c6c5bc5118f4b9105e7d049d3ad9d0f71182b77650e4fdb04539695489941
+  languageName: node
+  linkType: hard
+
+"to-buffer@npm:^1.2.0":
+  version: 1.2.2
+  resolution: "to-buffer@npm:1.2.2"
+  dependencies:
+    isarray: "npm:^2.0.5"
+    safe-buffer: "npm:^5.2.1"
+    typed-array-buffer: "npm:^1.0.3"
+  checksum: 10/69d806c20524ff1e4c44d49276bc96ff282dcae484780a3974e275dabeb75651ea430b074a2a4023701e63b3e1d87811cd82c0972f35280fe5461710e4872aba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 ## Summary
 
1. Why:
To remove CVEs:

     - [CVE-2025-9288](https://avd.aquasec.com/nvd/2025/cve-2025-9288/)

2. What:

     - Upgrade sha.js to 2.4.12 to remove [CVE-2025-9288](https://avd.aquasec.com/nvd/2025/cve-2025-9288/)
     - sha.js is coming from browserify but latest version has older vulnerable sha.js version so new sha.js 2.4.12 needed to be added to resolutions as this is a critical cve
 
 ## Additional evidence
 
 Partial output from security scanner Trivy:
<img width="1423" height="79" alt="cve babel shajs" src="https://github.com/user-attachments/assets/a30e2925-29ab-427f-ae0b-b538081d2b39" />

 ## Categorization
 
- [x] security/CVE