### PR TITLE
Uninstall sms in register revert

### DIFF
--- a/packages/babel-register/src/hook.cts
+++ b/packages/babel-register/src/hook.cts
@@ -5,9 +5,10 @@ const sourceMapSupport: typeof import("@cspotcode/source-map-support") = require
 let piratesRevert: () => void;
 const maps = Object.create(null);
 
+let sourceMapSupportInstalled = false;
+
 function installSourceMapSupport() {
-  // @ts-expect-error assign to function
-  installSourceMapSupport = () => {};
+  if (sourceMapSupportInstalled) return;
 
   sourceMapSupport.install({
     handleUncaughtExceptions: false,
@@ -22,6 +23,8 @@ function installSourceMapSupport() {
       }
     },
   });
+
+  sourceMapSupportInstalled = true;
 }
 
 function compile(client: IClient, inputCode: string, filename: string) {
@@ -50,6 +53,10 @@ function register(client: IClient, opts: Options = {}) {
 
 function revert() {
   if (piratesRevert) piratesRevert();
+  if (sourceMapSupportInstalled) {
+    sourceMapSupport.uninstall();
+    sourceMapSupportInstalled = false;
+  }
 }
 
 export = { register, revert };

--- a/packages/babel-register/src/index.cts
+++ b/packages/babel-register/src/index.cts
@@ -4,10 +4,11 @@ import hook = require("./hook.cjs");
 import workerClient = require("./worker-client.cjs");
 
 let client: IClient;
+let listener: undefined | ((signalOrCode: string | number) => void);
 function register(opts?: Options) {
   if (!client) {
     let hasClosed = false;
-    function listener(signalOrCode: string | number) {
+    listener = function (signalOrCode) {
       if (hasClosed) return;
       hasClosed = true;
       client.close();
@@ -15,7 +16,7 @@ function register(opts?: Options) {
         // eslint-disable-next-line n/no-process-exit
         process.exit(0);
       }
-    }
+    };
     process.on("exit", listener);
     process.on("SIGINT", listener);
     process.on("SIGTERM", listener);
@@ -24,8 +25,18 @@ function register(opts?: Options) {
   hook.register(client, opts);
 }
 
+function revert() {
+  hook.revert();
+  if (listener) {
+    process.off("exit", listener);
+    process.off("SIGINT", listener);
+    process.off("SIGTERM", listener);
+    listener = undefined;
+  }
+}
+
 export = Object.assign(register, {
-  revert: hook.revert,
+  revert,
   default: register,
   __esModule: true,
 });

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -183,7 +183,7 @@ describe("@babel/register", function () {
       expect(sourceMapSupport).toBe(true);
     });
 
-    test("uninstalls source map when reverting", () => {
+    test("uninstalls source map support when reverting", () => {
       setupRegister();
       currentHook("const a = 1;", testFile);
       revertRegister();

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -14,8 +14,7 @@ const testFileContent = fs.readFileSync(testFile, "utf-8");
 const testFileMjsContent = fs.readFileSync(testFileMjs, "utf-8");
 
 const piratesPath = require.resolve("pirates");
-const smsPath = require.resolve("source-map-support");
-const sms2Path = require.resolve("@cspotcode/source-map-support");
+const smsPath = require.resolve("@cspotcode/source-map-support");
 
 const defaultOptions = {
   exts: [".js", ".jsx", ".es6", ".es", ".mjs", ".cjs"],
@@ -26,15 +25,13 @@ function cleanCache() {
   try {
     fs.rmSync(testCacheFilename, { recursive: true, force: true });
   } catch (e) {
-    // It is convenient to always try to clear
+    // It is convenient to always try to clean
   }
 }
 
 function resetCache() {
   process.env.BABEL_CACHE_PATH = null;
 }
-
-const OLD_JEST_MOCKS = !!jest.doMock;
 
 describe("@babel/register", function () {
   let currentHook, currentOptions, sourceMapSupport;
@@ -68,45 +65,27 @@ describe("@babel/register", function () {
   });
 
   let originalRequireCacheDescriptor;
-  if (OLD_JEST_MOCKS) {
-    jest.doMock("pirates", () => mocks.pirates);
-    jest.doMock("source-map-support", () => mocks["source-map-support"]);
-    jest.doMock(
-      "@cspotcode/source-map-support",
-      () => mocks["source-map-support"],
+  beforeAll(() => {
+    originalRequireCacheDescriptor = Object.getOwnPropertyDescriptor(
+      Module,
+      "_cache",
     );
+  });
 
-    afterEach(() => {
-      jest.resetModules();
-    });
-  } else {
-    beforeAll(() => {
-      originalRequireCacheDescriptor = Object.getOwnPropertyDescriptor(
-        Module,
-        "_cache",
-      );
-    });
-
-    afterAll(() => {
-      Object.defineProperty(Module, "_cache", originalRequireCacheDescriptor);
-    });
-  }
+  afterAll(() => {
+    Object.defineProperty(Module, "_cache", originalRequireCacheDescriptor);
+  });
 
   describe("worker", () => {
-    if (!OLD_JEST_MOCKS) {
-      beforeEach(() => {
-        Object.defineProperty(Module, "_cache", {
-          ...originalRequireCacheDescriptor,
-          value: {
-            [piratesPath]: { exports: mocks.pirates },
-            [smsPath]: { exports: mocks["source-map-support"] },
-            [sms2Path]: {
-              exports: mocks["source-map-support"],
-            },
-          },
-        });
+    beforeEach(() => {
+      Object.defineProperty(Module, "_cache", {
+        ...originalRequireCacheDescriptor,
+        value: {
+          [piratesPath]: { exports: mocks.pirates },
+          [smsPath]: { exports: mocks["source-map-support"] },
+        },
       });
-    }
+    });
 
     const { setupRegister } = buildTests(require.resolve("../lib/index.cjs"));
 
@@ -140,7 +119,6 @@ describe("@babel/register", function () {
     function revertRegister() {
       if (babelRegister) {
         babelRegister.revert();
-        delete require.cache[registerFile];
         babelRegister = null;
       }
       cleanCache();

--- a/packages/babel-register/test/index.js
+++ b/packages/babel-register/test/index.js
@@ -56,13 +56,15 @@ describe("@babel/register", function () {
       install() {
         sourceMapSupport = true;
       },
+      uninstall() {
+        sourceMapSupport = false;
+      },
     },
   };
 
   beforeEach(() => {
     currentHook = null;
     currentOptions = null;
-    sourceMapSupport = false;
   });
 
   let originalRequireCacheDescriptor;
@@ -179,6 +181,14 @@ describe("@babel/register", function () {
       currentHook("const a = 1;", testFile);
 
       expect(sourceMapSupport).toBe(true);
+    });
+
+    test("uninstalls source map when reverting", () => {
+      setupRegister();
+      currentHook("const a = 1;", testFile);
+      revertRegister();
+
+      expect(sourceMapSupport).toBe(false);
     });
 
     test("installs source map support when requested", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we uninstall the `source-map-support` in the hook `revert` function, as the `revert` step should make the best efforts to remove any state change introduced in the `register` step.

We also remove event listeners attached to the process in the entry `revert`. This issue is detected by Node.js when we add a new test for the previous issue:

> MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit