### PR TITLE
fix: improve inputSourceMap URL handling

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -48,6 +48,7 @@
     "@babel/types": "workspace:^",
     "@types/gensync": "^1.0.0",
     "convert-source-map": "^2.0.0",
+    "find-up-simple": "^1.0.1",
     "gensync": "^1.0.0-beta.2",
     "import-meta-resolve": "^4.2.0",
     "json5": "^2.2.3",

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -114,6 +114,15 @@
       "browser": "./lib/transform-file-browser.js",
       "default": "./lib/transform-file.js"
     },
+    "#transformation/read-input-source-map-file": {
+      "babel-src": {
+        "browser": "./src/transformation/read-input-source-map-file-browser.ts",
+        "default": "./src/transformation/read-input-source-map-file.ts"
+      },
+      "types": "./lib/index.d.ts",
+      "browser": "./lib/transformation/read-input-source-map-file-browser.js",
+      "default": "./lib/transformation/read-input-source-map-file.js"
+    },
     "#hack-for-rollup-inlining-order-1": "./lib/errors/rewrite-stack-trace.js",
     "#hack-for-rollup-inlining-order-2": "./lib/config/caching.js"
   },

--- a/packages/babel-core/src/transformation/normalize-file.ts
+++ b/packages/babel-core/src/transformation/normalize-file.ts
@@ -7,6 +7,7 @@ import type * as t from "@babel/types";
 import type { PluginPasses } from "../config/index.ts";
 import convertSourceMap from "convert-source-map";
 import type { SourceMapConverter as Converter } from "convert-source-map";
+import { findUpSync } from "find-up-simple";
 import File from "./file/file.ts";
 import parser from "../parser/index.ts";
 import cloneDeep from "./util/clone-deep.ts";
@@ -27,6 +28,31 @@ export type NormalizedFile = {
   ast: t.File;
   inputMap: Converter | null;
 };
