### PR TITLE
fix(systemjs): improve module string name support

### DIFF
--- a/packages/babel-plugin-transform-modules-systemjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.ts
@@ -140,7 +140,10 @@ function constructExportCall(
             "=",
             t.memberExpression(
               t.identifier(exportObj),
-              t.identifier(exportName),
+              stringSpecifiers.has(exportName)
+                ? t.stringLiteral(exportName)
+                : t.identifier(exportName),
+              stringSpecifiers.has(exportName),
             ),
             exportValue,
           ),

--- a/packages/babel-plugin-transform-modules-systemjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.ts
@@ -97,15 +97,11 @@ function constructExportCall(
       const objectProperties = [];
       for (let i = 0; i < exportNames.length; i++) {
         const exportName = exportNames[i];
+        const exportNameNode = stringSpecifiers.has(exportName)
+          ? t.stringLiteral(exportName)
+          : t.identifier(exportName);
         const exportValue = exportValues[i];
-        objectProperties.push(
-          t.objectProperty(
-            stringSpecifiers.has(exportName)
-              ? t.stringLiteral(exportName)
-              : t.identifier(exportName),
-            exportValue,
-          ),
-        );
+        objectProperties.push(t.objectProperty(exportNameNode, exportValue));
       }
       statements.push(
         t.expressionStatement(
@@ -132,6 +128,10 @@ function constructExportCall(
 
     for (let i = 0; i < exportNames.length; i++) {
       const exportName = exportNames[i];
+      const computed = stringSpecifiers.has(exportName);
+      const exportNameNode = computed
+        ? t.stringLiteral(exportName)
+        : t.identifier(exportName);
       const exportValue = exportValues[i];
 
       statements.push(
@@ -140,10 +140,8 @@ function constructExportCall(
             "=",
             t.memberExpression(
               t.identifier(exportObj),
-              stringSpecifiers.has(exportName)
-                ? t.stringLiteral(exportName)
-                : t.identifier(exportName),
-              stringSpecifiers.has(exportName),
+              exportNameNode,
+              computed,
             ),
             exportValue,
           ),

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-from-with-export-star/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-from-with-export-star/input.mjs
@@ -1,0 +1,3 @@
+var foo, bar;
+export {foo as "default exports", bar} from "./other.mjs";
+export * from "./other.mjs";

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-from-with-export-star/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-from-with-export-star/output.mjs
@@ -1,0 +1,17 @@
+System.register(["./other.mjs"], function (_export, _context) {
+  "use strict";
+
+  var foo, bar;
+  return {
+    setters: [function (_otherMjs) {
+      var _exportObj = {};
+      for (var _key in _otherMjs) {
+        if (_key !== "default" && _key !== "__esModule") _exportObj[_key] = _otherMjs[_key];
+      }
+      _exportObj["default exports"] = _otherMjs.foo;
+      _exportObj.bar = _otherMjs.bar;
+      _export(_exportObj);
+    }],
+    execute: function () {}
+  };
+});

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier-with-export-star/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier-with-export-star/input.mjs
@@ -1,0 +1,3 @@
+var foo, bar;
+export {foo as "defaultExports", bar} from "./other.mjs";
+export * from "./other.mjs";

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier-with-export-star/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier-with-export-star/output.mjs
@@ -1,0 +1,17 @@
+System.register(["./other.mjs"], function (_export, _context) {
+  "use strict";
+
+  var foo, bar;
+  return {
+    setters: [function (_otherMjs) {
+      var _exportObj = {};
+      for (var _key in _otherMjs) {
+        if (_key !== "default" && _key !== "__esModule") _exportObj[_key] = _otherMjs[_key];
+      }
+      _exportObj.defaultExports = _otherMjs.foo;
+      _exportObj.bar = _otherMjs.bar;
+      _export(_exportObj);
+    }],
+    execute: function () {}
+  };
+});

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/import-named-with-import-star/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/import-named-with-import-star/input.mjs
@@ -1,0 +1,4 @@
+import {"default imports" as bar} from "foo";
+import * as foo from "foo";
+
+bar;

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/import-named-with-import-star/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/import-named-with-import-star/output.mjs
@@ -1,0 +1,14 @@
+System.register(["foo"], function (_export, _context) {
+  "use strict";
+
+  var bar, foo;
+  return {
+    setters: [function (_foo) {
+      bar = _foo["default imports"];
+      foo = _foo;
+    }],
+    execute: function () {
+      bar;
+    }
+  };
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | transform-systemjs outputs invalid AST when module string specifier is used with `export *`
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes incomplete implementation in https://github.com/babel/babel/pull/12091, where we missed the string module name support in the `exportStarTarget` branch of the `constructExportCall` call.