### PR TITLE
Catchup source map position in preserveFormat

### DIFF
--- a/packages/babel-generator/src/buffer.ts
+++ b/packages/babel-generator/src/buffer.ts
@@ -104,9 +104,13 @@ export default class Buffer {
    * Add a string to the buffer that cannot be reverted.
    */
 
-  append(str: string, maybeNewline: boolean): void {
+  append(
+    str: string,
+    maybeNewline: boolean,
+    ignoreMapping: boolean = false,
+  ): void {
     this._flush();
-    this._append(str, maybeNewline);
+    this._append(str, maybeNewline, ignoreMapping);
   }
 
   appendChar(char: number): void {
@@ -178,7 +182,7 @@ export default class Buffer {
     }
   }
 
-  _append(str: string, maybeNewline: boolean): void {
+  _append(str: string, maybeNewline: boolean, ignoreMapping: boolean): void {
     const len = str.length;
     const position = this._position;
     const sourcePos = this._sourcePosition;
@@ -195,7 +199,7 @@ export default class Buffer {
       this._str += str;
     }
 
-    const hasMap = this._map !== null;
+    const hasMap = !ignoreMapping && this._map !== null;
 
     if (!maybeNewline && !hasMap) {
       position.column += len;
@@ -361,14 +365,20 @@ export default class Buffer {
     this._flush();
 
     const pos = loc[prop];
-    const target = this._sourcePosition;
-
     if (pos) {
-      target.line = pos.line;
-      // TODO: Fix https://github.com/babel/babel/issues/15712 in downstream
-      target.column = Math.max(pos.column + columnOffset, 0);
-      target.filename = loc.filename;
+      this.setSourcePosition(
+        pos.line,
+        // TODO: Fix https://github.com/babel/babel/issues/15712 in downstream
+        Math.max(pos.column + columnOffset, 0),
+      );
+      this._sourcePosition.filename = loc.filename;
     }
+  }
+
+  setSourcePosition(line: number, column: number): void {
+    const target = this._sourcePosition;
+    target.line = line;
+    target.column = column;
   }
 
   getCurrentColumn(): number {

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -670,7 +670,8 @@ class Printer {
             // https://tc39.es/ecma262/#sec-white-space
             .replace(/[^\t\v\f\uFEFF\p{Space_Separator}]/gu, " ")
         : " ".repeat(spacesCount);
-      this._append(spaces, false);
+      this._buf.append(spaces, false, true);
+      this._buf.setSourcePosition(line, column);
       this.setLastChar(charCodes.space);
     }
   }

--- a/packages/babel-generator/test/preserve-format.js
+++ b/packages/babel-generator/test/preserve-format.js
@@ -162,7 +162,7 @@ describe("experimental_preserveFormat", () => {
       expect(out.code.trimEnd()).toBe(expected.trimEnd());
 
       expect(out.map.mappings).toMatchInlineSnapshot(
-        `";QACQ,MAAM,CAAC,GAAG,CAAC,CAAS;AAAA,kCACM,CAAU"`,
+        `";QACQ,MAAM,EAAE,EAAE,CAAC,SAAS;kCACM,UAAU"`,
       );
     });
 

--- a/packages/babel-generator/test/preserve-format.js
+++ b/packages/babel-generator/test/preserve-format.js
@@ -148,6 +148,7 @@ describe("experimental_preserveFormat", () => {
       const out = babel.transformSync(input, {
         configFile: false,
         plugins: [pluginTransformTypeScript],
+        sourceMaps: true,
         parserOpts: {
           createParenthesizedExpressions: true,
           tokens: true,
@@ -159,6 +160,10 @@ describe("experimental_preserveFormat", () => {
       });
 
       expect(out.code.trimEnd()).toBe(expected.trimEnd());
+
+      expect(out.map.mappings).toMatchInlineSnapshot(
+        `";QACQ,MAAM,CAAC,GAAG,CAAC,CAAS;AAAA,kCACM,CAAU"`,
+      );
     });
 
     it("identifier renaming", () => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Consider the case where we strip types from `var x: number = 1` in preserve format mode. Whenever we print a node, the generator automatically keeps the original source position up to date with the original node position.

This means that we would print the `Identifier("x")`, and then set the original source position to the space after `number` (because `: number` is part of the identifier node). Then, when printing `=`, we'd first print the necessary spaces to catch up with the correct location (`         `). Before doing that, `.append()` would insert a mapping, thus mapping the space _right after_ `x` in the generated code to the one right after `number` in the original code.

This PR changes two things:
- when adding spaces for catching up, they do not cause a mapping to be injected
- after adding spaces, we update the `sourcePosition` to actually point to where we catched up to thanks to the spaces

This change helps shaving multiple KBs off from the `preserveFormat` test cases in https://github.com/babel/babel/pull/18006, but it's also a correctness fix on its own.