### PR TITLE
Replace npmjs.com links with npmx.dev

### DIFF
--- a/.github/CHANGELOG-v6.md
+++ b/.github/CHANGELOG-v6.md
@@ -2098,7 +2098,7 @@ Some small but very important additions in this release:
 
 ### Preset options ([babel/notes](https://github.com/babel/notes/blob/master/2016-07/july-31.md#preset-options-pr-3331))
 
-Initially, presets were supposed to be one-off sets of plugins that didn't have any configuration. If you wanted to do something different you would make your own presets. There are [> 600 presets](https://www.npmjs.com/search?q=babel-preset-) on npm now. We want to give users more flexibility in certain cases: like when you want to pass the same option to multiple presets or to remove a default plugin.
+Initially, presets were supposed to be one-off sets of plugins that didn't have any configuration. If you wanted to do something different you would make your own presets. There are [> 600 presets](https://npmx.dev/search?q=babel-preset) on npm now. We want to give users more flexibility in certain cases: like when you want to pass the same option to multiple presets or to remove a default plugin.
 
 ### `loose` and `modules` options for `babel-preset-es2015` ([#3331](https://github.com/babel/babel/pull/3331), [#3627](https://github.com/babel/babel/pull/3627))
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,15 @@
 </p>
 
 <p align="center">
-  <a href="https://gitpod.io/#https://github.com/babel/babel"><img alt="Gitpod ready-to-code" src="https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod"></a>
-  <a href="https://pkg.pr.new/~/babel/babel"><img alt="pkg.pr.new" src="https://img.shields.io/npm/dm/@babel/core?style=flat&color=000&logo=babel&logoSize=auto"></a>
-</p>
-<p align="center">
-    <a href="https://www.npmjs.com/package/@babel/core"><img alt="v7 npm Downloads" src="https://img.shields.io/npm/dm/@babel/core.svg?maxAge=43200&label=v7%20downloads"></a>
-  <a href="https://www.npmjs.com/package/babel-core"><img alt="v6 npm Downloads" src="https://img.shields.io/npm/dm/babel-core.svg?maxAge=43200&label=v6%20downloads"></a>
+    <a href="https://npmx.dev/package/@babel/core"><img alt="npm Downloads" src="https://img.shields.io/npm/dm/@babel/core.svg?maxAge=43200&label=npm%20downloads&logo=babel&logoSize=auto"></a>
 </p>
 <p align="center">
   <a href="https://github.com/babel/babel/actions/workflows/ci.yml"><img alt="GitHub CI Status" src="https://github.com/babel/babel/actions/workflows/ci.yml/badge.svg?branch=main"></a>
-  <a href="https://codecov.io/github/babel/babel"><img alt="Coverage Status" src="https://img.shields.io/codecov/c/github/babel/babel/main.svg?maxAge=43200"></a>
+  <a href="https://codecov.io/github/babel/babel"><img alt="Coverage Status" src="https://img.shields.io/codecov/c/github/babel/babel/main.svg?maxAge=43200&logo=codecov"></a>
+  <a href="https://pkg.pr.new/~/babel/babel"><img alt="pkg.pr.new" src="https://img.shields.io/badge/PR_previews-pkg.pr.new-10a5e9"></a>
+</p>
+<p align="center">
   <a href="https://slack.babeljs.io/"><img alt="Slack Status" src="https://img.shields.io/badge/chat-on_slack-brightgreen?style=flat&logo=slack&logoColor=white"></a>
-  <a href="https://twitter.com/intent/follow?screen_name=babeljs"><img alt="Follow on Twitter" src="https://img.shields.io/twitter/follow/babeljs.svg?style=social&label=Follow"></a>
 </p>
 
 <h2 align="center">Supporting Babel</h2>