+
+function getInputMapPath(
+  filename: string,
+  root: string,
+  inputMapURL: string,
+): string | null {
+  const inputMapPath = path.resolve(path.dirname(filename), inputMapURL);
+  if (inputMapURL.includes("..")) {
+    const inputPackageJSONPath = findUpSync("package.json", {
+      cwd: path.dirname(filename),
+      stopAt: root,
+    });
+    const inputFileRoot = inputPackageJSONPath
+      ? path.dirname(inputPackageJSONPath)
+      : root;
+    const relativeInputMapPath = path.relative(inputFileRoot, inputMapPath);
+    if (relativeInputMapPath.startsWith("..")) {
+      debug(
+        `discarding input sourcemap "${inputMapPath}" outside of package root "${inputFileRoot}"`,
+      );
+      return null;
+    }
+  }
+  return inputMapPath;
+}
 
 export default function* normalizeFile(
   pluginPasses: PluginPasses,
@@ -78,14 +104,17 @@ export default function* normalizeFile(
       if (typeof options.filename === "string" && lastComment) {
         try {
           // when `lastComment` is non-null, EXTERNAL_SOURCEMAP_REGEX must have matches
-          const match: [string, string] = EXTERNAL_SOURCEMAP_REGEX.exec(
-            lastComment,
-          ) as any;
-          const inputMapContent = fs.readFileSync(
-            path.resolve(path.dirname(options.filename), match[1]),
-            "utf8",
+          const inputMapURL: string =
+            EXTERNAL_SOURCEMAP_REGEX.exec(lastComment)![1];
+          const inputMapPath = getInputMapPath(
+            options.filename,
+            options.root,
+            inputMapURL,
           );
-          inputMap = convertSourceMap.fromJSON(inputMapContent);
+          if (inputMapPath) {
+            const inputMapContent = fs.readFileSync(inputMapPath, "utf8");
+            inputMap = convertSourceMap.fromJSON(inputMapContent);
+          }
         } catch (err) {
           debug("discarding unknown file input sourcemap", err);
         }

--- a/packages/babel-core/src/transformation/normalize-file.ts
+++ b/packages/babel-core/src/transformation/normalize-file.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-import path from "node:path";
 import { createDebug } from "obug";
 import type { Handler } from "gensync";
 import { file, traverseFast } from "@babel/types";
@@ -7,7 +5,8 @@ import type * as t from "@babel/types";
 import type { PluginPasses } from "../config/index.ts";
 import convertSourceMap from "convert-source-map";
 import type { SourceMapConverter as Converter } from "convert-source-map";
-import { findUpSync } from "find-up-simple";
+// eslint-disable-next-line import/no-unresolved, import/extensions
+import readInputSourceMapFile from "#transformation/read-input-source-map-file";
 import File from "./file/file.ts";
 import parser from "../parser/index.ts";
 import cloneDeep from "./util/clone-deep.ts";
@@ -28,31 +27,6 @@ export type NormalizedFile = {
   ast: t.File;
   inputMap: Converter | null;
 };
-
-function getInputMapPath(
-  filename: string,
-  root: string,
-  inputMapURL: string,
-): string | null {
-  const inputMapPath = path.resolve(path.dirname(filename), inputMapURL);
-  if (inputMapURL.includes("..")) {
-    const inputPackageJSONPath = findUpSync("package.json", {
-      cwd: path.dirname(filename),
-      stopAt: root,
-    });
-    const inputFileRoot = inputPackageJSONPath
-      ? path.dirname(inputPackageJSONPath)
-      : root;
-    const relativeInputMapPath = path.relative(inputFileRoot, inputMapPath);
-    if (relativeInputMapPath.startsWith("..")) {
-      debug(
-        `discarding input sourcemap "${inputMapPath}" outside of package root "${inputFileRoot}"`,
-      );
-      return null;
-    }
-  }
-  return inputMapPath;
-}
 
 export default function* normalizeFile(
   pluginPasses: PluginPasses,
@@ -106,15 +80,11 @@ export default function* normalizeFile(
           // when `lastComment` is non-null, EXTERNAL_SOURCEMAP_REGEX must have matches
           const inputMapURL: string =
             EXTERNAL_SOURCEMAP_REGEX.exec(lastComment)![1];
-          const inputMapPath = getInputMapPath(
+          inputMap = readInputSourceMapFile(
             options.filename,
             options.root,
             inputMapURL,
           );
-          if (inputMapPath) {
-            const inputMapContent = fs.readFileSync(inputMapPath, "utf8");
-            inputMap = convertSourceMap.fromJSON(inputMapContent);
-          }
         } catch (err) {
           debug("discarding unknown file input sourcemap", err);
         }

--- a/packages/babel-core/src/transformation/read-input-source-map-file-browser.ts
+++ b/packages/babel-core/src/transformation/read-input-source-map-file-browser.ts
@@ -1,0 +1,5 @@
+export default function readInputSourceMapFile(): never {
+  throw new Error(
+    "Reading input source map files is not supported in browsers",
+  );
+}

--- a/packages/babel-core/src/transformation/read-input-source-map-file.ts
+++ b/packages/babel-core/src/transformation/read-input-source-map-file.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { findUpSync } from "find-up-simple";
 import { createDebug } from "obug";
 import convertSourceMap from "convert-source-map";
+import type { SourceMapConverter } from "convert-source-map";
 
 const debug = createDebug("babel:transform:file");
 
@@ -44,7 +45,7 @@ export default function readInputSourceMapFile(
   filename: string,
   root: string,
   inputMapURL: string,
-) {
+): SourceMapConverter | null {
   const inputMapPath = getInputMapPath(filename, root, inputMapURL);
   if (inputMapPath) {
     const inputMapContent = fs.readFileSync(inputMapPath, "utf8");

--- a/packages/babel-core/src/transformation/read-input-source-map-file.ts
+++ b/packages/babel-core/src/transformation/read-input-source-map-file.ts
@@ -11,17 +11,26 @@ function getInputMapPath(
   root: string,
   inputMapURL: string,
 ): string | null {
-  const inputMapPath = path.resolve(path.dirname(filename), inputMapURL);
-  if (inputMapURL.includes("..")) {
+  const inputFileDir = path.dirname(filename);
+  const inputMapPath = path.resolve(inputFileDir, inputMapURL);
+  const relativeToInputFileDir = path.relative(inputFileDir, inputMapPath);
+
+  if (
+    relativeToInputFileDir.startsWith("..") ||
+    path.isAbsolute(relativeToInputFileDir)
+  ) {
     const inputPackageJSONPath = findUpSync("package.json", {
-      cwd: path.dirname(filename),
+      cwd: inputFileDir,
       stopAt: root,
     });
     const inputFileRoot = inputPackageJSONPath
       ? path.dirname(inputPackageJSONPath)
       : root;
     const relativeInputMapPath = path.relative(inputFileRoot, inputMapPath);
-    if (relativeInputMapPath.startsWith("..")) {
+    if (
+      relativeInputMapPath.startsWith("..") ||
+      path.isAbsolute(relativeInputMapPath)
+    ) {
       debug(
         `discarding input sourcemap "${inputMapPath}" outside of package root "${inputFileRoot}"`,
       );

--- a/packages/babel-core/src/transformation/read-input-source-map-file.ts
+++ b/packages/babel-core/src/transformation/read-input-source-map-file.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+import { findUpSync } from "find-up-simple";
+import { createDebug } from "obug";
+import convertSourceMap from "convert-source-map";
+
+const debug = createDebug("babel:transform:file");
+
+function getInputMapPath(
+  filename: string,
+  root: string,
+  inputMapURL: string,
+): string | null {
+  const inputMapPath = path.resolve(path.dirname(filename), inputMapURL);
+  if (inputMapURL.includes("..")) {
+    const inputPackageJSONPath = findUpSync("package.json", {
+      cwd: path.dirname(filename),
+      stopAt: root,
+    });
+    const inputFileRoot = inputPackageJSONPath
+      ? path.dirname(inputPackageJSONPath)
+      : root;
+    const relativeInputMapPath = path.relative(inputFileRoot, inputMapPath);
+    if (relativeInputMapPath.startsWith("..")) {
+      debug(
+        `discarding input sourcemap "${inputMapPath}" outside of package root "${inputFileRoot}"`,
+      );
+      return null;
+    }
+  }
+  return inputMapPath;
+}
+
+export default function readInputSourceMapFile(
+  filename: string,
+  root: string,
+  inputMapURL: string,
+) {
+  const inputMapPath = getInputMapPath(filename, root, inputMapURL);
+  if (inputMapPath) {
+    const inputMapContent = fs.readFileSync(inputMapPath, "utf8");
+    return convertSourceMap.fromJSON(inputMapContent);
+  }
+  return null;
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-url-not-start-with-double-dot/babel.config.input.js.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-url-not-start-with-double-dot/babel.config.input.js.json
@@ -1,0 +1,7 @@
+{
+  "sourceMaps": true,
+  "inputSourceMap": true,
+  "generatorOpts": {
+    "compact": true
+  }
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-url-not-start-with-double-dot/input.js.map
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-url-not-start-with-double-dot/input.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"input.js","names":["Msg"],"sources":["input.ts"],"sourcesContent":["const enum Msg {\n  ThisMapShouldBeLoaded = \"This map should be loaded\"\n}\n"],"mappings":"IAAWA,GAAG,0BAAHA,GAAG;EAAHA,GAAG;EAAA,OAAHA,GAAG;AAAA,EAAHA,GAAG","ignoreList":[]}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-url-not-start-with-double-dot/node_modules/corp-lib/input.js
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-url-not-start-with-double-dot/node_modules/corp-lib/input.js
@@ -1,0 +1,6 @@
+var Msg = /*#__PURE__*/function (Msg) {
+  Msg["ThisMapShouldBeLoaded"] = "This map should be loaded";
+  return Msg;
+}(Msg || {});
+
+//# sourceMappingURL=sub/../../../input.js.map

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-url-not-start-with-double-dot/node_modules/corp-lib/package.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-url-not-start-with-double-dot/node_modules/corp-lib/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "name": "corp-lib"
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-url-not-start-with-double-dot/node_modules/corp-lib/sub/mod.js
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-url-not-start-with-double-dot/node_modules/corp-lib/sub/mod.js
@@ -1,0 +1,1 @@
+// Intentional empty file to keep the sub directory tracked in git.

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-within-root/babel.config.input.js.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-within-root/babel.config.input.js.json
@@ -1,0 +1,7 @@
+{
+  "sourceMaps": true,
+  "inputSourceMap": true,
+  "generatorOpts": {
+    "compact": true
+  }
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-within-root/root/sub/input.js.map
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-within-root/root/sub/input.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"input.js","names":["Msg"],"sources":["input.ts"],"sourcesContent":["const enum Msg {\n  ThisMapShouldBeLoaded = \"This map should be loaded\"\n}\n"],"mappings":"IAAWA,GAAG,0BAAHA,GAAG;EAAHA,GAAG;EAAA,OAAHA,GAAG;AAAA,EAAHA,GAAG","ignoreList":[]}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-within-root/root/sub/node_modules/corp-lib/input.js
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-within-root/root/sub/node_modules/corp-lib/input.js
@@ -1,0 +1,6 @@
+var Msg = /*#__PURE__*/function (Msg) {
+  Msg["ThisMapShouldBeLoaded"] = "This map should be loaded";
+  return Msg;
+}(Msg || {});
+
+//# sourceMappingURL=../../input.js.map

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-within-root/root/sub/node_modules/corp-lib/package.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules-within-root/root/sub/node_modules/corp-lib/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "name": "corp-lib"
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules/babel.config.input.js.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules/babel.config.input.js.json
@@ -1,0 +1,7 @@
+{
+  "sourceMaps": true,
+  "inputSourceMap": true,
+  "generatorOpts": {
+    "compact": true
+  }
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules/input.js.map
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules/input.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"input.js","names":["Msg"],"sources":["input.ts"],"sourcesContent":["const enum Msg {\n  ThisMapShouldBeLoaded = \"This map should be loaded\"\n}\n"],"mappings":"IAAWA,GAAG,0BAAHA,GAAG;EAAHA,GAAG;EAAA,OAAHA,GAAG;AAAA,EAAHA,GAAG","ignoreList":[]}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules/node_modules/corp-lib/input.js
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules/node_modules/corp-lib/input.js
@@ -1,0 +1,6 @@
+var Msg = /*#__PURE__*/function (Msg) {
+  Msg["ThisMapShouldBeLoaded"] = "This map should be loaded";
+  return Msg;
+}(Msg || {});
+
+//# sourceMappingURL=../../input.js.map

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules/node_modules/corp-lib/package.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-node-modules/node_modules/corp-lib/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "name": "corp-lib"
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root-within-node-modules/babel.config.input.js.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root-within-node-modules/babel.config.input.js.json
@@ -1,0 +1,5 @@
+{
+  "generatorOpts": {
+    "compact": true
+  }
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root-within-node-modules/node_modules/corp-app/input.js.map
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root-within-node-modules/node_modules/corp-app/input.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"input.js","names":["Msg"],"sources":["input.ts"],"sourcesContent":["const enum Msg {\n  ThisMapShouldBeLoaded = \"This map should be loaded\"\n}\n"],"mappings":"IAAWA,GAAG,0BAAHA,GAAG;EAAHA,GAAG;EAAA,OAAHA,GAAG;AAAA,EAAHA,GAAG","ignoreList":[]}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root-within-node-modules/node_modules/corp-app/package.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root-within-node-modules/node_modules/corp-app/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "name": "corp-app"
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root-within-node-modules/node_modules/corp-app/root/sub/input.js
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root-within-node-modules/node_modules/corp-app/root/sub/input.js
@@ -1,0 +1,6 @@
+var Msg = /*#__PURE__*/function (Msg) {
+  Msg["ThisMapShouldBeLoaded"] = "This map should be loaded";
+  return Msg;
+}(Msg || {});
+
+//# sourceMappingURL=../../input.js.map

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root/babel.config.input.js.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root/babel.config.input.js.json
@@ -1,0 +1,5 @@
+{
+  "generatorOpts": {
+    "compact": true
+  }
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root/input.js.map
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root/input.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"input.js","names":["Msg"],"sources":["input.ts"],"sourcesContent":["const enum Msg {\n  ThisMapShouldBeLoaded = \"This map should be loaded\"\n}\n"],"mappings":"IAAWA,GAAG,0BAAHA,GAAG;EAAHA,GAAG;EAAA,OAAHA,GAAG;AAAA,EAAHA,GAAG","ignoreList":[]}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root/root/sub/input.js
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/invalid-relative-up-across-root/root/sub/input.js
@@ -1,0 +1,6 @@
+var Msg = /*#__PURE__*/function (Msg) {
+  Msg["ThisMapShouldBeLoaded"] = "This map should be loaded";
+  return Msg;
+}(Msg || {});
+
+//# sourceMappingURL=../../input.js.map

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down-into-node-modules/babel.config.input.js.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down-into-node-modules/babel.config.input.js.json
@@ -1,0 +1,5 @@
+{
+  "generatorOpts": {
+    "compact": true
+  }
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down-into-node-modules/input.js
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down-into-node-modules/input.js
@@ -1,0 +1,6 @@
+var Msg = /*#__PURE__*/function (Msg) {
+  Msg["ThisMapShouldBeLoaded"] = "This map should be loaded";
+  return Msg;
+}(Msg || {});
+
+//# sourceMappingURL=node_modules/corp-source-maps/input.js.map

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down-into-node-modules/node_modules/corp-source-maps/input.js.map
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down-into-node-modules/node_modules/corp-source-maps/input.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"input.js","names":["Msg"],"sources":["input.ts"],"sourcesContent":["const enum Msg {\n  ThisMapShouldBeLoaded = \"This map should be loaded\"\n}\n"],"mappings":"IAAWA,GAAG,0BAAHA,GAAG;EAAHA,GAAG;EAAA,OAAHA,GAAG;AAAA,EAAHA,GAAG","ignoreList":[]}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down-into-node-modules/node_modules/corp-source-maps/package.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down-into-node-modules/node_modules/corp-source-maps/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "name": "corp-source-maps"
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down/babel.config.input.js.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down/babel.config.input.js.json
@@ -1,0 +1,5 @@
+{
+  "generatorOpts": {
+    "compact": true
+  }
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down/input.js
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down/input.js
@@ -1,0 +1,6 @@
+var Msg = /*#__PURE__*/function (Msg) {
+  Msg["ThisMapShouldBeLoaded"] = "This map should be loaded";
+  return Msg;
+}(Msg || {});
+
+//# sourceMappingURL=input.js.map

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down/input.js.map
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-down/input.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"input.js","names":["Msg"],"sources":["input.ts"],"sourcesContent":["const enum Msg {\n  ThisMapShouldBeLoaded = \"This map should be loaded\"\n}\n"],"mappings":"IAAWA,GAAG,0BAAHA,GAAG;EAAHA,GAAG;EAAA,OAAHA,GAAG;AAAA,EAAHA,GAAG","ignoreList":[]}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-node-modules/babel.config.input.js.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-node-modules/babel.config.input.js.json
@@ -1,0 +1,5 @@
+{
+  "generatorOpts": {
+    "compact": true
+  }
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-node-modules/node_modules/corp-lib/input.js.map
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-node-modules/node_modules/corp-lib/input.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"input.js","names":["Msg"],"sources":["input.ts"],"sourcesContent":["const enum Msg {\n  ThisMapShouldBeLoaded = \"This map should be loaded\"\n}\n"],"mappings":"IAAWA,GAAG,0BAAHA,GAAG;EAAHA,GAAG;EAAA,OAAHA,GAAG;AAAA,EAAHA,GAAG","ignoreList":[]}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-node-modules/node_modules/corp-lib/package.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-node-modules/node_modules/corp-lib/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "name": "corp-lib"
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-node-modules/node_modules/corp-lib/sub/input.js
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-node-modules/node_modules/corp-lib/sub/input.js
@@ -1,0 +1,6 @@
+var Msg = /*#__PURE__*/function (Msg) {
+  Msg["ThisMapShouldBeLoaded"] = "This map should be loaded";
+  return Msg;
+}(Msg || {});
+
+//# sourceMappingURL=../input.js.map

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-root/babel.config.input.js.json
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-root/babel.config.input.js.json
@@ -1,0 +1,5 @@
+{
+  "generatorOpts": {
+    "compact": true
+  }
+}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-root/root/input.js.map
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-root/root/input.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"input.js","names":["Msg"],"sources":["input.ts"],"sourcesContent":["const enum Msg {\n  ThisMapShouldBeLoaded = \"This map should be loaded\"\n}\n"],"mappings":"IAAWA,GAAG,0BAAHA,GAAG;EAAHA,GAAG;EAAA,OAAHA,GAAG;AAAA,EAAHA,GAAG","ignoreList":[]}

--- a/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-root/root/sub/input.js
+++ b/packages/babel-core/test/fixtures/input-source-map-resolution/relative-up-within-root/root/sub/input.js
@@ -1,0 +1,6 @@
+var Msg = /*#__PURE__*/function (Msg) {
+  Msg["ThisMapShouldBeLoaded"] = "This map should be loaded";
+  return Msg;
+}(Msg || {});
+
+//# sourceMappingURL=../input.js.map

--- a/packages/babel-core/test/input-source-map-resolution.js
+++ b/packages/babel-core/test/input-source-map-resolution.js
@@ -1,0 +1,383 @@
+import * as babel from "../lib/index.js";
+import convertSourceMap from "convert-source-map";
+import path from "node:path";
+import fs from "node:fs";
+import { commonJS } from "$repo-utils";
+
+const { __dirname } = commonJS(import.meta.url);
+
+// @see packages/babel-core/src/transformation/normalize-file.ts
+const EXTERNAL_SOURCEMAP_REGEX =
+  /^\/\/[@#][ \t]+sourceMappingURL=([^\s'"`]+)[ \t]*$/m;
+
+function dirTreeDisplay(dirPath, indent = "") {
+  let result = "";
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const isLast = i === entries.length - 1;
+    result += indent + (isLast ? "└─ " : "├─ ") + entry.name + "\n";
+    if (entry.isDirectory()) {
+      result += dirTreeDisplay(
+        path.join(dirPath, entry.name),
+        indent + (isLast ? "   " : "│  "),
+      );
+    }
+  }
+  return result;
+}
+
+function getInputSourceMapURL(inputFilePath) {
+  const inputCode = fs.readFileSync(inputFilePath, "utf8");
+  const match = inputCode.match(EXTERNAL_SOURCEMAP_REGEX);
+  return match ? match[1] : null;
+}
+
+function verifyInputFileSourceMapExistence(inputFilePath) {
+  const sourceMapURL = getInputSourceMapURL(inputFilePath);
+  const sourceMapPath = path.resolve(path.dirname(inputFilePath), sourceMapURL);
+  const sourceMap = convertSourceMap
+    .fromJSON(fs.readFileSync(sourceMapPath, "utf8"))
+    .toObject();
+  expect(sourceMap.sourcesContent).toHaveLength(1);
+  expect(sourceMap.sourcesContent[0]).toContain("const enum Msg");
+}
+
+function expectInputSourceMapIsApplied(result) {
+  expect(result.map.sourcesContent).toHaveLength(1);
+  expect(result.map.sourcesContent[0]).toContain("const enum Msg");
+  expect(result.map.sourcesContent[0]).toContain("This map should be loaded");
+}
+
+function expectInputSourceMapIsPresentButNotApplied(result, inputFilePath) {
+  expect(result.map.sourcesContent).toHaveLength(1);
+  expect(result.map.sourcesContent[0]).not.toContain("const enum Msg");
+  verifyInputFileSourceMapExistence(inputFilePath);
+}
+
+describe("input source map resolution", function () {
+  const base = path.join(__dirname, "fixtures/input-source-map-resolution");
+
+  let cwd;
+
+  beforeEach(function () {
+    cwd = process.cwd();
+    process.chdir(base);
+  });
+
+  afterEach(function () {
+    process.chdir(cwd);
+  });
+
+  it("should resolve input source map downward relative to the input file", function () {
+    const cwd = path.join(base, "relative-down");
+    process.chdir(cwd);
+
+    const inputFilePath = path.join(cwd, "input.js");
+
+    expect(dirTreeDisplay(cwd)).toMatchInlineSnapshot(`
+      "├─ babel.config.input.js.json
+      ├─ input.js
+      └─ input.js.map
+      "
+    `);
+
+    expect(getInputSourceMapURL(inputFilePath)).toMatchInlineSnapshot(
+      `"input.js.map"`,
+    );
+
+    const result = babel.transformFileSync(inputFilePath, {
+      babelrc: false,
+      configFile: path.join(cwd, "./babel.config.input.js.json"),
+      inputSourceMap: true,
+      sourceMap: true,
+    });
+
+    expectInputSourceMapIsApplied(result);
+  });
+
+  it("should resolve input source map downward across package.json boundaries", function () {
+    const cwd = path.join(base, "relative-down-into-node-modules");
+    process.chdir(cwd);
+
+    const inputFilePath = path.join(cwd, "input.js");
+
+    expect(dirTreeDisplay(cwd)).toMatchInlineSnapshot(`
+      "├─ babel.config.input.js.json
+      ├─ input.js
+      └─ node_modules
+         └─ corp-source-maps
+            ├─ input.js.map
+            └─ package.json
+      "
+    `);
+    expect(getInputSourceMapURL(inputFilePath)).toMatchInlineSnapshot(
+      `"node_modules/corp-source-maps/input.js.map"`,
+    );
+
+    const result = babel.transformFileSync(inputFilePath, {
+      babelrc: false,
+      configFile: path.join(cwd, "./babel.config.input.js.json"),
+      inputSourceMap: true,
+      sourceMap: true,
+    });
+
+    expectInputSourceMapIsApplied(result);
+  });
+
+  it("should resolve input source map upward within the root boundary", function () {
+    const cwd = path.join(base, "relative-up-within-root");
+    process.chdir(cwd);
+
+    const inputFilePath = path.join(cwd, "root", "sub", "input.js");
+
+    expect(dirTreeDisplay(cwd)).toMatchInlineSnapshot(`
+      "├─ babel.config.input.js.json
+      └─ root
+         ├─ input.js.map
+         └─ sub
+            └─ input.js
+      "
+    `);
+
+    expect(getInputSourceMapURL(inputFilePath)).toMatchInlineSnapshot(
+      `"../input.js.map"`,
+    );
+
+    const result = babel.transformFileSync(inputFilePath, {
+      babelrc: false,
+      root: path.join(cwd, "root"),
+      configFile: path.join(cwd, "./babel.config.input.js.json"),
+      inputSourceMap: true,
+      sourceMap: true,
+    });
+
+    expectInputSourceMapIsApplied(result);
+  });
+
+  it("should resolve input source map upward within the package.json boundary", function () {
+    const cwd = path.join(base, "relative-up-within-node-modules");
+    process.chdir(cwd);
+
+    const inputFilePath = path.join(
+      cwd,
+      "node_modules",
+      "corp-lib",
+      "sub",
+      "input.js",
+    );
+
+    expect(dirTreeDisplay(cwd)).toMatchInlineSnapshot(`
+      "├─ babel.config.input.js.json
+      └─ node_modules
+         └─ corp-lib
+            ├─ input.js.map
+            ├─ package.json
+            └─ sub
+               └─ input.js
+      "
+    `);
+
+    expect(getInputSourceMapURL(inputFilePath)).toMatchInlineSnapshot(
+      `"../input.js.map"`,
+    );
+
+    const result = babel.transformFileSync(inputFilePath, {
+      babelrc: false,
+      configFile: path.join(cwd, "./babel.config.input.js.json"),
+      inputSourceMap: true,
+      sourceMap: true,
+    });
+
+    expectInputSourceMapIsApplied(result);
+  });
+
+  it("should not resolve input source map upward across the package.json boundary", function () {
+    const cwd = path.join(base, "invalid-relative-up-across-node-modules");
+    process.chdir(cwd);
+
+    const inputFilePath = path.join(
+      cwd,
+      "node_modules",
+      "corp-lib",
+      "input.js",
+    );
+
+    expect(dirTreeDisplay(cwd)).toMatchInlineSnapshot(`
+      "├─ babel.config.input.js.json
+      ├─ input.js.map
+      └─ node_modules
+         └─ corp-lib
+            ├─ input.js
+            └─ package.json
+      "
+    `);
+
+    expect(getInputSourceMapURL(inputFilePath)).toMatchInlineSnapshot(
+      `"../../input.js.map"`,
+    );
+
+    const result = babel.transformFileSync(inputFilePath, {
+      babelrc: false,
+      configFile: path.join(cwd, "./babel.config.input.js.json"),
+      inputSourceMap: true,
+      sourceMap: true,
+    });
+
+    expectInputSourceMapIsPresentButNotApplied(result, inputFilePath);
+  });
+
+  it("should not resolve input source map upward across the root boundary", function () {
+    const cwd = path.join(base, "invalid-relative-up-across-root");
+    process.chdir(cwd);
+
+    const inputFilePath = path.join(process.cwd(), "root", "sub", "input.js");
+
+    expect(dirTreeDisplay(cwd)).toMatchInlineSnapshot(`
+      "├─ babel.config.input.js.json
+      ├─ input.js.map
+      └─ root
+         └─ sub
+            └─ input.js
+      "
+    `);
+
+    expect(getInputSourceMapURL(inputFilePath)).toMatchInlineSnapshot(
+      `"../../input.js.map"`,
+    );
+
+    const result = babel.transformFileSync(inputFilePath, {
+      babelrc: false,
+      root: path.join(cwd, "root"),
+      configFile: path.join(cwd, "./babel.config.input.js.json"),
+      inputSourceMap: true,
+      sourceMap: true,
+    });
+
+    expectInputSourceMapIsPresentButNotApplied(result, inputFilePath);
+  });
+
+  it("should not resolve input source map upward across the root boundary and within the package.json boundary", function () {
+    const cwd = path.join(
+      base,
+      "invalid-relative-up-across-root-within-node-modules",
+    );
+    process.chdir(cwd);
+
+    const inputFilePath = path.join(
+      cwd,
+      "node_modules",
+      "corp-app",
+      "root",
+      "sub",
+      "input.js",
+    );
+
+    expect(dirTreeDisplay(cwd)).toMatchInlineSnapshot(`
+      "├─ babel.config.input.js.json
+      └─ node_modules
+         └─ corp-app
+            ├─ input.js.map
+            ├─ package.json
+            └─ root
+               └─ sub
+                  └─ input.js
+      "
+    `);
+
+    expect(getInputSourceMapURL(inputFilePath)).toMatchInlineSnapshot(
+      `"../../input.js.map"`,
+    );
+
+    const result = babel.transformFileSync(inputFilePath, {
+      babelrc: false,
+      root: path.join(cwd, "node_modules", "corp-app", "root"),
+      configFile: path.join(cwd, "./babel.config.input.js.json"),
+      inputSourceMap: true,
+      sourceMap: true,
+    });
+
+    expectInputSourceMapIsPresentButNotApplied(result, inputFilePath);
+  });
+
+  it("should not resolve input source map upward across the package.json boundary and within the root boundary", function () {
+    const cwd = path.join(
+      base,
+      "invalid-relative-up-across-node-modules-within-root",
+    );
+    process.chdir(cwd);
+
+    const inputFilePath = path.join(
+      cwd,
+      "root",
+      "sub",
+      "node_modules",
+      "corp-lib",
+      "input.js",
+    );
+
+    expect(dirTreeDisplay(cwd)).toMatchInlineSnapshot(`
+      "├─ babel.config.input.js.json
+      └─ root
+         └─ sub
+            ├─ input.js.map
+            └─ node_modules
+               └─ corp-lib
+                  ├─ input.js
+                  └─ package.json
+      "
+    `);
+
+    expect(getInputSourceMapURL(inputFilePath)).toMatchInlineSnapshot(
+      `"../../input.js.map"`,
+    );
+
+    const result = babel.transformFileSync(inputFilePath, {
+      babelrc: false,
+      root: path.join(cwd, "root"),
+      configFile: path.join(cwd, "./babel.config.input.js.json"),
+      inputSourceMap: true,
+      sourceMap: true,
+    });
+
+    expectInputSourceMapIsPresentButNotApplied(result, inputFilePath);
+  });
+  it("should not resolve input source map across the package.json boundary using url not starting with ../", function () {
+    const cwd = path.join(
+      base,
+      "invalid-relative-up-across-node-modules-url-not-start-with-double-dot",
+    );
+    process.chdir(cwd);
+
+    const inputFilePath = path.join(
+      cwd,
+      "node_modules",
+      "corp-lib",
+      "input.js",
+    );
+
+    expect(dirTreeDisplay(cwd)).toMatchInlineSnapshot(`
+      "├─ babel.config.input.js.json
+      ├─ input.js.map
+      └─ node_modules
+         └─ corp-lib
+            ├─ input.js
+            ├─ package.json
+            └─ sub
+      "
+    `);
+
+    expect(getInputSourceMapURL(inputFilePath)).toMatchInlineSnapshot(
+      `"sub/../../../input.js.map"`,
+    );
+
+    const result = babel.transformFileSync(inputFilePath, {
+      babelrc: false,
+      configFile: path.join(cwd, "./babel.config.input.js.json"),
+      inputSourceMap: true,
+      sourceMap: true,
+    });
+
+    expectInputSourceMapIsPresentButNotApplied(result, inputFilePath);
+  });
+});

--- a/packages/babel-core/test/input-source-map-resolution.js
+++ b/packages/babel-core/test/input-source-map-resolution.js
@@ -342,6 +342,7 @@ describe("input source map resolution", function () {
 
     expectInputSourceMapIsPresentButNotApplied(result, inputFilePath);
   });
+
   it("should not resolve input source map across the package.json boundary using url not starting with ../", function () {
     const cwd = path.join(
       base,

--- a/packages/babel-core/test/input-source-map-resolution.js
+++ b/packages/babel-core/test/input-source-map-resolution.js
@@ -364,6 +364,7 @@ describe("input source map resolution", function () {
             ├─ input.js
             ├─ package.json
             └─ sub
+               └─ mod.js
       "
     `);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,6 +473,7 @@ __metadata:
     "@types/resolve": "npm:^1.3.2"
     "@types/semver": "npm:^5.4.0"
     convert-source-map: "npm:^2.0.0"
+    find-up-simple: "npm:^1.0.1"
     gensync: "npm:^1.0.0-beta.2"
     import-meta-resolve: "npm:^4.2.0"
     json5: "npm:^2.2.3"
@@ -10379,7 +10380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up-simple@npm:^1.0.0":
+"find-up-simple@npm:^1.0.0, find-up-simple@npm:^1.0.1":
   version: 1.0.1
   resolution: "find-up-simple@npm:1.0.1"
   checksum: 10/6e374bffda9f8425314eab47ef79752b6e77dcc95c0ad17d257aef48c32fe07bbc41bcafbd22941c25bb94fffaaaa8e178d928867d844c58100c7fe19ec82f72


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Improve handling of source map URL
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we improve the handling of source map url, especially for relative URL containing `..`.

For these URLs, Babel now will find the closest `package.json` directory or `options.root`, whichever is closer, and only read the source map file if it comes from that directory.

I will prepare a backport PR if we agree on the current design. The backport will be non-trivial as we have to switch `find-up-simple` for `find-up@6.3` with the `stopAt` support and then manually polyfill the syntax for Node.js 6.