### PR TITLE
Replace remaining whitelist/blacklist with inclusive alternatives

### DIFF
--- a/packages/babel-plugin-external-helpers/src/index.ts
+++ b/packages/babel-plugin-external-helpers/src/index.ts
@@ -3,24 +3,24 @@ import { types as t } from "@babel/core";
 
 export interface Options {
   helperVersion?: string;
-  whitelist?: false | string[];
+  allowlist?: false | string[];
 }
 
 export default declare((api, options: Options) => {
   api.assertVersion(REQUIRED_VERSION(7));
 
-  const { helperVersion = "7.0.0-beta.0", whitelist = false } = options;
+  const { helperVersion = "7.0.0-beta.0", allowlist = false } = options;
 
   if (
-    whitelist !== false &&
-    (!Array.isArray(whitelist) || whitelist.some(w => typeof w !== "string"))
+    allowlist !== false &&
+    (!Array.isArray(allowlist) || allowlist.some(w => typeof w !== "string"))
   ) {
     throw new Error(
-      ".whitelist must be undefined, false, or an array of strings",
+      ".allowlist must be undefined, false, or an array of strings",
     );
   }
 
-  const helperWhitelist = whitelist ? new Set(whitelist) : null;
+  const helperAllowlist = allowlist ? new Set(allowlist) : null;
 
   return {
     name: "external-helpers",
@@ -36,11 +36,12 @@ export default declare((api, options: Options) => {
           return;
         }
 
-        // babelCore.buildExternalHelpers() allows a whitelist of helpers that
-        // will be inserted into the external helpers list. That same whitelist
-        // should be passed into the plugin here in that case, so that we can
-        // avoid referencing 'babelHelpers.XX' when the helper does not exist.
-        if (helperWhitelist && !helperWhitelist.has(name)) return;
+        // babelCore.buildExternalHelpers() allows an allowlist of helpers
+        // that will be inserted into the external helpers list. That same
+        // allowlist should be passed into the plugin here in that case, so
+        // that we can avoid referencing 'babelHelpers.XX' when the helper
+        // does not exist.
+        if (helperAllowlist && !helperAllowlist.has(name)) return;
 
         return t.memberExpression(
           t.identifier("babelHelpers"),

--- a/packages/babel-plugin-external-helpers/src/index.ts
+++ b/packages/babel-plugin-external-helpers/src/index.ts
@@ -9,6 +9,13 @@ export interface Options {
 export default declare((api, options: Options) => {
   api.assertVersion(REQUIRED_VERSION(7));
 
+  if (Object.hasOwn(options, "whitelist")) {
+    throw new Error(
+      "The 'whitelist' option has been renamed to 'allowlist'. " +
+        "Please update your configuration.",
+    );
+  }
+
   const { helperVersion = "7.0.0-beta.0", allowlist = false } = options;
 
   if (

--- a/packages/babel-plugin-external-helpers/src/index.ts
+++ b/packages/babel-plugin-external-helpers/src/index.ts
@@ -10,10 +10,13 @@ export default declare((api, options: Options) => {
   api.assertVersion(REQUIRED_VERSION(7));
 
   if (Object.hasOwn(options, "whitelist")) {
-    throw new Error(
-      "The 'whitelist' option has been renamed to 'allowlist'. " +
-        "Please update your configuration.",
-    );
+    if (!Object.hasOwn(options, "allowlist")) {
+      throw new Error(
+        "The 'whitelist' option has been renamed to 'allowlist'. " +
+          "Please update your configuration.",
+      );
+    }
+    // Both options provided: new option takes precedence (supports Babel 7/8 cross-version compat)
   }
 
   const { helperVersion = "7.0.0-beta.0", allowlist = false } = options;

--- a/packages/babel-plugin-external-helpers/test/fixtures/opts/whitelist/options.json
+++ b/packages/babel-plugin-external-helpers/test/fixtures/opts/whitelist/options.json
@@ -4,7 +4,7 @@
     [
       "external-helpers",
       {
-        "whitelist": ["createClass"]
+        "allowlist": ["createClass"]
       }
     ],
     "transform-classes"

--- a/packages/babel-template/src/literal.ts
+++ b/packages/babel-template/src/literal.ts
@@ -61,11 +61,11 @@ function buildLiteralData<T>(
   const metadata = parseAndBuildMetadata(formatter, formatter.code(code), {
     parser: opts.parser,
 
-    // Explicitly include our generated names in the whitelist so users never
+    // Explicitly include our generated names in the allowlist so users never
     // have to think about whether their placeholder pattern will match.
-    placeholderWhitelist: new Set(
+    placeholderAllowlist: new Set(
       names.concat(
-        opts.placeholderWhitelist ? Array.from(opts.placeholderWhitelist) : [],
+        opts.placeholderAllowlist ? Array.from(opts.placeholderAllowlist) : [],
       ),
     ),
     placeholderPattern: opts.placeholderPattern,

--- a/packages/babel-template/src/options.ts
+++ b/packages/babel-template/src/options.ts
@@ -73,6 +73,13 @@ export function validate(opts: unknown): TemplateOpts {
     throw new Error("Unknown template options.");
   }
 
+  if (opts != null && Object.hasOwn(opts as object, "placeholderWhitelist")) {
+    throw new Error(
+      "The 'placeholderWhitelist' option has been renamed to " +
+        "'placeholderAllowlist'. Please update your configuration.",
+    );
+  }
+
   const {
     placeholderAllowlist,
     placeholderPattern,

--- a/packages/babel-template/src/options.ts
+++ b/packages/babel-template/src/options.ts
@@ -74,10 +74,13 @@ export function validate(opts: unknown): TemplateOpts {
   }
 
   if (opts != null && Object.hasOwn(opts as object, "placeholderWhitelist")) {
-    throw new Error(
-      "The 'placeholderWhitelist' option has been renamed to " +
-        "'placeholderAllowlist'. Please update your configuration.",
-    );
+    if (!Object.hasOwn(opts as object, "placeholderAllowlist")) {
+      throw new Error(
+        "The 'placeholderWhitelist' option has been renamed to " +
+          "'placeholderAllowlist'. Please update your configuration.",
+      );
+    }
+    // Both options provided: new option takes precedence (supports Babel 7/8 cross-version compat)
   }
 
   const {

--- a/packages/babel-template/src/options.ts
+++ b/packages/babel-template/src/options.ts
@@ -13,13 +13,13 @@ export type PublicOpts = {
    *
    * This option can be used when using %%foo%% style placeholders.
    */
-  placeholderWhitelist?: Set<string>;
+  placeholderAllowlist?: Set<string>;
   /**
    * A pattern to search for when looking for Identifier and StringLiteral
    * nodes that can be replaced.
    *
    * 'false' will disable placeholder searching entirely, leaving only the
-   * 'placeholderWhitelist' value to find replacements.
+   * 'placeholderAllowlist' value to find replacements.
    *
    * Defaults to /^[_$A-Z0-9]+$/.
    *
@@ -33,7 +33,7 @@ export type PublicOpts = {
   preserveComments?: boolean;
   /**
    * 'true' to use %%foo%% style placeholders, 'false' to use legacy placeholders
-   * described by placeholderPattern or placeholderWhitelist.
+   * described by placeholderPattern or placeholderAllowlist.
    * When it is not set, it behaves as 'true' if there are syntactic placeholders,
    * otherwise as 'false'.
    */
@@ -42,7 +42,7 @@ export type PublicOpts = {
 
 export type TemplateOpts = {
   parser: ParserOpts;
-  placeholderWhitelist?: Set<string>;
+  placeholderAllowlist?: Set<string>;
   placeholderPattern?: RegExp | false;
   preserveComments?: boolean;
   syntacticPlaceholders?: boolean;
@@ -50,7 +50,7 @@ export type TemplateOpts = {
 
 export function merge(a: TemplateOpts, b: TemplateOpts): TemplateOpts {
   const {
-    placeholderWhitelist = a.placeholderWhitelist,
+    placeholderAllowlist = a.placeholderAllowlist,
     placeholderPattern = a.placeholderPattern,
     preserveComments = a.preserveComments,
     syntacticPlaceholders = a.syntacticPlaceholders,
@@ -61,7 +61,7 @@ export function merge(a: TemplateOpts, b: TemplateOpts): TemplateOpts {
       ...a.parser,
       ...b.parser,
     },
-    placeholderWhitelist,
+    placeholderAllowlist,
     placeholderPattern,
     preserveComments,
     syntacticPlaceholders,
@@ -74,16 +74,16 @@ export function validate(opts: unknown): TemplateOpts {
   }
 
   const {
-    placeholderWhitelist,
+    placeholderAllowlist,
     placeholderPattern,
     preserveComments,
     syntacticPlaceholders,
     ...parser
   } = opts || ({} as any);
 
-  if (placeholderWhitelist != null && !(placeholderWhitelist instanceof Set)) {
+  if (placeholderAllowlist != null && !(placeholderAllowlist instanceof Set)) {
     throw new Error(
-      "'.placeholderWhitelist' must be a Set, null, or undefined",
+      "'.placeholderAllowlist' must be a Set, null, or undefined",
     );
   }
 
@@ -113,17 +113,17 @@ export function validate(opts: unknown): TemplateOpts {
   }
   if (
     syntacticPlaceholders === true &&
-    (placeholderWhitelist != null || placeholderPattern != null)
+    (placeholderAllowlist != null || placeholderPattern != null)
   ) {
     throw new Error(
-      "'.placeholderWhitelist' and '.placeholderPattern' aren't compatible" +
+      "'.placeholderAllowlist' and '.placeholderPattern' aren't compatible" +
         " with '.syntacticPlaceholders: true'",
     );
   }
 
   return {
     parser,
-    placeholderWhitelist: placeholderWhitelist || undefined,
+    placeholderAllowlist: placeholderAllowlist || undefined,
     placeholderPattern:
       placeholderPattern == null ? undefined : placeholderPattern,
     preserveComments: preserveComments == null ? undefined : preserveComments,

--- a/packages/babel-template/src/options.ts
+++ b/packages/babel-template/src/options.ts
@@ -73,8 +73,8 @@ export function validate(opts: unknown): TemplateOpts {
     throw new Error("Unknown template options.");
   }
 
-  if (opts != null && Object.hasOwn(opts as object, "placeholderWhitelist")) {
-    if (!Object.hasOwn(opts as object, "placeholderAllowlist")) {
+  if (opts != null && Object.hasOwn(opts, "placeholderWhitelist")) {
+    if (!Object.hasOwn(opts, "placeholderAllowlist")) {
       throw new Error(
         "The 'placeholderWhitelist' option has been renamed to " +
           "'placeholderAllowlist'. Please update your configuration.",

--- a/packages/babel-template/src/parse.ts
+++ b/packages/babel-template/src/parse.ts
@@ -40,7 +40,7 @@ export default function parseAndBuildMetadata<T>(
   opts: TemplateOpts,
 ): Metadata {
   const {
-    placeholderWhitelist,
+    placeholderAllowlist,
     placeholderPattern,
     preserveComments,
     syntacticPlaceholders,
@@ -57,7 +57,7 @@ export default function parseAndBuildMetadata<T>(
   const state: MetadataState = {
     syntactic: { placeholders: [], placeholderNames: new Set() },
     legacy: { placeholders: [], placeholderNames: new Set() },
-    placeholderWhitelist,
+    placeholderAllowlist,
     placeholderPattern,
     syntacticPlaceholders,
   };
@@ -100,12 +100,12 @@ function placeholderVisitorHandler(
 
   if (
     hasSyntacticPlaceholders &&
-    (state.placeholderPattern != null || state.placeholderWhitelist != null)
+    (state.placeholderPattern != null || state.placeholderAllowlist != null)
   ) {
     // This check is also in options.js. We need it there to handle the default
     // .syntacticPlaceholders behavior.
     throw new Error(
-      "'.placeholderWhitelist' and '.placeholderPattern' aren't compatible" +
+      "'.placeholderAllowlist' and '.placeholderPattern' aren't compatible" +
         " with '.syntacticPlaceholders: true'",
     );
   }
@@ -114,7 +114,7 @@ function placeholderVisitorHandler(
     !hasSyntacticPlaceholders &&
     (state.placeholderPattern === false ||
       !(state.placeholderPattern || PATTERN).test(name)) &&
-    !state.placeholderWhitelist?.has(name)
+    !state.placeholderAllowlist?.has(name)
   ) {
     return;
   }
@@ -184,7 +184,7 @@ type MetadataState = {
     placeholders: Placeholder[];
     placeholderNames: Set<string>;
   };
-  placeholderWhitelist?: Set<string>;
+  placeholderAllowlist?: Set<string>;
   placeholderPattern?: RegExp | false;
   syntacticPlaceholders?: boolean;
 };

--- a/packages/babel-template/src/populate.ts
+++ b/packages/babel-template/src/populate.ts
@@ -28,7 +28,7 @@ export default function populatePlaceholders(
         throw new Error(
           `Error: No substitution given for "${placeholderName}". If this is not meant to be a
             placeholder you may want to consider passing one of the following options to @babel/template:
-            - { placeholderPattern: false, placeholderWhitelist: new Set(['${placeholderName}'])}
+            - { placeholderPattern: false, placeholderAllowlist: new Set(['${placeholderName}'])}
             - { placeholderPattern: /^${placeholderName}$/ }`,
         );
       }

--- a/packages/babel-template/test/index.js
+++ b/packages/babel-template/test/index.js
@@ -121,13 +121,13 @@ describe("@babel/template", function () {
       expect(result[1].expression).toEqual(id);
     });
 
-    it("should allow passing in a whitelist of replacement names", () => {
+    it("should allow passing in an allowlist of replacement names", () => {
       const id = t.identifier("someIdent");
       const result = template(
         `
           some_id;
         `,
-        { placeholderWhitelist: new Set(["some_id"]) },
+        { placeholderAllowlist: new Set(["some_id"]) },
       )({ some_id: id });
 
       expect(result.type).toBe("ExpressionStatement");
@@ -176,7 +176,7 @@ describe("@babel/template", function () {
       }).toThrow(
         `Error: No substitution given for "ANOTHER_ID". If this is not meant to be a
             placeholder you may want to consider passing one of the following options to @babel/template:
-            - { placeholderPattern: false, placeholderWhitelist: new Set(['ANOTHER_ID'])}
+            - { placeholderPattern: false, placeholderAllowlist: new Set(['ANOTHER_ID'])}
             - { placeholderPattern: /^ANOTHER_ID$/ }`,
       );
     });
@@ -416,11 +416,11 @@ describe("@babel/template", function () {
       }).toThrow(/aren't compatible with '.syntacticPlaceholders: true'/);
     });
 
-    it("whitelist", () => {
+    it("allowlist", () => {
       expect(() => {
         template(`%%A%% + %%B%%`, {
           placeholderPattern: false,
-          placeholderWhitelist: new Set(["B"]),
+          placeholderAllowlist: new Set(["B"]),
         })();
       }).toThrow(/aren't compatible with '.syntacticPlaceholders: true'/);
     });

--- a/packages/babel-template/test/index.js
+++ b/packages/babel-template/test/index.js
@@ -133,6 +133,27 @@ describe("@babel/template", function () {
       expect(result.type).toBe("ExpressionStatement");
       expect(result.expression).toBe(id);
     });
+    it("should throw when using deprecated placeholderWhitelist without placeholderAllowlist", () => {
+      expect(() => {
+        template("FOO;", { placeholderWhitelist: new Set(["FOO"]) });
+      }).toThrow(/placeholderWhitelist.*renamed.*placeholderAllowlist/);
+    });
+
+    it("should not throw when both placeholderWhitelist and placeholderAllowlist are provided", () => {
+      const id = t.identifier("someIdent");
+      const result = template(
+        `
+          some_id;
+        `,
+        {
+          placeholderWhitelist: new Set(["some_id"]),
+          placeholderAllowlist: new Set(["some_id"]),
+        },
+      )({ some_id: id });
+
+      expect(result.type).toBe("ExpressionStatement");
+      expect(result.expression).toBe(id);
+    });
 
     it("should allow passing in a RegExp to match replacement patterns", () => {
       const id = t.identifier("someIdent");

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -54,6 +54,19 @@ function explode$1<S>(visitor: Visitor<S>): ExplodedVisitor<S> {
   // @ts-expect-error `visitor` will be cast to ExplodedVisitor by this function
   visitor._exploded = true;
 
+  // Handle deprecated 'blacklist' option: only error if 'denylist' is not also provided.
+  // If both are present, 'denylist' takes precedence (supports Babel 7/8 cross-version compat).
+  if (Object.hasOwn(visitor as object, "blacklist")) {
+    if (!Object.hasOwn(visitor as object, "denylist")) {
+      throw new Error(
+        "The 'blacklist' visitor option has been renamed to 'denylist'. " +
+          "Please update your configuration.",
+      );
+    }
+    // Both provided — 'denylist' will be used; 'blacklist' key is silently ignored.
+    delete (visitor as any).blacklist;
+  }
+
   // normalise pipes
   for (const nodeType of Object.keys(visitor) as (keyof Visitor)[]) {
     if (shouldIgnoreKey(nodeType)) continue;

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -348,8 +348,7 @@ function shouldIgnoreKey(key: string): key is
   | "shouldSkip"
   | "denylist"
   | "noScope"
-  | "skipKeys"
-  | "blacklist" {
+  | "skipKeys" {
   // internal/hidden key
   if (key.startsWith("_")) return true;
 

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -360,6 +360,13 @@ function shouldIgnoreKey(key: string): key is
     return true;
   }
 
+  if (key === "blacklist") {
+    throw new Error(
+      "The 'blacklist' visitor option has been renamed to 'denylist'. " +
+        "Please update your configuration.",
+    );
+  }
+
   return false;
 }
 

--- a/packages/babel-traverse/test/visitors.js
+++ b/packages/babel-traverse/test/visitors.js
@@ -87,4 +87,21 @@ describe("visitors", () => {
       `);
     });
   });
+
+  describe("deprecated option handling", () => {
+    it("should throw when using deprecated blacklist without denylist", () => {
+      expect(() => {
+        visitors.explode({ blacklist: ["MemberExpression"], enter() {} });
+      }).toThrow(/blacklist.*renamed.*denylist/);
+    });
+
+    it("should not throw when both blacklist and denylist are provided", () => {
+      const visitor = visitors.explode({
+        blacklist: ["MemberExpression"],
+        denylist: ["MemberExpression"],
+        enter() {},
+      });
+      expect(visitor._exploded).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Follow-up to #11758 and #17671. Replaces the remaining non-inclusive whitelist/blacklist terminology in active source code for the Babel 8 release.

**Changes:**
- **@babel/plugin-external-helpers**: Rename whitelist option to allowlist (public API, breaking)
- **@babel/template**: Rename placeholderWhitelist option to placeholderAllowlist (public API, breaking)
- **@babel/traverse**: Remove leftover blacklist from TypeScript type union in shouldIgnoreKey (runtime support already removed in #17671)

**Intentionally kept as-is:**
- removed.ts entries for blacklist/whitelist (detect legacy Babel 5 config)
- --whitelist CLI flag in babel-build-external-helpers (already throws helpful error pointing to --allowlist)
- Integration test sed patches for external dependencies (jest, vue-cli)
- Historical changelogs

**Note:** The test fixture directory packages/babel-plugin-external-helpers/test/fixtures/opts/whitelist/ should also be renamed to allowlist/, but I was unable to do so in this PR. Happy to update if needed.

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | Yes
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes (updated existing tests)
| Documentation PR Link    | n/a
| Any Dependency Changes?  | No
| License                  | MIT