### PR TITLE
chore: bump github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
@@ -68,9 +68,9 @@ jobs:
     #    YARN_NODE_LINKER: pnp # use pnp linker for better linking performance and stricter checks
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
@@ -97,7 +97,7 @@ jobs:
       - name: Ensure cwd does not contain uncommitted changes
         run: |
           node ./scripts/assert-dir-git-clean.ts "\`make build\` and \`node scripts/cleanup-fixtures.ts\`"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: babel-artifact
           path: |
@@ -119,9 +119,9 @@ jobs:
     #    YARN_NODE_LINKER: pnp # use pnp linker for better linking performance and stricter checks
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
@@ -144,16 +144,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
           cache: "yarn"
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel-artifact
       - name: Lint
@@ -168,9 +168,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
@@ -178,7 +178,7 @@ jobs:
       - name: Install
         run: |
           yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel-artifact
       - name: Run tests
@@ -204,9 +204,9 @@ jobs:
         node-version: [24, 22, 20]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest # Run yarn on latest node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
@@ -214,11 +214,11 @@ jobs:
       - name: Install
         run: |
           yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel-artifact
       - name: Use Node.js ${{ matrix.node-version }} # Checkout node version for test executor
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Ensure that @babel/node's list of node flags is up to date
@@ -242,16 +242,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
           cache: "yarn"
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel-artifact
       - name: Test
@@ -268,9 +268,9 @@ jobs:
     #    YARN_NODE_LINKER: pnp # use pnp linker for better linking performance and stricter checks
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
@@ -282,7 +282,7 @@ jobs:
           BABEL_ENV: test-legacy
           BABEL_9_BREAKING: true
           STRIP_BABEL_VERSION_FLAG: true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: babel9-artifact
           path: |
@@ -302,16 +302,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
           cache: "yarn"
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel9-artifact
       - name: Lint
@@ -326,9 +326,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
@@ -336,7 +336,7 @@ jobs:
       - name: Install
         run: |
           yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel9-artifact
       - name: Run tests
@@ -362,16 +362,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
           cache: "yarn"
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel9-artifact
       - name: Test
@@ -386,16 +386,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
           cache: "yarn"
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel-artifact
       - name: Download tests
@@ -413,9 +413,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
@@ -442,7 +442,7 @@ jobs:
           # The "Support self-references on old Node.js" step mutates the
           # package.json file, causing a yarn.lock update.
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel-artifact
       - name: Generate absoluteRuntime tests
@@ -479,9 +479,9 @@ jobs:
           ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
@@ -508,13 +508,13 @@ jobs:
           # The "Support self-references on old Node.js" step mutates the
           # package.json file, causing a yarn.lock update.
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel-artifact
       - name: Generate absoluteRuntime tests
         run: yarn test:runtime:generate-absolute-runtime
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Test Node.js ${{ matrix.node-version }}
@@ -530,15 +530,15 @@ jobs:
         eslint-version: [9.0.0]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           cache: "yarn"
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel-artifact
       - name: Downgrade ESLint to ${{ matrix.eslint-version }}
@@ -552,14 +552,14 @@ jobs:
     if: github.repository == 'babel/babel'
     steps:
       - name: Checkout Babel
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
       - name: Checkout test runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: babel/babel-test262-runner
           path: babel-test262-runner
@@ -574,7 +574,7 @@ jobs:
         env:
           TEST262_PATH: ../build/test262
       - name: Upload chunks artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test262-chunks
           path: ~/test262-chunks.json
@@ -589,19 +589,19 @@ jobs:
     needs: [build, test262-prepare]
     steps:
       - name: Checkout Babel
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
       - name: Install
         run: yarn install
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: babel-artifact
       - name: Checkout test runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: babel/babel-test262-runner
           path: babel-test262-runner
@@ -614,7 +614,7 @@ jobs:
       - name: Download test262
         run: make bootstrap-test262
       - name: Download chunks file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: test262-chunks
       - name: Run test262
@@ -631,7 +631,7 @@ jobs:
           CHUNKS_FILE: ../test262-chunks.json
           CHUNK: ${{ matrix.chunk }}
       - name: Create artifact with report results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test262-result-${{ matrix.chunk }}
           path: ~/test262-${{ matrix.chunk }}.tap
