### PR TITLE
perf: Improve the performance of `NodePath` creation

### DIFF
--- a/packages/babel-core/src/transformation/file/file.ts
+++ b/packages/babel-core/src/transformation/file/file.ts
@@ -42,13 +42,14 @@ export default class File {
     this.ast = ast;
     this.inputMap = inputMap;
 
-    this.path = NodePath.get({
-      hub: this.hub,
-      parentPath: null,
-      parent: this.ast,
-      container: this.ast,
-      key: "program",
-    }).setContext() as NodePath<t.Program>;
+    this.path = NodePath.get(
+      this.ast,
+      this.ast,
+      "program",
+      undefined,
+      undefined,
+      this.hub,
+    ).setContext() as NodePath<t.Program>;
     this.scope = this.path.scope;
   }
 

--- a/packages/babel-traverse/src/context.ts
+++ b/packages/babel-traverse/src/context.ts
@@ -1,76 +1,24 @@
-import NodePath from "./path/index.ts";
-import { VISITOR_KEYS } from "@babel/types";
+import type NodePath from "./path/index.ts";
 import type Scope from "./scope/index.ts";
 import type { ExplodedTraverseOptions } from "./index.ts";
 import type * as t from "@babel/types";
-import type { Visitor } from "./types.ts";
-import { popContext, pushContext, resync } from "./path/context.ts";
 
 export default class TraversalContext<S = unknown> {
   constructor(
     scope: Scope | null | undefined,
     opts: ExplodedTraverseOptions<S>,
     state: S,
-    parentPath: NodePath | undefined,
   ) {
-    this.parentPath = parentPath;
     this.scope = scope;
     this.state = state;
     this.opts = opts;
   }
 
-  declare parentPath: NodePath | undefined;
   declare scope: Scope | null | undefined;
   declare state: S;
   declare opts: ExplodedTraverseOptions<S>;
   queue: NodePath<t.Node | null>[] | null = null;
   priorityQueue: NodePath<t.Node | null>[] | null = null;
-
-  /**
-   * This method does a simple check to determine whether or not we really need to attempt
-   * visit a node. This will prevent us from constructing a NodePath.
-   */
-
-  shouldVisit(node: t.Node): boolean {
-    const opts = this.opts as Visitor;
-    if (opts.enter || opts.exit) return true;
-
-    // check if we have a visitor for this node
-    if (opts[node.type]) return true;
-
-    // check if we're going to traverse into this node
-    const keys: string[] | undefined = VISITOR_KEYS[node.type];
-    if (!keys?.length) return false;
-
-    // we need to traverse into this node so ensure that it has children to traverse into!
-    for (const key of keys) {
-      if (
-        // @ts-expect-error key is from visitor keys
-        node[key]
-      ) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  create(
-    node: t.Node,
-    container: t.Node | t.Node[],
-    key: string | number,
-    listKey?: string,
-  ): NodePath {
-    // We don't need to `.setContext()` here, since `.visitQueue()` already
-    // calls `.pushContext`.
-    return NodePath.get({
-      parentPath: this.parentPath,
-      parent: node,
-      container,
-      key: key,
-      listKey,
-    });
-  }
 
   maybeQueue(path: NodePath<t.Node | null>, notPriority?: boolean) {
     if (this.queue) {
@@ -79,109 +27,6 @@ export default class TraversalContext<S = unknown> {
       } else {
         this.priorityQueue!.push(path);
       }
-    }
-  }
-
-  visitMultiple(container: t.Node[], parent: t.Node, listKey: string) {
-    // nothing to traverse!
-    if (container.length === 0) return false;
-
-    const queue = [];
-
-    // build up initial queue
-    for (let key = 0; key < container.length; key++) {
-      const node = container[key];
-      if (node && this.shouldVisit(node)) {
-        queue.push(this.create(parent, container, key, listKey));
-      }
-    }
-
-    return this.visitQueue(queue);
-  }
-
-  visitSingle(node: t.Node, key: string): boolean {
-    if (
-      this.shouldVisit(
-        // @ts-expect-error key may not index node
-        node[key],
-      )
-    ) {
-      return this.visitQueue([this.create(node, node, key)]);
-    } else {
-      return false;
-    }
-  }
-
-  visitQueue(queue: NodePath<t.Node | null>[]): boolean {
-    // set queue
-    this.queue = queue;
-    this.priorityQueue = [];
-
-    const visited = new WeakSet();
-    let stop = false;
-    let visitIndex = 0;
-
-    // visit the queue
-    for (; visitIndex < queue.length; ) {
-      const path = queue[visitIndex];
-      visitIndex++;
-      resync.call(path);
-
-      // this path no longer belongs to the tree
-      if (path.key === null) continue;
-
-      if (
-        path.contexts.length === 0 ||
-        path.contexts[path.contexts.length - 1] !== this
-      ) {
-        // The context might already have been pushed when this path was inserted and queued.
-        // If we always re-pushed here, we could get duplicates and risk leaving contexts
-        // on the stack after the traversal has completed, which could break things.
-        pushContext.call(path, this);
-      }
-
-      // this path no longer belongs to the tree
-
-      // ensure we don't visit the same node twice
-      const { node } = path;
-      // @ts-expect-error node may be null
-      if (visited.has(node)) continue;
-      if (node) visited.add(node);
-
-      if (path.visit()) {
-        stop = true;
-        break;
-      }
-
-      if (this.priorityQueue.length) {
-        stop = this.visitQueue(this.priorityQueue);
-        this.priorityQueue = [];
-        this.queue = queue;
-        if (stop) break;
-      }
-    }
-
-    // pop contexts
-    for (let i = 0; i < visitIndex; i++) {
-      if (queue[i].key === null) continue;
-      popContext.call(queue[i]);
-    }
-
-    // clear queue
-    this.queue = null;
-
-    return stop;
-  }
-
-  visit(node: t.Node, key: string) {
-    // @ts-expect-error key may not index node
-    const nodes = node[key] as t.Node | t.Node[] | null;
-    if (!nodes) return false;
-
-    if (Array.isArray(nodes)) {
-      return this.visitMultiple(nodes, node, key);
-    } else {
-      return this.visitSingle(node, key);
     }
   }
 }

--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -63,8 +63,6 @@ export function isDenylisted(this: NodePath): boolean {
 function restoreContext(path: NodePath, context: TraversalContext) {
   if (path.context !== context) {
     path.context = context;
-    path.state = context.state;
-    path.opts = context.opts;
   }
 }
 
@@ -190,9 +188,6 @@ export function setContext<S = unknown>(
 
   if (context) {
     this.context = context;
-    this.state = context.state;
-    // Discard the S type parameter from context.opts
-    this.opts = context.opts as typeof this.opts;
   }
 
   setScope.call(this);
@@ -312,7 +307,6 @@ export function setKey(this: NodePath, key: string | number) {
   this.node =
     // @ts-expect-error this.key must present in this.container
     this.container[this.key];
-  this.type = this.node?.type;
 }
 
 export function requeue(this: NodePath<t.Node | null>, pathToQueue = this) {

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -301,13 +301,13 @@ export function getSibling(
   this: NodePath<t.Node | null>,
   key: string | number,
 ): NodePath {
-  return NodePath.get({
-    parentPath: this.parentPath,
-    parent: this.parent,
-    container: this.container!,
-    listKey: this.listKey!,
-    key: key,
-  }).setContext(this.context);
+  return NodePath.get(
+    this.parent,
+    this.container!,
+    key,
+    this.listKey,
+    this.parentPath,
+  ).setContext(this.context);
 }
 
 export function getPrevSibling(this: NodePath<t.Node | null>): NodePath {
@@ -444,21 +444,10 @@ export function _getKey<T extends t.Node>(
   if (Array.isArray(container)) {
     // requested a container so give them all the paths
     return container.map((_, i) => {
-      return NodePath.get({
-        listKey: key,
-        parentPath: this,
-        parent: node,
-        container: container,
-        key: i,
-      }).setContext(context);
+      return NodePath.get(node, container, i, key, this).setContext(context);
     });
   } else {
-    return NodePath.get({
-      parentPath: this,
-      parent: node,
-      container: node,
-      key: key,
-    }).setContext(context);
+    return NodePath.get(node, node, key, undefined, this).setContext(context);
   }
 }
 

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -73,8 +73,12 @@ const NodePath_Final = class NodePath {
   declare scope: Scope;
 
   contexts: TraversalContext[] = [];
-  state: any = null;
-  declare opts: ExplodedTraverseOptions;
+  get state(): any {
+    return this.context?.state;
+  }
+  get opts(): ExplodedTraverseOptions {
+    return this.context?.opts;
+  }
 
   @bit.storage _traverseFlags: number = 0;
   @bit(REMOVED) accessor removed = false;
@@ -87,24 +91,19 @@ const NodePath_Final = class NodePath {
   listKey: string | null | undefined = null;
   key: string | number | null = null;
   node: t.Node | null = null;
-  type: t.Node["type"] | null = null;
+  get type(): t.Node["type"] | null {
+    return this.node ? this.node.type : null;
+  }
   _store: Map<t.Node, NodePath_Final> | null = null;
 
-  static get({
-    hub,
-    parentPath,
-    parent,
-    container,
-    listKey,
-    key,
-  }: {
-    hub?: HubInterface;
-    parentPath: NodePath_Final | null | undefined;
-    parent: t.Node;
-    container: t.Node | t.Node[];
-    listKey?: string | null;
-    key: string | number;
-  }): NodePath_Final {
+  static get(
+    parent: t.Node,
+    container: t.Node | t.Node[],
+    key: string | number,
+    listKey?: string | null,
+    parentPath?: NodePath_Final | null,
+    hub?: HubInterface,
+  ): NodePath_Final {
     if (!hub && parentPath) {
       hub = parentPath.hub;
     }

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -372,13 +372,9 @@ export function unshiftContainer<
   // get the first path and insert our nodes before it, if it doesn't exist then it
   // doesn't matter, our nodes will be inserted anyway
   const container = (this.node as N)[listKey] as t.Node[];
-  const path = NodePath.get({
-    parentPath: this,
-    parent: this.node,
-    container,
-    listKey,
-    key: 0,
-  }).setContext(this.context);
+  const path = NodePath.get(this.node, container, 0, listKey, this).setContext(
+    this.context,
+  );
 
   return _containerInsertBefore.call(path, verifiedNodes) as NodePaths<Nodes>;
 }
@@ -396,13 +392,13 @@ export function pushContainer<
   // nodes, effectively inlining it
 
   const container = (this.node as N)[listKey] as t.Node[];
-  const path = NodePath.get({
-    parentPath: this,
-    parent: this.node,
+  const path = NodePath.get(
+    this.node,
     container,
+    container.length,
     listKey,
-    key: container.length,
-  }).setContext(this.context);
+    this,
+  ).setContext(this.context);
 
   return path.replaceWithMultiple(verifiedNodes) as NodePaths<Nodes>;
 }

--- a/packages/babel-traverse/src/path/replacement.ts
+++ b/packages/babel-traverse/src/path/replacement.ts
@@ -199,7 +199,6 @@ export function replaceWith(
 
   // replace the node
   _replaceWith.call(this, replacement);
-  this.type = replacement.type;
 
   // potentially create new scope
   setScope.call(this);

--- a/packages/babel-traverse/src/scope/traverseForScope.ts
+++ b/packages/babel-traverse/src/scope/traverseForScope.ts
@@ -42,15 +42,7 @@ export default function traverseForScope(
     }
 
     const path =
-      inPath ||
-      NodePath.get({
-        hub,
-        parentPath,
-        parent,
-        container,
-        listKey,
-        key,
-      });
+      inPath || NodePath.get(parent, container, key, listKey, parentPath, hub);
 
     _forceSetScope.call(path);
 

--- a/packages/babel-traverse/src/traverse-node.ts
+++ b/packages/babel-traverse/src/traverse-node.ts
@@ -136,7 +136,7 @@ export function traverseNode<S = unknown>(
   const keys = VISITOR_KEYS[node.type];
   if (!keys?.length) return false;
 
-  const ctx = new TraversalContext(scope, opts, state, path);
+  const ctx = new TraversalContext(scope, opts, state);
   if (visitSelf) {
     if (skipKeys?.[path!.parentKey]) return false;
     return _visitPaths(ctx, [path!]);
@@ -159,30 +159,12 @@ export function traverseNode<S = unknown>(
       if (!prop.length) continue;
       const paths = [];
       for (let i = 0; i < prop.length; i++) {
-        const childPath = NodePath.get({
-          parentPath: path,
-          parent: node,
-          container: prop,
-          key: i,
-          listKey: key,
-          hub,
-        });
+        const childPath = NodePath.get(node, prop, i, key, path, hub);
         paths.push(childPath);
       }
       if (_visitPaths(ctx, paths)) return true;
     } else {
-      if (
-        _visitPaths(ctx, [
-          NodePath.get({
-            parentPath: path,
-            parent: node,
-            container: node,
-            key,
-            listKey: null,
-            hub,
-          }),
-        ])
-      ) {
+      if (_visitPaths(ctx, [NodePath.get(node, node, key, null, path, hub)])) {
         return true;
       }
     }

--- a/packages/babel-traverse/test/arrow-transform.js
+++ b/packages/babel-traverse/test/arrow-transform.js
@@ -13,8 +13,13 @@ function assertConversion(
   const inputAst = wrapMethod(input, methodName, extend);
   const outputAst = wrapMethod(output, methodName, extend);
 
-  const rootPath = NodePath.get({
-    hub: {
+  const rootPath = NodePath.get(
+    inputAst,
+    inputAst,
+    "program",
+    undefined,
+    undefined,
+    {
       addHelper(helperName) {
         return t.memberExpression(
           t.identifier("babelHelpers"),
@@ -22,11 +27,7 @@ function assertConversion(
         );
       },
     },
-    parentPath: null,
-    parent: inputAst,
-    container: inputAst,
-    key: "program",
-  }).setContext();
+  ).setContext();
 
   rootPath.traverse({
     ClassMethod(path) {

--- a/packages/babel-traverse/test/scope.js
+++ b/packages/babel-traverse/test/scope.js
@@ -36,14 +36,8 @@ function createNode(node) {
   // This puts the path into the cache internally
   // We afterwards traverse ast, as we need to start traversing
   // at the File node and not the Program node
-  NodePath.get({
-    hub: {
-      buildError: (_, msg) => new Error(msg),
-    },
-    parentPath: null,
-    parent: ast,
-    container: ast,
-    key: "program",
+  NodePath.get(ast, ast, "program", undefined, undefined, {
+    buildError: (_, msg) => new Error(msg),
   }).setContext();
 
   return ast;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`real-case-scope.mjs` is a bench that only collects scope information, while `real-case.mjs` is a traverse with `noScope`.
```
PS F:\babel\benchmark\babel-traverse> node .\real-case-scope.mjs
Recommend running with --expose-gc.
babel-traverse/real-case-scope.mjs babel-parser-express.ts @ current: 420 ops/sec ±3.92% 1640 runs (3.049ms)
babel-traverse/real-case-scope.mjs babel-parser-express.ts @ baseline: 405 ops/sec ±3.72% 1597 runs (3.131ms)
babel-traverse/real-case-scope.mjs jquery-3.6.js @ current: 83.13 ops/sec ±3.23% 380 runs (13ms)
babel-traverse/real-case-scope.mjs jquery-3.6.js @ baseline: 78.28 ops/sec ±3% 362 runs (14ms)
babel-traverse/real-case-scope.mjs ts-checker.mjs @ current: 9.71 ops/sec ±2.3% 64 runs (104ms)
babel-traverse/real-case-scope.mjs ts-checker.mjs @ baseline: 9.36 ops/sec ±2.16% 64 runs (108ms)
babel-traverse/real-case-scope.mjs ts-parser.mjs @ current: 70.07 ops/sec ±2.98% 327 runs (15ms)
babel-traverse/real-case-scope.mjs ts-parser.mjs @ baseline: 67.27 ops/sec ±2.9% 316 runs (16ms)
babel-traverse/real-case-scope.mjs ts-parser.ts @ current: 61.14 ops/sec ±2.93% 288 runs (17ms)
babel-traverse/real-case-scope.mjs ts-parser.ts @ baseline: 60.67 ops/sec ±2.71% 288 runs (17ms)
babel-traverse/real-case-scope.mjs typescript-5.6.2.js @ current: 2.45 ops/sec ±1.34% 64 runs (410ms)
babel-traverse/real-case-scope.mjs typescript-5.6.2.js @ baseline: 2.39 ops/sec ±1.32% 64 runs (419ms)
PS F:\babel\benchmark\babel-traverse> node .\real-case.mjs
Recommend running with --expose-gc.
babel-traverse/real-case.mjs babel-parser-express.ts @ current: 170 ops/sec ±3.71% 714 runs (7.006ms)
babel-traverse/real-case.mjs babel-parser-express.ts @ baseline: 166 ops/sec ±3.61% 703 runs (7.118ms)
babel-traverse/real-case.mjs jquery-3.6.js @ current: 41.36 ops/sec ±2.66% 200 runs (25ms)
babel-traverse/real-case.mjs jquery-3.6.js @ baseline: 39.84 ops/sec ±2.77% 192 runs (26ms)
babel-traverse/real-case.mjs ts-checker.mjs @ current: 5.28 ops/sec ±1.53% 64 runs (190ms)
babel-traverse/real-case.mjs ts-checker.mjs @ baseline: 5.2 ops/sec ±1.36% 64 runs (193ms)
babel-traverse/real-case.mjs ts-parser.mjs @ current: 34.53 ops/sec ±2.33% 169 runs (30ms)
babel-traverse/real-case.mjs ts-parser.mjs @ baseline: 33.7 ops/sec ±2.24% 165 runs (30ms)
babel-traverse/real-case.mjs ts-parser.ts @ current: 29.32 ops/sec ±1.96% 145 runs (35ms)
babel-traverse/real-case.mjs ts-parser.ts @ baseline: 28.6 ops/sec ±2.15% 141 runs (35ms)
babel-traverse/real-case.mjs typescript-5.6.2.js @ current: 1.33 ops/sec ±1.14% 64 runs (755ms)
babel-traverse/real-case.mjs typescript-5.6.2.js @ baseline: 1.28 ops/sec ±1.45% 64 runs (782ms)
```