--- a/packages/README.md
+++ b/packages/README.md
@@ -13,10 +13,10 @@ A monorepo, muhahahahahaha. See the [monorepo design doc](/doc/design/monorepo.m
 
 | Package | Version |
 |---------|---------|
-| [`@babel/core`](/packages/babel-core) | [![npm](https://img.shields.io/npm/v/@babel/core.svg?maxAge=3600)](https://www.npmjs.com/package/@babel/core) |
-| [`@babel/parser`](/packages/babel-parser) | [![npm](https://img.shields.io/npm/v/@babel/parser.svg?maxAge=3600)](https://www.npmjs.com/package/@babel/parser) |
-| [`@babel/traverse`](/packages/babel-traverse) | [![npm](https://img.shields.io/npm/v/@babel/traverse.svg?maxAge=3600)](https://www.npmjs.com/package/@babel/traverse) |
-| [`@babel/generator`](/packages/babel-generator) | [![npm](https://img.shields.io/npm/v/@babel/generator.svg?maxAge=3600)](https://www.npmjs.com/package/@babel/generator) |
+| [`@babel/core`](/packages/babel-core) | [![npm](https://img.shields.io/npm/v/@babel/core.svg?maxAge=3600)](https://npmx.dev/package/@babel/core) |
+| [`@babel/parser`](/packages/babel-parser) | [![npm](https://img.shields.io/npm/v/@babel/parser.svg?maxAge=3600)](https://npmx.dev/package/@babel/parser) |
+| [`@babel/traverse`](/packages/babel-traverse) | [![npm](https://img.shields.io/npm/v/@babel/traverse.svg?maxAge=3600)](https://npmx.dev/package/@babel/traverse) |
+| [`@babel/generator`](/packages/babel-generator) | [![npm](https://img.shields.io/npm/v/@babel/generator.svg?maxAge=3600)](https://npmx.dev/package/@babel/generator) |
 
 [`@babel/core`](/packages/babel-core) is the Babel compiler itself; it exposes the `babel.transform` method, where `transformedCode = transform(src).code`.
 
@@ -36,13 +36,13 @@ Check out the [`babel-handbook`](https://github.com/thejameskyle/babel-handbook/
 
 | Package | Version |
 |---------|---------|
-| [`@babel/cli`](/packages/babel-cli) | [![npm](https://img.shields.io/npm/v/@babel/cli.svg?maxAge=3600)](https://www.npmjs.com/package/@babel/cli) |
-| [`@babel/types`](/packages/babel-types) | [![npm](https://img.shields.io/npm/v/@babel/types.svg?maxAge=3600)](https://www.npmjs.com/package/@babel/types) |
-| [`@babel/runtime`](/packages/babel-runtime) | [![npm](https://img.shields.io/npm/v/@babel/runtime.svg?maxAge=3600)](https://www.npmjs.com/package/@babel/runtime) |
-| [`@babel/register`](/packages/babel-register) | [![npm](https://img.shields.io/npm/v/@babel/register.svg?maxAge=3600)](https://www.npmjs.com/package/@babel/register) |
-| [`@babel/template`](/packages/babel-template) | [![npm](https://img.shields.io/npm/v/@babel/template.svg?maxAge=3600)](https://www.npmjs.com/package/@babel/template) |
-| [`@babel/helpers`](/packages/babel-helpers) | [![npm](https://img.shields.io/npm/v/@babel/helpers.svg?maxAge=3600)](https://www.npmjs.com/package/@babel/helpers) |
-| [`@babel/code-frame`](/packages/babel-code-frame) | [![npm](https://img.shields.io/npm/v/@babel/code-frame.svg?maxAge=3600)](https://www.npmjs.com/package/@babel/code-frame) |
+| [`@babel/cli`](/packages/babel-cli) | [![npm](https://img.shields.io/npm/v/@babel/cli.svg?maxAge=3600)](https://npmx.dev/package/@babel/cli) |
+| [`@babel/types`](/packages/babel-types) | [![npm](https://img.shields.io/npm/v/@babel/types.svg?maxAge=3600)](https://npmx.dev/package/@babel/types) |
+| [`@babel/runtime`](/packages/babel-runtime) | [![npm](https://img.shields.io/npm/v/@babel/runtime.svg?maxAge=3600)](https://npmx.dev/package/@babel/runtime) |
+| [`@babel/register`](/packages/babel-register) | [![npm](https://img.shields.io/npm/v/@babel/register.svg?maxAge=3600)](https://npmx.dev/package/@babel/register) |
+| [`@babel/template`](/packages/babel-template) | [![npm](https://img.shields.io/npm/v/@babel/template.svg?maxAge=3600)](https://npmx.dev/package/@babel/template) |
+| [`@babel/helpers`](/packages/babel-helpers) | [![npm](https://img.shields.io/npm/v/@babel/helpers.svg?maxAge=3600)](https://npmx.dev/package/@babel/helpers) |
+| [`@babel/code-frame`](/packages/babel-code-frame) | [![npm](https://img.shields.io/npm/v/@babel/code-frame.svg?maxAge=3600)](https://npmx.dev/package/@babel/code-frame) |
 
 - [`@babel/cli`](/packages/babel-cli) is the CLI tool that runs `@babel/core` and helps with outputting to a directory, a file, stdout and more (also includes `@babel/node` cli). Check out the [docs](https://babeljs.io/docs/usage/cli/).
 - [`@babel/types`](/packages/babel-types) is used to validate, build and change AST nodes.
@@ -60,15 +60,15 @@ The transformer[s] used in Babel are the independent pieces of code that transfo
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| [`@babel/preset-env`](/packages/babel-preset-env) | [![npm](https://img.shields.io/npm/v/@babel/preset-env.svg?maxAge=?maxAge=3600)](https://www.npmjs.com/package/@babel/preset-env) | automatically determines plugins and polyfills you need based on your supported environments |
+| [`@babel/preset-env`](/packages/babel-preset-env) | [![npm](https://img.shields.io/npm/v/@babel/preset-env.svg?maxAge=3600)](https://npmx.dev/package/@babel/preset-env) | automatically determines plugins and polyfills you need based on your supported environments |
 
-> You can find community maintained presets on [npm](https://www.npmjs.com/search?q=babel-preset)
+> You can find community maintained presets on [npm](https://npmx.dev/search?q=babel-preset)
 
 ### [Plugins](http://babeljs.io/docs/plugins)
 
 Plugins are the heart of Babel and what make it work.
 
-> You can find community plugins on [npm](https://www.npmjs.com/search?q=babel-plugin).
+> You can find community plugins on [npm](https://npmx.dev/search?q=babel-plugin).
 
 #### Transform Plugins
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
https://npmx.dev/ yet is a new frontend for the npm registry, created by people close to the vite community. It's officially launching tomorrow, but I have been using it for the past few weeks and it's so much better than [npmjs.org](http://npmjs.org/).

Some cool things:

- it has auto-generated docs from the TS types, for example https://npmx.dev/package-docs/@babel%2Ftypes/v/8.0.0-rc.2. If we add JSDoc descriptions, they will show up there too. It might be worth getting good enough JSDoc that we can stop, for example, maintaining the `@babel/types` docs on our website. We'll probably need to work with npmx.dev folks to help them better support our needs for it to happen though.
- it lets users click on a little drop down to see the install command with all the various package manager CLIs, rather than showing only install instructions for npm. This aligns with what we did on our website, to give "fair treatment" to all the clients.
- the code viewer is much nicer than the npm one, and you can link to files in it: https://npmx.dev/package-code/@babel/core/v/7.29.0 (and the browser back button works!)

npmx.dev still has multiple bugs, but there is _almost nothing_ that npmjs.com does better then it so I think it's worth changing our links.

I did not update two links:
- https://github.com/babel/babel/blob/cd22e3a8faac6e83ca99389f78046d0e2947bce5/.github/workflows/issue-triage.yml#L102
  npmx.dev does not have a page to show all the versions of a package. I think this is the only feature that npmjs.com does better than npmx.dev: we should keep the npmjs.com URL there. I opened https://github.com/npmx-dev/npmx.dev/issues/1846 to track implementing this on the npmx.dev side.
- the `scripts/ensure-package-exists.ts` script. I _think_ npmx.dev is going to also have better package admin management than npm, but I have not explored yet how it works. It will require adding a dependency to the monorepo so that npmx.dev can talk locally to it to do admin stuff (rather than sending your password to their server), but that package has not been published yet.

This PR also slightly reorganizes the badges in our main readme, removing the GitPod and v6 downloads ones.