### PR TITLE
[7.x backport] Fix undefined when 64 indents

### DIFF
--- a/packages/babel-generator/src/buffer.ts
+++ b/packages/babel-generator/src/buffer.ts
@@ -143,7 +143,7 @@ export default class Buffer {
 
     if (char === -1) {
       const indent =
-        repeat > 64
+        repeat >= 64
           ? this._indentChar.repeat(repeat)
           : spaceIndents[repeat / 2];
       this._str += indent;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #17775 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
