### PR TITLE
fix(code-frame): use 0-based columns to match Babel AST locations (#1…

### DIFF
--- a/packages/babel-code-frame/src/common.ts
+++ b/packages/babel-code-frame/src/common.ts
@@ -58,7 +58,7 @@ export function getMarkerLines(
 } {
   const startLoc: Location = {
     // @ts-expect-error default value
-    column: 0,
+    column: null,
     // @ts-expect-error default value
     line: -1,
     ...loc.start,
@@ -91,29 +91,32 @@ export function getMarkerLines(
     for (let i = 0; i <= lineDiff; i++) {
       const lineNumber = i + startLine;
 
-      if (!startColumn) {
+      if (startColumn == null) {
         markerLines[lineNumber] = true;
       } else if (i === 0) {
         const sourceLength = source[lineNumber - 1].length;
 
-        markerLines[lineNumber] = [startColumn, sourceLength - startColumn + 1];
+        markerLines[lineNumber] = [startColumn, sourceLength - startColumn];
       } else if (i === lineDiff) {
         markerLines[lineNumber] = [0, endColumn];
       } else {
-        const sourceLength = source[lineNumber - i].length;
+        const sourceLength = source[lineNumber - 1].length;
 
         markerLines[lineNumber] = [0, sourceLength];
       }
     }
   } else {
     if (startColumn === endColumn) {
-      if (startColumn) {
+      if (startColumn != null) {
         markerLines[startLine] = [startColumn, 0];
       } else {
         markerLines[startLine] = true;
       }
     } else {
-      markerLines[startLine] = [startColumn, endColumn - startColumn];
+      // Defensive: if either column is missing, normalize to avoid NaN.
+      const safeStart = startColumn ?? 0;
+      const safeEnd = endColumn ?? safeStart;
+      markerLines[startLine] = [safeStart, safeEnd - safeStart];
     }
   }
 
@@ -169,7 +172,7 @@ export function _codeFrameColumns(
         let markerLine = "";
         if (Array.isArray(hasMarker)) {
           const markerSpacing = line
-            .slice(0, Math.max(hasMarker[0] - 1, 0))
+            .slice(0, hasMarker[0])
             .replace(/[^\t]/g, " ");
           const numberOfMarkers = hasMarker[1] || 1;
 

--- a/packages/babel-code-frame/test/color-detection.js
+++ b/packages/babel-code-frame/test/color-detection.js
@@ -29,7 +29,7 @@ describe("highlight", function () {
       const rawLines = "console.log('babel')";
       const result = codeFrameColumns(
         rawLines,
-        { start: { line: 1, column: 9 } },
+        { start: { line: 1, column: 8 } },
         { highlightCode: true },
       );
       const stripped = stripVTControlCharacters(result);
@@ -56,7 +56,7 @@ describe("highlight", function () {
         {
           start: {
             line: 1,
-            column: 1,
+            column: 0,
           },
           end: {
             line: 3,
@@ -178,7 +178,7 @@ describe("highlight", function () {
       const rawLines = "console.log('babel')";
       const result = codeFrameColumns(
         rawLines,
-        { start: { line: 1, column: 9 } },
+        { start: { line: 1, column: 8 } },
         { highlightCode: true },
       );
       const stripped = stripVTControlCharacters(result);

--- a/packages/babel-code-frame/test/index.js
+++ b/packages/babel-code-frame/test/index.js
@@ -5,7 +5,7 @@ describe("@babel/code-frame", function () {
   test("basic usage", function () {
     const rawLines = ["class Foo {", "  constructor()", "};"].join("\n");
     expect(
-      codeFrameColumns(rawLines, { start: { line: 2, column: 16 } }),
+      codeFrameColumns(rawLines, { start: { line: 2, column: 15 } }),
     ).toEqual(
       [
         "  1 | class Foo {",
@@ -40,7 +40,7 @@ describe("@babel/code-frame", function () {
       "}",
     ].join("\n");
     expect(
-      codeFrameColumns(rawLines, { start: { line: 7, column: 2 } }),
+      codeFrameColumns(rawLines, { start: { line: 7, column: 1 } }),
     ).toEqual(
       [
         "   5 |  * @param b Number",
@@ -69,7 +69,7 @@ describe("@babel/code-frame", function () {
       "}",
     ].join("\n");
     expect(
-      codeFrameColumns(rawLines, { start: { line: 6, column: 2 } }),
+      codeFrameColumns(rawLines, { start: { line: 6, column: 1 } }),
     ).toEqual(
       [
         "  4 |  * @param a Number",
@@ -90,7 +90,7 @@ describe("@babel/code-frame", function () {
       "\t};",
     ].join("\n");
     expect(
-      codeFrameColumns(rawLines, { start: { line: 2, column: 25 } }),
+      codeFrameColumns(rawLines, { start: { line: 2, column: 24 } }),
     ).toEqual(
       [
         "  1 | \tclass Foo {",
@@ -118,7 +118,7 @@ describe("@babel/code-frame", function () {
     expect(
       codeFrameColumns(
         rawLines,
-        { start: { line: 7, column: 2 } },
+        { start: { line: 7, column: 1 } },
         { linesAbove: 1 },
       ),
     ).toEqual(
@@ -150,7 +150,7 @@ describe("@babel/code-frame", function () {
     expect(
       codeFrameColumns(
         rawLines,
-        { start: { line: 7, column: 2 } },
+        { start: { line: 7, column: 1 } },
         { linesBelow: 1 },
       ),
     ).toEqual(
@@ -181,7 +181,7 @@ describe("@babel/code-frame", function () {
     expect(
       codeFrameColumns(
         rawLines,
-        { start: { line: 7, column: 2 } },
+        { start: { line: 7, column: 1 } },
         { linesAbove: 1, linesBelow: 1 },
       ),
     ).toEqual(
@@ -242,7 +242,7 @@ describe("@babel/code-frame", function () {
   test("basic usage, new API", function () {
     const rawLines = ["class Foo {", "  constructor()", "};"].join("\n");
     expect(
-      codeFrameColumns(rawLines, { start: { line: 2, column: 16 } }),
+      codeFrameColumns(rawLines, { start: { line: 2, column: 15 } }),
     ).toEqual(
       [
         "  1 | class Foo {",
@@ -257,8 +257,8 @@ describe("@babel/code-frame", function () {
     const rawLines = ["class Foo {", "  constructor()", "};"].join("\n");
     expect(
       codeFrameColumns(rawLines, {
-        start: { line: 2, column: 3 },
-        end: { line: 2, column: 16 },
+        start: { line: 2, column: 2 },
+        end: { line: 2, column: 15 },
       }),
     ).toEqual(
       [
@@ -276,7 +276,7 @@ describe("@babel/code-frame", function () {
     );
     expect(
       codeFrameColumns(rawLines, {
-        start: { line: 2, column: 17 },
+        start: { line: 2, column: 16 },
         end: { line: 3, column: 3 },
       }),
     ).toEqual(
@@ -301,7 +301,7 @@ describe("@babel/code-frame", function () {
     ].join("\n");
     expect(
       codeFrameColumns(rawLines, {
-        start: { line: 2, column: 17 },
+        start: { line: 2, column: 16 },
         end: { line: 4, column: 3 },
       }),
     ).toEqual(
@@ -344,7 +344,7 @@ describe("@babel/code-frame", function () {
     expect(
       codeFrameColumns(
         rawLines,
-        { start: { line: 2, column: 16 } },
+        { start: { line: 2, column: 15 } },
         {
           message: "Missing {",
         },
@@ -391,7 +391,7 @@ describe("@babel/code-frame", function () {
       codeFrameColumns(
         rawLines,
         {
-          start: { line: 2, column: 17 },
+          start: { line: 2, column: 16 },
           end: { line: 4, column: 3 },
         },
         {
@@ -456,5 +456,62 @@ describe("@babel/code-frame", function () {
       "  101 | const a = 1;
       > 102 | const b = 1"
     `);
+  });
+
+  test("should handle 0-based columns from Babel AST locations", function () {
+    const code = 'x = "foobar";';
+    // "foobar" (with quotes) starts at column 4 (0-based), ends at column 12 (0-based exclusive)
+    const loc = {
+      start: { line: 1, column: 4 },
+      end: { line: 1, column: 12 },
+    };
+    const result = codeFrameColumns(code, loc);
+    // The underline should cover "foobar" (with quotes) starting at the correct position
+    expect(result).toEqual(
+      ['> 1 | x = "foobar";', "    |     ^^^^^^^^"].join("\n"),
+    );
+  });
+
+  test("should handle 0-based column 0", function () {
+    const code = '"foobar";';
+    const loc = {
+      start: { line: 1, column: 0 },
+      end: { line: 1, column: 8 },
+    };
+    const result = codeFrameColumns(code, loc);
+    expect(result).toEqual(['> 1 | "foobar";', "    | ^^^^^^^^"].join("\n"));
+  });
+
+  test("middle lines in a 4+ line range use each line's own length", function () {
+    const rawLines = [
+      "class Foo {",
+      "  constructor() {",
+      "    short",
+      "    a much longer middle line here",
+      "    end",
+      "  }",
+      "};",
+    ].join("\n");
+    expect(
+      codeFrameColumns(rawLines, {
+        start: { line: 2, column: 16 },
+        end: { line: 6, column: 3 },
+      }),
+    ).toEqual(
+      [
+        "  1 | class Foo {",
+        "> 2 |   constructor() {",
+        "    |                 ^",
+        "> 3 |     short",
+        "    | ^^^^^^^^^",
+        "> 4 |     a much longer middle line here",
+        "    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
+        "> 5 |     end",
+        "    | ^^^^^^^",
+        "> 6 |   }",
+        "    | ^^^",
+        "  7 | };",
+      ].join("\n"),
+    );
   });
 });

--- a/packages/babel-core/src/parser/index.ts
+++ b/packages/babel-core/src/parser/index.ts
@@ -64,7 +64,7 @@ export default function* parser(
         {
           start: {
             line: loc.line,
-            column: loc.column + 1,
+            column: loc.column,
           },
         },
         {

--- a/packages/babel-core/src/transformation/file/file.ts
+++ b/packages/babel-core/src/transformation/file/file.ts
@@ -215,13 +215,13 @@ export default class File {
           {
             start: {
               line: loc.start.line,
-              column: loc.start.column + 1,
+              column: loc.start.column,
             },
             end:
               loc.end && loc.start.line === loc.end.line
                 ? {
                     line: loc.end.line,
-                    column: loc.end.column + 1,
+                    column: loc.end.column,
                   }
                 : undefined,
           },

--- a/packages/babel-parser/test/helpers/to-contextual-syntax-error.js
+++ b/packages/babel-parser/test/helpers/to-contextual-syntax-error.js
@@ -11,8 +11,7 @@ export default function toContextualSyntaxError(
 
   const { startLine = 1, startColumn = 0 } = options || {};
   const line = error.loc.line - startLine + 1;
-  const column =
-    1 + (line === 1 ? error.loc.column - startColumn : error.loc.column);
+  const column = line === 1 ? error.loc.column - startColumn : error.loc.column;
   const frame = codeFrameColumns(
     source,
     { start: { line, column } },

--- a/packages/babel-traverse/src/path/replacement.ts
+++ b/packages/babel-traverse/src/path/replacement.ts
@@ -99,7 +99,7 @@ export function replaceWithSourceString(
         codeFrameColumns(replacement, {
           start: {
             line: loc.line,
-            column: loc.column + 1,
+            column: loc.column,
           },
         });
       err.code = "BABEL_REPLACE_SOURCE_ERROR";


### PR DESCRIPTION
| Q                         | A |
| ------------------------- | --- |
| Fixed Issues?             | Fixes #17316 |
| Patch: Bug Fix?           | 👍 |
| Major: Breaking Change?   | Potentially |
| Minor: New Feature?       |  |
| Tests Added + Pass?       | Yes |
| Documentation PR Link     | N/A |
| Any Dependency Changes?   | No |
| License                   | MIT |

## Summary

Fixes #17316

`codeFrameColumns` currently treats columns as 1-based, while Babel AST locations are 0-based. This mismatch causes caret/underline markers to be off by one character when `codeFrameColumns` is called with AST locations directly.

This PR updates `@babel/code-frame` to treat columns as 0-based, and removes the corresponding `+ 1` compensations in internal callers (`@babel/core`, `@babel/traverse`) that were working around the previous behavior.

## Changes

### `@babel/code-frame` (`common.ts`)

- Changed default column sentinel from `0` to `null` so that column `0` is a valid position
- Replaced falsy checks (`!startColumn`, `if (startColumn)`) with explicit null checks (`startColumn == null`, `startColumn != null`)
- Removed `+ 1` compensation in marker length calculation
- Removed `- 1` offset in marker spacing calculation

### `@babel/core` and `@babel/traverse`

- Removed `column: loc.column + 1` in 3 call sites that were converting 0-based AST columns to 1-based before passing them to `codeFrameColumns`

### Tests

- Updated existing test inputs from 1-based to 0-based columns
- Added 2 new tests verifying correct behavior with 0-based columns (including column 0)

## Breaking change note

 This may be a breaking change for external consumers who manually pass 1-based column values to `codeFrameColumns`.

Consumers passing Babel AST `.loc` objects (the primary use case) will now receive correct results without manual adjustment.

If preferred, this change can be targeted for Babel 8.

## Test plan

- All `@babel/code-frame` tests pass (31 tests)
- All `@babel/core` tests pass (483 tests)
- All `@babel/parser` tests pass (16,083 tests)
- All `@babel/traverse` tests pass (650 tests)
- Verified manually with `@babel/parser` output for both valid code (AST loc) and syntax errors (error loc)
