### PR TITLE
Update Babel 8 config item brand

### DIFF
--- a/packages/babel-core/src/config/caching.ts
+++ b/packages/babel-core/src/config/caching.ts
@@ -37,16 +37,16 @@ function* genTrue() {
   return true;
 }
 
-export function makeWeakCache<ArgT extends object, ResultT, SideChannel>(
+export function makeWeakCache<ArgT extends WeakKey, ResultT, SideChannel>(
   handler: (
     arg: ArgT,
     cache: CacheConfigurator<SideChannel>,
   ) => Handler<ResultT> | ResultT,
-): (arg: ArgT, data: SideChannel) => Handler<ResultT> {
+): (arg: ArgT, data?: SideChannel) => Handler<ResultT> {
   return makeCachedFunction<ArgT, ResultT, SideChannel>(WeakMap, handler);
 }
 
-export function makeWeakCacheSync<ArgT extends object, ResultT, SideChannel>(
+export function makeWeakCacheSync<ArgT extends WeakKey, ResultT, SideChannel>(
   handler: (arg: ArgT, cache?: CacheConfigurator<SideChannel>) => ResultT,
 ): (arg: ArgT, data?: SideChannel) => ResultT {
   return synchronize<[ArgT, SideChannel], ResultT>(
@@ -59,7 +59,7 @@ export function makeStrongCache<ArgT, ResultT, SideChannel>(
     arg: ArgT,
     cache: CacheConfigurator<SideChannel>,
   ) => Handler<ResultT> | ResultT,
-): (arg: ArgT, data: SideChannel) => Handler<ResultT> {
+): (arg: ArgT, data?: SideChannel) => Handler<ResultT> {
   return makeCachedFunction<ArgT, ResultT, SideChannel>(Map, handler);
 }
 
@@ -309,11 +309,10 @@ class CacheConfigurator<SideChannel = void> {
     );
 
     if (isThenable(key)) {
-      // @ts-expect-error todo(flow->ts): improve function return type annotation
       return key.then((key: unknown) => {
         this._pairs.push([key, fn]);
         return key;
-      });
+      }) as T;
     }
 
     this._pairs.push([key, fn]);

--- a/packages/babel-core/src/config/config-descriptors.ts
+++ b/packages/babel-core/src/config/config-descriptors.ts
@@ -102,13 +102,11 @@ export function createCachedDescriptors(
     options: optionsWithResolvedBrowserslistConfigFile(options, dirname),
     plugins: plugins
       ? () =>
-          // @ts-expect-error todo(flow->ts) ts complains about incorrect arguments
           // eslint-disable-next-line @typescript-eslint/no-use-before-define
           createCachedPluginDescriptors(plugins, dirname)(alias)
       : () => handlerOf([]),
     presets: presets
       ? () =>
-          // @ts-expect-error todo(flow->ts) ts complains about incorrect arguments
           // eslint-disable-next-line @typescript-eslint/no-use-before-define
           createCachedPresetDescriptors(presets, dirname)(alias)(
             !!passPerPreset,

--- a/packages/babel-core/src/config/files/configuration.ts
+++ b/packages/babel-core/src/config/files/configuration.ts
@@ -95,10 +95,9 @@ function* readConfigCode(
     );
   }
 
-  // @ts-expect-error todo(flow->ts)
-  if (typeof options.then === "function") {
-    // @ts-expect-error We use ?. in case options is a thenable but not a promise
-    options.catch?.(() => {});
+  if (typeof (options as any).then === "function") {
+    // We use ?. in case options is a thenable but not a promise
+    (options as any).catch?.(() => {});
     throw new ConfigError(
       `You appear to be using an async configuration, ` +
         `which your current version of Babel does not support. ` +

--- a/packages/babel-core/src/config/item.ts
+++ b/packages/babel-core/src/config/item.ts
@@ -36,7 +36,7 @@ export function* createConfigItem<API>(
   return createItemFromDescriptor(descriptor);
 }
 
-const CONFIG_ITEM_BRAND = Symbol.for("@babel/core@7 - ConfigItem");
+const CONFIG_ITEM_BRAND = Symbol.for("@babel/core@8 - ConfigItem");
 
 export function getItemDescriptor<API>(
   item: unknown,
@@ -65,7 +65,6 @@ class ConfigItem<API> {
    */
   _descriptor: UnloadedDescriptor<API>;
 
-  // TODO(Babel 9): Check if this symbol needs to be updated
   /**
    * Used to detect ConfigItem instances from other Babel instances.
    */

--- a/packages/babel-core/src/config/printer.ts
+++ b/packages/babel-core/src/config/printer.ts
@@ -7,15 +7,14 @@ import type {
   UnloadedDescriptor,
 } from "./config-descriptors.ts";
 
-// todo: Use flow enums when @babel/transform-flow-types supports it
-export const ChainFormatter = {
-  Programmatic: 0,
-  Config: 1,
-};
+export const enum ChainFormatter {
+  Programmatic = 0,
+  Config = 1,
+}
 
 type PrintableConfig = {
   content: OptionsAndDescriptors;
-  type: (typeof ChainFormatter)[keyof typeof ChainFormatter];
+  type: ChainFormatter;
   callerName: string | undefined | null;
   filepath: string | undefined | null;
   index: number | undefined | null;
@@ -24,7 +23,7 @@ type PrintableConfig = {
 
 const Formatter = {
   title(
-    type: (typeof ChainFormatter)[keyof typeof ChainFormatter],
+    type: ChainFormatter,
     callerName?: string | null,
     filepath?: string | null,
   ): string {
@@ -99,7 +98,7 @@ export class ConfigPrinter {
   _stack: PrintableConfig[] = [];
   configure(
     enabled: boolean,
-    type: (typeof ChainFormatter)[keyof typeof ChainFormatter],
+    type: ChainFormatter,
     {
       callerName,
       filepath,

--- a/packages/babel-core/src/config/validation/option-assertions.ts
+++ b/packages/babel-core/src/config/validation/option-assertions.ts
@@ -454,8 +454,7 @@ export function assertAssumptions(
     throw new Error(`${msg(loc)} must be an object or undefined.`);
   }
 
-  // todo(flow->ts): remove any
-  let root: any = loc;
+  let root: GeneralPath | NestingPath = loc;
   do {
     root = root.parent;
   } while (root.type !== "root");

--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -393,7 +393,6 @@ export function validate(
     );
   } catch (error) {
     const configError = new ConfigError(error.message, filename);
-    // @ts-expect-error TODO: .code is not defined on ConfigError or Error
     if (error.code) configError.code = error.code;
     throw configError;
   }

--- a/packages/babel-core/src/errors/config-error.ts
+++ b/packages/babel-core/src/errors/config-error.ts
@@ -9,4 +9,5 @@ export default class ConfigError extends Error {
     expectedError(this);
     if (filename) injectVirtualStackFrame(this, filename);
   }
+  declare code: string;
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Babel 8 shares the same config item brand with Babel 7
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we updated the Babel 8 config item brand, previously the brand is shared with Babel 7, which means a Babel 7 config item can be treated as a Babel 8 config item. This is not intended as Babel 8 introduced a few breaking configuration changes.

We also clean up a few todo items.