@@ -642,21 +642,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: test262
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { name: test262-result-0 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { name: test262-result-1 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { name: test262-result-2 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { name: test262-result-3 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { name: test262-result-4 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { name: test262-result-5 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { name: test262-result-6 }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { name: test262-result-7 }
       - name: Merge chunk results
         run: |
@@ -664,12 +664,12 @@ jobs:
               test262-4.tap test262-5.tap test262-6.tap test262-7.tap \
             | npx tap-merge > test262.tap
       - name: Create artifact with report results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test262-result
           path: test262.tap
       - name: Checkout test runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: babel/babel-test262-runner
           path: babel-test262-runner
@@ -695,9 +695,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           check-latest: true
@@ -712,9 +712,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "*"
           cache: "yarn"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           cache: "yarn"
@@ -32,7 +32,7 @@ jobs:
       - name: Pack published packages
         working-directory: /tmp
         run: tar -cvf verdaccio-workspace.tar verdaccio-workspace
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: verdaccio-workspace
           path: /tmp/verdaccio-workspace.tar
@@ -60,27 +60,27 @@ jobs:
         id: yarn1-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       # Pin node to 22 for create-react-app project.
       # The create-react-app e2e breaking test throws
       # http fetch GET https://localhost:4873/zwitch/-/zwitch-1.0.5.tgz attempt 3 failed with ERR_SSL_WRONG_VERSION_NUMBER
       # when installing on Node.js 24. It might be an npm issue.
       - name: Use Node.js ${{ matrix.project == 'create-react-app' && '22' || 'latest' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.project == 'create-react-app' && '22' || '25.6.1' }}
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - name: Use yarn1 cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: yarn1-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn1-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn1-e2e-${{ matrix.project }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn1-e2e-${{ matrix.project }}-
       - name: Use yarn cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -90,7 +90,7 @@ jobs:
         run: |
           rm -rf ${{ steps.yarn1-cache-dir-path.outputs.dir }}/*babel*
           rm -rf ${{ steps.yarn-cache-dir-path.outputs.dir }}/*babel*
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: verdaccio-workspace
           path: /tmp

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "25.6.1"
           cache: "yarn"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the new tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: This release will publish the following packages
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: latest
           check-latest: true
@@ -66,7 +66,7 @@ jobs:
     outputs:
       branch: ${{ steps.branch-name.outputs.branch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -106,11 +106,11 @@ jobs:
       (needs.git-version.result == 'success' || needs.git-version.result == 'skipped') &&
       needs.ensure-npm-packages-exist.result == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: latest
           check-latest: true
@@ -144,7 +144,7 @@ jobs:
       #
       # - name: Upload babel-types docs
       #   continue-on-error: true
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@v7
       #   with:
       #     name: babel-types-docs
       #     path: build/types.md
@@ -161,7 +161,7 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog }}
       version: ${{ steps.tags.outputs.new }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -214,7 +214,7 @@ jobs:
       needs.github-release.result == 'success' &&
       needs.github-release.outputs.is-main
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Checkout the temporary branch
@@ -254,13 +254,13 @@ jobs:
   #     needs.github-release.result == 'success' &&
   #     needs.github-release.outputs.is-main
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v6
   #       with:
   #         repository: babel/website
   #         fetch-depth: 0 # Otherwise we cannot push
   #         persist-credentials: false # So that we can push with BOT_TOKEN, otherwise it doesn't trigger CI
   #     - name: Download babel-types docs
-  #       uses: actions/download-artifact@v4
+  #       uses: actions/download-artifact@v8
   #       with:
   #         name: babel-types-docs
   #         # Downloaded as ./docs/types.md

--- a/.github/workflows/repl.yml
+++ b/.github/workflows/repl.yml
@@ -14,7 +14,7 @@ jobs:
     name: Create or update REPL comment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/update-compat-data.yml
+++ b/.github/workflows/update-compat-data.yml
@@ -14,13 +14,13 @@ jobs:
     permissions:
       contents: write # for Git to git push
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           repository: kangax/compat-table
           path: packages/babel-compat-data/build/compat-table
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "*"
       - name: Get latest kangax/compat-table commit

--- a/.github/workflows/update-parser-tests.yml
+++ b/.github/workflows/update-parser-tests.yml
@@ -17,13 +17,13 @@ jobs:
       contents: write # for Git to git push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           repository: tc39/test262
           path: build/test262
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "*"
           cache: "yarn"

--- a/.github/workflows/update-windows-fixtures.yml
+++ b/.github/workflows/update-windows-fixtures.yml
@@ -40,7 +40,7 @@ jobs:
             fs.appendFileSync(GITHUB_OUTPUT, `repository=${repository}\n`);
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ steps.pr-meta.outputs.repository }}
           ref: ${{ steps.pr-meta.outputs.branch }}
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false # So that we can push with BOT_TOKEN, otherwise it doesn't trigger CI
 
       - name: Use Node.js latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "*"
           cache: "yarn"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Upgrade all `actions/*` CI dependencies
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
GitHub CI starts deprecating old `actions/*`: 

> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

from a recent CI run: https://github.com/babel/babel/actions/runs/23448031036/job/68217183015.

In this PR we bumped all `actions/*` CI dependencies, where

cache is upgraded from v4 to v5
checkout is upgraded from v4 to v6
download-artifact is upgraded from v4 to v8
setup-node is upgraded from v4 to v6
upload-artifact is upgraded from v4 to v7

If the CI passes, I will create a similar PR for the 7.x branch.