### PR TITLE
Fix TS5055 error when running `make tscheck` twice

### DIFF
--- a/scripts/generators/tsconfig.ts
+++ b/scripts/generators/tsconfig.ts
@@ -370,14 +370,16 @@ maybeWriteFile(
           strict: true,
         },
         include: [
-          "./lib/libdom-minimal.d.ts",
-          "dts/**/*.d.ts",
+          "lib/libdom-minimal.d.ts",
+          "dts/codemods/*/src/**/*.ts",
+          "dts/eslint/*/src/**/*.ts",
+          "dts/packages/*/src/**/*.ts",
           "*.mts",
           "*.ts",
           "scripts/**/*.ts",
           "packages/*/test/*.tst.ts",
         ],
-        exclude: ["dts/**/*.tst.d.ts"],
+        exclude: [],
         references: Array.from(new Set(projectsFolders.values()))
           .sort()
           .map(path => ({ path })),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,16 +8,16 @@
     "strict": true
   },
   "include": [
-    "./lib/libdom-minimal.d.ts",
-    "dts/**/*.d.ts",
+    "lib/libdom-minimal.d.ts",
+    "dts/codemods/*/src/**/*.ts",
+    "dts/eslint/*/src/**/*.ts",
+    "dts/packages/*/src/**/*.ts",
     "*.mts",
     "*.ts",
     "scripts/**/*.ts",
     "packages/*/test/*.tst.ts"
   ],
-  "exclude": [
-    "dts/**/*.tst.d.ts"
-  ],
+  "exclude": [],
   "references": [
     {
       "path": "./codemods/babel-plugin-codemod-object-assign-to-object-spread"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | TS throws TS5055 error when running `yarn tsc -p tsconfig.json` after `make tscheck`
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Currently TS throws the following error when one runs `make tscheck` twice:

```
...
Cannot write file '/path/to/babel/dts/scripts/generators/npm-ignore.d.ts' because it would overwrite input file.
...
Found 29 errors
```

The error is thrown from the type checking the top level project. This is likely due to the recently merged https://github.com/babel/babel/pull/17767 as we output the dts of `scripts/generator/npm-ignore.ts` to `dts/scripts/generators/npm-ignore.d.ts`, which is also covered by the `input` spec: `dts/**/*.d.ts`.

The CI unfortunately can not catch this error because the top level project `tscheck` is run before `dts` files are generated.

Here we include only `dts` files generated from the `src` folder of the sub packages.