### PR TITLE
fix(regenerator): handle destructuring hoist crash in async (#17517)

### DIFF
--- a/packages/babel-plugin-transform-regenerator/src/regenerator/hoist.ts
+++ b/packages/babel-plugin-transform-regenerator/src/regenerator/hoist.ts
@@ -24,16 +24,23 @@ export function hoist(
     const exprs: t.Expression[] = [];
 
     (
-      vdec.declarations as (t.VariableDeclarator & { id: t.Identifier })[]
+      vdec.declarations as t.VariableDeclarator[]
     ).forEach(function (dec) {
-      // Note: We duplicate 'dec.id' here to ensure that the variable declaration IDs don't
+      // Note: We duplicate identifiers here to ensure that variable declaration IDs don't
       // have the same 'loc' value, since that can make sourcemaps and retainLines behave poorly.
-      vars[dec.id.name] = t.identifier(dec.id.name);
+      //
+      // `dec.id` can be a destructuring pattern if the user didn't run
+      // `@babel/plugin-transform-destructuring` before regenerator (see #17517).
+      // In that case, collect all binding identifiers instead of assuming `id` is an Identifier.
+      const bindings = t.getBindingIdentifiers(dec.id);
+      for (const name of Object.keys(bindings)) {
+        vars[name] = t.identifier(name);
+      }
 
       if (dec.init) {
-        exprs.push(t.assignmentExpression("=", dec.id, dec.init));
+        exprs.push(t.assignmentExpression("=", dec.id as any, dec.init));
       } else if (includeIdentifiers) {
-        exprs.push(dec.id);
+        exprs.push(dec.id as any);
       }
     });
 

--- a/packages/babel-plugin-transform-regenerator/test/regression-17517.js
+++ b/packages/babel-plugin-transform-regenerator/test/regression-17517.js
@@ -1,0 +1,34 @@
+import { transformSync } from "@babel/core";
+
+describe("regression", () => {
+  it("does not crash on destructuring inside async functions (#17517)", () => {
+    const code = `
+      const testA = async () => {
+        return async () => {
+          const { resData, config } = {}
+          console.log('a', resData)
+        }
+      }
+
+      const testB = async () => {
+        await testA()
+      }
+
+      console.log(testB)
+    `;
+
+    expect(() =>
+      transformSync(code, {
+        filename: "input.js",
+        configFile: false,
+        babelrc: false,
+        sourceType: "module",
+        plugins: [
+          require.resolve("@babel/plugin-transform-async-to-generator"),
+          require.resolve("../lib/index.js"),
+        ],
+      }),
+    ).not.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Problem
When running `@babel/plugin-transform-async-to-generator` followed by `@babel/plugin-transform-regenerator`, async code containing untransformed destructuring can crash with:

- `Property name expected type of string but got undefined`

Repro from `#17517`:

```js
const testA = async () => {
  return async () => {
    const { resData, config } = {}
    console.log('a', resData)
  }
}
```

## Cause
Regenerator's `hoist` pass assumed every `VariableDeclarator` has an `Identifier` id, and used `dec.id.name` when collecting vars. With destructuring, `dec.id` is a pattern so `name` is `undefined`, triggering the `@babel/types` invariant.

## Solution
Collect binding identifiers via `getBindingIdentifiers(dec.id)` instead of assuming `Identifier`, so patterns are supported and the transform no longer crashes.

## Tests
- Added a regression test covering the repro (`packages/babel-plugin-transform-regenerator/test/regression-17517.js`).

Fixes #17517
