### PR TITLE
fix: ensure `targets.esmodules` is validated

### DIFF
--- a/packages/babel-standalone/src/transformScriptTags.ts
+++ b/packages/babel-standalone/src/transformScriptTags.ts
@@ -85,7 +85,7 @@ function buildBabelOptions(
   };
 
   if (script.type === "module") {
-    targets.esmodules = "intersect";
+    targets.esmodules = true;
   }
 
   return {

--- a/packages/babel-standalone/test/transform-script-tags.test.js
+++ b/packages/babel-standalone/test/transform-script-tags.test.js
@@ -79,4 +79,30 @@ describe("transformScriptTags", () => {
       });
     });
   });
+  it("should support data-targets attribute with data-type: module", () => {
+    const input = `globalThis ?? window; /\\p{ASCII}/v`;
+    const targets = "chrome 84"; // Chrome 84 supports nullish coalescing but not the `v` flag in regexps.
+    const dom = new JSDOM(
+      `<!DOCTYPE html><head><script>${standaloneSource}</script><script type="text/babel" data-targets="${targets}" data-type="module">${input}</script></head>`,
+      { runScripts: "dangerously" },
+    );
+    return new Promise((resolve, reject) => {
+      dom.window.addEventListener("DOMContentLoaded", () => {
+        try {
+          const transformedScriptElement =
+            dom.window.document.head.children.item(2);
+          expect(
+            transformedScriptElement.getAttribute("data-targets"),
+          ).toBeNull();
+          expect(transformedScriptElement.innerHTML).toContain(
+            `globalThis ?? window;
+/\\p{ASCII}/u;`,
+          );
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17769 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The PR ensures that `targets.esmodules` is valid. The typing allows both boolean and `intersect` but the runtime validation said otherwise. I will fix the type discrepancies in another PR.

As is revealed in the new test case, the `esmodules: true` in standalone behaves exactly as `esmodules: "intersect"`, I think this PR suffices to fix the regression. 