### PR TITLE
chore: inline REQUIRED_VERSION(7) special case

### DIFF
--- a/babel.config.ts
+++ b/babel.config.ts
@@ -232,16 +232,13 @@ export default function (api: ConfigAPI) {
           [
             pluginRequiredVersionMacro,
             {
-              overwrite(requiredVersion: string | number) {
+              overwrite(requiredVersion: string) {
                 if (!process.env.IS_PUBLISH || env === "standalone") {
                   if (bool(process.env.BABEL_9_BREAKING)) {
                     // Match packages/babel-core/src/index.ts
                     return packageJson.version + "999999999";
                   }
                   return packageJson.version;
-                }
-                if (requiredVersion === 7) {
-                  requiredVersion = "^7.0.0-0 || ^8.0.0";
                 }
                 if (packageJson.version.includes("-")) {
                   // for pre-releases
@@ -387,10 +384,7 @@ function pluginRequiredVersionMacro(
   {
     overwrite,
   }: {
-    overwrite: (
-      requiredVersion: string | number,
-      filename: string
-    ) => string | null;
+    overwrite: (requiredVersion: string, filename: string) => string | null;
   }
 ) {
   const fnName = "REQUIRED_VERSION";

--- a/eslint/babel-eslint-parser/src/parse.ts
+++ b/eslint/babel-eslint-parser/src/parse.ts
@@ -21,7 +21,7 @@ let client: Client;
 
 export default function parse(code: string, options: Options) {
   // Ensure we're using a version of `@babel/core` that includes `parse()` and `tokTypes`.
-  const minSupportedCoreVersion = REQUIRED_VERSION(">=7.2.0 || ^8.0.0");
+  const minSupportedCoreVersion = REQUIRED_VERSION("^7.2.0 || ^8.0.0");
 
   if (typeof isRunningMinSupportedCoreVersion !== "boolean") {
     isRunningMinSupportedCoreVersion = semver.satisfies(

--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -1,6 +1,5 @@
 declare const IS_STANDALONE: boolean;
 declare const PACKAGE_JSON: { name: string; version: string };
-declare function REQUIRED_VERSION(version: number): number | string;
 declare function REQUIRED_VERSION(version: string): string;
 
 declare namespace NodeJS {

--- a/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/src/index.ts
+++ b/packages/babel-plugin-bugfix-firefox-class-in-computed-class-key/src/index.ts
@@ -2,7 +2,7 @@ import type { types as t, NodePath } from "@babel/core";
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(({ types: t, assertVersion }) => {
-  assertVersion(REQUIRED_VERSION(7));
+  assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   function containsClassExpression(path: NodePath<t.Node | null>) {
     if (t.isClassExpression(path.node)) return true;

--- a/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/src/index.ts
+++ b/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/src/index.ts
@@ -3,7 +3,7 @@ import { shouldTransform } from "./util.ts";
 
 export default declare(api => {
   const { types: t, assertVersion } = api;
-  assertVersion(REQUIRED_VERSION(7));
+  assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "plugin-bugfix-safari-rest-destructuring-rhs-array",

--- a/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/src/index.ts
+++ b/packages/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining/src/index.ts
@@ -4,7 +4,7 @@ import { shouldTransform } from "./util.ts";
 import type { NodePath, types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const noDocumentAll = api.assumption("noDocumentAll") ?? false;
   const pureGetters = api.assumption("pureGetters") ?? false;

--- a/packages/babel-plugin-external-helpers/src/index.ts
+++ b/packages/babel-plugin-external-helpers/src/index.ts
@@ -7,7 +7,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const { helperVersion = "7.0.0-beta.0", whitelist = false } = options;
 

--- a/packages/babel-plugin-proposal-do-expressions/src/index.ts
+++ b/packages/babel-plugin-proposal-do-expressions/src/index.ts
@@ -6,7 +6,7 @@ import {
 } from "./utils.ts";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
   const { types: t } = api;
   const noDocumentAll = api.assumption("noDocumentAll") ?? false;
 

--- a/packages/babel-plugin-proposal-export-default-from/src/index.ts
+++ b/packages/babel-plugin-proposal-export-default-from/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "proposal-export-default-from",

--- a/packages/babel-plugin-proposal-function-bind/src/index.ts
+++ b/packages/babel-plugin-proposal-function-bind/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t, type Scope } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   function getTempId(scope: Scope) {
     let id = scope.path.getData("functionBind");

--- a/packages/babel-plugin-proposal-function-sent/src/index.ts
+++ b/packages/babel-plugin-proposal-function-sent/src/index.ts
@@ -3,7 +3,7 @@ import wrapFunction from "@babel/helper-wrap-function";
 import { types as t, type Visitor } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const isFunctionSent = (node: t.MetaProperty) =>
     t.isIdentifier(node.meta, { name: "function" }) &&

--- a/packages/babel-plugin-proposal-partial-application/src/index.ts
+++ b/packages/babel-plugin-proposal-partial-application/src/index.ts
@@ -3,7 +3,7 @@ import syntaxPartialApplication from "@babel/plugin-syntax-partial-application";
 import { types as t, type Scope } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   /**
    * a function to figure out if a call expression has

--- a/packages/babel-plugin-proposal-pipeline-operator/src/index.ts
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/index.ts
@@ -10,7 +10,7 @@ const visitorsPerProposal = {
 };
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "proposal-pipeline-operator",

--- a/packages/babel-plugin-proposal-throw-expressions/src/index.ts
+++ b/packages/babel-plugin-proposal-throw-expressions/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "proposal-throw-expressions",

--- a/packages/babel-plugin-transform-arrow-functions/src/index.ts
+++ b/packages/babel-plugin-transform-arrow-functions/src/index.ts
@@ -5,7 +5,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const noNewArrows = api.assumption("noNewArrows") ?? !options.spec;
 

--- a/packages/babel-plugin-transform-block-scoped-functions/src/index.ts
+++ b/packages/babel-plugin-transform-block-scoped-functions/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t, type Visitor, type NodePath } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   function transformStatementList(
     parentPath: NodePath,

--- a/packages/babel-plugin-transform-block-scoping/src/index.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/index.ts
@@ -16,7 +16,7 @@ export interface Options {
 }
 
 export default declare((api, opts: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const { throwIfClosureRequired = false, tdz: tdzEnabled = false } = opts;
   if (typeof throwIfClosureRequired !== "boolean") {

--- a/packages/babel-plugin-transform-classes/src/index.ts
+++ b/packages/babel-plugin-transform-classes/src/index.ts
@@ -23,7 +23,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const { loose = false } = options;
 

--- a/packages/babel-plugin-transform-computed-properties/src/index.ts
+++ b/packages/babel-plugin-transform-computed-properties/src/index.ts
@@ -16,7 +16,7 @@ type PropertyInfo = {
 };
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const setComputedProperties =
     api.assumption("setComputedProperties") ?? options.loose;

--- a/packages/babel-plugin-transform-destructuring/src/index.ts
+++ b/packages/babel-plugin-transform-destructuring/src/index.ts
@@ -32,7 +32,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const { useBuiltIns = false } = options;
 

--- a/packages/babel-plugin-transform-duplicate-keys/src/index.ts
+++ b/packages/babel-plugin-transform-duplicate-keys/src/index.ts
@@ -11,7 +11,7 @@ function getName(
 }
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-duplicate-keys",

--- a/packages/babel-plugin-transform-dynamic-import/src/index.ts
+++ b/packages/babel-plugin-transform-dynamic-import/src/index.ts
@@ -16,7 +16,7 @@ bundler handle dynamic imports.
 `;
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-dynamic-import",

--- a/packages/babel-plugin-transform-export-namespace-from/src/index.ts
+++ b/packages/babel-plugin-transform-export-namespace-from/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-export-namespace-from",

--- a/packages/babel-plugin-transform-flow-comments/src/index.ts
+++ b/packages/babel-plugin-transform-flow-comments/src/index.ts
@@ -4,7 +4,7 @@ import { types as t, type NodePath } from "@babel/core";
 import generateCode from "@babel/generator";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   function commentFromString(comment: string | t.Comment): t.Comment {
     return typeof comment === "string"

--- a/packages/babel-plugin-transform-flow-strip-types/src/index.ts
+++ b/packages/babel-plugin-transform-flow-strip-types/src/index.ts
@@ -8,7 +8,7 @@ export interface Options {
 }
 
 export default declare((api, opts: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const FLOW_DIRECTIVE = /@flow(?:\s+(?:strict(?:-local)?|weak))?|@noflow/;
 

--- a/packages/babel-plugin-transform-for-of/src/index.ts
+++ b/packages/babel-plugin-transform-for-of/src/index.ts
@@ -32,7 +32,7 @@ function buildLoopBody(
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   {
     const { assumeArray, allowArrayLike, loose } = options;

--- a/packages/babel-plugin-transform-function-name/src/index.ts
+++ b/packages/babel-plugin-transform-function-name/src/index.ts
@@ -2,7 +2,7 @@ import { isRequired } from "@babel/helper-compilation-targets";
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
   const supportUnicodeId = !isRequired(
     "transform-unicode-escapes",
     api.targets(),

--- a/packages/babel-plugin-transform-instanceof/src/index.ts
+++ b/packages/babel-plugin-transform-instanceof/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-instanceof",

--- a/packages/babel-plugin-transform-jscript/src/index.ts
+++ b/packages/babel-plugin-transform-jscript/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-jscript",

--- a/packages/babel-plugin-transform-literals/src/index.ts
+++ b/packages/babel-plugin-transform-literals/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-literals",

--- a/packages/babel-plugin-transform-member-expression-literals/src/index.ts
+++ b/packages/babel-plugin-transform-member-expression-literals/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-member-expression-literals",

--- a/packages/babel-plugin-transform-modules-amd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-amd/src/index.ts
@@ -61,7 +61,7 @@ type State = {
 };
 
 export default declare<State>((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const { allowTopLevelThis, strict, strictMode, importInterop, noInterop } =
     options;

--- a/packages/babel-plugin-transform-modules-commonjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-commonjs/src/index.ts
@@ -32,7 +32,7 @@ export interface Options extends PluginOptions {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const {
     // 'true' for imports to strictly have .default, instead of having

--- a/packages/babel-plugin-transform-modules-systemjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.ts
@@ -169,7 +169,7 @@ type ReassignmentVisitorState = {
 };
 
 export default declare<PluginState>((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const { systemGlobal = "System", allowTopLevelThis = false } = options;
   const reassignmentVisited = new WeakSet();

--- a/packages/babel-plugin-transform-modules-umd/src/index.ts
+++ b/packages/babel-plugin-transform-modules-umd/src/index.ts
@@ -52,7 +52,7 @@ export interface Options extends PluginOptions {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const {
     globals,

--- a/packages/babel-plugin-transform-new-target/src/index.ts
+++ b/packages/babel-plugin-transform-new-target/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t, type NodePath } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-new-target",

--- a/packages/babel-plugin-transform-object-set-prototype-of-to-assign/src/index.ts
+++ b/packages/babel-plugin-transform-object-set-prototype-of-to-assign/src/index.ts
@@ -1,7 +1,7 @@
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-object-set-prototype-of-to-assign",

--- a/packages/babel-plugin-transform-object-super/src/index.ts
+++ b/packages/babel-plugin-transform-object-super/src/index.ts
@@ -18,7 +18,7 @@ function replacePropertySuper(
 }
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
   const newLets = new Set<{
     scopePath: NodePath;
     id: t.Identifier;

--- a/packages/babel-plugin-transform-parameters/src/index.ts
+++ b/packages/babel-plugin-transform-parameters/src/index.ts
@@ -8,7 +8,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const ignoreFunctionLength =
     api.assumption("ignoreFunctionLength") ?? options.loose;

--- a/packages/babel-plugin-transform-property-literals/src/index.ts
+++ b/packages/babel-plugin-transform-property-literals/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-property-literals",

--- a/packages/babel-plugin-transform-proto-to-assign/src/index.ts
+++ b/packages/babel-plugin-transform-proto-to-assign/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t, type File } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   function isProtoKey(node: t.ObjectExpression["properties"][number]) {
     return (

--- a/packages/babel-plugin-transform-react-constant-elements/src/index.ts
+++ b/packages/babel-plugin-transform-react-constant-elements/src/index.ts
@@ -13,7 +13,7 @@ interface VisitorState {
   targetScope: Scope;
 }
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const { allowMutablePropsOnTags } = options;
 

--- a/packages/babel-plugin-transform-react-display-name/src/index.ts
+++ b/packages/babel-plugin-transform-react-display-name/src/index.ts
@@ -7,7 +7,7 @@ type ReactCreateClassCall = t.CallExpression & {
 };
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   function addDisplayName(id: string, call: ReactCreateClassCall) {
     const props = call.arguments[0].properties;

--- a/packages/babel-plugin-transform-react-inline-elements/src/index.ts
+++ b/packages/babel-plugin-transform-react-inline-elements/src/index.ts
@@ -3,7 +3,7 @@ import helper from "@babel/helper-builder-react-jsx";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   function hasRefOrSpread(attrs: t.JSXOpeningElement["attributes"]) {
     for (let i = 0; i < attrs.length; i++) {

--- a/packages/babel-plugin-transform-react-pure-annotations/src/index.ts
+++ b/packages/babel-plugin-transform-react-pure-annotations/src/index.ts
@@ -26,7 +26,7 @@ const PURE_CALLS: [string, Set<string>][] = [
 ];
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-react-pure-annotations",

--- a/packages/babel-plugin-transform-regenerator/src/index.ts
+++ b/packages/babel-plugin-transform-regenerator/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { getVisitor } from "./regenerator/visit.ts";
 
 export default declare(({ assertVersion }) => {
-  assertVersion(REQUIRED_VERSION(7));
+  assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-regenerator",

--- a/packages/babel-plugin-transform-reserved-words/src/index.ts
+++ b/packages/babel-plugin-transform-reserved-words/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t, type NodePath } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-reserved-words",

--- a/packages/babel-plugin-transform-runtime/src/index.ts
+++ b/packages/babel-plugin-transform-runtime/src/index.ts
@@ -14,7 +14,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options, dirname) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const {
     version: runtimeVersion = "8.0.0-beta.0",

--- a/packages/babel-plugin-transform-shorthand-properties/src/index.ts
+++ b/packages/babel-plugin-transform-shorthand-properties/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-shorthand-properties",

--- a/packages/babel-plugin-transform-spread/src/index.ts
+++ b/packages/babel-plugin-transform-spread/src/index.ts
@@ -11,7 +11,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const iterableIsArray = api.assumption("iterableIsArray") ?? options.loose;
   const arrayLikeIsIterable =

--- a/packages/babel-plugin-transform-sticky-regex/src/index.ts
+++ b/packages/babel-plugin-transform-sticky-regex/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-sticky-regex",

--- a/packages/babel-plugin-transform-strict-mode/src/index.ts
+++ b/packages/babel-plugin-transform-strict-mode/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-strict-mode",

--- a/packages/babel-plugin-transform-template-literals/src/index.ts
+++ b/packages/babel-plugin-transform-template-literals/src/index.ts
@@ -6,7 +6,7 @@ export interface Options {
 }
 
 export default declare((api, options: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const ignoreToPrimitiveHint =
     api.assumption("ignoreToPrimitiveHint") ?? options.loose;

--- a/packages/babel-plugin-transform-typeof-symbol/src/index.ts
+++ b/packages/babel-plugin-transform-typeof-symbol/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return {
     name: "transform-typeof-symbol",

--- a/packages/babel-plugin-transform-typescript/src/index.ts
+++ b/packages/babel-plugin-transform-typescript/src/index.ts
@@ -102,7 +102,7 @@ export default declare((api, opts: Options) => {
   // Ref: https://github.com/babel/babel/issues/15089
   const { types: t, template } = api;
 
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const JSX_PRAGMA_REGEX = /\*?\s*@jsx((?:Frag)?)\s+(\S+)/;
 

--- a/packages/babel-plugin-transform-unicode-escapes/src/index.ts
+++ b/packages/babel-plugin-transform-unicode-escapes/src/index.ts
@@ -2,7 +2,7 @@ import { declare } from "@babel/helper-plugin-utils";
 import { types as t, type NodePath } from "@babel/core";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const surrogate = /[\ud800-\udfff]/g;
   const unicodeEscape = /(\\+)u\{([0-9a-fA-F]+)\}/g;

--- a/packages/babel-plugin-transform-unicode-regex/src/index.ts
+++ b/packages/babel-plugin-transform-unicode-regex/src/index.ts
@@ -3,7 +3,7 @@ import { createRegExpFeaturePlugin } from "@babel/helper-create-regexp-features-
 import { declare } from "@babel/helper-plugin-utils";
 
 export default declare(api => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   return createRegExpFeaturePlugin({
     name: "transform-unicode-regex",

--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -193,7 +193,7 @@ function supportsExportNamespaceFrom(caller: CallerMetadata | undefined) {
 }
 
 export default declarePreset((api, opts: Partial<Options>) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const babelTargets = api.targets();
 

--- a/packages/babel-preset-flow/src/index.ts
+++ b/packages/babel-preset-flow/src/index.ts
@@ -3,7 +3,7 @@ import transformFlowStripTypes from "@babel/plugin-transform-flow-strip-types";
 import normalizeOptions from "./normalize-options.ts";
 
 export default declarePreset((api, opts) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
   const {
     all,
     ignoreExtensions = false,

--- a/packages/babel-preset-react/src/index.ts
+++ b/packages/babel-preset-react/src/index.ts
@@ -20,7 +20,7 @@ export interface Options {
 }
 
 export default declarePreset((api, opts: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const {
     development = api.env(env => env === "development"),

--- a/packages/babel-preset-typescript/src/index.ts
+++ b/packages/babel-preset-typescript/src/index.ts
@@ -7,7 +7,7 @@ import pluginRewriteTSImports from "./plugin-rewrite-ts-imports.ts";
 import type { PluginItem } from "@babel/core";
 
 export default declarePreset((api, opts: Options) => {
-  api.assertVersion(REQUIRED_VERSION(7));
+  api.assertVersion(REQUIRED_VERSION("^7.0.0-0 || ^8.0.0"));
 
   const {
     ignoreExtensions,


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we inlined the `REQUIRED_VERSION(7)` special case, which previously were rewritten to `^7.0.0-0 || ^8.0.0`. This is a bit confusing for the Babel 8 main branch.

Also fixed the `minSupportedCoreVersion` of `@babel/eslint-parser`, previously it was `">=7.2.0 || ^8.0.0"`, which is essentially `>=7.2.0`.