### PR TITLE
Support flow extends bound

### DIFF
--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -797,16 +797,25 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       );
     }
 
-    flowParseRestrictedIdentifier(
+    flowParseRestrictedIdentifierName(
       liberal?: boolean,
       declaration?: boolean,
-    ): N.Identifier {
+    ): string {
       this.checkReservedType(
         this.state.value,
         this.state.startLoc,
         declaration,
       );
-      return this.parseIdentifier(liberal);
+      return this.parseIdentifierName(liberal);
+    }
+
+    flowParseRestrictedIdentifier(
+      liberal?: boolean,
+      declaration?: boolean,
+    ): N.Identifier {
+      const node = this.startNode<N.Identifier>();
+      const name = this.flowParseRestrictedIdentifierName(liberal, declaration);
+      return this.createIdentifier(node, name);
     }
 
     // Type aliases
@@ -875,17 +884,24 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
     // Type annotations
 
+    flowParseTypeParameterBound(): N.TypeAnnotation | undefined {
+      if (this.match(tt.colon) || this.isContextual(tt._extends)) {
+        const node = this.startNode<N.TypeAnnotation>();
+        this.next();
+        node.typeAnnotation = this.flowParseType();
+        return this.finishNode(node, "TypeAnnotation");
+      }
+    }
+
     flowParseTypeParameter(requireDefault: boolean = false): N.TypeParameter {
       const nodeStartLoc = this.state.startLoc;
 
       const node = this.startNode<N.TypeParameter>();
-
       const variance = this.flowParseVariance();
 
-      const ident = this.flowParseTypeAnnotatableIdentifier();
-      node.name = ident.name;
+      node.name = this.flowParseRestrictedIdentifierName();
       node.variance = variance;
-      node.bound = ident.typeAnnotation as N.TypeAnnotation | null;
+      node.bound = this.flowParseTypeParameterBound();
 
       if (this.match(tt.eq)) {
         this.eat(tt.eq);

--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -498,9 +498,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       node: Undone<N.DeclareVariable>,
     ): N.DeclareVariable {
       this.next();
-      node.id = this.flowParseTypeAnnotatableIdentifier(
-        /*allowPrimitiveOverride*/ true,
-      );
+      node.id = this.flowParseTypeAnnotatableIdentifier();
       this.scope.declareName(
         node.id.name,
         BindingFlag.TYPE_VAR,
@@ -1929,17 +1927,13 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       return this.finishNode(node, "TypeAnnotation");
     }
 
-    flowParseTypeAnnotatableIdentifier(
-      allowPrimitiveOverride?: boolean,
-    ): N.Identifier {
-      const ident = allowPrimitiveOverride
-        ? this.parseIdentifier()
-        : this.flowParseRestrictedIdentifier();
+    flowParseTypeAnnotatableIdentifier(): N.Identifier {
+      const node = this.startNode<N.Identifier>();
+      const name = this.parseIdentifierName();
       if (this.match(tt.colon)) {
-        ident.typeAnnotation = this.flowParseTypeAnnotation();
-        this.resetEndLocation(ident);
+        node.typeAnnotation = this.flowParseTypeAnnotation();
       }
-      return ident;
+      return this.createIdentifier(node, name);
     }
 
     typeCastToParameter(node: N.TypeCastExpression): N.Expression {

--- a/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends-comments/input.js
+++ b/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends-comments/input.js
@@ -1,0 +1,1 @@
+class A</* 0 */T/* 1 */extends/* 2 */Foo/* 3 */> {}

--- a/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends-comments/output.json
+++ b/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends-comments/output.json
@@ -1,0 +1,107 @@
+{
+  "type": "File",
+  "start":0,"end":51,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":51,"index":51}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":51,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":51,"index":51}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":51,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":51,"index":51}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"A"},
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start":7,"end":48,"loc":{"start":{"line":1,"column":7,"index":7},"end":{"line":1,"column":48,"index":48}},
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start":15,"end":40,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":40,"index":40}},
+              "name": "T",
+              "variance": null,
+              "bound": {
+                "type": "TypeAnnotation",
+                "start":23,"end":40,"loc":{"start":{"line":1,"column":23,"index":23},"end":{"line":1,"column":40,"index":40}},
+                "typeAnnotation": {
+                  "type": "GenericTypeAnnotation",
+                  "start":37,"end":40,"loc":{"start":{"line":1,"column":37,"index":37},"end":{"line":1,"column":40,"index":40}},
+                  "typeParameters": null,
+                  "id": {
+                    "type": "Identifier",
+                    "start":37,"end":40,"loc":{"start":{"line":1,"column":37,"index":37},"end":{"line":1,"column":40,"index":40},"identifierName":"Foo"},
+                    "name": "Foo"
+                  },
+                  "leadingComments": [
+                    {
+                      "type": "CommentBlock",
+                      "value": " 2 ",
+                      "start":30,"end":37,"loc":{"start":{"line":1,"column":30,"index":30},"end":{"line":1,"column":37,"index":37}}
+                    }
+                  ]
+                },
+                "leadingComments": [
+                  {
+                    "type": "CommentBlock",
+                    "value": " 1 ",
+                    "start":16,"end":23,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":23,"index":23}}
+                  }
+                ]
+              },
+              "trailingComments": [
+                {
+                  "type": "CommentBlock",
+                  "value": " 3 ",
+                  "start":40,"end":47,"loc":{"start":{"line":1,"column":40,"index":40},"end":{"line":1,"column":47,"index":47}}
+                }
+              ],
+              "leadingComments": [
+                {
+                  "type": "CommentBlock",
+                  "value": " 0 ",
+                  "start":8,"end":15,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":15,"index":15}}
+                }
+              ]
+            }
+          ]
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":49,"end":51,"loc":{"start":{"line":1,"column":49,"index":49},"end":{"line":1,"column":51,"index":51}},
+          "body": []
+        }
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  },
+  "comments": [
+    {
+      "type": "CommentBlock",
+      "value": " 0 ",
+      "start":8,"end":15,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":15,"index":15}}
+    },
+    {
+      "type": "CommentBlock",
+      "value": " 1 ",
+      "start":16,"end":23,"loc":{"start":{"line":1,"column":16,"index":16},"end":{"line":1,"column":23,"index":23}}
+    },
+    {
+      "type": "CommentBlock",
+      "value": " 2 ",
+      "start":30,"end":37,"loc":{"start":{"line":1,"column":30,"index":30},"end":{"line":1,"column":37,"index":37}}
+    },
+    {
+      "type": "CommentBlock",
+      "value": " 3 ",
+      "start":40,"end":47,"loc":{"start":{"line":1,"column":40,"index":40},"end":{"line":1,"column":47,"index":47}}
+    }
+  ]
+}

