### PR TITLE
Node version check cleanup

### DIFF
--- a/packages/babel-core/test/config-ts-integration-ts-node.js
+++ b/packages/babel-core/test/config-ts-integration-ts-node.js
@@ -1,64 +1,46 @@
 import { loadPartialConfigSync } from "../lib/index.js";
 import path from "node:path";
-import semver from "semver";
 import { commonJS } from "$repo-utils";
 
 const { __dirname, require } = commonJS(import.meta.url);
 
-// We skip older versions of node testing for two reasons.
-// 1. ts-node and ts don't support the old version of node.
-// 2. In the old version of node, jest has been registered in `require.extensions`, which will cause babel to disable the transforming as expected.
-const shouldSkip = semver.lt(process.version, "14.0.0");
-
-(shouldSkip ? describe : describe.skip)(
-  "@babel/core config with ts [dummy]",
-  () => {
-    it("dummy", () => {
-      expect(1).toBe(1);
-    });
-  },
-);
-
 // The integration tests should not be mixed with other tests because the `register` function
 // will affect node's built-in ts support.
-(shouldSkip ? describe.skip : describe)(
-  "@babel/core config ts-node integration",
-  () => {
-    let service;
-    beforeAll(() => {
-      service = require("ts-node").register({
-        experimentalResolver: true,
-        compilerOptions: {
-          module: "CommonJS",
-        },
-      });
-      service.enabled(true);
+describe("@babel/core config ts-node integration", () => {
+  let service;
+  beforeAll(() => {
+    service = require("ts-node").register({
+      experimentalResolver: true,
+      compilerOptions: {
+        module: "CommonJS",
+      },
     });
-    afterAll(() => {
-      service.enabled(false);
+    service.enabled(true);
+  });
+  afterAll(() => {
+    service.enabled(false);
+  });
+  it("should work with ts-node", async () => {
+    require(
+      path.join(
+        __dirname,
+        "fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts",
+      ),
+    );
+
+    const config = loadPartialConfigSync({
+      configFile: path.join(
+        __dirname,
+        "fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts",
+      ),
     });
-    it("should work with ts-node", async () => {
-      require(
-        path.join(
-          __dirname,
-          "fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts",
-        ),
-      );
 
-      const config = loadPartialConfigSync({
-        configFile: path.join(
-          __dirname,
-          "fixtures/config-ts/simple-cts-with-ts-node/babel.config.cts",
-        ),
-      });
-
-      expect(config.options.targets).toMatchInlineSnapshot(`
+    expect(config.options.targets).toMatchInlineSnapshot(`
         Object {
           "node": "12.0.0",
         }
       `);
 
-      expect(config.options.sourceRoot).toMatchInlineSnapshot(`"/a/b"`);
-    });
-  },
-);
+    expect(config.options.sourceRoot).toMatchInlineSnapshot(`"/a/b"`);
+  });
+});

--- a/packages/babel-core/test/esm-cjs-integration.js
+++ b/packages/babel-core/test/esm-cjs-integration.js
@@ -1,11 +1,7 @@
 import { execFile } from "node:child_process";
 import { createRequire } from "node:module";
-import { describeSatisfies, itNegate, itSatisfies } from "$repo-utils";
 
 const require = createRequire(import.meta.url);
-
-// "minNodeVersion": "22.0.0" <-- For Ctrl+F when dropping node 20
-const versionHasRequireESM = "^20.19.0 || >=22.12.0";
 
 async function run(name, ...flags) {
   return new Promise((res, rej) => {
@@ -122,70 +118,28 @@ describe("usage from cjs", () => {
 });
 
 describe("sync loading of ESM plugins", () => {
-  itNegate(itSatisfies(versionHasRequireESM))(
-    "without --experimental-require-module flag",
-    async () => {
-      await expect(run("transform-sync-esm-plugin.mjs")).rejects.toThrow(
-        "You appear to be using a native ECMAScript module plugin, which is " +
-          "only supported when running Babel asynchronously or when using the " +
-          "Node.js `--experimental-require-module` flag.",
+  describe("without --experimental-require-module flag", () => {
+    it("sync", async () => {
+      const { stdout } = await run(
+        "transform-sync-esm-plugin.mjs",
+        "--experimental-require-module",
       );
-    },
-  );
-
-  describeSatisfies(versionHasRequireESM)(
-    "without --experimental-require-module flag",
-    () => {
-      it("sync", async () => {
-        const { stdout } = await run(
-          "transform-sync-esm-plugin.mjs",
-          "--experimental-require-module",
-        );
-        expect(stdout).toMatchInlineSnapshot(`
+      expect(stdout).toMatchInlineSnapshot(`
             "\\"Replaced!\\";
             "
         `);
-      });
+    });
 
-      it("top-level await", async () => {
-        await expect(
-          run(
-            "transform-sync-esm-plugin-tla.mjs",
-            "--experimental-require-module",
-          ),
-        ).rejects.toThrow(
-          "You appear to be using a plugin that contains top-level await, " +
-            "which is only supported when running Babel asynchronously.",
-        );
-      });
-    },
-  );
-
-  describeSatisfies(">=20.0.0 < 20.19.0")(
-    "with --experimental-require-module flag",
-    () => {
-      it("sync with --experimental-require-module flag", async () => {
-        const { stdout } = await run(
-          "transform-sync-esm-plugin.mjs",
+    it("top-level await", async () => {
+      await expect(
+        run(
+          "transform-sync-esm-plugin-tla.mjs",
           "--experimental-require-module",
-        );
-        expect(stdout).toMatchInlineSnapshot(`
-            "\\"Replaced!\\";
-            "
-        `);
-      });
-
-      it("top-level await with --experimental-require-module flag", async () => {
-        await expect(
-          run(
-            "transform-sync-esm-plugin-tla.mjs",
-            "--experimental-require-module",
-          ),
-        ).rejects.toThrow(
-          "You appear to be using a plugin that contains top-level await, " +
-            "which is only supported when running Babel asynchronously.",
-        );
-      });
-    },
-  );
+        ),
+      ).rejects.toThrow(
+        "You appear to be using a plugin that contains top-level await, " +
+          "which is only supported when running Babel asynchronously.",
+      );
+    });
+  });
 });

--- a/packages/babel-core/test/resolution.js
+++ b/packages/babel-core/test/resolution.js
@@ -363,9 +363,7 @@ describe("addon resolution", function () {
         plugins: ["foo"],
       });
     }).toThrow(
-      parseInt(process.versions.node, 10) <= 10
-        ? /Cannot (?:find|resolve) module 'babel-plugin-foo'/
-        : /Cannot (?:find|resolve) module 'babel-plugin-foo'.*\n- If you want to resolve "foo", use "module:foo"/s,
+      /Cannot (?:find|resolve) module 'babel-plugin-foo'.*\n- If you want to resolve "foo", use "module:foo"/s,
     );
   });
 
