### PR TITLE
chore: add custom no-extraneous-dependencies rule

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,11 @@ catalog:
   core-js-compat: ^3.48.0
   semver: ^7.7.3
 
+catalogs:
+  dev:
+    terser: "^5.43.1"
+    typescript: "6.0.2"
+
 compressionLevel: mixed
 
 conditions:

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -254,8 +254,8 @@ export default defineConfig([
     files: sourceFiles("js,ts,cjs,mjs"),
     ignores: [
       // These are bundled
-      "packages/babel-parser/src/**/*.{js,ts}",
-      "packages/babel-standalone/src/**/*.{js,ts}",
+      "packages/babel-parser/**/*.{js,ts}",
+      "packages/babel-standalone/**/*.{js,ts}",
     ],
     rules: {
       "@babel/development-internal/no-extraneous-dependencies": [

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -111,7 +111,10 @@ export default defineConfig([
     },
     rules: {
       "n/no-process-exit": "error",
-      "import/no-extraneous-dependencies": "error",
+      "@babel/development-internal/no-extraneous-dependencies": [
+        "error",
+        { allowlist: ["charcodes"] },
+      ],
       "import/export": "error",
       "regexp/match-any": ["error", { allows: ["[^]", "dotAll"] }],
       "unicorn/prefer-set-has": "error",
@@ -251,20 +254,36 @@ export default defineConfig([
     files: sourceFiles("js,ts,cjs,mjs"),
     ignores: [
       // These are bundled
-      "packages/babel-parser/**/*.{js,ts}",
-      "packages/babel-standalone/**/*.{js,ts}",
+      "packages/babel-parser/src/**/*.{js,ts}",
+      "packages/babel-standalone/src/**/*.{js,ts}",
     ],
     rules: {
-      "import/no-extraneous-dependencies": [
+      "@babel/development-internal/no-extraneous-dependencies": [
         "error",
-        { includeTypes: true, devDependencies: false },
+        {
+          allowlist: ["charcodes"],
+          includeTypes: true,
+          devDependencies: false,
+        },
       ],
     },
   },
   {
     files: ["packages/*/test/*.tst.ts"],
     rules: {
-      "import/no-extraneous-dependencies": "off",
+      "@babel/development-internal/no-extraneous-dependencies": [
+        "error",
+        { allowlist: ["$repo-utils", "tstyche"] },
+      ],
+    },
+  },
+  {
+    files: ["packages/*/scripts/**/*.{js,ts}", "scripts/**/*.{js,cjs,mjs}"],
+    rules: {
+      "@babel/development-internal/no-extraneous-dependencies": [
+        "error",
+        { allowlist: ["$repo-utils"] },
+      ],
     },
   },
   {
@@ -297,7 +316,6 @@ export default defineConfig([
       "jest/no-test-callback": "off",
       "jest/valid-describe": "off",
       "import/extensions": ["error", "always"],
-      "import/no-extraneous-dependencies": "off",
       "no-restricted-imports": ["error", { patterns: ["**/src/**"] }],
     },
   },
@@ -308,15 +326,28 @@ export default defineConfig([
         "error",
         { version: "20.19.0", ignores: ["module"] },
       ],
+      "@babel/development-internal/no-extraneous-dependencies": [
+        "error",
+        {
+          allowlist: ["$repo-utils"],
+        },
+      ],
       "import/no-unresolved": "error",
     },
   },
   {
+    files: ["packages/babel-standalone/test/**/*.{js,ts}"],
+    rules: {
+      "@babel/development-internal/no-extraneous-dependencies": [
+        "error",
+        {
+          packageDir: "./packages/babel-standalone",
+        },
+      ],
+    },
+  },
+  {
     files: [...sourceFiles("js,ts,mjs"), ...testFiles, "test/**/*.js"],
-    ignores: [
-      // @babel/register is the require() hook, so it will always be CJS-based
-      "packages/babel-register/**/*.{js,ts}",
-    ],
     rules: {
       "no-restricted-globals": ["error", ...cjsGlobals],
       "no-restricted-imports": [
@@ -352,71 +383,10 @@ export default defineConfig([
       "comma-dangle": "off",
       "no-func-assign": "off",
       "prefer-spread": "off",
-      "import/no-extraneous-dependencies": "off",
       "import/no-unresolved": "off",
       "@typescript-eslint/prefer-includes": "off",
       "@typescript-eslint/prefer-optional-chain": "off",
       "unicorn/prefer-includes": "off",
-    },
-  },
-  {
-    files: ["packages/babel-helpers/scripts/**.{js,ts}"],
-    rules: {
-      "import/no-extraneous-dependencies": [
-        "error",
-        { packageDir: ["./packages/babel-helpers", "./"] },
-      ],
-    },
-  },
-  {
-    files: ["packages/babel-traverse/scripts/**/*.js"],
-    rules: {
-      "import/no-extraneous-dependencies": [
-        "error",
-        { packageDir: "./packages/babel-traverse" },
-      ],
-    },
-  },
-  {
-    files: ["packages/babel-types/scripts/**/*.ts"],
-    rules: {
-      "import/no-extraneous-dependencies": [
-        "error",
-        { packageDir: ["./packages/babel-types", "./"] },
-      ],
-    },
-  },
-  {
-    files: ["packages/babel-plugin-transform-runtime/scripts/**/*.js"],
-    rules: {
-      "import/no-extraneous-dependencies": [
-        "error",
-        { packageDir: "./packages/babel-plugin-transform-runtime" },
-      ],
-    },
-  },
-  {
-    files: ["packages/babel-preset-env/data/**/*.js"],
-    rules: {
-      "import/no-extraneous-dependencies": [
-        "error",
-        { packageDir: "./packages/babel-preset-env" },
-      ],
-    },
-  },
-  {
-    files: ["packages/babel-types/scripts/**/*.js"],
-    rules: {
-      "import/no-extraneous-dependencies": [
-        "error",
-        { packageDir: ["./packages/babel-types", "./"] },
-      ],
-    },
-  },
-  {
-    files: ["scripts/**/*.{js,cjs,mjs}"],
-    rules: {
-      "import/no-extraneous-dependencies": ["error", { packageDir: "./" }],
     },
   },
   {

--- a/eslint/babel-eslint-parser/src/worker/configuration.ts
+++ b/eslint/babel-eslint-parser/src/worker/configuration.ts
@@ -1,9 +1,10 @@
 import { loadPartialConfigAsync } from "@babel/core";
 import type { InputOptions, NormalizedOptions } from "@babel/core";
 import type { Options } from "../types";
-import type { PartialConfig } from "../../../../packages/babel-core/src/config";
-// eslint-disable-next-line import/no-extraneous-dependencies
-import type { ParserPlugin } from "@babel/parser";
+import type { PartialConfig } from "@babel/core";
+type ParserPlugin = NonNullable<
+  NonNullable<InputOptions["parserOpts"]>["plugins"]
+>[number];
 
 /**
  * Merge user supplied estree plugin options to default estree plugin options

--- a/eslint/babel-eslint-plugin-development-internal/package.json
+++ b/eslint/babel-eslint-plugin-development-internal/package.json
@@ -16,10 +16,12 @@
   },
   "homepage": "https://github.com/babel/babel/tree/master/eslint/babel-eslint-plugin-development-internal",
   "peerDependencies": {
-    "eslint": "^9.0.0 || ^10.0.0"
+    "eslint": "^9.0.0 || ^10.0.0",
+    "eslint-plugin-import": "^2.31.0"
   },
   "devDependencies": {
-    "eslint": "^10.0.0"
+    "eslint": "^10.0.0",
+    "eslint-plugin-import": "^2.31.0"
   },
   "type": "module",
   "exports": {

--- a/eslint/babel-eslint-plugin-development-internal/src/index.ts
+++ b/eslint/babel-eslint-plugin-development-internal/src/index.ts
@@ -1,4 +1,5 @@
 import type { ESLint } from "eslint";
+import noExtraneousDependencies from "./rules/no-extraneous-dependencies.ts";
 import reportErrorMessageFormat from "./rules/report-error-message-format.ts";
 
 const meta = {
@@ -7,6 +8,7 @@ const meta = {
 };
 
 const rules = {
+  "no-extraneous-dependencies": noExtraneousDependencies,
   "report-error-message-format": reportErrorMessageFormat,
 };
 

--- a/eslint/babel-eslint-plugin-development-internal/src/rules/no-extraneous-dependencies.ts
+++ b/eslint/babel-eslint-plugin-development-internal/src/rules/no-extraneous-dependencies.ts
@@ -1,0 +1,54 @@
+import type { Rule } from "eslint";
+import eslintPluginImport from "eslint-plugin-import";
+
+const rule = eslintPluginImport.rules["no-extraneous-dependencies"];
+
+const meta = rule.meta;
+
+// @ts-expect-error overwrite eslint-plugin-import schema to add allowlist option
+meta.schema[0].properties = {
+  // @ts-expect-error overwrite eslint-plugin-import schema to add allowlist option
+  ...meta.schema[0].properties,
+  allowlist: {
+    type: "array",
+    items: {
+      type: "string",
+    },
+    description:
+      "An array of package names to allow as extraneous dependencies. This is useful for packages that are privately defined on the root repo.",
+  },
+};
+
+function extractPackageNameFromErrorMessage(message: string): string | null {
+  const match = /^'(.+?)'/.exec(message);
+  return match ? match[1] : null;
+}
+
+export default {
+  meta: meta,
+  create(context) {
+    const options = context.options[0] || {};
+    const allowlist = new Set(options.allowlist || []);
+    const originalReport = context.report;
+    return rule.create(
+      Object.freeze(
+        Object.create(context, {
+          report: {
+            enumerable: true,
+            value(...args: Parameters<Rule.RuleContext["report"]>) {
+              // @ts-expect-error - eslint-plugin-import uses deprecated context#report signatures
+              const message = args[1];
+              if (typeof message === "string") {
+                const packageName = extractPackageNameFromErrorMessage(message);
+                if (packageName && allowlist.has(packageName)) {
+                  return;
+                }
+              }
+              originalReport(...args);
+            },
+          },
+        }),
+      ),
+    );
+  },
+} as Rule.RuleModule;

--- a/eslint/babel-eslint-shared-fixtures/package.json
+++ b/eslint/babel-eslint-shared-fixtures/package.json
@@ -10,6 +10,7 @@
     "@babel/plugin-syntax-decorators": "workspace:^",
     "@babel/plugin-syntax-do-expressions": "workspace:^",
     "@babel/plugin-syntax-export-default-from": "workspace:^",
+    "@babel/plugin-syntax-flow": "workspace:^",
     "@babel/plugin-syntax-jsx": "workspace:^",
     "@babel/plugin-syntax-pipeline-operator": "workspace:^",
     "eslint": "^10.0.0"

--- a/eslint/babel-eslint-tests/package.json
+++ b/eslint/babel-eslint-tests/package.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "@babel/core": "workspace:^",
     "@babel/eslint-parser": "workspace:^",
+    "@babel/eslint-plugin": "workspace:^",
+    "@babel/parser": "workspace:^",
     "@babel/plugin-proposal-decorators": "workspace:^",
     "@babel/plugin-proposal-do-expressions": "workspace:^",
     "@babel/preset-flow": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -85,10 +85,10 @@
     "rollup-plugin-polyfill-node": "^0.13.0",
     "semver": "catalog:",
     "shelljs": "^0.8.5",
-    "terser": "^5.43.1",
+    "terser": "catalog:dev",
     "test262-stream": "^1.4.0",
     "tstyche": "^6.2.0",
-    "typescript": "6.0.2",
+    "typescript": "catalog:dev",
     "typescript-eslint": "8.56.0"
   },
   "workspaces": [

--- a/packages/babel-code-frame/src/highlight.ts
+++ b/packages/babel-code-frame/src/highlight.ts
@@ -1,7 +1,5 @@
 import type { Token as JSToken, JSXToken } from "js-tokens";
 import jsTokens from "js-tokens";
-// We inline this package
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 
 import {

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@babel/helper-transform-fixture-test-runner": "workspace:^",
     "@babel/plugin-syntax-flow": "workspace:^",
+    "@babel/plugin-syntax-jsx": "workspace:^",
     "@babel/plugin-transform-flow-strip-types": "workspace:^",
     "@babel/plugin-transform-modules-commonjs": "workspace:^",
     "@babel/preset-env": "workspace:^",

--- a/packages/babel-generator/src/buffer.ts
+++ b/packages/babel-generator/src/buffer.ts
@@ -1,8 +1,6 @@
 import type SourceMap from "./source-map.ts";
 import type { SourceLocation } from "@babel/types";
 
-// We inline this package
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charcodes from "charcodes";
 
 export type Loc = SourceLocation;

--- a/packages/babel-generator/src/generators/classes.ts
+++ b/packages/babel-generator/src/generators/classes.ts
@@ -5,8 +5,6 @@ import {
 } from "@babel/types";
 import type * as t from "@babel/types";
 
-// We inline this package
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 import { _shouldPrintDecoratorsBeforeExport } from "./expressions.ts";
 import { _tsPrintClassMemberModifiers } from "./typescript.ts";

--- a/packages/babel-generator/src/generators/expressions.ts
+++ b/packages/babel-generator/src/generators/expressions.ts
@@ -6,8 +6,6 @@ import {
   isNewExpression,
   isPattern,
 } from "@babel/types";
-// We inline this package
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 import type * as t from "@babel/types";
 import { TokenContext } from "../node/index.ts";

--- a/packages/babel-generator/src/generators/methods.ts
+++ b/packages/babel-generator/src/generators/methods.ts
@@ -1,7 +1,6 @@
 import type Printer from "../printer.ts";
 import type * as t from "@babel/types";
 import { isIdentifier, type ParentMaps } from "@babel/types";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 import { TokenContext } from "../node/index.ts";
 

--- a/packages/babel-generator/src/generators/statements.ts
+++ b/packages/babel-generator/src/generators/statements.ts
@@ -2,8 +2,6 @@ import type Printer from "../printer.ts";
 import { isFor, isIfStatement, isStatement, isVoidPattern } from "@babel/types";
 import type * as t from "@babel/types";
 
-// We inline this package
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 import { TokenContext } from "../node/index.ts";
 

--- a/packages/babel-generator/src/generators/types.ts
+++ b/packages/babel-generator/src/generators/types.ts
@@ -2,8 +2,6 @@ import type Printer from "../printer.ts";
 import { isAssignmentPattern, isIdentifier } from "@babel/types";
 import type * as t from "@babel/types";
 import jsesc from "jsesc";
-// We inline this package
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 import { _methodHead } from "./methods.ts";
 

--- a/packages/babel-generator/src/generators/typescript.ts
+++ b/packages/babel-generator/src/generators/typescript.ts
@@ -1,6 +1,5 @@
 import type Printer from "../printer.ts";
 import type * as t from "@babel/types";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 import { _functionHead, _param, _parameters } from "./methods.ts";
 import { _classMethodHead } from "./classes.ts";

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -22,8 +22,6 @@ import type SourceMap from "./source-map.ts";
 import type { TraceMap } from "@jridgewell/trace-mapping";
 import type { Token } from "@babel/parser";
 
-// We inline this package
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 
 const SCIENTIFIC_NOTATION = /e/i;

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -18,8 +18,6 @@ export function hasDecorators(node: t.Class) {
   return hasOwnDecorators(node) || node.body.body.some(hasOwnDecorators);
 }
 
-// We inline this package
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 interface Options {
   /** @deprecated use `constantSuper` assumption instead. Only supported in 2021-12 version. */

--- a/packages/babel-helper-string-parser/src/index.ts
+++ b/packages/babel-helper-string-parser/src/index.ts
@@ -1,5 +1,3 @@
-// We inline this package
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 
 // The following character codes are forbidden from being

--- a/packages/babel-helper-validator-identifier/src/identifier.ts
+++ b/packages/babel-helper-validator-identifier/src/identifier.ts
@@ -1,5 +1,3 @@
-// We inline this package
-
 /*
 Reason to disable eslint rules:
   - no-misleading-character-class: This rule is disabled because it will check if a combining mark (\p{M}) is following a base character. It is possible that an identifier char is not following a base character.
@@ -9,7 +7,6 @@ Reason to disable eslint rules:
 */
 
 /* eslint no-misleading-character-class: off, regexp/no-obscure-range: off, regexp/no-misleading-unicode-character: off, regexp/use-ignore-case: off */
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as charCodes from "charcodes";
 
 // ## Character categories

--- a/packages/babel-helpers/package.json
+++ b/packages/babel-helpers/package.json
@@ -21,8 +21,10 @@
   "devDependencies": {
     "@babel/generator": "workspace:^",
     "@babel/helper-plugin-test-runner": "workspace:^",
+    "@babel/helper-transform-fixture-test-runner": "workspace:^",
     "@babel/parser": "workspace:^",
-    "regenerator-runtime": "^0.14.0"
+    "regenerator-runtime": "^0.14.0",
+    "terser": "catalog:dev"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/packages/babel-parser/package.json
+++ b/packages/babel-parser/package.json
@@ -42,7 +42,8 @@
     "@babel/helper-fixtures": "workspace:^",
     "@babel/helper-string-parser": "workspace:^",
     "@babel/helper-validator-identifier": "workspace:^",
-    "charcodes": "^0.2.0"
+    "charcodes": "^0.2.0",
+    "typescript": "catalog:dev"
   },
   "bin": "./bin/babel-parser.js",
   "type": "module",

--- a/packages/babel-parser/scripts/build-error-info.ts
+++ b/packages/babel-parser/scripts/build-error-info.ts
@@ -1,5 +1,4 @@
 import { readFileSync, writeFileSync } from "node:fs";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import ts from "typescript";
 
 function extractErrorInfo(filename: string) {

--- a/packages/babel-plugin-transform-regexp-modifiers/package.json
+++ b/packages/babel-plugin-transform-regexp-modifiers/package.json
@@ -28,7 +28,8 @@
     "@babel/core": "workspace:^"
   },
   "devDependencies": {
-    "@babel/core": "workspace:^"
+    "@babel/core": "workspace:^",
+    "@babel/helper-plugin-test-runner": "workspace:^"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/scripts/repo-utils/package.json
+++ b/scripts/repo-utils/package.json
@@ -1,8 +1,15 @@
 {
   "type": "module",
   "main": "index.cjs",
+  "name": "$repo-utils",
+  "private": true,
   "exports": {
     ".": "./index.cjs",
     "./babel-top-level": "./babel.js"
+  },
+  "dependencies": {
+    "semver": "catalog:",
+    "@babel/core": "workspace:^",
+    "@babel/preset-typescript": "workspace:^"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -467,6 +467,7 @@ __metadata:
     "@babel/helpers": "workspace:^"
     "@babel/parser": "workspace:^"
     "@babel/plugin-syntax-flow": "workspace:^"
+    "@babel/plugin-syntax-jsx": "workspace:^"
     "@babel/plugin-transform-flow-strip-types": "workspace:^"
     "@babel/plugin-transform-modules-commonjs": "workspace:^"
     "@babel/preset-env": "workspace:^"
@@ -519,8 +520,10 @@ __metadata:
   resolution: "@babel/eslint-plugin-development-internal@workspace:eslint/babel-eslint-plugin-development-internal"
   dependencies:
     eslint: "npm:^10.0.0"
+    eslint-plugin-import: "npm:^2.31.0"
   peerDependencies:
     eslint: ^9.0.0 || ^10.0.0
+    eslint-plugin-import: ^2.31.0
   languageName: unknown
   linkType: soft
 
@@ -534,7 +537,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@babel/eslint-plugin@workspace:eslint/babel-eslint-plugin":
+"@babel/eslint-plugin@workspace:^, @babel/eslint-plugin@workspace:eslint/babel-eslint-plugin":
   version: 0.0.0-use.local
   resolution: "@babel/eslint-plugin@workspace:eslint/babel-eslint-plugin"
   dependencies:
@@ -557,6 +560,7 @@ __metadata:
     "@babel/plugin-syntax-decorators": "workspace:^"
     "@babel/plugin-syntax-do-expressions": "workspace:^"
     "@babel/plugin-syntax-export-default-from": "workspace:^"
+    "@babel/plugin-syntax-flow": "workspace:^"
     "@babel/plugin-syntax-jsx": "workspace:^"
     "@babel/plugin-syntax-pipeline-operator": "workspace:^"
     eslint: "npm:^10.0.0"
@@ -569,6 +573,8 @@ __metadata:
   dependencies:
     "@babel/core": "workspace:^"
     "@babel/eslint-parser": "workspace:^"
+    "@babel/eslint-plugin": "workspace:^"
+    "@babel/parser": "workspace:^"
     "@babel/plugin-proposal-decorators": "workspace:^"
     "@babel/plugin-proposal-do-expressions": "workspace:^"
     "@babel/preset-flow": "workspace:^"
@@ -1233,10 +1239,12 @@ __metadata:
   dependencies:
     "@babel/generator": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
+    "@babel/helper-transform-fixture-test-runner": "workspace:^"
     "@babel/parser": "workspace:^"
     "@babel/template": "workspace:^"
     "@babel/types": "workspace:^"
     regenerator-runtime: "npm:^0.14.0"
+    terser: "catalog:dev"
   languageName: unknown
   linkType: soft
 
@@ -1306,6 +1314,7 @@ __metadata:
     "@babel/helper-validator-identifier": "workspace:^"
     "@babel/types": "workspace:^"
     charcodes: "npm:^0.2.0"
+    typescript: "catalog:dev"
   bin:
     parser: ./bin/babel-parser.js
   languageName: unknown
@@ -3357,6 +3366,7 @@ __metadata:
   dependencies:
     "@babel/core": "workspace:^"
     "@babel/helper-create-regexp-features-plugin": "workspace:^"
+    "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-plugin-utils": "workspace:^"
   peerDependencies:
     "@babel/core": "workspace:^"
@@ -7308,10 +7318,10 @@ __metadata:
     rollup-plugin-polyfill-node: "npm:^0.13.0"
     semver: "catalog:"
     shelljs: "npm:^0.8.5"
-    terser: "npm:^5.43.1"
+    terser: "catalog:dev"
     test262-stream: "npm:^1.4.0"
     tstyche: "npm:^6.2.0"
-    typescript: "npm:6.0.2"
+    typescript: "catalog:dev"
     typescript-eslint: "npm:8.56.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->


In this PR we introduce a custom eslint rule `@babel/development-internal/no-extraneous-dependencies`, which filters the report from `import/no-extraneous-dependencies` and mutes those library accpeted by the `allowlist` option.

The custom rule is to address contributors' frustrate that the origin rule is missing such options: there was even `import/no-extraneous-dependencies: "off"` in our current ESLint config, which unfortunately also hides those unsound imports.

Here is a motivation list of the `allowlist` option.

1. We use a private library `$repo-utils` across the code base. It is a private package for test scripts and we don't even want it to show up in the devDependencies of the published `package.json`
2. We use a library `charcodes` and always inline them via rollup, therefore `charcodes` is in the `devDependencies`. But it is clumsy to specify every source file with `charcodes` import and turn on the `devDependencies` rule option.
3. Certain imports such as `tstyche` are meant to be used universally in the whole monorepo. However, it is clumsy to add it to each libraries' devDependencies (This might be addressed by the yarn catalog in the future)

/cc @ljharb I can prepare a PR to `eslint-plugin-import` if the `allowlist` option aligns to the project's vision.