--- a/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends-multiple/input.js
+++ b/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends-multiple/input.js
@@ -1,0 +1,1 @@
+class A<T extends string, U extends number> {}

--- a/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends-multiple/output.json
+++ b/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends-multiple/output.json
@@ -1,0 +1,65 @@
+{
+  "type": "File",
+  "start":0,"end":46,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":46,"index":46}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":46,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":46,"index":46}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":46,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":46,"index":46}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"A"},
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start":7,"end":43,"loc":{"start":{"line":1,"column":7,"index":7},"end":{"line":1,"column":43,"index":43}},
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start":8,"end":24,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":24,"index":24}},
+              "name": "T",
+              "variance": null,
+              "bound": {
+                "type": "TypeAnnotation",
+                "start":10,"end":24,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":24,"index":24}},
+                "typeAnnotation": {
+                  "type": "StringTypeAnnotation",
+                  "start":18,"end":24,"loc":{"start":{"line":1,"column":18,"index":18},"end":{"line":1,"column":24,"index":24}}
+                }
+              }
+            },
+            {
+              "type": "TypeParameter",
+              "start":26,"end":42,"loc":{"start":{"line":1,"column":26,"index":26},"end":{"line":1,"column":42,"index":42}},
+              "name": "U",
+              "variance": null,
+              "bound": {
+                "type": "TypeAnnotation",
+                "start":28,"end":42,"loc":{"start":{"line":1,"column":28,"index":28},"end":{"line":1,"column":42,"index":42}},
+                "typeAnnotation": {
+                  "type": "NumberTypeAnnotation",
+                  "start":36,"end":42,"loc":{"start":{"line":1,"column":36,"index":36},"end":{"line":1,"column":42,"index":42}}
+                }
+              }
+            }
+          ]
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":44,"end":46,"loc":{"start":{"line":1,"column":44,"index":44},"end":{"line":1,"column":46,"index":46}},
+          "body": []
+        }
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends/input.js
+++ b/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends/input.js
@@ -1,0 +1,7 @@
+class C<T extends Foo> {}
+
+function F<T extends Foo>() {}
+
+interface I<T extends Foo> {}
+
+type T<P extends Foo> = I<P>;

