### PR TITLE
chore: avoid outdated regex in readNumber

### DIFF
--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -1180,6 +1180,9 @@ export default abstract class Tokenizer extends CommentsParser {
       next = this.input.charCodeAt(this.state.pos);
     }
 
+    // remove "_" for numeric literal separator. It should not include "n" for bigint literal
+    const str = this.input.slice(start, this.state.pos).replaceAll("_", "");
+
     if (next === charCodes.lowercaseN) {
       // disallow floats, legacy octal syntax and non octal decimals
       // new style octal ("0o") is handled in this.readRadixNumber
@@ -1193,9 +1196,6 @@ export default abstract class Tokenizer extends CommentsParser {
     if (isIdentifierStart(this.codePointAtPos(this.state.pos))) {
       throw this.raise(Errors.NumberIdentifier, this.state.curPosition());
     }
-
-    // remove "_" for numeric literal separator, and trailing `m` or `n`
-    const str = this.input.slice(start, this.state.pos).replace(/[_mn]/g, "");
 
     if (isBigInt) {
       this.finishToken(tt.bigint, str);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The `m` in the regex `[_mn]` is no longer relevant. And it turns out we don't have to use regex at all with the `replaceAll` method.