### PR TITLE
Remove `NodePath#toComputedKey`

### DIFF
--- a/packages/babel-helper-wrap-function/src/index.ts
+++ b/packages/babel-helper-wrap-function/src/index.ts
@@ -112,7 +112,9 @@ function classOrObjectMethod(
     ];
 
     (
-      path.get("body.body.0.argument.callee.object.arguments.0") as NodePath
+      path.get(
+        "body.body.0.argument.callee.object.arguments.0",
+      ) as NodePath<t.FunctionExpression>
     ).unwrapFunctionEnvironment();
   } else {
     // return asyncToGenerator(function*() { ... })();
@@ -122,7 +124,9 @@ function classOrObjectMethod(
 
     // Unwrap the wrapper IIFE's environment so super and this and such still work.
     (
-      path.get("body.body.0.argument.callee.arguments.0") as NodePath
+      path.get(
+        "body.body.0.argument.callee.arguments.0",
+      ) as NodePath<t.FunctionExpression>
     ).unwrapFunctionEnvironment();
   }
 

--- a/packages/babel-plugin-transform-block-scoping/src/index.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/index.ts
@@ -130,7 +130,9 @@ export default declare((api, opts: Options) => {
             transformBlockScopedVariable(headPath, state, tdzEnabled);
           }
 
-          varPath.get("declarations.0.init").unwrapFunctionEnvironment();
+          (
+            varPath.get("declarations.0.init") as NodePath<t.FunctionExpression>
+          ).unwrapFunctionEnvironment();
         }
       },
 

--- a/packages/babel-plugin-transform-regenerator/src/regenerator/visit.ts
+++ b/packages/babel-plugin-transform-regenerator/src/regenerator/visit.ts
@@ -33,7 +33,7 @@ export const getVisitor = (): Visitor<PluginPass> => ({
 
     // Unwrap the wrapper IIFE's environment so super and this and such still work.
     (
-      path.get("body.body.0.argument.callee") as NodePath
+      path.get("body.body.0.argument.callee") as NodePath<t.FunctionExpression>
     ).unwrapFunctionEnvironment();
   },
   Function: {

--- a/packages/babel-traverse/src/path/conversion.ts
+++ b/packages/babel-traverse/src/path/conversion.ts
@@ -9,7 +9,6 @@ import {
   conditionalExpression,
   expressionStatement,
   identifier,
-  isIdentifier,
   jsxIdentifier,
   logicalExpression,
   LOGICAL_OPERATORS,
@@ -46,24 +45,6 @@ import type NodePath from "./index.ts";
 import type { Visitor } from "../types.ts";
 import { setup } from "./context.ts";
 import type Scope from "../scope/index.ts";
-
-export function toComputedKey(this: NodePath) {
-  let key;
-  if (this.isMemberExpression()) {
-    key = this.node.property;
-  } else if (this.isProperty() || this.isMethod()) {
-    key = this.node.key;
-  } else {
-    throw new ReferenceError("todo");
-  }
-
-  // @ts-expect-error todo(flow->ts) computed does not exist in ClassPrivateProperty
-  if (!this.node.computed) {
-    if (isIdentifier(key)) key = stringLiteral(key.name);
-  }
-
-  return key;
-}
 
 export function ensureBlock(
   this: NodePath<
@@ -136,7 +117,11 @@ export function ensureBlock(
  * you have wrapped some set of items in an IIFE or other function, but want "this", "arguments", and super"
  * to continue behaving as expected.
  */
-export function unwrapFunctionEnvironment(this: NodePath<t.Node | null>) {
+export function unwrapFunctionEnvironment(
+  this: NodePath<
+    t.ArrayExpression | t.FunctionExpression | t.FunctionDeclaration
+  >,
+) {
   if (
     !this.isArrowFunctionExpression() &&
     !this.isFunctionExpression() &&
@@ -168,8 +153,8 @@ export function arrowFunctionToExpression(
     // TODO(Babel 9): Consider defaulting to `false` for spec compliance
     noNewArrows = true,
   }: {
-    allowInsertArrow?: boolean | void;
-    allowInsertArrowWithRest?: boolean | void;
+    allowInsertArrow?: boolean;
+    allowInsertArrowWithRest?: boolean;
     noNewArrows?: boolean;
   } = {},
 ): NodePath<
@@ -254,9 +239,9 @@ const getSuperCallsVisitor = environmentVisitor<{
 function hoistFunctionEnvironment(
   fnPath: NodePath<t.Function>,
   // TODO(Babel 9): Consider defaulting to `false` for spec compliance
-  noNewArrows: boolean | void = true,
-  allowInsertArrow: boolean | void = true,
-  allowInsertArrowWithRest: boolean | void = true,
+  noNewArrows: boolean = true,
+  allowInsertArrow: boolean = true,
+  allowInsertArrowWithRest: boolean = true,
 ): { thisBinding: string; fnPath: NodePath<t.Function> } {
   let arrowParent;
   let thisEnvFn: NodePath<t.Function> = fnPath.findParent(p => {

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -243,7 +243,6 @@ const methods = {
   evaluate: NodePath_evaluation.evaluate,
 
   // NodePath_conversion
-  toComputedKey: NodePath_conversion.toComputedKey,
   ensureBlock: NodePath_conversion.ensureBlock,
   unwrapFunctionEnvironment: NodePath_conversion.unwrapFunctionEnvironment,
   arrowFunctionToExpression: NodePath_conversion.arrowFunctionToExpression,

--- a/packages/babel-traverse/src/path/introspection.ts
+++ b/packages/babel-traverse/src/path/introspection.ts
@@ -11,6 +11,7 @@ import {
   isStringLiteral,
   isType,
   matchesPattern as _matchesPattern,
+  toComputedKey,
 } from "@babel/types";
 import type * as t from "@babel/types";
 
@@ -548,7 +549,7 @@ export function _resolve(
     // this is dangerous, as non-direct target assignments will mutate it's state
     // making this resolution inaccurate
 
-    const targetKey = this.toComputedKey();
+    const targetKey = toComputedKey(this.node);
     if (!isLiteral(targetKey)) return;
 
     // @ts-expect-error todo(flow->ts): NullLiteral

--- a/packages/babel-traverse/test/path/index.js
+++ b/packages/babel-traverse/test/path/index.js
@@ -155,7 +155,6 @@ describe("NodePath", () => {
           "skipKey",
           "splitExportDeclaration",
           "stop",
-          "toComputedKey",
           "unshiftContainer",
           "unwrapFunctionEnvironment",
           "willIMaybeExecuteBefore",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This is a duplicate of `toComputedKey` in `@babel/types`.