### PR TITLE
test: use `replaceAll` rather than escaped regex

### DIFF
--- a/packages/babel-cli/test/helpers/runner.js
+++ b/packages/babel-cli/test/helpers/runner.js
@@ -22,24 +22,17 @@ const pluginLocs = [
   .map(getPath)
   .join(",");
 
-function escapeRegExp(string) {
-  return string.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
-}
-
 const normalizeOutput = function (str, cwd) {
   let result = str
-    .replace(/\(\d+ms\)/g, "(123ms)")
-    .replace(new RegExp(escapeRegExp(cwd), "g"), "<CWD>")
+    .replaceAll(/\(\d+ms\)/g, "(123ms)")
+    .replaceAll(cwd, "<CWD>")
     // (non-win32) /foo/babel/packages -> <CWD>/packages
     // (win32) C:\foo\babel\packages -> <CWD>\packages
-    .replace(new RegExp(escapeRegExp(rootDir), "g"), "<ROOTDIR>");
+    .replaceAll(rootDir, "<ROOTDIR>");
   if (process.platform === "win32") {
     result = result
       // C:\\foo\\babel\\packages -> <CWD>\\packages (in js string literal)
-      .replace(
-        new RegExp(escapeRegExp(rootDir.replace(/\\/g, "\\\\")), "g"),
-        "<ROOTDIR>",
-      );
+      .replaceAll(rootDir.replaceAll("\\", "\\\\"), "<ROOTDIR>");
   }
   return result;
 };

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -440,10 +440,6 @@ function validateFile(
   }
 }
 
-function escapeRegExp(string: string) {
-  return string.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
-}
-
 function normalizeOutput(
   code: string,
   { normalizePathSeparator = false } = {},
@@ -457,20 +453,16 @@ function normalizeOutput(
     .trim()
     // (non-win32) /foo/babel/packages -> <CWD>/packages
     // (win32) C:\foo\babel\packages -> <CWD>\packages
-    .replace(new RegExp(escapeRegExp(dir), "g"), symbol);
+    .replaceAll(dir, symbol);
   if (process.platform === "win32") {
     result = result
       // C:/foo/babel/packages -> <CWD>/packages
-      .replace(new RegExp(escapeRegExp(dir.replace(/\\/g, "/")), "g"), symbol)
+      .replaceAll(dir.replaceAll("\\", "/"), symbol)
       // C:\\foo\\babel\\packages -> <CWD>\\packages (in js string literal)
-      .replace(
-        new RegExp(escapeRegExp(dir.replace(/\\/g, "\\\\")), "g"),
-        symbol,
-      );
+      .replaceAll(dir.replaceAll("\\", "\\\\"), symbol);
     if (normalizePathSeparator) {
-      result = result.replace(
-        new RegExp(`${escapeRegExp(symbol)}[\\w\\\\/.-]+`, "g"),
-        path => path.replace(/\\\\?/g, "/"),
+      result = result.replaceAll(/<CWD>[\w\\/.-]+/g, path =>
+        path.replaceAll(/\\\\?/g, "/"),
       );
     }
   }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes #15886
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Revival of https://github.com/babel/babel/pull/15886. Let's see if the Windows CI can be green.