### PR TITLE
[Babel 8] Disallow excess arguments in babel-external-helpers

### DIFF
--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@jridgewell/trace-mapping": "^0.3.28",
-    "commander": "^12.1.0",
+    "commander": "^14.0.2",
     "convert-source-map": "^2.0.0",
     "glob": "^13.0.0",
     "slash": "^5.1.0"

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -27,8 +27,8 @@
     "@jridgewell/trace-mapping": "^0.3.28",
     "commander": "^12.1.0",
     "convert-source-map": "^2.0.0",
-    "glob": "^12.0.0",
-    "slash": "^3.0.0"
+    "glob": "^13.0.0",
+    "slash": "^5.1.0"
   },
   "optionalDependencies": {
     "chokidar": "^3.6.0"

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -161,13 +161,10 @@ program.option(
   "--out-file-extension [string]",
   "Use a specific extension for the output files",
 );
+program.argument("[files...]", "List of files to compile.");
 
 program.version(PACKAGE_JSON.version + " (@babel/core " + version + ")");
-program.usage("[options] <files ...>");
-// register an empty action handler so that program.js can throw on
-// unknown options _after_ args
-// see https://github.com/tj/program.js/issues/561#issuecomment-522209408
-program.action(() => {});
+program.usage("[options] [files...]");
 
 export type CmdOptions = {
   babelOptions: InputOptions;

--- a/packages/babel-cli/test/fixtures/babel-external-helpers/invalid-excess-arguments/options.json
+++ b/packages/babel-cli/test/fixtures/babel-external-helpers/invalid-excess-arguments/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["output-type", "global"]
+}

--- a/packages/babel-cli/test/fixtures/babel-external-helpers/invalid-excess-arguments/stderr.txt
+++ b/packages/babel-cli/test/fixtures/babel-external-helpers/invalid-excess-arguments/stderr.txt
@@ -1,0 +1,1 @@
+error: too many arguments. Expected 0 arguments but got 2.

--- a/packages/babel-node/package.json
+++ b/packages/babel-node/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@babel/register": "workspace:^",
-    "commander": "^12.1.0",
+    "commander": "^14.0.2",
     "core-js": "^3.48.0",
     "v8flags": "^4.0.1"
   },

--- a/packages/babel-node/src/program-setup.ts
+++ b/packages/babel-node/src/program-setup.ts
@@ -54,6 +54,10 @@ program.option(
 );
 program.option("-w, --plugins [string]", "", collect);
 program.option("-b, --presets [string]", "", collect);
+program.argument(
+  "[arguments...]",
+  "Path to the script for evaluation or arguments passed to the script.",
+);
 
 program.version(PACKAGE_JSON.version);
 program.usage(`[options] [ -e "script" | script.js ] [--] [arguments]`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,11 +290,11 @@ __metadata:
     "@types/fs-readdir-recursive": "npm:^1.1.0"
     "@types/glob": "npm:^7.2.0"
     chokidar: "npm:^3.6.0"
-    commander: "npm:^12.1.0"
+    commander: "npm:^14.0.2"
     convert-source-map: "npm:^2.0.0"
-    glob: "npm:^12.0.0"
+    glob: "npm:^13.0.0"
     semver: "npm:^7.7.3"
-    slash: "npm:^3.0.0"
+    slash: "npm:^5.1.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
   dependenciesMeta:
@@ -1270,7 +1270,7 @@ __metadata:
     "@babel/register": "workspace:^"
     "@babel/runtime": "workspace:^"
     "@types/v8flags": "npm:^3.1.1"
-    commander: "npm:^12.1.0"
+    commander: "npm:^14.0.2"
     core-js: "npm:^3.48.0"
     v8flags: "npm:^4.0.1"
   peerDependencies:
@@ -8508,6 +8508,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^14.0.2":
+  version: 14.0.2
+  resolution: "commander@npm:14.0.2"
+  checksum: 10/2d202db5e5f9bb770112a3c1579b893d17ac6f6d932183077308bdd96d0f87f0bbe6a68b5b9ed2cf3b2514be6bb7de637480703c0e2db9741ee1b383237deb26
+  languageName: node
+  linkType: hard
+
 "commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
@@ -10985,6 +10992,17 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 10/6e21b3f1f1fa635836d45e54bbe50704884cc3e310e0cc011cfb5429db65a030e12936d99b07e66236370efe45dc8c8b26fa5334dbf555d6f8709e0315c77c30
+  languageName: node
+  linkType: hard
+
+"glob@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "glob@npm:13.0.0"
+  dependencies:
+    minimatch: "npm:^10.1.1"
+    minipass: "npm:^7.1.2"
+    path-scurry: "npm:^2.0.0"
+  checksum: 10/de390721d29ee1c9ea41e40ec2aa0de2cabafa68022e237dc4297665a5e4d650776f2573191984ea1640aba1bf0ea34eddef2d8cbfbfc2ad24b5fb0af41d8846
   languageName: node
   linkType: hard
 
@@ -16225,6 +16243,13 @@ __metadata:
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
   checksum: 10/94a93fff615f25a999ad4b83c9d5e257a7280c90a32a7cb8b4a87996e4babf322e469c42b7f649fd5796edd8687652f3fb452a86dc97a816f01113183393f11c
+  languageName: node
+  linkType: hard
+
+"slash@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "slash@npm:5.1.0"
+  checksum: 10/2c41ec6fb1414cd9bba0fa6b1dd00e8be739e3fe85d079c69d4b09ca5f2f86eafd18d9ce611c0c0f686428638a36c272a6ac14799146a8295f259c10cc45cde4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | Bumped `commander`, `glob` and `slash` to the latest major releases.
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we bumped three external dependencies to the latest major releases. As a result of the `commander.js` update, the `babel-external-helpers` cli now rejects excess arguments. I think this change is reasonable as that script does not expect an input argument, any passed arguments might indicate that there is something wrong, i.e. if `--output-type` is written as `output-type`, this check will throw an error "unexpected arguments", currently the script will silently accept the arguments even if they are not used.

Aside: I think we could also consider extract the `babel-external-helpers` script from the `babel-cli` library, maybe into a dedicate library, since most `@babel/cli` users would not need this script.