### PR TITLE
fix(parser): performance issue due to debug code

### DIFF
--- a/packages/babel-parser/src/parser/node.ts
+++ b/packages/babel-parser/src/parser/node.ts
@@ -18,8 +18,10 @@ class Node implements NodeBase {
     this.start = pos;
     this.end = 0;
     this.loc = new SourceLocation(loc);
-    if (parser?.optionFlags & OptionFlags.Ranges) this.range = [pos, 0];
-    if (parser?.filename) this.loc.filename = parser.filename;
+    if (parser != null) {
+      if (parser.optionFlags & OptionFlags.Ranges) this.range = [pos, 0];
+      if (parser.filename) this.loc.filename = parser.filename;
+    }
   }
 
   type: string = "";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Babel Parser 8 is 50% slower than Babel Parser 7 since 8.0.0-rc.1 on some benchmark cases
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Here is the benchmark result between 7.29.0 and 8.0.0-rc.2 when running `benchmark/babel-parser/many-async-arrows/bench.mjs`

```
baseline 256 async arrow functions: 6_922 ops/sec ±2.5% (0.144ms)
baseline 512 async arrow functions: 3_305 ops/sec ±0.47% (0.303ms)
baseline 1024 async arrow functions: 1_649 ops/sec ±1.67% (0.606ms)
baseline 2048 async arrow functions: 825 ops/sec ±0.76% (1.211ms)
current 256 async arrow functions: 2_435 ops/sec ±0.2% (0.411ms)
current 512 async arrow functions: 1_215 ops/sec ±0.19% (0.823ms)
current 1024 async arrow functions: 589 ops/sec ±1.83% (1.697ms)
current 2048 async arrow functions: 303 ops/sec ±0.22% (3.297ms)
```

In this PR we fixed a performance regression introduced in https://github.com/babel/babel/pull/17756, where we only inlined the `NODE_ENV` environment when building the `@babel/standalone`. This unfortunately impacts `@babel/parser` because we have debug code in the hot path `finishNodeAt`, and although the debug code error is probably not activated for end users, the `process.env` access has to be supported from a C++ runtime, which incurs a great toll on the performance.

Here is the benchmark result between 7.29.0 and this PR, I will investigate if there are any other performance issues and open new PRs.

```
baseline 256 async arrow functions: 6_875 ops/sec ±0.65% (0.145ms)
baseline 512 async arrow functions: 3_346 ops/sec ±0.48% (0.299ms)
baseline 1024 async arrow functions: 1_636 ops/sec ±1.42% (0.611ms)
baseline 2048 async arrow functions: 825 ops/sec ±0.29% (1.212ms)
current 256 async arrow functions: 5_878 ops/sec ±0.15% (0.17ms)
current 512 async arrow functions: 2_907 ops/sec ±1.18% (0.344ms)
current 1024 async arrow functions: 1_464 ops/sec ±0.2% (0.683ms)
current 2048 async arrow functions: 727 ops/sec ±0.16% (1.375ms)
```