@@ -379,9 +377,7 @@ describe("addon resolution", function () {
         presets: ["foo"],
       });
     }).toThrow(
-      parseInt(process.versions.node, 10) <= 10
-        ? /Cannot (?:find|resolve) module 'babel-preset-foo'/
-        : /Cannot (?:find|resolve) module 'babel-preset-foo'.*\n- Did you mean "@babel\/foo"\?/s,
+      /Cannot (?:find|resolve) module 'babel-preset-foo'.*\n- Did you mean "@babel\/foo"\?/s,
     );
   });
 
@@ -395,9 +391,7 @@ describe("addon resolution", function () {
         plugins: ["foo"],
       });
     }).toThrow(
-      parseInt(process.versions.node, 10) <= 10
-        ? /Cannot (?:find|resolve) module 'babel-plugin-foo'/
-        : /Cannot (?:find|resolve) module 'babel-plugin-foo'.*\n- Did you mean "@babel\/foo"\?/s,
+      /Cannot (?:find|resolve) module 'babel-plugin-foo'.*\n- Did you mean "@babel\/foo"\?/s,
     );
   });
 
@@ -411,9 +405,7 @@ describe("addon resolution", function () {
         presets: ["testplugin"],
       });
     }).toThrow(
-      parseInt(process.versions.node, 10) <= 10
-        ? /Cannot (?:find|resolve) module 'babel-preset-testplugin'/
-        : /Cannot (?:find|resolve) module 'babel-preset-testplugin'.*\n- Did you accidentally pass a plugin as a preset\?/s,
+      /Cannot (?:find|resolve) module 'babel-preset-testplugin'.*\n- Did you accidentally pass a plugin as a preset\?/s,
     );
   });
 
@@ -427,9 +419,7 @@ describe("addon resolution", function () {
         plugins: ["testpreset"],
       });
     }).toThrow(
-      parseInt(process.versions.node, 10) <= 10
-        ? /Cannot (?:find|resolve) module 'babel-plugin-testpreset'/
-        : /Cannot (?:find|resolve) module 'babel-plugin-testpreset'.*\n- Did you accidentally pass a preset as a plugin\?/s,
+      /Cannot (?:find|resolve) module 'babel-plugin-testpreset'.*\n- Did you accidentally pass a preset as a plugin\?/s,
     );
   });
 

--- a/packages/babel-preset-flow/src/index.ts
+++ b/packages/babel-preset-flow/src/index.ts
@@ -13,11 +13,6 @@ export default declarePreset((api, opts) => {
   const plugins: any[] = [[transformFlowStripTypes, { all }]];
 
   if (useHermesParser) {
-    if (Number.parseInt(process.versions.node, 10) < 12) {
-      throw new Error(
-        "The Hermes parser is only supported in Node 12 and later.",
-      );
-    }
     if (IS_STANDALONE) {
       throw new Error(
         "The Hermes parser is not supported in the @babel/standalone.",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we clean up a few node versions checks. Babel 8 now requires `^20.19.0 || >=22.12.0`, so some test branches for old Node.js versions are no longer reachable.

We also remove a node.js detection branch in the `preset-flow`.