--- a/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends/output.json
+++ b/packages/babel-parser/test/fixtures/flow/bounded-polymorphism/extends/output.json
@@ -1,0 +1,206 @@
+{
+  "type": "File",
+  "start":0,"end":119,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":29,"index":119}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":119,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":7,"column":29,"index":119}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start":0,"end":25,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":25,"index":25}},
+        "id": {
+          "type": "Identifier",
+          "start":6,"end":7,"loc":{"start":{"line":1,"column":6,"index":6},"end":{"line":1,"column":7,"index":7},"identifierName":"C"},
+          "name": "C"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start":7,"end":22,"loc":{"start":{"line":1,"column":7,"index":7},"end":{"line":1,"column":22,"index":22}},
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start":8,"end":21,"loc":{"start":{"line":1,"column":8,"index":8},"end":{"line":1,"column":21,"index":21}},
+              "name": "T",
+              "variance": null,
+              "bound": {
+                "type": "TypeAnnotation",
+                "start":10,"end":21,"loc":{"start":{"line":1,"column":10,"index":10},"end":{"line":1,"column":21,"index":21}},
+                "typeAnnotation": {
+                  "type": "GenericTypeAnnotation",
+                  "start":18,"end":21,"loc":{"start":{"line":1,"column":18,"index":18},"end":{"line":1,"column":21,"index":21}},
+                  "typeParameters": null,
+                  "id": {
+                    "type": "Identifier",
+                    "start":18,"end":21,"loc":{"start":{"line":1,"column":18,"index":18},"end":{"line":1,"column":21,"index":21},"identifierName":"Foo"},
+                    "name": "Foo"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start":23,"end":25,"loc":{"start":{"line":1,"column":23,"index":23},"end":{"line":1,"column":25,"index":25}},
+          "body": []
+        }
+      },
+      {
+        "type": "FunctionDeclaration",
+        "start":27,"end":57,"loc":{"start":{"line":3,"column":0,"index":27},"end":{"line":3,"column":30,"index":57}},
+        "id": {
+          "type": "Identifier",
+          "start":36,"end":37,"loc":{"start":{"line":3,"column":9,"index":36},"end":{"line":3,"column":10,"index":37},"identifierName":"F"},
+          "name": "F"
+        },
+        "generator": false,
+        "async": false,
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start":37,"end":52,"loc":{"start":{"line":3,"column":10,"index":37},"end":{"line":3,"column":25,"index":52}},
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start":38,"end":51,"loc":{"start":{"line":3,"column":11,"index":38},"end":{"line":3,"column":24,"index":51}},
+              "name": "T",
+              "variance": null,
+              "bound": {
+                "type": "TypeAnnotation",
+                "start":40,"end":51,"loc":{"start":{"line":3,"column":13,"index":40},"end":{"line":3,"column":24,"index":51}},
+                "typeAnnotation": {
+                  "type": "GenericTypeAnnotation",
+                  "start":48,"end":51,"loc":{"start":{"line":3,"column":21,"index":48},"end":{"line":3,"column":24,"index":51}},
+                  "typeParameters": null,
+                  "id": {
+                    "type": "Identifier",
+                    "start":48,"end":51,"loc":{"start":{"line":3,"column":21,"index":48},"end":{"line":3,"column":24,"index":51},"identifierName":"Foo"},
+                    "name": "Foo"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start":55,"end":57,"loc":{"start":{"line":3,"column":28,"index":55},"end":{"line":3,"column":30,"index":57}},
+          "body": [],
+          "directives": []
+        }
+      },
+      {
+        "type": "InterfaceDeclaration",
+        "start":59,"end":88,"loc":{"start":{"line":5,"column":0,"index":59},"end":{"line":5,"column":29,"index":88}},
+        "id": {
+          "type": "Identifier",
+          "start":69,"end":70,"loc":{"start":{"line":5,"column":10,"index":69},"end":{"line":5,"column":11,"index":70},"identifierName":"I"},
+          "name": "I"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start":70,"end":85,"loc":{"start":{"line":5,"column":11,"index":70},"end":{"line":5,"column":26,"index":85}},
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start":71,"end":84,"loc":{"start":{"line":5,"column":12,"index":71},"end":{"line":5,"column":25,"index":84}},
+              "name": "T",
+              "variance": null,
+              "bound": {
+                "type": "TypeAnnotation",
+                "start":73,"end":84,"loc":{"start":{"line":5,"column":14,"index":73},"end":{"line":5,"column":25,"index":84}},
+                "typeAnnotation": {
+                  "type": "GenericTypeAnnotation",
+                  "start":81,"end":84,"loc":{"start":{"line":5,"column":22,"index":81},"end":{"line":5,"column":25,"index":84}},
+                  "typeParameters": null,
+                  "id": {
+                    "type": "Identifier",
+                    "start":81,"end":84,"loc":{"start":{"line":5,"column":22,"index":81},"end":{"line":5,"column":25,"index":84},"identifierName":"Foo"},
+                    "name": "Foo"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "extends": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start":86,"end":88,"loc":{"start":{"line":5,"column":27,"index":86},"end":{"line":5,"column":29,"index":88}},
+          "callProperties": [],
+          "properties": [],
+          "indexers": [],
+          "internalSlots": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start":90,"end":119,"loc":{"start":{"line":7,"column":0,"index":90},"end":{"line":7,"column":29,"index":119}},
+        "id": {
+          "type": "Identifier",
+          "start":95,"end":96,"loc":{"start":{"line":7,"column":5,"index":95},"end":{"line":7,"column":6,"index":96},"identifierName":"T"},
+          "name": "T"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start":96,"end":111,"loc":{"start":{"line":7,"column":6,"index":96},"end":{"line":7,"column":21,"index":111}},
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start":97,"end":110,"loc":{"start":{"line":7,"column":7,"index":97},"end":{"line":7,"column":20,"index":110}},
+              "name": "P",
+              "variance": null,
+              "bound": {
+                "type": "TypeAnnotation",
+                "start":99,"end":110,"loc":{"start":{"line":7,"column":9,"index":99},"end":{"line":7,"column":20,"index":110}},
+                "typeAnnotation": {
+                  "type": "GenericTypeAnnotation",
+                  "start":107,"end":110,"loc":{"start":{"line":7,"column":17,"index":107},"end":{"line":7,"column":20,"index":110}},
+                  "typeParameters": null,
+                  "id": {
+                    "type": "Identifier",
+                    "start":107,"end":110,"loc":{"start":{"line":7,"column":17,"index":107},"end":{"line":7,"column":20,"index":110},"identifierName":"Foo"},
+                    "name": "Foo"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "type": "GenericTypeAnnotation",
+          "start":114,"end":118,"loc":{"start":{"line":7,"column":24,"index":114},"end":{"line":7,"column":28,"index":118}},
+          "typeParameters": {
+            "type": "TypeParameterInstantiation",
+            "start":115,"end":118,"loc":{"start":{"line":7,"column":25,"index":115},"end":{"line":7,"column":28,"index":118}},
+            "params": [
+              {
+                "type": "GenericTypeAnnotation",
+                "start":116,"end":117,"loc":{"start":{"line":7,"column":26,"index":116},"end":{"line":7,"column":27,"index":117}},
+                "typeParameters": null,
+                "id": {
+                  "type": "Identifier",
+                  "start":116,"end":117,"loc":{"start":{"line":7,"column":26,"index":116},"end":{"line":7,"column":27,"index":117},"identifierName":"P"},
+                  "name": "P"
+                }
+              }
+            ]
+          },
+          "id": {
+            "type": "Identifier",
+            "start":114,"end":115,"loc":{"start":{"line":7,"column":24,"index":114},"end":{"line":7,"column":25,"index":115},"identifierName":"I"},
+            "name": "I"
+          }
+        }
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/scripts/parser-tests/flow/allowlist.md
+++ b/scripts/parser-tests/flow/allowlist.md
@@ -30,7 +30,7 @@
 - [types/reserved/function.js](../../../build/flow/src/parser/test/flow/types/reserved/function.js)
 - [types/typeof/with-targs-bad-newline.js](../../../build/flow/src/parser/test/flow/types/typeof/with-targs-bad-newline.js)
 
-## 96 valid programs produced a parsing error
+## 95 valid programs produced a parsing error
 
 - [ES6/modules/migrated_0020.js](../../../build/flow/src/parser/test/flow/ES6/modules/migrated_0020.js)
 - [JSX/jsx_type_args_implicit.js](../../../build/flow/src/parser/test/flow/JSX/jsx_type_args_implicit.js)
@@ -80,7 +80,6 @@
 - [ts_syntax/readonly_type.js](../../../build/flow/src/parser/test/flow/ts_syntax/readonly_type.js)
 - [ts_syntax/readonly_variance.js](../../../build/flow/src/parser/test/flow/ts_syntax/readonly_variance.js)
 - [ts_syntax/satisfies.js](../../../build/flow/src/parser/test/flow/ts_syntax/satisfies.js)
-- [ts_syntax/type_param_extends.js](../../../build/flow/src/parser/test/flow/ts_syntax/type_param_extends.js)
 - [type_guards/arrows.js](../../../build/flow/src/parser/test/flow/type_guards/arrows.js)
 - [type_guards/asserts_is.js](../../../build/flow/src/parser/test/flow/type_guards/asserts_is.js)
 - [type_guards/callback.js](../../../build/flow/src/parser/test/flow/type_guards/callback.js)


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Closes https://github.com/babel/babel/pull/17857
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
<s>This PR includes commits from #17904.</s>

This PR revives PR https://github.com/babel/babel/pull/17857. The `babel-generator` will still prints `:` for both `extends` and `:` parameter bound, since the flow has not yet officially deprecated `:`: [There is no deprecation message for `function foo<L: string>() {}` yet](https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+h46fNRLuKxJIGWh8MeT0ZfhYlCStpHzNsFBAMIQkIEQwJODAQfiEyfCEoAGsoCAB3KHw4KrBMsAALfAA3KjgsXGxxZC4eAw1m-GhcWn9aY3wWZlc+-g1mbDqJbDYAWglxxJ63AxJi7AlG2lXhXFwZ9z2Do5PRHEoLgyKwTqp1zce8qChFrpIqY41VqmDA+T4gIo-MB-AGrCCMLLQbirRoYGrgor-GDYVYIA7LSgkVZkCQE7q9dxFfIrVbMdJwMjghSeBIhPwYEhkSgqeEmTIQB7bPoAX34kA0SRgz0RUAABDBiAAeAAyyFl9lMUAQAD4ABQASllwGFuRAzRMJDg0CSzQADFYAMy2gDsVgAjCBhUA).