### PR TITLE
Pass `file` instead of `path` to importToPlatformApi builders

### DIFF
--- a/packages/babel-plugin-proposal-import-wasm-source/src/index.ts
+++ b/packages/babel-plugin-proposal-import-wasm-source/src/index.ts
@@ -23,7 +23,7 @@ export default declare(api => {
       template.expression.ast`WebAssembly.compileStreaming(${fetch})`,
     nodeFsSync: (read: t.Expression) =>
       template.expression.ast`new WebAssembly.Module(${read})`,
-    nodeFsAsync: template.expression`WebAssembly.compile`,
+    nodeFsAsync: () => template.expression.ast`WebAssembly.compile`,
   };
 
   const getHelper = (file: File) => {
@@ -74,7 +74,7 @@ export default declare(api => {
 
           data.push({
             id: specifier.local,
-            fetch: helper.buildFetch(decl.node.source, path),
+            fetch: helper.buildFetch(decl.node.source, this.file),
           });
           decl.remove();
         }
@@ -93,7 +93,7 @@ export default declare(api => {
         }
 
         path.replaceWith(
-          getHelper(this.file).buildFetchAsync(path.node.source, path),
+          getHelper(this.file).buildFetchAsync(path.node.source, this.file),
         );
       },
     },

--- a/packages/babel-plugin-transform-json-modules/src/index.ts
+++ b/packages/babel-plugin-transform-json-modules/src/index.ts
@@ -98,7 +98,7 @@ export default declare((api, options: Options) => {
           }
           id ??= path.scope.generateUidIdentifier("_");
 
-          let fetch = helper.buildFetch(decl.node.source, path);
+          let fetch = helper.buildFetch(decl.node.source, this.file);
 
           if (needsNS) {
             if (helper.needsAwait) {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I'm working on support for https://github.com/tc39/proposal-import-bytes, and it would be helpful to have the `file` passed to the "Pieces builders" so that I can easily inject helpers in there.

This is _technically_ a breaking change, but it's unobservable for users that are not manually using the helper package, given that right now versions are pinned. I'm opening this as its own PR because we need to ship it at latest in 8.0.0, when we'll stop pinning dependencies.