### PR TITLE
polish(parser): improve ImportExpression error recovery

### DIFF
--- a/packages/babel-parser/src/parse-error/standard-errors.ts
+++ b/packages/babel-parser/src/parse-error/standard-errors.ts
@@ -115,7 +115,7 @@ export default {
   ImportCallArity: ({ phase }: { phase?: string | null }) =>
     `\`import${phase ? `.${phase}` : ""}()\` requires exactly one or two arguments.`,
   ImportCallNotNewExpression: ({ phase }: { phase?: string | null }) =>
-    `Cannot use new with import${phase ? `.${phase}` : ""}(...).`,
+    `Cannot use new with import${phase ? `.${phase}` : ""}().`,
   ImportCallSpreadArgument: ({ phase }: { phase?: string | null }) =>
     `\`...\` is not allowed in \`import${phase ? `.${phase}` : ""}()\`.`,
   IncompatibleRegExpUVFlags:

--- a/packages/babel-parser/src/parse-error/standard-errors.ts
+++ b/packages/babel-parser/src/parse-error/standard-errors.ts
@@ -112,9 +112,12 @@ export default {
   IllegalReturn: "'return' outside of function.",
   ImportBindingIsString: ({ importName }: { importName: string }) =>
     `A string literal cannot be used as an imported binding.\n- Did you mean \`import { "${importName}" as foo }\`?`,
-  ImportCallArity: `\`import()\` requires exactly one or two arguments.`,
-  ImportCallNotNewExpression: "Cannot use new with import(...).",
-  ImportCallSpreadArgument: "`...` is not allowed in `import()`.",
+  ImportCallArity: ({ phase }: { phase?: string | null }) =>
+    `\`import${phase ? `.${phase}` : ""}()\` requires exactly one or two arguments.`,
+  ImportCallNotNewExpression: ({ phase }: { phase?: string | null }) =>
+    `Cannot use new with import${phase ? `.${phase}` : ""}(...).`,
+  ImportCallSpreadArgument: ({ phase }: { phase?: string | null }) =>
+    `\`...\` is not allowed in \`import${phase ? `.${phase}` : ""}()\`.`,
   IncompatibleRegExpUVFlags:
     "The 'u' and 'v' regular expression flags cannot be enabled at the same time.",
   InvalidBigIntLiteral: "Invalid BigIntLiteral.",

--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -1006,7 +1006,7 @@ export default abstract class ExpressionParser extends LValParser {
     allowPlaceholder?: boolean,
     nodeForExtra?: Undone<N.Node> | null,
     refExpressionErrors?: ExpressionErrors | null,
-  ): N.Expression[] {
+  ): (N.Expression | N.SpreadElement)[] {
     const elts: N.Expression[] = [];
     let first = true;
 
@@ -2958,29 +2958,22 @@ export default abstract class ExpressionParser extends LValParser {
     this: Parser,
     node: Undone<N.ImportExpression>,
   ): N.ImportExpression {
-    this.next(); // eat tt.parenL
-    node.source = this.parseMaybeAssignAllowIn();
-    node.options = null;
-    if (this.eat(tt.comma)) {
-      if (!this.match(tt.parenR)) {
-        node.options = this.parseMaybeAssignAllowIn();
-        if (this.eat(tt.comma)) {
-          this.addTrailingCommaExtraToNode(node.options);
-          if (!this.match(tt.parenR)) {
-            // keep consuming arguments, to then throw ImportCallArity
-            // instead of "expected )"
-            do {
-              this.parseMaybeAssignAllowIn();
-            } while (this.eat(tt.comma) && !this.match(tt.parenR));
-
-            this.raise(Errors.ImportCallArity, node);
-          }
+    this.next(); // eat `(`
+    const args = this.parseCallExpressionArguments();
+    if (args.length === 0 || args.length > 2) {
+      this.raise(Errors.ImportCallArity, node);
+    } else {
+      for (const arg of args) {
+        if (arg.type === "SpreadElement") {
+          this.raise(Errors.ImportCallSpreadArgument, arg);
         }
-      } else {
-        this.addTrailingCommaExtraToNode(node.source);
       }
     }
-    this.expect(tt.parenR);
+    // @ts-expect-error we allow SpreadElement for error recovery
+    node.source = args[0];
+    // @ts-expect-error we allow SpreadElement for error recovery
+    node.options = args[1] ?? null;
+
     return this.finishNode(node, "ImportExpression");
   }
 

--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -1900,10 +1900,11 @@ export default abstract class ExpressionParser extends LValParser {
     // @ts-expect-error we allow callee to be Import and Super to throw a
     // recoverable error later
     node.callee = callee;
-    if (
-      (isImport && callee.type === "ImportExpression") ||
-      callee.type === "Import" // This check implies isImport
-    ) {
+    if (isImport && callee.type === "ImportExpression") {
+      this.raise(Errors.ImportCallNotNewExpression, callee, callee);
+    }
+    if (callee.type === "Import") {
+      // This check implies isImport
       this.raise(Errors.ImportCallNotNewExpression, callee);
     }
     if (callee.type === "Super") {
@@ -2961,11 +2962,11 @@ export default abstract class ExpressionParser extends LValParser {
     this.next(); // eat `(`
     const args = this.parseCallExpressionArguments();
     if (args.length === 0 || args.length > 2) {
-      this.raise(Errors.ImportCallArity, node);
+      this.raise(Errors.ImportCallArity, node, node);
     } else {
       for (const arg of args) {
         if (arg.type === "SpreadElement") {
-          this.raise(Errors.ImportCallSpreadArgument, arg);
+          this.raise(Errors.ImportCallSpreadArgument, arg, node);
         }
       }
     }

--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -470,9 +470,9 @@ export default (superClass: typeof Parser) =>
 
       if (node.callee.type === "Import") {
         this.castNodeTo(node, "ImportExpression");
-        (node as N.Node as N.EstreeImportExpression).source = node
+        (node as N.Node as N.ImportExpression).source = node
           .arguments[0] as N.Expression;
-        (node as N.Node as N.EstreeImportExpression).options =
+        (node as N.Node as N.ImportExpression).options =
           (node.arguments[1] as N.Expression) ?? null;
 
         // arguments isn't optional in the type definition

--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -170,10 +170,10 @@ export default (superClass: typeof Parser) =>
     isValidDirective(stmt: N.Statement): stmt is N.ExpressionStatement {
       return (
         stmt.type === "ExpressionStatement" &&
-        (stmt.expression as N.ESTreeExpression).type === "Literal" &&
-        typeof (stmt.expression as unknown as N.EstreeLiteral).value ===
+        (stmt.expression as N.Node as N.ESTreeExpression).type === "Literal" &&
+        typeof (stmt.expression as N.Node as N.EstreeLiteral).value ===
           "string" &&
-        !(stmt.expression as unknown as N.EstreeLiteral).extra?.parenthesized
+        !(stmt.expression as N.Node as N.EstreeLiteral).extra?.parenthesized
       );
     }
 

--- a/packages/babel-parser/src/types.ts
+++ b/packages/babel-parser/src/types.ts
@@ -187,7 +187,6 @@ export type ESTreeLiteral = EstreeLiteral | EstreeBigIntLiteral;
 
 export type ESTreeExpression =
   | EstreeChainExpression
-  | EstreeImportExpression
   | ESTreeLiteral
   | EstreeTSEmptyBodyFunctionExpression;
 
@@ -280,12 +279,6 @@ export interface EstreeMethodDefinition extends EstreeMethodDefinitionBase {
   type: "MethodDefinition";
   value: N.FunctionExpression;
   variance?: N.Variance | null;
-}
-
-export interface EstreeImportExpression extends BaseNode {
-  type: "ImportExpression";
-  source: N.Expression;
-  options?: N.Expression | null;
 }
 
 export interface EstreePrivateIdentifier extends BaseNode {

--- a/packages/babel-parser/test/fixtures/es2020/dynamic-import-createImportExpression-false/invalid-new/output.json
+++ b/packages/babel-parser/test/fixtures/es2020/dynamic-import-createImportExpression-false/invalid-new/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":18,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":18,"index":18}},
   "errors": [
-    "SyntaxError: Cannot use new with import(...). (1:4)"
+    "SyntaxError: Cannot use new with import(). (1:4)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2020/dynamic-import/invalid-arguments-spread/options.json
+++ b/packages/babel-parser/test/fixtures/es2020/dynamic-import/invalid-arguments-spread/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:7)"
-}

--- a/packages/babel-parser/test/fixtures/es2020/dynamic-import/invalid-arguments-spread/output.json
+++ b/packages/babel-parser/test/fixtures/es2020/dynamic-import/invalid-arguments-spread/output.json
@@ -1,0 +1,44 @@
+{
+  "type": "File",
+  "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
+  "errors": [
+    "SyntaxError: `...` is not allowed in `import()`. (1:7)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
+        "expression": {
+          "type": "ImportExpression",
+          "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
+          "source": {
+            "type": "SpreadElement",
+            "start":7,"end":13,"loc":{"start":{"line":1,"column":7,"index":7},"end":{"line":1,"column":13,"index":13}},
+            "argument": {
+              "type": "ArrayExpression",
+              "start":10,"end":13,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":13,"index":13}},
+              "elements": [
+                {
+                  "type": "NumericLiteral",
+                  "start":11,"end":12,"loc":{"start":{"line":1,"column":11,"index":11},"end":{"line":1,"column":12,"index":12}},
+                  "extra": {
+                    "rawValue": 1,
+                    "raw": "1"
+                  },
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "options": null
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2020/dynamic-import/invalid-new/output.json
+++ b/packages/babel-parser/test/fixtures/es2020/dynamic-import/invalid-new/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":18,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":18,"index":18}},
   "errors": [
-    "SyntaxError: Cannot use new with import(...). (1:4)"
+    "SyntaxError: Cannot use new with import(). (1:4)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/es2020/dynamic-import/multiple-args/output.json
+++ b/packages/babel-parser/test/fixtures/es2020/dynamic-import/multiple-args/output.json
@@ -30,8 +30,7 @@
             "start":16,"end":23,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":23,"index":23}},
             "extra": {
               "rawValue": "world",
-              "raw": "'world'",
-              "trailingComma": 23
+              "raw": "'world'"
             },
             "value": "world"
           }

--- a/packages/babel-parser/test/fixtures/es2020/dynamic-import/no-args/options.json
+++ b/packages/babel-parser/test/fixtures/es2020/dynamic-import/no-args/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:7)"
-}

--- a/packages/babel-parser/test/fixtures/es2020/dynamic-import/no-args/output.json
+++ b/packages/babel-parser/test/fixtures/es2020/dynamic-import/no-args/output.json
@@ -1,0 +1,25 @@
+{
+  "type": "File",
+  "start":0,"end":9,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":9,"index":9}},
+  "errors": [
+    "SyntaxError: `import()` requires exactly one or two arguments. (1:0)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":9,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":9,"index":9}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":9,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":9,"index":9}},
+        "expression": {
+          "type": "ImportExpression",
+          "start":0,"end":8,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":8,"index":8}},
+          "options": null
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2025/import-attributes/incorrect-arity/options.json
+++ b/packages/babel-parser/test/fixtures/es2025/import-attributes/incorrect-arity/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:7)"
-}

--- a/packages/babel-parser/test/fixtures/es2025/import-attributes/incorrect-arity/output.json
+++ b/packages/babel-parser/test/fixtures/es2025/import-attributes/incorrect-arity/output.json
@@ -1,0 +1,91 @@
+{
+  "type": "File",
+  "start":0,"end":73,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":63,"index":73}},
+  "errors": [
+    "SyntaxError: `import()` requires exactly one or two arguments. (1:0)",
+    "SyntaxError: `import()` requires exactly one or two arguments. (2:0)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":73,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":63,"index":73}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":9,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":9,"index":9}},
+        "expression": {
+          "type": "ImportExpression",
+          "start":0,"end":8,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":8,"index":8}},
+          "options": null
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start":10,"end":73,"loc":{"start":{"line":2,"column":0,"index":10},"end":{"line":2,"column":63,"index":73}},
+        "expression": {
+          "type": "ImportExpression",
+          "start":10,"end":72,"loc":{"start":{"line":2,"column":0,"index":10},"end":{"line":2,"column":62,"index":72}},
+          "source": {
+            "type": "StringLiteral",
+            "start":17,"end":29,"loc":{"start":{"line":2,"column":7,"index":17},"end":{"line":2,"column":19,"index":29}},
+            "extra": {
+              "rawValue": "./foo.json",
+              "raw": "\"./foo.json\""
+            },
+            "value": "./foo.json"
+          },
+          "options": {
+            "type": "ObjectExpression",
+            "start":31,"end":56,"loc":{"start":{"line":2,"column":21,"index":31},"end":{"line":2,"column":46,"index":56}},
+            "properties": [
+              {
+                "type": "ObjectProperty",
+                "start":33,"end":54,"loc":{"start":{"line":2,"column":23,"index":33},"end":{"line":2,"column":44,"index":54}},
+                "method": false,
+                "key": {
+                  "type": "Identifier",
+                  "start":33,"end":37,"loc":{"start":{"line":2,"column":23,"index":33},"end":{"line":2,"column":27,"index":37},"identifierName":"with"},
+                  "name": "with"
+                },
+                "computed": false,
+                "shorthand": false,
+                "value": {
+                  "type": "ObjectExpression",
+                  "start":39,"end":54,"loc":{"start":{"line":2,"column":29,"index":39},"end":{"line":2,"column":44,"index":54}},
+                  "properties": [
+                    {
+                      "type": "ObjectProperty",
+                      "start":41,"end":53,"loc":{"start":{"line":2,"column":31,"index":41},"end":{"line":2,"column":43,"index":53}},
+                      "method": false,
+                      "key": {
+                        "type": "Identifier",
+                        "start":41,"end":45,"loc":{"start":{"line":2,"column":31,"index":41},"end":{"line":2,"column":35,"index":45},"identifierName":"type"},
+                        "name": "type"
+                      },
+                      "computed": false,
+                      "shorthand": false,
+                      "value": {
+                        "type": "StringLiteral",
+                        "start":47,"end":53,"loc":{"start":{"line":2,"column":37,"index":47},"end":{"line":2,"column":43,"index":53}},
+                        "extra": {
+                          "rawValue": "json",
+                          "raw": "\"json\""
+                        },
+                        "value": "json"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2025/import-attributes/invalid-spread-element-import-call/options.json
+++ b/packages/babel-parser/test/fixtures/es2025/import-attributes/invalid-spread-element-import-call/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (1:21)"
-}

--- a/packages/babel-parser/test/fixtures/es2025/import-attributes/invalid-spread-element-import-call/output.json
+++ b/packages/babel-parser/test/fixtures/es2025/import-attributes/invalid-spread-element-import-call/output.json
@@ -1,0 +1,45 @@
+{
+  "type": "File",
+  "start":0,"end":28,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":28,"index":28}},
+  "errors": [
+    "SyntaxError: `...` is not allowed in `import()`. (1:21)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":28,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":28,"index":28}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":28,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":28,"index":28}},
+        "expression": {
+          "type": "ImportExpression",
+          "start":0,"end":27,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":27,"index":27}},
+          "source": {
+            "type": "StringLiteral",
+            "start":7,"end":19,"loc":{"start":{"line":1,"column":7,"index":7},"end":{"line":1,"column":19,"index":19}},
+            "extra": {
+              "rawValue": "./foo.json",
+              "raw": "\"./foo.json\""
+            },
+            "value": "./foo.json"
+          },
+          "options": {
+            "type": "SpreadElement",
+            "start":21,"end":26,"loc":{"start":{"line":1,"column":21,"index":21},"end":{"line":1,"column":26,"index":26}},
+            "argument": {
+              "type": "ArrayExpression",
+              "start":24,"end":26,"loc":{"start":{"line":1,"column":24,"index":24},"end":{"line":1,"column":26,"index":26}},
+              "elements": []
+            }
+          }
+        }
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/es2025/import-attributes/trailing-comma-dynamic/output.json
+++ b/packages/babel-parser/test/fixtures/es2025/import-attributes/trailing-comma-dynamic/output.json
@@ -18,8 +18,7 @@
             "start":7,"end":15,"loc":{"start":{"line":1,"column":7,"index":7},"end":{"line":1,"column":15,"index":15}},
             "extra": {
               "rawValue": "foo.js",
-              "raw": "\"foo.js\"",
-              "trailingComma": 15
+              "raw": "\"foo.js\""
             },
             "value": "foo.js"
           },
@@ -84,10 +83,7 @@
                   ]
                 }
               }
-            ],
-            "extra": {
-              "trailingComma": 64
-            }
+            ]
           }
         }
       }

--- a/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/incorrect-arity/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/incorrect-arity/input.js
@@ -1,0 +1,2 @@
+import.defer();
+import.defer("foo", bar, baz);

--- a/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/incorrect-arity/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/incorrect-arity/output.json
@@ -1,0 +1,53 @@
+{
+  "type": "File",
+  "start":0,"end":46,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":30,"index":46}},
+  "errors": [
+    "SyntaxError: `import.defer()` requires exactly one or two arguments. (1:0)",
+    "SyntaxError: `import.defer()` requires exactly one or two arguments. (2:0)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":46,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":2,"column":30,"index":46}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":15,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":15,"index":15}},
+        "expression": {
+          "type": "ImportExpression",
+          "start":0,"end":14,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":14,"index":14}},
+          "phase": "defer",
+          "options": null
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start":16,"end":46,"loc":{"start":{"line":2,"column":0,"index":16},"end":{"line":2,"column":30,"index":46}},
+        "expression": {
+          "type": "ImportExpression",
+          "start":16,"end":45,"loc":{"start":{"line":2,"column":0,"index":16},"end":{"line":2,"column":29,"index":45}},
+          "phase": "defer",
+          "source": {
+            "type": "StringLiteral",
+            "start":29,"end":34,"loc":{"start":{"line":2,"column":13,"index":29},"end":{"line":2,"column":18,"index":34}},
+            "extra": {
+              "rawValue": "foo",
+              "raw": "\"foo\""
+            },
+            "value": "foo"
+          },
+          "options": {
+            "type": "Identifier",
+            "start":36,"end":39,"loc":{"start":{"line":2,"column":20,"index":36},"end":{"line":2,"column":23,"index":39},"identifierName":"bar"},
+            "name": "bar"
+          }
+        }
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/invalid-new-callee/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/invalid-new-callee/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":23,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":23,"index":23}},
   "errors": [
-    "SyntaxError: Cannot use new with import(...). (1:4)"
+    "SyntaxError: Cannot use new with import.defer(...). (1:4)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/invalid-new-callee/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/invalid-new-callee/output.json
@@ -2,7 +2,7 @@
   "type": "File",
   "start":0,"end":23,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":23,"index":23}},
   "errors": [
-    "SyntaxError: Cannot use new with import.defer(...). (1:4)"
+    "SyntaxError: Cannot use new with import.defer(). (1:4)"
   ],
   "program": {
     "type": "Program",

--- a/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/invalid-spread/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/invalid-spread/input.js
@@ -1,0 +1,1 @@
+import.defer(...["foo", { with: { type: "json" } }]);

--- a/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/invalid-spread/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation/invalid-spread/output.json
@@ -1,0 +1,93 @@
+{
+  "type": "File",
+  "start":0,"end":53,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":53,"index":53}},
+  "errors": [
+    "SyntaxError: `...` is not allowed in `import.defer()`. (1:13)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":53,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":53,"index":53}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start":0,"end":53,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":53,"index":53}},
+        "expression": {
+          "type": "ImportExpression",
+          "start":0,"end":52,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":52,"index":52}},
+          "phase": "defer",
+          "source": {
+            "type": "SpreadElement",
+            "start":13,"end":51,"loc":{"start":{"line":1,"column":13,"index":13},"end":{"line":1,"column":51,"index":51}},
+            "argument": {
+              "type": "ArrayExpression",
+              "start":16,"end":51,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":51,"index":51}},
+              "elements": [
+                {
+                  "type": "StringLiteral",
+                  "start":17,"end":22,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":1,"column":22,"index":22}},
+                  "extra": {
+                    "rawValue": "foo",
+                    "raw": "\"foo\""
+                  },
+                  "value": "foo"
+                },
+                {
+                  "type": "ObjectExpression",
+                  "start":24,"end":50,"loc":{"start":{"line":1,"column":24,"index":24},"end":{"line":1,"column":50,"index":50}},
+                  "properties": [
+                    {
+                      "type": "ObjectProperty",
+                      "start":26,"end":48,"loc":{"start":{"line":1,"column":26,"index":26},"end":{"line":1,"column":48,"index":48}},
+                      "method": false,
+                      "key": {
+                        "type": "Identifier",
+                        "start":26,"end":30,"loc":{"start":{"line":1,"column":26,"index":26},"end":{"line":1,"column":30,"index":30},"identifierName":"with"},
+                        "name": "with"
+                      },
+                      "computed": false,
+                      "shorthand": false,
+                      "value": {
+                        "type": "ObjectExpression",
+                        "start":32,"end":48,"loc":{"start":{"line":1,"column":32,"index":32},"end":{"line":1,"column":48,"index":48}},
+                        "properties": [
+                          {
+                            "type": "ObjectProperty",
+                            "start":34,"end":46,"loc":{"start":{"line":1,"column":34,"index":34},"end":{"line":1,"column":46,"index":46}},
+                            "method": false,
+                            "key": {
+                              "type": "Identifier",
+                              "start":34,"end":38,"loc":{"start":{"line":1,"column":34,"index":34},"end":{"line":1,"column":38,"index":38},"identifierName":"type"},
+                              "name": "type"
+                            },
+                            "computed": false,
+                            "shorthand": false,
+                            "value": {
+                              "type": "StringLiteral",
+                              "start":40,"end":46,"loc":{"start":{"line":1,"column":40,"index":40},"end":{"line":1,"column":46,"index":46}},
+                              "extra": {
+                                "rawValue": "json",
+                                "raw": "\"json\""
+                              },
+                              "value": "json"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "options": null
+        }
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/call-expr/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/call-expr/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["partialApplication"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/call-on-SuperProperty/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/call-on-SuperProperty/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["partialApplication"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/for-any-arg/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/for-any-arg/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["partialApplication"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/from-left/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/from-left/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["partialApplication"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/from-right/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/from-right/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["partialApplication"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/in-SuperCall/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/in-SuperCall/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["partialApplication"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/in-new/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/in-new/options.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["partialApplication"]
-}

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/invalid-in-ImportCall/input.js
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/invalid-in-ImportCall/input.js
@@ -1,0 +1,1 @@
+const importJSON = import(?, { with: { type: "json" } });

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/invalid-in-ImportCall/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/invalid-in-ImportCall/output.json
@@ -1,0 +1,85 @@
+{
+  "type": "File",
+  "start":0,"end":57,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":57,"index":57}},
+  "errors": [
+    "SyntaxError: Unexpected argument placeholder. (1:26)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":57,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":57,"index":57}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":57,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":57,"index":57}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":6,"end":56,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":56,"index":56}},
+            "id": {
+              "type": "Identifier",
+              "start":6,"end":16,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":16,"index":16},"identifierName":"importJSON"},
+              "name": "importJSON"
+            },
+            "init": {
+              "type": "ImportExpression",
+              "start":19,"end":56,"loc":{"start":{"line":1,"column":19,"index":19},"end":{"line":1,"column":56,"index":56}},
+              "source": {
+                "type": "ArgumentPlaceholder",
+                "start":26,"end":27,"loc":{"start":{"line":1,"column":26,"index":26},"end":{"line":1,"column":27,"index":27}}
+              },
+              "options": {
+                "type": "ObjectExpression",
+                "start":29,"end":55,"loc":{"start":{"line":1,"column":29,"index":29},"end":{"line":1,"column":55,"index":55}},
+                "properties": [
+                  {
+                    "type": "ObjectProperty",
+                    "start":31,"end":53,"loc":{"start":{"line":1,"column":31,"index":31},"end":{"line":1,"column":53,"index":53}},
+                    "method": false,
+                    "key": {
+                      "type": "Identifier",
+                      "start":31,"end":35,"loc":{"start":{"line":1,"column":31,"index":31},"end":{"line":1,"column":35,"index":35},"identifierName":"with"},
+                      "name": "with"
+                    },
+                    "computed": false,
+                    "shorthand": false,
+                    "value": {
+                      "type": "ObjectExpression",
+                      "start":37,"end":53,"loc":{"start":{"line":1,"column":37,"index":37},"end":{"line":1,"column":53,"index":53}},
+                      "properties": [
+                        {
+                          "type": "ObjectProperty",
+                          "start":39,"end":51,"loc":{"start":{"line":1,"column":39,"index":39},"end":{"line":1,"column":51,"index":51}},
+                          "method": false,
+                          "key": {
+                            "type": "Identifier",
+                            "start":39,"end":43,"loc":{"start":{"line":1,"column":39,"index":39},"end":{"line":1,"column":43,"index":43},"identifierName":"type"},
+                            "name": "type"
+                          },
+                          "computed": false,
+                          "shorthand": false,
+                          "value": {
+                            "type": "StringLiteral",
+                            "start":45,"end":51,"loc":{"start":{"line":1,"column":45,"index":45},"end":{"line":1,"column":51,"index":51}},
+                            "extra": {
+                              "rawValue": "json",
+                              "raw": "\"json\""
+                            },
+                            "value": "json"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "kind": "const"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["partialApplication"]
+}

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/top-level-argument-binary-expression/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/top-level-argument-binary-expression/options.json
@@ -1,4 +1,3 @@
 {
-  "plugins": ["partialApplication"],
   "throws": "Unexpected token (1:0)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/partial-application/top-level-argument-method-call/options.json
+++ b/packages/babel-parser/test/fixtures/experimental/partial-application/top-level-argument-method-call/options.json
@@ -1,4 +1,3 @@
 {
-  "plugins": ["partialApplication"],
   "throws": "Unexpected token (1:0)"
 }

--- a/packages/babel-parser/test/fixtures/experimental/source-phase-imports/dynamic-import-comments/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/source-phase-imports/dynamic-import-comments/output.json
@@ -19,8 +19,7 @@
             "start":49,"end":54,"loc":{"start":{"line":1,"column":49,"index":49},"end":{"line":1,"column":54,"index":54}},
             "extra": {
               "rawValue": "foo",
-              "raw": "\"foo\"",
-              "trailingComma": 61
+              "raw": "\"foo\""
             },
             "value": "foo",
             "trailingComments": [

--- a/packages/babel-parser/test/fixtures/experimental/source-phase-imports/dynamic-import-options-comments/output.json
+++ b/packages/babel-parser/test/fixtures/experimental/source-phase-imports/dynamic-import-options-comments/output.json
@@ -41,9 +41,6 @@
             "type": "Identifier",
             "start":71,"end":78,"loc":{"start":{"line":1,"column":71,"index":71},"end":{"line":1,"column":78,"index":78},"identifierName":"options"},
             "name": "options",
-            "extra": {
-              "trailingComma": 86
-            },
             "trailingComments": [
               {
                 "type": "CommentBlock",

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -157,9 +157,9 @@ type ErrorInfoCompressed = {
   IllegalLanguageModeDirective: [];
   IllegalReturn: [];
   ImportBindingIsString: [{ importName: string }];
-  ImportCallArity: [];
-  ImportCallNotNewExpression: [];
-  ImportCallSpreadArgument: [];
+  ImportCallArity: [{ phase?: string | null | undefined }];
+  ImportCallNotNewExpression: [{ phase?: string | null | undefined }];
+  ImportCallSpreadArgument: [{ phase?: string | null | undefined }];
   IncompatibleRegExpUVFlags: [];
   InvalidBigIntLiteral: [];
   InvalidCodePoint: [];


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we improve the error recovery capacity when parsing `ImportExpression`. Previously in Babel 7 we parsed the import expressions as a `CallExpression[callee=Import]` node and emit such errors.

This PR also prints the `phase` of an `ImportExpression` in the error message.