### PR TITLE
fix: Remove `decorators` from `TSDeclareMethod`

### DIFF
--- a/packages/babel-generator/src/generators/classes.ts
+++ b/packages/babel-generator/src/generators/classes.ts
@@ -267,8 +267,11 @@ export function ClassPrivateMethod(this: Printer, node: t.ClassPrivateMethod) {
 export function _classMethodHead(
   this: Printer,
   node: t.ClassMethod | t.ClassPrivateMethod | t.TSDeclareMethod,
+  allowDecorators = true,
 ) {
-  this.printJoin(node.decorators);
+  if (allowDecorators) {
+    this.printJoin((node as t.ClassMethod | t.ClassPrivateMethod).decorators);
+  }
 
   if (!this.format.preserveFormat) {
     // catch up to method key, avoid line break

--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -115,7 +115,7 @@ export function TSDeclareFunction(
 }
 
 export function TSDeclareMethod(this: Printer, node: t.TSDeclareMethod) {
-  _classMethodHead.call(this, node);
+  _classMethodHead.call(this, node, false);
   this.semicolon();
 }
 

--- a/packages/babel-parser/src/parse-error/standard-errors.ts
+++ b/packages/babel-parser/src/parse-error/standard-errors.ts
@@ -53,6 +53,7 @@ export default {
   }: {
     kind: "await using" | "const" | "destructuring" | "using";
   }) => `Missing initializer in ${kind} declaration.`,
+  DecoratorAbstractMethod: "Decorators can't be used with an abstract method.",
   DecoratorArgumentsOutsideParentheses:
     "Decorator arguments must be moved inside parentheses: use '@(decorator(args))' instead of '@(decorator)(args)'.",
   DecoratorsBeforeAfterExport:

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -1650,13 +1650,26 @@ export default abstract class StatementParser extends ExpressionParser {
 
       if (
         // @ts-expect-error Fixme
-        member.kind === "constructor" &&
-        // @ts-expect-error Fixme
         member.decorators &&
         // @ts-expect-error Fixme
         member.decorators.length > 0
       ) {
-        this.raise(Errors.DecoratorConstructor, member);
+        if (
+          this.hasPlugin("typescript") &&
+          (this.hasPlugin("estree")
+            ? // @ts-expect-error Fixme
+              member.type === "TSAbstractMethodDefinition"
+            : // @ts-expect-error Fixme
+              member.type === "TSDeclareMethod")
+        ) {
+          this.raise(Errors.DecoratorAbstractMethod, member);
+        }
+        if (
+          // @ts-expect-error Fixme
+          member.kind === "constructor"
+        ) {
+          this.raise(Errors.DecoratorConstructor, member);
+        }
       }
     }
 

--- a/packages/babel-parser/src/types.ts
+++ b/packages/babel-parser/src/types.ts
@@ -1426,7 +1426,7 @@ export interface TSDeclareFunction extends OptTSDeclareFunction {
 }
 
 export interface TSDeclareMethod
-  extends FunctionBase, ClassMethodOrDeclareMethodCommon {
+  extends FunctionBase, Omit<ClassMethodOrDeclareMethodCommon, "decorators"> {
   type: "TSDeclareMethod";
   kind: MethodKind;
 }

--- a/packages/babel-parser/test/fixtures/experimental/decorators/typescript-abstract-method/input.ts
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/typescript-abstract-method/input.ts
@@ -1,0 +1,4 @@
+abstract class C5 {
+  @a
+  abstract foo(): void;
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorators/typescript-abstract-method/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/typescript-abstract-method/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["decorators", "typescript"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/decorators/typescript-abstract-method/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/decorators/typescript-abstract-method/output.json
@@ -1,0 +1,69 @@
+{
+  "type": "File",
+  "start":0,"end":50,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":1,"index":50}},
+  "errors": [
+    "SyntaxError: Decorators can't be used with an abstract method. (2:2)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":50,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":1,"index":50}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":50,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":4,"column":1,"index":50}},
+        "abstract": true,
+        "id": {
+          "type": "Identifier",
+          "start":15,"end":17,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":17,"index":17},"identifierName":"C5"},
+          "name": "C5"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":18,"end":50,"loc":{"start":{"line":1,"column":18,"index":18},"end":{"line":4,"column":1,"index":50}},
+          "body": [
+            {
+              "type": "TSDeclareMethod",
+              "start":22,"end":48,"loc":{"start":{"line":2,"column":2,"index":22},"end":{"line":3,"column":23,"index":48}},
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start":22,"end":24,"loc":{"start":{"line":2,"column":2,"index":22},"end":{"line":2,"column":4,"index":24}},
+                  "expression": {
+                    "type": "Identifier",
+                    "start":23,"end":24,"loc":{"start":{"line":2,"column":3,"index":23},"end":{"line":2,"column":4,"index":24},"identifierName":"a"},
+                    "name": "a"
+                  }
+                }
+              ],
+              "abstract": true,
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start":36,"end":39,"loc":{"start":{"line":3,"column":11,"index":36},"end":{"line":3,"column":14,"index":39},"identifierName":"foo"},
+                "name": "foo"
+              },
+              "computed": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "returnType": {
+                "type": "TSTypeAnnotation",
+                "start":41,"end":47,"loc":{"start":{"line":3,"column":16,"index":41},"end":{"line":3,"column":22,"index":47}},
+                "typeAnnotation": {
+                  "type": "TSVoidKeyword",
+                  "start":43,"end":47,"loc":{"start":{"line":3,"column":18,"index":43},"end":{"line":3,"column":22,"index":47}}
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -130,6 +130,7 @@ type ErrorInfoCompressed = {
   DeclarationMissingInitializer: [
     { kind: "await using" | "const" | "destructuring" | "using" },
   ];
+  DecoratorAbstractMethod: [];
   DecoratorArgumentsOutsideParentheses: [];
   DecoratorsBeforeAfterExport: [];
   DecoratorConstructor: [];

--- a/packages/babel-types/src/ast-types/generated/index.ts
+++ b/packages/babel-types/src/ast-types/generated/index.ts
@@ -1792,7 +1792,6 @@ export interface TSDeclareFunction extends BaseNode {
 
 export interface TSDeclareMethodComputed extends BaseNode {
   type: "TSDeclareMethod";
-  decorators?: Decorator[] | null;
   typeParameters?: TSTypeParameterDeclaration | null;
   params: (FunctionParameter | TSParameterProperty)[];
   returnType?: TSTypeAnnotation | null;
@@ -1810,7 +1809,6 @@ export interface TSDeclareMethodComputed extends BaseNode {
 }
 export interface TSDeclareMethodNonComputed extends BaseNode {
   type: "TSDeclareMethod";
-  decorators?: Decorator[] | null;
   typeParameters?: TSTypeParameterDeclaration | null;
   params: (FunctionParameter | TSParameterProperty)[];
   returnType?: TSTypeAnnotation | null;
@@ -4068,7 +4066,6 @@ export interface ParentMaps {
     | ObjectProperty
     | Placeholder
     | RestElement
-    | TSDeclareMethod
     | TSParameterProperty;
   Directive: BlockStatement | Program;
   DirectiveLiteral: Directive;

--- a/packages/babel-types/src/builders/generated/lowercase.ts
+++ b/packages/babel-types/src/builders/generated/lowercase.ts
@@ -2725,21 +2725,18 @@ export function tsDeclareFunction(
   return node;
 }
 export function tsDeclareMethod(
-  decorators: t.Decorator[] | null | undefined,
   key: t.Expression,
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   params: (t.FunctionParameter | t.TSParameterProperty)[],
   returnType?: t.TSTypeAnnotation | null,
 ): Extract<t.TSDeclareMethod, { computed: true }>;
 export function tsDeclareMethod(
-  decorators: t.Decorator[] | null | undefined,
   key: t.Identifier | t.StringLiteral | t.NumericLiteral | t.BigIntLiteral,
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   params: (t.FunctionParameter | t.TSParameterProperty)[],
   returnType?: t.TSTypeAnnotation | null,
 ): Extract<t.TSDeclareMethod, { computed: false }>;
 export function tsDeclareMethod(
-  decorators: t.Decorator[] | null | undefined,
   key:
     | t.Identifier
     | t.StringLiteral
@@ -2751,7 +2748,6 @@ export function tsDeclareMethod(
   returnType?: t.TSTypeAnnotation | null,
 ): t.TSDeclareMethod;
 export function tsDeclareMethod(
-  decorators: t.Decorator[] | null | undefined = null,
   key:
     | t.Identifier
     | t.StringLiteral
@@ -2764,7 +2760,6 @@ export function tsDeclareMethod(
 ): t.TSDeclareMethod {
   const node = {
     type: "TSDeclareMethod",
-    decorators,
     key,
     typeParameters,
     params,
@@ -2776,7 +2771,6 @@ export function tsDeclareMethod(
     static: false,
   } as t.TSDeclareMethod;
   const defs = NODE_FIELDS.TSDeclareMethod;
-  validate(defs.decorators, node, "decorators", decorators, 1);
   validate(defs.key, node, "key", key, 1);
   validate(defs.typeParameters, node, "typeParameters", typeParameters, 1);
   validate(defs.params, node, "params", params, 1);

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -1854,7 +1854,7 @@ export const classMethodOrPropertyCommon = () => ({
   },
 });
 
-export const classMethodOrDeclareMethodCommon = () => ({
+export const classMethodOrDeclareMethodCommon = (allowDecorators = true) => ({
   ...functionCommon(),
   ...classMethodOrPropertyCommon(),
   params: validateArrayOfType("FunctionParameter", "TSParameterProperty"),
@@ -1869,10 +1869,14 @@ export const classMethodOrDeclareMethodCommon = () => ({
     ),
     optional: true,
   },
-  decorators: {
-    validate: arrayOfType("Decorator"),
-    optional: true,
-  },
+  ...(allowDecorators
+    ? {
+        decorators: {
+          validate: arrayOfType("Decorator"),
+          optional: true,
+        },
+      }
+    : {}),
 });
 
 defineType("ClassMethod", {

--- a/packages/babel-types/src/definitions/typescript.ts
+++ b/packages/babel-types/src/definitions/typescript.ts
@@ -74,10 +74,10 @@ defineType("TSDeclareFunction", {
 });
 
 defineType("TSDeclareMethod", {
-  visitor: ["decorators", "key", "typeParameters", "params", "returnType"],
+  visitor: ["key", "typeParameters", "params", "returnType"],
   ...classMethodOrPropertyUnionShapeCommon(),
   fields: {
-    ...classMethodOrDeclareMethodCommon(),
+    ...classMethodOrDeclareMethodCommon(false),
     ...tSFunctionTypeAnnotationCommon(),
   },
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
At the same time, an error is thrown in the parser for this situation.
https://github.com/babel/babel/issues/17525