### PR TITLE
[7.x backport] Add `developmentSourceSelf` to JSX transform

### DIFF
--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/auto-import-dev/options.json
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/auto-import-dev/options.json
@@ -1,4 +1,4 @@
 {
-  "plugins": ["transform-react-jsx-development"],
+  "plugins": [["transform-react-jsx-development", { "sourceSelf": true }]],
   "sourceType": "module"
 }

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/disallow-__self-as-jsx-attribute/options.json
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/disallow-__self-as-jsx-attribute/options.json
@@ -1,4 +1,4 @@
 {
   "throws": "Duplicate __self prop found. You are most likely using the deprecated transform-react-jsx-self Babel plugin. Both __source and __self are automatically set when using the automatic runtime. Please remove transform-react-jsx-source and transform-react-jsx-self from your Babel config.",
-  "plugins": ["transform-react-jsx-development"]
+  "plugins": [["transform-react-jsx-development", { "sourceSelf": true }]]
 }

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/disallow-__source-as-jsx-attribute/options.json
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/disallow-__source-as-jsx-attribute/options.json
@@ -1,4 +1,4 @@
 {
   "throws": "Duplicate __source prop found. You are most likely using the deprecated transform-react-jsx-source Babel plugin. Both __source and __self are automatically set when using the automatic runtime. Please remove transform-react-jsx-source and transform-react-jsx-self from your Babel config.",
-  "plugins": ["transform-react-jsx-development"]
+  "plugins": [["transform-react-jsx-development", { "sourceSelf": true }]]
 }

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/generated-jsx/options.json
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/generated-jsx/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
     "./plugin.js",
-    ["transform-react-jsx-development", { "runtime": "automatic" }]
+    ["transform-react-jsx-development", { "runtime": "automatic", "sourceSelf": true }]
   ]
 }

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/no-source-self/input.js
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/no-source-self/input.js
@@ -1,0 +1,10 @@
+var x = (
+  <>
+    <div>
+      <span />
+      <div key="1" />
+      <div key="2" meow="wolf" />
+      {[<span key={"0"} />, <span key={"1"} />]}
+    </div>
+  </>
+);

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/no-source-self/options.json
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/no-source-self/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    ["transform-react-jsx-development", { "sourceSelf": true }],
+    ["transform-react-jsx-development", { "sourceSelf": false }],
     "transform-react-display-name",
     "transform-arrow-functions"
   ]

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/no-source-self/output.js
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/no-source-self/output.js
@@ -1,0 +1,8 @@
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
+var x = /*#__PURE__*/_reactJsxDevRuntime.jsxDEV(_reactJsxDevRuntime.Fragment, {
+  children: /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("div", {
+    children: [/*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, void 0, false), /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("div", {}, "1", false), /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("div", {
+      meow: "wolf"
+    }, "2", false), [/*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, "0", false), /*#__PURE__*/_reactJsxDevRuntime.jsxDEV("span", {}, "1", false)]]
+  }, void 0, true)
+}, void 0, false);

