### PR TITLE
Fix thread synchronization issues in `@babel/register`

### DIFF
--- a/packages/babel-register/src/worker-client.cts
+++ b/packages/babel-register/src/worker-client.cts
@@ -47,19 +47,21 @@ class WorkerClient extends Client {
     { env: markInRegisterWorker(process.env) },
   );
 
-  #signal = new Int32Array(new SharedArrayBuffer(4));
-
   constructor() {
     super((action, payload) => {
-      this.#signal[0] = 0;
+      // We create a new SharedArrayBuffer every time rather than reusing
+      // the same one, otherwise sometimes its contents get corrupted and
+      // Atomics.wait wakes up too early.
+      // https://github.com/babel/babel/pull/14541
+      const signal = new Int32Array(new SharedArrayBuffer(4));
       const subChannel = new worker_threads.MessageChannel();
 
       this.#worker.postMessage(
-        { signal: this.#signal, port: subChannel.port1, action, payload },
+        { signal, port: subChannel.port1, action, payload },
         [subChannel.port1],
       );
 
-      Atomics.wait(this.#signal, 0, 0);
+      Atomics.wait(signal, 0, 0);
       const { message } = worker_threads.receiveMessageOnPort(
         subChannel.port2,
       )!;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
We have already applied the fix to `@babel/eslint-parser`.
Ref: https://github.com/babel/babel/pull/14541

https://github.com/babel/babel/actions/runs/23682460647/job/68996658460
```
FAIL packages/babel-node/test/batch-test-runner/3.js
babel-node [3/8] > cli arguments-categories
    Error: "/home/runner/work/babel/babel/packages/babel-node/lib/babel-node" "--expose_gc" "-w" "./plugin-binary.js" "./foo.js" "--expose-gc-as=gc2" "--config-file" "./config.json" "--extensions=.js,.ts" "bar": expect(received).toBe(expected) // Object.is equality
    
    - Expected
    + Received
    
      Warning: --expose-gc-as, --config-file, --extensions are a valid option for Babel or Node.js, but they are defined after the script name. Up to Babel 7 they would have been passed to Babel, while now they are passed to the script itself.
        If the intention is to pass them to Babel, move them before the filename:
          babel-node --expose_gc -w ./plugin-binary.js --expose-gc-as=gc2 --config-file ./config.json --extensions=.js,.ts ./foo.js bar
        If passing them to the script is intended, you can silence this warning by explicitly using the -- separator before the script name:
          babel-node --expose_gc -w ./plugin-binary.js -- ./foo.js --expose-gc-as=gc2 --config-file ./config.json --extensions=.js,.ts bar
    + /home/runner/work/babel/babel/packages/babel-register/lib/worker-client.cjs:49
    +         message
    +         ^
    +
    + TypeError: Cannot destructure property 'message' of 'worker_threads.receiveMessageOnPort(...)' as it is undefined.
    +     at WorkerClient.<anonymous> (/home/runner/work/babel/babel/packages/babel-register/lib/worker-client.cjs:49:9)
    +     at WorkerClient.transform (/home/runner/work/babel/babel/packages/babel-register/lib/worker-client.cjs:23:22)
    +     at compile (/home/runner/work/babel/babel/packages/babel-register/lib/hook.cjs:26:25)
    +     at Module._compile (/home/runner/work/babel/babel/node_modules/pirates/lib/index.js:124:29)
    +     at node:internal/modules/cjs/loader:1943:10
    +     at Object.newLoader [as .js] (/home/runner/work/babel/babel/node_modules/pirates/lib/index.js:134:7)
    +     at Module.load (node:internal/modules/cjs/loader:1533:32)
    +     at Module._load (node:internal/modules/cjs/loader:1335:12)
    +     at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    +     at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
    +
    + Node.js v24.14.0
        at assertTest (file:///home/runner/work/babel/babel/packages/babel-helper-transform-fixture-test-runner/src/process.ts:105:24)
        at ChildProcess.<anonymous> (file:///home/runner/work/babel/babel/packages/babel-helper-transform-fixture-test-runner/src/process.ts:349:17)
        at ChildProcess.emit (node:events:508:28)
        at maybeClose (node:internal/child_process:1100:16)
        at Socket.<anonymous> (node:internal/child_process:457:11)
        at Socket.emit (node:events:508:28)
        at Pipe.<anonymous> (node:net:346:12)
```