### PR TITLE
Align `sourceFilename` across core, parser, and generator

### DIFF
--- a/packages/babel-cli/src/babel/dir.ts
+++ b/packages/babel-cli/src/babel/dir.ts
@@ -44,7 +44,7 @@ export default async function ({
     try {
       const res = await util.compile(src, {
         ...babelOptions,
-        sourceFileName: slash(path.relative(dest + "/..", src)),
+        sourceFilename: slash(path.relative(dest + "/..", src)),
       });
 
       if (!res) return FILE_TYPE.IGNORED;

--- a/packages/babel-cli/src/babel/file.ts
+++ b/packages/babel-cli/src/babel/file.ts
@@ -144,7 +144,7 @@ export default async function ({
 
     const res = await util.transformRepl(cliOptions.filename, code, {
       ...babelOptions,
-      sourceFileName: "stdin",
+      sourceFilename: "stdin",
     });
 
     output([res]);
@@ -184,7 +184,7 @@ export default async function ({
         try {
           return await util.compile(filename, {
             ...babelOptions,
-            sourceFileName: sourceFilename,
+            sourceFilename,
             // Since we're compiling everything to be merged together,
             // "inline" applies to the final output file, but not to the individual
             // files being concatenated.

--- a/packages/babel-cli/src/babel/options.ts
+++ b/packages/babel-cli/src/babel/options.ts
@@ -289,7 +289,7 @@ export default function parseArgv(args: string[]): CmdOptions | null {
     auxiliaryCommentBefore: opts.auxiliaryCommentBefore,
     auxiliaryCommentAfter: opts.auxiliaryCommentAfter,
     sourceMaps: opts.sourceMaps,
-    sourceFileName: opts.sourceFileName,
+    sourceFilename: opts.sourceFilename,
     sourceRoot: opts.sourceRoot,
 
     // Commander will default the "--no-" arguments to true, but we want to

--- a/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR with multiple files-windows/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR with multiple files-windows/stdout.txt
@@ -23,7 +23,7 @@ programmatic options from @babel/cli
     "<ROOTDIR>//packages//babel-plugin-transform-strict-mode//lib//index.js",
     "<ROOTDIR>//packages//babel-plugin-transform-modules-commonjs//lib//index.js"
   ],
-  "sourceFileName": "src/foo.js",
+  "sourceFilename": "src/foo.js",
   "caller": {
     "name": "@babel/cli",
     "supportsStaticESM": false,

--- a/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR with multiple files/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR with multiple files/stdout.txt
@@ -23,7 +23,7 @@ programmatic options from @babel/cli
     "<ROOTDIR>/packages/babel-plugin-transform-strict-mode/lib/index.js",
     "<ROOTDIR>/packages/babel-plugin-transform-modules-commonjs/lib/index.js"
   ],
-  "sourceFileName": "src/foo.js",
+  "sourceFilename": "src/foo.js",
   "caller": {
     "name": "@babel/cli",
     "supportsStaticESM": false,

--- a/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR-windows/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR-windows/stdout.txt
@@ -23,7 +23,7 @@ programmatic options from @babel/cli
     "<ROOTDIR>//packages//babel-plugin-transform-strict-mode//lib//index.js",
     "<ROOTDIR>//packages//babel-plugin-transform-modules-commonjs//lib//index.js"
   ],
-  "sourceFileName": "../src/foo.js",
+  "sourceFilename": "../src/foo.js",
   "caller": {
     "name": "@babel/cli",
     "supportsStaticESM": false,

--- a/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR/stdout.txt
+++ b/packages/babel-cli/test/fixtures/babel/env - SHOW_CONFIG_FOR/stdout.txt
@@ -118,7 +118,7 @@ programmatic options from @babel/cli
     "<ROOTDIR>/packages/babel-plugin-transform-modules-commonjs/lib/index.js"
   ],
   "configFile": "./my-config.js",
-  "sourceFileName": "./src/index.js",
+  "sourceFilename": "./src/index.js",
   "caller": {
     "name": "@babel/cli",
     "supportsStaticESM": false,

--- a/packages/babel-core/src/config/files/module-types.ts
+++ b/packages/babel-core/src/config/files/module-types.ts
@@ -169,7 +169,7 @@ function ensureTsSupport<T>(
     configFile: false,
     sourceType: "unambiguous",
     sourceMaps: "inline",
-    sourceFileName: path.basename(filepath),
+    sourceFilename: path.basename(filepath),
     presets: [
       [
         getTSPreset(filepath),

--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -116,7 +116,7 @@ const COMMON_VALIDATORS: ValidatorSet = {
   highlightCode: assertBoolean as Validator<InputOptions["highlightCode"]>,
   sourceMaps: assertSourceMaps as Validator<InputOptions["sourceMaps"]>,
   sourceMap: assertSourceMaps as Validator<InputOptions["sourceMap"]>,
-  sourceFileName: assertString as Validator<InputOptions["sourceFileName"]>,
+  sourceFilename: assertString as Validator<InputOptions["sourceFilename"]>,
   sourceRoot: assertString as Validator<InputOptions["sourceRoot"]>,
   parserOpts: assertObject as Validator<InputOptions["parserOpts"]>,
   generatorOpts: assertObject as Validator<InputOptions["generatorOpts"]>,
@@ -198,7 +198,7 @@ export type InputOptions = {
   // Sourcemap generation options.
   sourceMaps?: SourceMapsOption;
   sourceMap?: SourceMapsOption;
-  sourceFileName?: string;
+  sourceFilename?: string;
   sourceRoot?: string;
   // Todo(Babel 9): Deprecate top level parserOpts
   parserOpts?: ParserOptions;

--- a/packages/babel-core/src/transformation/file/generate.ts
+++ b/packages/babel-core/src/transformation/file/generate.ts
@@ -67,7 +67,7 @@ export default function generateCode(
         outputMap = mergeSourceMap(
           inputMap.toObject(),
           outputMap,
-          generatorOpts.sourceFileName!,
+          generatorOpts.sourceFilename!,
         );
       } else {
         // We cannot output a decoded map, so retrieve the encoded form. Because

--- a/packages/babel-core/src/transformation/file/merge-map.ts
+++ b/packages/babel-core/src/transformation/file/merge-map.ts
@@ -4,15 +4,15 @@ import remapping from "@jridgewell/remapping";
 export default function mergeSourceMap(
   inputMap: SourceMap,
   map: SourceMap,
-  sourceFileName: string,
+  sourceFilename: string,
 ): SourceMap {
-  // On win32 machines, the sourceFileName uses backslash paths like
+  // On win32 machines, the sourceFilename uses backslash paths like
   // `C:\foo\bar.js`. But sourcemaps are always posix paths, so we need to
   // normalize to regular slashes before we can merge (else we won't find the
   // source associated with our input map).
   // This mirrors code done while generating the output map at
   // https://github.com/babel/babel/blob/5c2fcadc9ae34fd20dd72b1111d5cf50476d700d/packages/babel-generator/src/source-map.ts#L102
-  const source = sourceFileName.replace(/\\/g, "/");
+  const source = sourceFilename.replace(/\\/g, "/");
 
   // Prevent an infinite recursion if one of the input map's sources has the
   // same resolved path as the input map. In the case, it would keep find the

--- a/packages/babel-core/src/transformation/normalize-opts.ts
+++ b/packages/babel-core/src/transformation/normalize-opts.ts
@@ -16,7 +16,7 @@ export default function normalizeOptions(
     sourceMaps = !!inputSourceMap,
     sourceRoot = undefined,
 
-    sourceFileName = path.basename(filenameRelative),
+    sourceFilename,
 
     comments = true,
     compact = "auto",
@@ -31,9 +31,7 @@ export default function normalizeOptions(
       sourceType:
         path.extname(filenameRelative) === ".mjs" ? "module" : sourceType,
 
-      // @ts-expect-error We should have passed `sourceFilename` here
-      // pending https://github.com/babel/babel/issues/15917#issuecomment-2789278964
-      sourceFileName: filename,
+      sourceFilename: filename,
       plugins: [],
       ...opts.parserOpts,
     },
@@ -54,7 +52,8 @@ export default function normalizeOptions(
       // babel-generator does not differentiate between `true`, `"inline"` or `"both"`
       sourceMaps: !!sourceMaps,
       sourceRoot,
-      sourceFileName,
+      sourceFilename:
+        sourceFilename ?? filename ?? path.basename(filenameRelative),
 
       ...opts.generatorOpts,
     },

--- a/packages/babel-core/test/fixtures/parse/output.json
+++ b/packages/babel-core/test/fixtures/parse/output.json
@@ -2,7 +2,6 @@
   "type": "File",
   "start": 0,
   "end": 91,
-  "errors": [],
   "loc": {
     "start": {
       "line": 1,
@@ -15,6 +14,7 @@
       "index": 91
     }
   },
+  "errors": [],
   "program": {
     "type": "Program",
     "start": 0,
@@ -31,8 +31,8 @@
         "index": 91
       }
     },
-    "interpreter": null,
     "sourceType": "module",
+    "interpreter": null,
     "body": [
       {
         "type": "ClassDeclaration",
@@ -270,6 +270,7 @@
                     },
                     "name": "target"
                   },
+                  "computed": false,
                   "property": {
                     "type": "Identifier",
                     "start": 71,
@@ -288,8 +289,7 @@
                       "identifierName": "annotated"
                     },
                     "name": "annotated"
-                  },
-                  "computed": false
+                  }
                 },
                 "right": {
                   "type": "BooleanLiteral",

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-multiple-output-sources-complete-replace/plugin.js
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-multiple-output-sources-complete-replace/plugin.js
@@ -5,12 +5,12 @@ module.exports = function (babel) {
     visitor: {
       Program(path) {
         const { file } = this;
-        const { sourceFileName } = file.opts.generatorOpts;
+        const { sourceFilename } = file.opts.generatorOpts;
 
         // This injects the sourcesContent, though I don't imagine anyone's
         // doing it.
         file.code = {
-            [sourceFileName]: file.code,
+            [sourceFilename]: file.code,
             'bar.js': '<bar />',
             'baz.js': 'baz();',
         };

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-multiple-output-sources/plugin.js
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-multiple-output-sources/plugin.js
@@ -5,7 +5,7 @@ module.exports = function (babel) {
     visitor: {
       CallExpression(path) {
         const { file } = this;
-        const { sourceFileName } = file.opts.generatorOpts;
+        const { sourceFilename } = file.opts.generatorOpts;
         const callee = path.node;
         const { loc } = callee;
 
@@ -22,7 +22,7 @@ module.exports = function (babel) {
         // This injects the sourcesContent, though I don't imagine anyone's
         // doing it.
         file.code = {
-            [sourceFileName]: file.code,
+            [sourceFilename]: file.code,
             'test.js': '<bar />',
         };
         path.stop();

--- a/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-sources-complete-replace/plugin.js
+++ b/packages/babel-core/test/fixtures/transformation/source-maps/input-source-map-sources-complete-replace/plugin.js
@@ -5,12 +5,12 @@ module.exports = function (babel) {
     visitor: {
       Program(path) {
         const { file } = this;
-        const { sourceFileName } = file.opts.generatorOpts;
+        const { sourceFilename } = file.opts.generatorOpts;
 
         // This injects the sourcesContent, though I don't imagine anyone's
         // doing it.
         file.code = {
-            [sourceFileName]: file.code,
+            [sourceFilename]: file.code,
             'test.js': '<bar />',
         };
       },

--- a/packages/babel-core/test/parse.js
+++ b/packages/babel-core/test/parse.js
@@ -24,7 +24,18 @@ describe("parseSync", function () {
       filename: fixture("input.js"),
       cwd: fixture(),
     });
-    expect(JSON.parse(JSON.stringify(result))).toEqual(output);
+    // When a filename is provided, the parser sets loc.filename on all nodes.
+    // Strip it before comparing to the fixture since it contains absolute paths.
+    const resultJson = JSON.parse(
+      JSON.stringify(result, (key, value) =>
+        key === "filename" &&
+        typeof value === "string" &&
+        value.endsWith("input.js")
+          ? undefined
+          : value,
+      ),
+    );
+    expect(resultJson).toEqual(output);
   });
 
   it("should parse using passed in configuration", function () {

--- a/packages/babel-generator/src/index.ts
+++ b/packages/babel-generator/src/index.ts
@@ -200,7 +200,7 @@ export interface GeneratorOptions {
    * The filename for the source code (i.e. the code in the `code` argument).
    * This will only be used if `code` is a string.
    */
-  sourceFileName?: string;
+  sourceFilename?: string;
 
   /**
    * Options for outputting jsesc representation.

--- a/packages/babel-generator/src/source-map.ts
+++ b/packages/babel-generator/src/source-map.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   GenMapping,
   maybeAddMapping,
@@ -27,7 +28,22 @@ import { originalPositionFor, TraceMap } from "@jridgewell/trace-mapping";
 export default class SourceMap {
   private _map: GenMapping;
   private _rawMappings: Mapping[] | undefined;
-  private _sourceFileName: string | undefined;
+
+  // The source filename used in the source map's "sources" array.
+  // This is the "normalized" version: if sourceRoot is set, it's
+  // relative to sourceRoot; if the path is absolute with no sourceRoot,
+  // it's reduced to its basename. Relative paths are kept as-is.
+  #sourceFilename: string | undefined;
+
+  // The original absolute filename (opts.filename, or opts.sourceFilename
+  // as a fallback), converted to a POSIX path.
+  // This is used in #resolveSourceFilename to detect when a node's
+  // loc.filename refers to the main source file, so we can map it back
+  // to the normalized #sourceFilename instead of creating a duplicate
+  // source entry.
+  #rawSourceFilename: string | undefined;
+
+  private _sourceRoot: string | undefined;
 
   // Any real line is > 0, so init to 0 is fine.
   private _lastGenLine = 0;
@@ -41,14 +57,22 @@ export default class SourceMap {
 
   constructor(
     opts: {
-      sourceFileName?: string;
+      filename?: string; // The complete filename
+      sourceFilename?: string; // The name for `sources` in the source map
       sourceRoot?: string;
       inputSourceMap?: SourceMapInput;
     },
     code: string | Record<string, string> | null | undefined,
   ) {
     const map = (this._map = new GenMapping({ sourceRoot: opts.sourceRoot }));
-    this._sourceFileName = opts.sourceFileName?.replace(/\\/g, "/");
+    this._sourceRoot = opts.sourceRoot;
+    this.#rawSourceFilename = (opts.filename ?? opts.sourceFilename)?.replace(
+      /\\/g,
+      "/",
+    );
+    this.#sourceFilename = this.#normalizeFilename(
+      opts.sourceFilename?.replace(/\\/g, "/"),
+    );
     this._rawMappings = undefined;
 
     if (opts.inputSourceMap) {
@@ -67,7 +91,7 @@ export default class SourceMap {
     }
 
     if (typeof code === "string" && !opts.inputSourceMap) {
-      setSourceContent(map, this._sourceFileName!, code);
+      setSourceContent(map, this.#sourceFilename!, code);
     } else if (typeof code === "object") {
       for (const sourceFileName of Object.keys(code!)) {
         setSourceContent(
@@ -92,6 +116,33 @@ export default class SourceMap {
 
   getRawMappings(): Mapping[] {
     return (this._rawMappings ||= allMappings(this._map));
+  }
+
+  #normalizeFilename(filename: string | undefined): string | undefined {
+    if (filename && path.isAbsolute(filename)) {
+      if (this._sourceRoot) {
+        return path.relative(this._sourceRoot, filename);
+      }
+      return path.basename(filename);
+    }
+    return filename;
+  }
+
+  /**
+   * Resolve the source filename for a mapping entry. If the loc filename
+   * matches the main source file (raw or normalized), use _sourceFilename.
+   * Otherwise normalize it as a secondary source.
+   */
+  #resolveSourceFilename(filename: string | null | undefined): string {
+    if (!filename) return this.#sourceFilename!;
+    const normalized = filename.replace(/\\/g, "/");
+    if (
+      normalized === this.#rawSourceFilename ||
+      normalized === this.#sourceFilename
+    ) {
+      return this.#sourceFilename!;
+    }
+    return this.#normalizeFilename(normalized) ?? normalized;
   }
 
   /**
@@ -138,7 +189,7 @@ export default class SourceMap {
       } else {
         originalMapping = {
           name: null,
-          source: filename?.replace(/\\/g, "/") || this._sourceFileName!,
+          source: this.#resolveSourceFilename(filename),
           line: line,
           column: column!,
         };

--- a/packages/babel-generator/test/index.js
+++ b/packages/babel-generator/test/index.js
@@ -321,7 +321,7 @@ describe("generation", function () {
       ast,
       {
         filename: "inline",
-        sourceFileName: "inline",
+        sourceFilename: "inline",
         sourceMaps: true,
       },
       code,
@@ -553,7 +553,7 @@ describe("generation", function () {
       ast,
       {
         filename: "inline",
-        sourceFileName: "inline",
+        sourceFilename: "inline",
         sourceMaps: true,
       },
       code,
@@ -574,7 +574,7 @@ describe("generation", function () {
       ast,
       {
         filename: "inline",
-        sourceFileName: "inline",
+        sourceFilename: "inline",
         sourceMaps: true,
       },
       code,
@@ -593,7 +593,7 @@ describe("generation", function () {
 
     const ast = parse(code, { filename: "a.js" }).program;
     const generated = generate(ast, {
-      sourceFileName: "a.js",
+      sourceFilename: "a.js",
       sourceMaps: true,
     });
 
@@ -1592,7 +1592,7 @@ suites.forEach(function (testSuite) {
             };
             const actualAst = parse(actualCode, parserOpts);
             const options = {
-              sourceFileName: path.relative(__dirname, actual.loc),
+              sourceFilename: path.relative(__dirname, actual.loc),
               ...task.options,
               sourceMaps: task.sourceMap ? true : task.options.sourceMaps,
             };

--- a/packages/babel-generator/test/preserve-format.js
+++ b/packages/babel-generator/test/preserve-format.js
@@ -90,7 +90,7 @@ describe("experimental_preserveFormat", () => {
             tokens: true,
           };
           const generatorOpts = {
-            sourceFileName: path.relative(__dirname, task.actual.loc),
+            sourceFilename: path.relative(__dirname, task.actual.loc),
             ...task.options,
             retainLines: true,
             experimental_preserveFormat: true,

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -270,7 +270,7 @@ async function run(task: Test) {
       cwd: path.dirname(self.loc!),
       filename: self.loc,
       filenameRelative: self.filename,
-      sourceFileName: self.filename,
+      sourceFilename: self.filename,
       ...(doNotSetSourceType ? {} : { sourceType: "script" }),
       babelrc: false,
       configFile: false,

--- a/packages/babel-standalone/src/transformScriptTags.ts
+++ b/packages/babel-standalone/src/transformScriptTags.ts
@@ -93,7 +93,7 @@ function buildBabelOptions(
     presets,
     plugins,
     sourceMaps: "inline" as const,
-    sourceFileName: filename,
+    sourceFilename: filename,
     targets,
   };
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Closes https://github.com/babel/babel/issues/15917 and closes https://github.com/babel/babel/pull/15911. 

Closes #13518.

Closes #17458 

Marking as draft because I want to add getters for the old spelling for legacy compatibility.