--- a/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/source-and-self-defined/options.json
+++ b/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/source-and-self-defined/options.json
@@ -1,6 +1,6 @@
 {
   "plugins": [
-    "transform-react-jsx-development",
+    ["transform-react-jsx-development", { "sourceSelf": true }],
     "transform-react-jsx-source",
     "transform-react-jsx-self"
   ],

--- a/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
+++ b/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts
@@ -58,14 +58,20 @@ export interface Options {
   useBuiltIns: boolean;
   useSpread?: boolean;
 }
-export default function createPlugin({
+
+export interface OptionsDevelopment extends Options {
+  sourceSelf?: boolean;
+}
+
+export default function createPlugin<const Development extends boolean>({
   name,
   development,
 }: {
   name: string;
-  development: boolean;
+  development: Development;
 }) {
-  return declare((_, options: Options) => {
+  type Opts = Development extends true ? OptionsDevelopment : Options;
+  return declare((_, options: Opts) => {
     const {
       pure: PURE_ANNOTATION,
 
@@ -83,6 +89,11 @@ export default function createPlugin({
       pragma: PRAGMA_DEFAULT = DEFAULT.pragma,
       pragmaFrag: PRAGMA_FRAG_DEFAULT = DEFAULT.pragmaFrag,
     } = options;
+
+    const sourceSelf = development
+      ? ((options as OptionsDevelopment).sourceSelf ??
+        (process.env.BABEL_8_BREAKING ? false : true))
+      : undefined;
 
     if (process.env.BABEL_8_BREAKING) {
       if ("useSpread" in options) {
@@ -242,7 +253,7 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
               );
             }
 
-            if (development) {
+            if (development && sourceSelf) {
               // Returns whether the class has specified a superclass.
               function isDerivedClass(classNode: Class) {
                 return classNode.superClass !== null;
@@ -630,11 +641,13 @@ You can set \`throwIfNamespace: false\` to bypass this warning.`,
           extracted.key ?? path.scope.buildUndefinedNode(),
           t.booleanLiteral(children.length > 1),
         );
-        if (extracted.__source) {
-          args.push(extracted.__source);
-          if (extracted.__self) args.push(extracted.__self);
-        } else if (extracted.__self) {
-          args.push(path.scope.buildUndefinedNode(), extracted.__self);
+        if (sourceSelf) {
+          if (extracted.__source) {
+            args.push(extracted.__source);
+            if (extracted.__self) args.push(extracted.__self);
+          } else if (extracted.__self) {
+            args.push(path.scope.buildUndefinedNode(), extracted.__self);
+          }
         }
       } else if (extracted.key !== undefined) {
         args.push(extracted.key);

--- a/packages/babel-preset-react/src/index.ts
+++ b/packages/babel-preset-react/src/index.ts
@@ -8,6 +8,7 @@ import type { PluginItem } from "@babel/core";
 
 export interface Options {
   development?: boolean;
+  developmentSourceSelf?: boolean;
   importSource?: string;
   pragma?: string;
   pragmaFrag?: string;
@@ -25,6 +26,7 @@ export default declarePreset((api, opts: Options) => {
     development = process.env.BABEL_8_BREAKING
       ? api.env(env => env === "development")
       : false,
+    developmentSourceSelf,
     importSource,
     pragma,
     pragmaFrag,
@@ -45,6 +47,7 @@ export default declarePreset((api, opts: Options) => {
               runtime,
               throwIfNamespace,
               pure,
+              sourceSelf: developmentSourceSelf,
             }
           : {
               importSource,
@@ -55,6 +58,7 @@ export default declarePreset((api, opts: Options) => {
               pure,
               useBuiltIns: !!opts.useBuiltIns,
               useSpread: opts.useSpread,
+              sourceSelf: developmentSourceSelf,
             },
       ] satisfies PluginItem,
       transformReactDisplayName,

--- a/packages/babel-preset-react/src/normalize-options.ts
+++ b/packages/babel-preset-react/src/normalize-options.ts
@@ -29,6 +29,7 @@ export default function normalizeOptions(options: any = {}) {
 
     const TopLevelOptions = {
       development: "development",
+      developmentSourceSelf: "developmentSourceSelf",
       importSource: "importSource",
       pragma: "pragma",
       pragmaFrag: "pragmaFrag",
@@ -40,6 +41,11 @@ export default function normalizeOptions(options: any = {}) {
     const development = v.validateBooleanOption(
       TopLevelOptions.development,
       options.development,
+    );
+    const developmentSourceSelf = v.validateBooleanOption(
+      TopLevelOptions.developmentSourceSelf,
+      options.developmentSourceSelf,
+      false,
     );
     let importSource = v.validateStringOption(
       TopLevelOptions.importSource,
@@ -78,6 +84,7 @@ export default function normalizeOptions(options: any = {}) {
 
     return {
       development,
+      developmentSourceSelf,
       importSource,
       pragma,
       pragmaFrag,
@@ -105,8 +112,14 @@ export default function normalizeOptions(options: any = {}) {
     const development =
       options.development == null ? undefined : !!options.development;
 
+    const developmentSourceSelf =
+      options.developmentSourceSelf == null
+        ? true
+        : !!options.developmentSourceSelf;
+
     return {
       development,
+      developmentSourceSelf,
       importSource,
       pragma,
       pragmaFrag,

--- a/packages/babel-preset-react/test/fixtures/preset-options/development-no-source-self/input.js
+++ b/packages/babel-preset-react/test/fixtures/preset-options/development-no-source-self/input.js
@@ -1,0 +1,1 @@
+<Foo bar="baz" />

--- a/packages/babel-preset-react/test/fixtures/preset-options/development-no-source-self/options.json
+++ b/packages/babel-preset-react/test/fixtures/preset-options/development-no-source-self/options.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["react", { "runtime": "automatic", "development": true, "developmentSourceSelf": false }]]
+}

--- a/packages/babel-preset-react/test/fixtures/preset-options/development-no-source-self/output.js
+++ b/packages/babel-preset-react/test/fixtures/preset-options/development-no-source-self/output.js
@@ -1,0 +1,4 @@
+var _reactJsxDevRuntime = require("react/jsx-dev-runtime");
+/*#__PURE__*/_reactJsxDevRuntime.jsxDEV(Foo, {
+  bar: "baz"
+}, void 0, false);

--- a/packages/babel-preset-react/test/fixtures/preset-options/development-runtime-automatic/options.json
+++ b/packages/babel-preset-react/test/fixtures/preset-options/development-runtime-automatic/options.json
@@ -1,3 +1,3 @@
 {
-  "presets": [["react", { "runtime": "automatic", "development": true }]]
+  "presets": [["react", { "runtime": "automatic", "development": true, "developmentSourceSelf": true }]]
 }

--- a/packages/babel-preset-react/test/fixtures/preset-options/development/options.json
+++ b/packages/babel-preset-react/test/fixtures/preset-options/development/options.json
@@ -1,3 +1,3 @@
 {
-  "presets": [["react", { "development": true, "runtime": "classic" }]]
+  "presets": [["react", { "development": true, "developmentSourceSelf": true, "runtime": "classic" }]]
 }

--- a/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/options.json
+++ b/packages/babel-preset-react/test/fixtures/regression/another-preset-with-custom-jsx-keep-source-self/options.json
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["react", { "development": true }],
+    ["react", { "development": true, "developmentSourceSelf": true }],
     "./emotion-css-prop-preset.js"
   ]
 }

--- a/packages/babel-preset-react/test/fixtures/regression/runtime-classic-allow-multiple-source-self/my-preset.js
+++ b/packages/babel-preset-react/test/fixtures/regression/runtime-classic-allow-multiple-source-self/my-preset.js
@@ -1,3 +1,3 @@
 module.exports = () => ({
-  presets: [["../../../../lib/index.js", { development: true, runtime: "classic" }]],
+  presets: [["../../../../lib/index.js", { development: true, developmentSourceSelf: true, runtime: "classic" }]],
 });

--- a/packages/babel-preset-react/test/fixtures/regression/runtime-classic-allow-multiple-source-self/options.json
+++ b/packages/babel-preset-react/test/fixtures/regression/runtime-classic-allow-multiple-source-self/options.json
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["react", { "development": true, "runtime": "classic" }],
+    ["react", { "development": true, "developmentSourceSelf": true, "runtime": "classic" }],
     "./my-preset"
   ]
 }

--- a/packages/babel-preset-react/test/index.js
+++ b/packages/babel-preset-react/test/index.js
@@ -35,13 +35,8 @@ describe("react preset", () => {
         envName: "development",
       }).code,
     ).toMatchInlineSnapshot(`
-      "var _jsxFileName = \\"\\";
-      import { jsxDEV as _jsxDEV } from \\"react/jsx-dev-runtime\\";
-      /*#__PURE__*/_jsxDEV(\\"a\\", {}, void 0, false, {
-        fileName: _jsxFileName,
-        lineNumber: 1,
-        columnNumber: 1
-      }, this);"
+      "import { jsxDEV as _jsxDEV } from \\"react/jsx-dev-runtime\\";
+      /*#__PURE__*/_jsxDEV(\\"a\\", {}, void 0, false);"
     `);
 
     expect(

--- a/packages/babel-preset-react/test/normalize-options.skip-bundled.js
+++ b/packages/babel-preset-react/test/normalize-options.skip-bundled.js
@@ -9,14 +9,16 @@ describe("normalize options", () => {
         "@babel/preset-react: 'throwIfNamespaces' is not a valid top-level option.\n- Did you mean 'throwIfNamespace'?",
       );
     });
-    it.each(["development", "pure", "throwIfNamespace"])(
-      "should throw when `%p` is not a boolean",
-      optionName => {
-        expect(() => normalizeOptions({ [optionName]: 0 })).toThrow(
-          `@babel/preset-react: '${optionName}' option must be a boolean.`,
-        );
-      },
-    );
+    it.each([
+      "development",
+      "developmentSourceSelf",
+      "pure",
+      "throwIfNamespace",
+    ])("should throw when `%p` is not a boolean", optionName => {
+      expect(() => normalizeOptions({ [optionName]: 0 })).toThrow(
+        `@babel/preset-react: '${optionName}' option must be a boolean.`,
+      );
+    });
     it.each(["importSource", "pragma", "pragmaFrag", "runtime"])(
       "should throw when `%p` is not a string",
       optionName => {
@@ -60,6 +62,7 @@ describe("normalize options", () => {
       expect(normalizeOptions({})).toMatchInlineSnapshot(`
         Object {
           "development": undefined,
+          "developmentSourceSelf": false,
           "importSource": "react",
           "pragma": undefined,
           "pragmaFrag": undefined,
@@ -71,6 +74,7 @@ describe("normalize options", () => {
       expect(normalizeOptions({ runtime: "classic" })).toMatchInlineSnapshot(`
         Object {
           "development": undefined,
+          "developmentSourceSelf": false,
           "importSource": undefined,
           "pragma": "React.createElement",
           "pragmaFrag": "React.Fragment",
@@ -101,6 +105,7 @@ describe("normalize options", () => {
       expect(normalizeOptions({})).toMatchInlineSnapshot(`
         Object {
           "development": undefined,
+          "developmentSourceSelf": true,
           "importSource": undefined,
           "pragma": "React.createElement",
           "pragmaFrag": "React.Fragment",
@@ -114,6 +119,7 @@ describe("normalize options", () => {
       expect(normalizeOptions({ runtime: "automatic" })).toMatchInlineSnapshot(`
         Object {
           "development": undefined,
+          "developmentSourceSelf": true,
           "importSource": undefined,
           "pragma": undefined,
           "pragmaFrag": undefined,


### PR DESCRIPTION
## Summary

Backport of #17845 to the `7.x` branch, as requested by @nicolo-ribaudo.

Adds a `developmentSourceSelf` option to `@babel/preset-react` (and `sourceSelf` to the underlying JSX development plugin) that controls whether `__source` and `__self` attributes are injected in `jsxDEV` calls.

React 19.2+ generates these from the callsite, making Babel injection unnecessary and sometimes harmful (duplicated props warnings).

### Defaults

| Branch | Default | Rationale |
|--------|---------|-----------|
| 7.x (Babel 7) | `true` | Preserves backward compatibility |
| 7.x (Babel 8 path) | `false` | React 19.2+ is the common target |

### Usage

Users on React 19.2+ can opt out:
```json
{
  "presets": [["@babel/preset-react", {
    "runtime": "automatic",
    "developmentSourceSelf": false
  }]]
}
```

### Changes

- `create-plugin.ts`: Added `sourceSelf` option to development plugin; gates `__source`/`__self` injection behind it
- `normalize-options.ts`: Added `developmentSourceSelf` validation/normalization with appropriate defaults
- `preset index.ts`: Passes `developmentSourceSelf` through as `sourceSelf` to plugin
- Test fixtures updated to explicitly set `sourceSelf: true` / `developmentSourceSelf: true` where needed
- New test fixtures for `sourceSelf: false` / `developmentSourceSelf: false` behavior

All tests pass in both Babel 7 and Babel 8 modes.
