### PR TITLE
chore: bump eslint-plugin peer deps

### DIFF
--- a/eslint/babel-eslint-plugin-development-internal/package.json
+++ b/eslint/babel-eslint-plugin-development-internal/package.json
@@ -16,8 +16,8 @@
   },
   "homepage": "https://github.com/babel/babel/tree/master/eslint/babel-eslint-plugin-development-internal",
   "peerDependencies": {
-    "@babel/eslint-parser": ">=7.11.0",
-    "eslint": ">=7.5.0"
+    "@babel/eslint-parser": "workspace:^",
+    "eslint": "^9.0.0 || ^10.0.0"
   },
   "devDependencies": {
     "eslint": "^10.0.0"

--- a/eslint/babel-eslint-plugin/package.json
+++ b/eslint/babel-eslint-plugin/package.json
@@ -37,8 +37,8 @@
   },
   "homepage": "https://babel.dev/",
   "peerDependencies": {
-    "@babel/eslint-parser": "^7.11.0",
-    "eslint": "^9.0.0"
+    "@babel/eslint-parser": "workspace:^",
+    "eslint": "^9.0.0 || ^10.0.0"
   },
   "devDependencies": {
     "eslint": "^10.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,8 +523,8 @@ __metadata:
   dependencies:
     eslint: "npm:^10.0.0"
   peerDependencies:
-    "@babel/eslint-parser": ">=7.11.0"
-    eslint: ">=7.5.0"
+    "@babel/eslint-parser": "workspace:^"
+    eslint: ^9.0.0 || ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -542,8 +542,8 @@ __metadata:
   dependencies:
     eslint: "npm:^10.0.0"
   peerDependencies:
-    "@babel/eslint-parser": ^7.11.0
-    eslint: ^9.0.0
+    "@babel/eslint-parser": "workspace:^"
+    eslint: ^9.0.0 || ^10.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/17872
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

As a follow-up to #17811, this PR bumps the `peerDependencies` of `@babel/eslint-plugin` and the `@babel/eslint-plugin-development-internal`, to be aligned with the current `peerDependencies` of `@babel/eslint-parser`.