### PR TITLE
fix: Improve type reasoning for visitors containing `|`

### DIFF
--- a/packages/babel-helper-module-transforms/src/rewrite-this.ts
+++ b/packages/babel-helper-module-transforms/src/rewrite-this.ts
@@ -1,4 +1,5 @@
 import { types as t } from "@babel/core";
+import type { TraverseOptions, ExplodedVisitor } from "@babel/traverse";
 import traverse, { visitors, type NodePath } from "@babel/traverse";
 
 /**
@@ -6,7 +7,7 @@ import traverse, { visitors, type NodePath } from "@babel/traverse";
  * top-level scope to be `void 0` (undefined).
  *
  */
-let rewriteThisVisitor: Parameters<typeof traverse>[1];
+let rewriteThisVisitor: TraverseOptions & ExplodedVisitor;
 
 export default function rewriteThis(programPath: NodePath) {
   if (!rewriteThisVisitor) {

--- a/packages/babel-traverse/src/context.ts
+++ b/packages/babel-traverse/src/context.ts
@@ -1,15 +1,15 @@
+import type { ExplodedVisitor, TraverseOptions } from "./types.ts";
 import type NodePath from "./path/index.ts";
-import type { ExplodedTraverseOptions } from "./index.ts";
 import type * as t from "@babel/types";
 
 export default class TraversalContext<S = unknown> {
-  constructor(opts: ExplodedTraverseOptions<S>, state: S) {
+  constructor(opts: TraverseOptions & ExplodedVisitor<S>, state: S) {
     this.state = state;
     this.opts = opts;
   }
 
   declare state: S;
-  declare opts: ExplodedTraverseOptions<S>;
+  declare opts: TraverseOptions & ExplodedVisitor<S>;
   queue: NodePath<t.Node | null>[] | null = null;
   priorityQueue: NodePath<t.Node | null>[] | null = null;
 

--- a/packages/babel-traverse/src/index.ts
+++ b/packages/babel-traverse/src/index.ts
@@ -10,10 +10,16 @@ import type * as t from "@babel/types";
 import * as cache from "./cache.ts";
 import type NodePath from "./path/index.ts";
 import type { default as Scope, Binding } from "./scope/index.ts";
-import type { ExplodedVisitor, Visitor, VisitorBase } from "./types.ts";
+import type {
+  ExplodedVisitor,
+  Visitor,
+  VisitorBase,
+  VisitorProp,
+  TraverseOptions,
+} from "./types.ts";
 import { traverseNode } from "./traverse-node.ts";
 
-export type { ExplodedVisitor, Visitor, VisitorBase, Binding };
+export type { ExplodedVisitor, Visitor, VisitorBase, Binding, TraverseOptions };
 export { default as NodePath } from "./path/index.ts";
 export { default as Scope, type BindingKind } from "./scope/index.ts";
 export { default as Hub } from "./hub.ts";
@@ -22,38 +28,45 @@ export type { VisitWrapper } from "./visitors.ts";
 
 export { visitors };
 
-export type TraverseOptions<S = t.Node> = {
-  scope?: Scope;
-  noScope?: boolean;
-  denylist?: string[];
-  shouldSkip?: (node: NodePath) => boolean;
-} & Visitor<S>;
-
-export type ExplodedTraverseOptions<S = t.Node> = TraverseOptions<S> &
-  ExplodedVisitor<S>;
-
-function traverse<S>(
+function traverse<S, T extends object>(
   parent: t.Node,
-  opts: TraverseOptions<S>,
+  opts: {
+    [P in keyof T]: VisitorProp<S, P & string>;
+  },
   scope: Scope | null | undefined,
   state: S,
   parentPath?: NodePath,
   visitSelf?: boolean,
 ): void;
-
-function traverse(
+function traverse<T extends object>(
   parent: t.Node,
-  opts: TraverseOptions,
+  opts: {
+    [P in keyof T]: VisitorProp<any, P & string>;
+  },
   scope?: Scope | null,
   state?: any,
   parentPath?: NodePath,
   visitSelf?: boolean,
 ): void;
-
-function traverse<Options extends TraverseOptions>(
+function traverse<S>(
   parent: t.Node,
-  // @ts-expect-error provide {} as default value for Options
-  opts: Options = {},
+  opts: TraverseOptions & Visitor<S>,
+  scope: Scope | null | undefined,
+  state: S,
+  parentPath?: NodePath,
+  visitSelf?: boolean,
+): void;
+function traverse(
+  parent: t.Node,
+  opts: TraverseOptions & Visitor<any>,
+  scope?: Scope | null,
+  state?: any,
+  parentPath?: NodePath,
+  visitSelf?: boolean,
+): void;
+function traverse(
+  parent: t.Node,
+  opts: any = {},
   scope?: Scope | null,
   state?: any,
   parentPath?: NodePath,
@@ -79,11 +92,11 @@ function traverse<Options extends TraverseOptions>(
     return;
   }
 
-  visitors.explode(opts as Visitor);
+  visitors.explode(opts);
 
   traverseNode(
     parent,
-    opts as ExplodedVisitor,
+    opts,
     scope,
     state,
     parentPath,
@@ -105,7 +118,7 @@ traverse.cheap = function (node: t.Node, enter: (node: t.Node) => void) {
 
 traverse.node = function (
   node: t.Node,
-  opts: ExplodedTraverseOptions,
+  opts: TraverseOptions & ExplodedVisitor,
   scope?: Scope,
   state?: any,
   path?: NodePath,

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -1,10 +1,14 @@
 import type { HubInterface } from "../hub.ts";
 import type TraversalContext from "../context.ts";
-import type { ExplodedTraverseOptions } from "../index.ts";
 import * as virtualTypes from "./lib/virtual-types.ts";
 import { createDebug } from "obug";
 import traverse from "../index.ts";
-import type { Visitor } from "../types.ts";
+import type {
+  Visitor,
+  VisitorProp,
+  TraverseOptions,
+  ExplodedVisitor,
+} from "../types.ts";
 import Scope from "../scope/index.ts";
 import { validate } from "@babel/types";
 import * as t from "@babel/types";
@@ -74,7 +78,7 @@ const NodePath_Final = class NodePath {
 
   contexts: TraversalContext[] = [];
   state: any = null;
-  declare opts: ExplodedTraverseOptions;
+  declare opts: TraverseOptions & ExplodedVisitor;
 
   @bit.storage _traverseFlags: number = 0;
   @bit(REMOVED) accessor removed = false;
@@ -161,8 +165,25 @@ const NodePath_Final = class NodePath {
     return this.hub.buildError(this.node!, msg, Error);
   }
 
-  traverse<T>(this: NodePath_Final, visitor: Visitor<T>, state: T): void;
-  traverse(this: NodePath_Final, visitor: Visitor): void;
+  traverse<S, T extends object>(
+    this: NodePath_Final,
+    visitor: {
+      [P in keyof T]: VisitorProp<S, P & string>;
+    },
+    state: S,
+  ): void;
+  traverse<T extends object>(
+    this: NodePath_Final,
+    visitor: {
+      [P in keyof T]: VisitorProp<any, P & string>;
+    },
+  ): void;
+  traverse<S>(
+    this: NodePath_Final,
+    visitor: TraverseOptions & Visitor<S>,
+    state: S,
+  ): void;
+  traverse(this: NodePath_Final, visitor: TraverseOptions & Visitor<any>): void;
   traverse(this: NodePath_Final, visitor: any, state?: any) {
     traverse(this.node, visitor, this.scope, state, this);
   }

--- a/packages/babel-traverse/src/traverse-node.ts
+++ b/packages/babel-traverse/src/traverse-node.ts
@@ -1,5 +1,6 @@
 import TraversalContext from "./context.ts";
-import { Hub, type ExplodedTraverseOptions } from "./index.ts";
+import type { ExplodedVisitor, TraverseOptions } from "./types.ts";
+import { Hub } from "./index.ts";
 import NodePath from "./path/index.ts";
 import type Scope from "./scope/index.ts";
 import type * as t from "@babel/types";
@@ -126,7 +127,7 @@ function _visit(ctx: TraversalContext, path: NodePath<t.Node | null>) {
  */
 export function traverseNode<S = unknown>(
   node: t.Node,
-  opts: ExplodedTraverseOptions<S>,
+  opts: TraverseOptions & ExplodedVisitor<S>,
   scope?: Scope | null,
   state?: S,
   path?: NodePath,

--- a/packages/babel-traverse/src/types.ts
+++ b/packages/babel-traverse/src/types.ts
@@ -1,5 +1,5 @@
 import type * as t from "@babel/types";
-import type { NodePath } from "./index.ts";
+import type { NodePath, Scope } from "./index.ts";
 import type { VirtualTypeAliases } from "./path/lib/virtual-types.ts";
 import type {
   ExplVisitorBase,
@@ -72,3 +72,26 @@ export type VisitNodeFunction<S, P extends t.Node> = (
   path: NodePath<P>,
   state: S,
 ) => void;
+
+type Split<S extends string> = S extends `${infer L}|${infer R}`
+  ? L | Split<R>
+  : S;
+
+type ToNode<S extends string, N = Split<S>> = N extends keyof t.Aliases
+  ? t.Aliases[N]
+  : N extends keyof VirtualTypeAliases
+    ? VirtualTypeAliases[N]
+    : Extract<t.Node, { type: N }>;
+
+type OptionKeys = keyof TraverseOptions;
+
+export type VisitorProp<S, K extends string> = K extends OptionKeys
+  ? TraverseOptions[K]
+  : VisitNode<S, ToNode<K>>;
+
+export type TraverseOptions = {
+  scope?: Scope;
+  noScope?: boolean;
+  denylist?: string[];
+  shouldSkip?: (node: NodePath) => boolean;
+};

--- a/packages/babel-traverse/src/visitors.ts
+++ b/packages/babel-traverse/src/visitors.ts
@@ -9,7 +9,12 @@ import {
   __internal__deprecationWarning as deprecationWarning,
 } from "@babel/types";
 import type { ExplodedVisitor, NodePath, Visitor } from "./index.ts";
-import type { ExplVisitNode, VisitNodeFunction, VisitPhase } from "./types.ts";
+import type {
+  ExplVisitNode,
+  VisitNodeFunction,
+  VisitPhase,
+  VisitorProp,
+} from "./types.ts";
 
 type VIRTUAL_TYPES = keyof typeof virtualTypes;
 function isVirtualType(type: string): type is VIRTUAL_TYPES {
@@ -49,6 +54,10 @@ export { explode$1 as explode };
  * * `enter` and `exit` functions are wrapped in arrays, to ease merging of
  *   visitors
  */
+function explode$1<S, T extends object>(visitor: {
+  [P in keyof T]: VisitorProp<any, P & string>;
+}): ExplodedVisitor<S>;
+function explode$1<S>(visitor: Visitor<S>): ExplodedVisitor<S>;
 function explode$1<S>(visitor: Visitor<S>): ExplodedVisitor<S> {
   if (isExplodedVisitor(visitor)) return visitor;
   // @ts-expect-error `visitor` will be cast to ExplodedVisitor by this function
@@ -398,6 +407,6 @@ const _environmentVisitor: Visitor = {
   },
 };
 
-export function environmentVisitor<S>(visitor: Visitor<S>): Visitor<S> {
+export function environmentVisitor<S>(visitor: Visitor<S>): ExplodedVisitor<S> {
   return merge([_environmentVisitor, visitor]);
 }

--- a/packages/babel-traverse/test/index.tst.ts
+++ b/packages/babel-traverse/test/index.tst.ts
@@ -94,24 +94,6 @@ describe("traverse", () => {
     });
   });
 
-  describe("NodePath#is*", () => {
-    it("allows null", () => {
-      const path = {} as NodePath<t.VariableDeclarator>;
-      const init = path.get("init");
-      expect(init).type.toBe<NodePath<t.Expression | null>>();
-      if (init.isIdentifier()) {
-        expect(init).type.toBe<NodePath<t.Identifier>>();
-      }
-    });
-
-    it("virtual types", () => {
-      const path = {} as NodePath<t.Node>;
-      if (path.isBindingIdentifier()) {
-        expect(path).type.toBe<NodePath<t.Identifier>>();
-      }
-    });
-  });
-
   describe("Visitor", () => {
     describe("Union types", () => {
       it("traverse", () => {
@@ -143,7 +125,7 @@ describe("traverse", () => {
         } as TraverseOptions & Visitor);
       });
 
-      it("path#traverse", () => {
+      it("NodePath#traverse", () => {
         (({}) as NodePath<t.Node>).traverse({
           "ImportDeclaration|ExportDeclaration"(path) {
             expect(path).type.toBe<
@@ -159,6 +141,24 @@ describe("traverse", () => {
           noScope: true,
         } as TraverseOptions & Visitor);
       });
+    });
+  });
+
+  describe("NodePath#is*", () => {
+    it("allows null", () => {
+      const path = {} as NodePath<t.VariableDeclarator>;
+      const init = path.get("init");
+      expect(init).type.toBe<NodePath<t.Expression | null>>();
+      if (init.isIdentifier()) {
+        expect(init).type.toBe<NodePath<t.Identifier>>();
+      }
+    });
+
+    it("virtual types", () => {
+      const path = {} as NodePath<t.Node>;
+      if (path.isBindingIdentifier()) {
+        expect(path).type.toBe<NodePath<t.Identifier>>();
+      }
     });
   });
 

--- a/packages/babel-traverse/test/index.tst.ts
+++ b/packages/babel-traverse/test/index.tst.ts
@@ -1,5 +1,6 @@
 import { expect, it, describe } from "tstyche";
-import type { NodePath, Visitor } from "../src/index.ts";
+import type { NodePath, Visitor, TraverseOptions } from "../src/index.ts";
+import { default as traverse, visitors } from "../src/index.ts";
 import type * as t from "@babel/types";
 
 describe("traverse", () => {
@@ -112,18 +113,52 @@ describe("traverse", () => {
   });
 
   describe("Visitor", () => {
-    // TODO: support `strictFunctionTypes: true`
-    it.todo("Union types", () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const visitor: Visitor<unknown> = {
-        "ImportDeclaration|ExportDeclaration"(
-          path: NodePath<t.ImportDeclaration | t.ExportDeclaration>,
-        ) {
-          expect(path).type.toBe<
-            NodePath<t.ImportDeclaration | t.ExportDeclaration>
-          >();
-        },
-      };
+    describe("Union types", () => {
+      it("traverse", () => {
+        traverse({} as t.Node, {
+          "ImportDeclaration|ExportDeclaration"(path) {
+            expect(path).type.toBe<
+              NodePath<t.ImportDeclaration | t.ExportDeclaration>
+            >();
+          },
+          noScope: true,
+        });
+        traverse({} as t.Node, {} as Visitor);
+      });
+
+      it("visitors.explode", () => {
+        visitors.explode({
+          "ImportDeclaration|ExportDeclaration"(path) {
+            expect(path).type.toBe<
+              NodePath<t.ImportDeclaration | t.ExportDeclaration>
+            >();
+          },
+          noScope: true,
+        });
+        visitors.explode({
+          "ImportDeclaration|ExportDeclaration"(path) {
+            expect(path).type.toBe<NodePath<t.Node>>();
+          },
+          noScope: true,
+        } as TraverseOptions & Visitor);
+      });
+
+      it("path#traverse", () => {
+        (({}) as NodePath<t.Node>).traverse({
+          "ImportDeclaration|ExportDeclaration"(path) {
+            expect(path).type.toBe<
+              NodePath<t.ImportDeclaration | t.ExportDeclaration>
+            >();
+          },
+          noScope: true,
+        });
+        (({}) as NodePath<t.Node>).traverse({
+          "ImportDeclaration|ExportDeclaration"(path) {
+            expect(path).type.toBe<NodePath<t.Node>>();
+          },
+          noScope: true,
+        } as TraverseOptions & Visitor);
+      });
     });
   });
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This resolves the issue where every `nodeA|nodeB` would be complained about by TS when `strictFunctionTypes: true`.
It also provides better type reasoning.
Due to the limitations of TypeScript, this can only be implemented within function calls.