### PR TITLE
Migrate regenerator tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "@babel/plugin-syntax-unicode-sets-regex/@babel/helper-create-regexp-features-plugin": "workspace:*",
     "interpret@npm:^2.2.0": "patch:interpret@npm%3A3.1.1#~/.yarn/patches/interpret-npm-3.1.1-715bac2bd7.patch",
     "interpret@npm:^1.0.0": "patch:interpret@npm%3A3.1.1#~/.yarn/patches/interpret-npm-3.1.1-715bac2bd7.patch",
-    "interpret@npm:^3.1.1": "patch:interpret@npm%3A3.1.1#~/.yarn/patches/interpret-npm-3.1.1-715bac2bd7.patch"
+    "interpret@npm:^3.1.1": "patch:interpret@npm%3A3.1.1#~/.yarn/patches/interpret-npm-3.1.1-715bac2bd7.patch",
+    "c8/yargs": "patch:yargs@npm%3A18.0.0#~/.yarn/patches/yargs-npm-18.0.0-ec82bf7b61.patch"
   },
   "engines": {
     "yarn": ">=1.4.0"

--- a/package.json
+++ b/package.json
@@ -110,9 +110,7 @@
     "@babel/plugin-syntax-unicode-sets-regex/@babel/helper-create-regexp-features-plugin": "workspace:*",
     "interpret@npm:^2.2.0": "patch:interpret@npm%3A3.1.1#~/.yarn/patches/interpret-npm-3.1.1-715bac2bd7.patch",
     "interpret@npm:^1.0.0": "patch:interpret@npm%3A3.1.1#~/.yarn/patches/interpret-npm-3.1.1-715bac2bd7.patch",
-    "interpret@npm:^3.1.1": "patch:interpret@npm%3A3.1.1#~/.yarn/patches/interpret-npm-3.1.1-715bac2bd7.patch",
-    "yargs@npm:^16.2.0": "patch:yargs@npm%3A18.0.0#~/.yarn/patches/yargs-npm-18.0.0-ec82bf7b61.patch",
-    "yargs@npm:^17.7.2": "patch:yargs@npm%3A18.0.0#~/.yarn/patches/yargs-npm-18.0.0-ec82bf7b61.patch"
+    "interpret@npm:^3.1.1": "patch:interpret@npm%3A3.1.1#~/.yarn/patches/interpret-npm-3.1.1-715bac2bd7.patch"
   },
   "engines": {
     "yarn": ">=1.4.0"

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -33,6 +33,7 @@
     "@babel/plugin-transform-parameters": "workspace:^",
     "@babel/plugin-transform-runtime": "workspace:^",
     "babel-plugin-polyfill-regenerator": "^1.0.0-rc.2",
+    "jest": "^30.1.1",
     "recast": "^0.23.3",
     "uglify-js": "^3.14.0"
   },

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -33,7 +33,7 @@
     "@babel/plugin-transform-parameters": "workspace:^",
     "@babel/plugin-transform-runtime": "workspace:^",
     "babel-plugin-polyfill-regenerator": "^1.0.0-rc.2",
-    "jest": "^30.1.1",
+    "jest": "^30.4.2",
     "recast": "^0.23.3",
     "uglify-js": "^3.14.0"
   },

--- a/packages/babel-plugin-transform-regenerator/package.json
+++ b/packages/babel-plugin-transform-regenerator/package.json
@@ -33,7 +33,6 @@
     "@babel/plugin-transform-parameters": "workspace:^",
     "@babel/plugin-transform-runtime": "workspace:^",
     "babel-plugin-polyfill-regenerator": "^1.0.0-rc.2",
-    "mocha": "^10.0.0",
     "recast": "^0.23.3",
     "uglify-js": "^3.14.0"
   },

--- a/packages/babel-plugin-transform-regenerator/test/regenerator-fixtures/jest.config.js
+++ b/packages/babel-plugin-transform-regenerator/test/regenerator-fixtures/jest.config.js
@@ -2,10 +2,12 @@
 
 /** @type {import('jest').Config} */
 const config = {
+  runner: "jest-light-runner",
+  testEnvironment: "node",
   // https://github.com/nodejs/node/pull/58588#issuecomment-2961692890
   testTimeout: 10000,
   // Disable transform for test files since they are already transformed by the convert step in regenerator.js.
   transform: {},
-}
+};
 
 module.exports = config;

--- a/packages/babel-plugin-transform-regenerator/test/regenerator-fixtures/jest.config.js
+++ b/packages/babel-plugin-transform-regenerator/test/regenerator-fixtures/jest.config.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+/** @type {import('jest').Config} */
+const config = {
+  // https://github.com/nodejs/node/pull/58588#issuecomment-2961692890
+  testTimeout: 10000,
+  // Disable transform for test files since they are already transformed by the convert step in regenerator.js.
+  transform: {},
+}
+
+module.exports = config;

--- a/packages/babel-plugin-transform-regenerator/test/regenerator-fixtures/tests.transform.js
+++ b/packages/babel-plugin-transform-regenerator/test/regenerator-fixtures/tests.transform.js
@@ -167,7 +167,7 @@ describe("uglifyjs dead code removal", function () {
   });
 });
 
-context("functions", function () {
+describe("functions", function () {
   function marksCorrectly(marked, varName) {
     // marked should be a VariableDeclarator
     n.VariableDeclarator.assert(marked);

--- a/packages/babel-plugin-transform-regenerator/test/regenerator.js
+++ b/packages/babel-plugin-transform-regenerator/test/regenerator.js
@@ -12,7 +12,7 @@ import {
   mkdirSync,
   readFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { spawn } from "node:child_process";
 import { transformSync } from "@babel/core";
 import checkDuplicatedNodes from "@babel/helper-check-duplicate-nodes";
@@ -27,10 +27,9 @@ import pluginTransformBlockScoping from "@babel/plugin-transform-block-scoping";
 import pluginTransformArrowFunctions from "@babel/plugin-transform-arrow-functions";
 import pluginTransformParameters from "@babel/plugin-transform-parameters";
 import pluginProposalFunctionSent from "@babel/plugin-proposal-function-sent";
+import * as jest from "jest";
 
-const { require, __dirname } = commonJS(import.meta.url);
-
-const jestDir = dirname(require.resolve("jest/package.json"));
+const { __dirname } = commonJS(import.meta.url);
 
 // https://github.com/facebook/regenerator/blob/cb755fd82c648cbc5307a5a2d61cdd598e698fc4/packages/preset/index.js#L9
 const regeneratorPreset = [
@@ -120,42 +119,24 @@ function enqueue(cmd, args = []) {
     } else if (cmd === "jest") {
       // Matches https://github.com/facebook/regenerator/blob/cb755fd82c648cbc5307a5a2d61cdd598e698fc4/.github/workflows/node.js.yml#L19
       describe("jest", () => {
-        if (args.length !== 1) {
-          throw new Error("Expected exactly one test file argument");
-        }
-        const testFile = join(__dirname, args[0]);
-        it(`${args.join(" ")}`, () =>
-          new Promise((resolve, reject) => {
-            let stdout = "";
-            let stderr = "";
+        const testFiles = args.map(file => join(__dirname, file));
+        it(`${args.join(" ")}`, async () => {
+          const options = {
+            projects: [join(__dirname, "regenerator-fixtures")],
+            config: join(__dirname, "regenerator-fixtures", "jest.config.js"),
+            testMatch: testFiles,
+            testPathPattern: testFiles,
+          };
+          try {
             // Each test file is run in a separate process to avoid interference between tests (e.g. shared.js exports writable Symbol).
-            const cp = spawn(
-              process.execPath,
-              [
-                join(jestDir, "bin", "jest.js"),
-                "--config",
-                join(__dirname, "regenerator-fixtures", "jest.config.js"),
-                "--testMatch",
-                testFile,
-                "--",
-                testFile,
-              ],
-              { cwd: __dirname },
-            );
-            cp.stdout.on("data", chunk => {
-              stdout += chunk;
-            });
-            cp.stderr.on("data", chunk => {
-              stderr += chunk;
-            });
-            cp.on("exit", async err => {
-              if (err) {
-                reject(new Error(`STDOUT:\n${stdout}\nSTDERR:\n${stderr}`));
-              } else {
-                resolve();
-              }
-            });
-          }));
+            const { results } = await jest.runCLI(options, options.projects);
+            if (!results.success) {
+              throw new Error("Jest tests failed");
+            }
+          } catch (err) {
+            throw new Error("Jest tests failed", { cause: err });
+          }
+        });
       });
     } else {
       it(`${cmd} ${args.join(" ")}`, () =>

--- a/packages/babel-plugin-transform-regenerator/test/regenerator.js
+++ b/packages/babel-plugin-transform-regenerator/test/regenerator.js
@@ -104,6 +104,8 @@ function convertOldHelper(es6File, es5File, callback) {
   });
 }
 
+const jestTaskQueue = [];
+
 function enqueue(cmd, args = []) {
   describe("regenerator", () => {
     if (typeof cmd === "function") {
@@ -118,44 +120,7 @@ function enqueue(cmd, args = []) {
           }),
         ));
     } else if (cmd === "jest") {
-      // Matches https://github.com/facebook/regenerator/blob/cb755fd82c648cbc5307a5a2d61cdd598e698fc4/.github/workflows/node.js.yml#L19
-      describe("jest", () => {
-        if (args.length !== 1) {
-          throw new Error("Expected exactly one test file argument");
-        }
-        const testFile = join(__dirname, args[0]);
-        it(`${args.join(" ")}`, () =>
-          new Promise((resolve, reject) => {
-            let stdout = "";
-            let stderr = "";
-            const cp = spawn(
-              process.execPath,
-              [
-                join(jestDir, "bin", "jest.js"),
-                "--config",
-                join(__dirname, "regenerator-fixtures", "jest.config.js"),
-                "--testMatch",
-                testFile,
-                "--",
-                testFile,
-              ],
-              { cwd: __dirname },
-            );
-            cp.stdout.on("data", chunk => {
-              stdout += chunk;
-            });
-            cp.stderr.on("data", chunk => {
-              stderr += chunk;
-            });
-            cp.on("exit", async err => {
-              if (err) {
-                reject(new Error(`STDOUT:\n${stdout}\nSTDERR:\n${stderr}`));
-              } else {
-                resolve();
-              }
-            });
-          }));
-      });
+      jestTaskQueue.push(args);
     } else {
       it(`${cmd} ${args.join(" ")}`, () =>
         new Promise((resolve, reject) => {
@@ -396,3 +361,42 @@ enqueue("jest", [
 enqueue("jest", ["./regenerator-fixtures/frozen-intrinsics.js"]);
 
 enqueue("jest", ["./regenerator-fixtures/tmp/no-symbol.es5.js"]);
+
+function consumeJestTaskQueue() {
+  describe("regenerator > jest", () => {
+    const testFiles = jestTaskQueue.flat().map(file => join(__dirname, file));
+    it(`${testFiles.join(" ")}`, () =>
+      new Promise((resolve, reject) => {
+        let stdout = "";
+        let stderr = "";
+        const cp = spawn(
+          process.execPath,
+          [
+            join(jestDir, "bin", "jest.js"),
+            "--config",
+            join(__dirname, "regenerator-fixtures", "jest.config.js"),
+            "--testMatch",
+            ...testFiles,
+            "--",
+            ...testFiles,
+          ],
+          { cwd: __dirname },
+        );
+        cp.stdout.on("data", chunk => {
+          stdout += chunk;
+        });
+        cp.stderr.on("data", chunk => {
+          stderr += chunk;
+        });
+        cp.on("exit", async err => {
+          if (err) {
+            reject(new Error(`STDOUT:\n${stdout}\nSTDERR:\n${stderr}`));
+          } else {
+            resolve();
+          }
+        });
+      }));
+  });
+}
+
+consumeJestTaskQueue();

--- a/packages/babel-plugin-transform-regenerator/test/regenerator.js
+++ b/packages/babel-plugin-transform-regenerator/test/regenerator.js
@@ -104,8 +104,6 @@ function convertOldHelper(es6File, es5File, callback) {
   });
 }
 
-const jestTaskQueue = [];
-
 function enqueue(cmd, args = []) {
   describe("regenerator", () => {
     if (typeof cmd === "function") {
@@ -120,7 +118,44 @@ function enqueue(cmd, args = []) {
           }),
         ));
     } else if (cmd === "jest") {
-      jestTaskQueue.push(args);
+      // Matches https://github.com/facebook/regenerator/blob/cb755fd82c648cbc5307a5a2d61cdd598e698fc4/.github/workflows/node.js.yml#L19
+      describe("jest", () => {
+        if (args.length !== 1) {
+          throw new Error("Expected exactly one test file argument");
+        }
+        const testFile = join(__dirname, args[0]);
+        it(`${args.join(" ")}`, () =>
+          new Promise((resolve, reject) => {
+            let stdout = "";
+            let stderr = "";
+            const cp = spawn(
+              process.execPath,
+              [
+                join(jestDir, "bin", "jest.js"),
+                "--config",
+                join(__dirname, "regenerator-fixtures", "jest.config.js"),
+                "--testMatch",
+                testFile,
+                "--",
+                testFile,
+              ],
+              { cwd: __dirname },
+            );
+            cp.stdout.on("data", chunk => {
+              stdout += chunk;
+            });
+            cp.stderr.on("data", chunk => {
+              stderr += chunk;
+            });
+            cp.on("exit", async err => {
+              if (err) {
+                reject(new Error(`STDOUT:\n${stdout}\nSTDERR:\n${stderr}`));
+              } else {
+                resolve();
+              }
+            });
+          }));
+      });
     } else {
       it(`${cmd} ${args.join(" ")}`, () =>
         new Promise((resolve, reject) => {
@@ -361,42 +396,3 @@ enqueue("jest", [
 enqueue("jest", ["./regenerator-fixtures/frozen-intrinsics.js"]);
 
 enqueue("jest", ["./regenerator-fixtures/tmp/no-symbol.es5.js"]);
-
-function consumeJestTaskQueue() {
-  describe("regenerator > jest", () => {
-    const testFiles = jestTaskQueue.flat().map(file => join(__dirname, file));
-    it(`${testFiles.join(" ")}`, () =>
-      new Promise((resolve, reject) => {
-        let stdout = "";
-        let stderr = "";
-        const cp = spawn(
-          process.execPath,
-          [
-            join(jestDir, "bin", "jest.js"),
-            "--config",
-            join(__dirname, "regenerator-fixtures", "jest.config.js"),
-            "--testMatch",
-            ...testFiles,
-            "--",
-            ...testFiles,
-          ],
-          { cwd: __dirname },
-        );
-        cp.stdout.on("data", chunk => {
-          stdout += chunk;
-        });
-        cp.stderr.on("data", chunk => {
-          stderr += chunk;
-        });
-        cp.on("exit", async err => {
-          if (err) {
-            reject(new Error(`STDOUT:\n${stdout}\nSTDERR:\n${stderr}`));
-          } else {
-            resolve();
-          }
-        });
-      }));
-  });
-}
-
-consumeJestTaskQueue();

--- a/packages/babel-plugin-transform-regenerator/test/regenerator.js
+++ b/packages/babel-plugin-transform-regenerator/test/regenerator.js
@@ -128,6 +128,7 @@ function enqueue(cmd, args = []) {
           new Promise((resolve, reject) => {
             let stdout = "";
             let stderr = "";
+            // Each test file is run in a separate process to avoid interference between tests (e.g. shared.js exports writable Symbol).
             const cp = spawn(
               process.execPath,
               [

--- a/packages/babel-plugin-transform-regenerator/test/regenerator.js
+++ b/packages/babel-plugin-transform-regenerator/test/regenerator.js
@@ -30,7 +30,7 @@ import pluginProposalFunctionSent from "@babel/plugin-proposal-function-sent";
 
 const { require, __dirname } = commonJS(import.meta.url);
 
-const mochaDir = dirname(require.resolve("mocha"));
+const jestDir = dirname(require.resolve("jest/package.json"));
 
 // https://github.com/facebook/regenerator/blob/cb755fd82c648cbc5307a5a2d61cdd598e698fc4/packages/preset/index.js#L9
 const regeneratorPreset = [
@@ -117,9 +117,13 @@ function enqueue(cmd, args = []) {
             }
           }),
         ));
-    } else if (cmd === "mocha") {
+    } else if (cmd === "jest") {
       // Matches https://github.com/facebook/regenerator/blob/cb755fd82c648cbc5307a5a2d61cdd598e698fc4/.github/workflows/node.js.yml#L19
-      describe("mocha", () => {
+      describe("jest", () => {
+        if (args.length !== 1) {
+          throw new Error("Expected exactly one test file argument");
+        }
+        const testFile = join(__dirname, args[0]);
         it(`${args.join(" ")}`, () =>
           new Promise((resolve, reject) => {
             let stdout = "";
@@ -127,13 +131,13 @@ function enqueue(cmd, args = []) {
             const cp = spawn(
               process.execPath,
               [
-                join(mochaDir, "bin", "mocha.js"),
-                // https://github.com/nodejs/node/pull/58588#issuecomment-2961692890
-                "--timeout",
-                "10000",
-                "--reporter",
-                "spec",
-                ...args,
+                join(jestDir, "bin", "jest.js"),
+                "--config",
+                join(__dirname, "regenerator-fixtures", "jest.config.js"),
+                "--testMatch",
+                testFile,
+                "--",
+                testFile,
               ],
               { cwd: __dirname },
             );
@@ -372,23 +376,23 @@ enqueue(convert, [
   "./regenerator-fixtures/tmp/replaceWith-falsy.es5.js",
 ]);
 
-enqueue("mocha", ["./regenerator-fixtures/tmp/tests.es5.js"]);
-enqueue("mocha", ["./regenerator-fixtures/tmp/tests.es5-old.js"]);
-enqueue("mocha", ["./regenerator-fixtures/tmp/tests-node4.es5.js"]);
-enqueue("mocha", ["./regenerator-fixtures/tmp/non-native.es5.js"]);
-enqueue("mocha", ["./regenerator-fixtures/tmp/async.es5.js"]);
-enqueue("mocha", ["./regenerator-fixtures/tmp/async.es5-old.js"]);
-enqueue("mocha", ["./regenerator-fixtures/tmp/async-custom-promise.es5.js"]);
-enqueue("mocha", ["./regenerator-fixtures/tmp/regression.es5.js"]);
-enqueue("mocha", ["./regenerator-fixtures/tests.transform.js"]);
-enqueue("mocha", ["./regenerator-fixtures/tmp/class.regenerator.js"]);
+enqueue("jest", ["./regenerator-fixtures/tmp/tests.es5.js"]);
+enqueue("jest", ["./regenerator-fixtures/tmp/tests.es5-old.js"]);
+enqueue("jest", ["./regenerator-fixtures/tmp/tests-node4.es5.js"]);
+enqueue("jest", ["./regenerator-fixtures/tmp/non-native.es5.js"]);
+enqueue("jest", ["./regenerator-fixtures/tmp/async.es5.js"]);
+enqueue("jest", ["./regenerator-fixtures/tmp/async.es5-old.js"]);
+enqueue("jest", ["./regenerator-fixtures/tmp/async-custom-promise.es5.js"]);
+enqueue("jest", ["./regenerator-fixtures/tmp/regression.es5.js"]);
+enqueue("jest", ["./regenerator-fixtures/tests.transform.js"]);
+enqueue("jest", ["./regenerator-fixtures/tmp/class.regenerator.js"]);
 
-enqueue("mocha", ["./regenerator-fixtures/tests-node4.es6.js"]);
+enqueue("jest", ["./regenerator-fixtures/tests-node4.es6.js"]);
 
-enqueue("mocha", [
+enqueue("jest", [
   "./regenerator-fixtures/non-writable-tostringtag-property.js",
 ]);
 
-enqueue("mocha", ["./regenerator-fixtures/frozen-intrinsics.js"]);
+enqueue("jest", ["./regenerator-fixtures/frozen-intrinsics.js"]);
 
-enqueue("mocha", ["./regenerator-fixtures/tmp/no-symbol.es5.js"]);
+enqueue("jest", ["./regenerator-fixtures/tmp/no-symbol.es5.js"]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3254,7 +3254,7 @@ __metadata:
     "@babel/plugin-transform-parameters": "workspace:^"
     "@babel/plugin-transform-runtime": "workspace:^"
     babel-plugin-polyfill-regenerator: "npm:^1.0.0-rc.2"
-    jest: "npm:^30.1.1"
+    jest: "npm:^30.4.2"
     recast: "npm:^0.23.3"
     uglify-js: "npm:^3.14.0"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8390,6 +8390,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cliui@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "cliui@npm:9.0.1"
+  dependencies:
+    string-width: "npm:^7.2.0"
+    strip-ansi: "npm:^7.1.0"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10/df43d8d1c6e3254cbb64b1905310d5f6672c595496a3cbe76946c6d24777136886470686f2772ac9edfe547a74bb70e8017530b3554715aee119efd7752fc0d9
+  languageName: node
+  linkType: hard
+
 "clone-deep@npm:^4.0.1":
   version: 4.0.1
   resolution: "clone-deep@npm:4.0.1"
@@ -16347,7 +16358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^7.0.0":
+"string-width@npm:^7.0.0, string-width@npm:^7.2.0":
   version: 7.2.0
   resolution: "string-width@npm:7.2.0"
   dependencies:
@@ -18273,12 +18284,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^22.0.0":
+  version: 22.0.0
+  resolution: "yargs-parser@npm:22.0.0"
+  checksum: 10/f13c42bad6ebed1a587a72f2db5694f5fa772bcaf409a701691d13cf74eb5adfcf61a2611de08807e319b829d3e5e6e1578b16ebe174cae8e8be3bf7b8e7a19e
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:^7.0.0":
   version: 7.0.0
   resolution: "yargs-parser@npm:7.0.0"
   dependencies:
     camelcase: "npm:^4.1.0"
   checksum: 10/733a86e1547488b0c72aaef7dd68d3e1d85bbb278ee20a09b71637b57768b91971f6ff45a4879f6161f04694020aca0781e52e87c03ba5a6e99aa97db209d3cd
+  languageName: node
+  linkType: hard
+
+"yargs@npm:18.0.0":
+  version: 18.0.0
+  resolution: "yargs@npm:18.0.0"
+  dependencies:
+    cliui: "npm:^9.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    string-width: "npm:^7.2.0"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^22.0.0"
+  checksum: 10/5af36234871390386b31cac99f00e79fcbc2ead858a61b30a8ca381c5fde5df8af0b407c36b000d3f774bcbe4aec5833f2f1c915f6ddc49ce97b78176b651801
   languageName: node
   linkType: hard
 
@@ -18342,6 +18374,20 @@ __metadata:
     decamelize: "npm:^1.0.0"
     window-size: "npm:0.1.0"
   checksum: 10/869fa54609d4575cae1df1e525e9a22a86fa13ed88c1c68759368af9b8e0af1775b1ea2fc91789a0007523461e1390946e22f65a6fb831eb5a06b7a52bdbf257
+  languageName: node
+  linkType: hard
+
+"yargs@patch:yargs@npm%3A18.0.0#~/.yarn/patches/yargs-npm-18.0.0-ec82bf7b61.patch":
+  version: 18.0.0
+  resolution: "yargs@patch:yargs@npm%3A18.0.0#~/.yarn/patches/yargs-npm-18.0.0-ec82bf7b61.patch::version=18.0.0&hash=a19fec"
+  dependencies:
+    cliui: "npm:^9.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    string-width: "npm:^7.2.0"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^22.0.0"
+  checksum: 10/740f44dee4dfef0f3d851fa837f17f37f03330b9ad79b3b8897c1ad09293b6f463e9627307850c6df7a5acfeeffe7d6172c5467da4aadb25f5c31cd4ddd1e0a7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3254,6 +3254,7 @@ __metadata:
     "@babel/plugin-transform-parameters": "workspace:^"
     "@babel/plugin-transform-runtime": "workspace:^"
     babel-plugin-polyfill-regenerator: "npm:^1.0.0-rc.2"
+    jest: "npm:^30.1.1"
     recast: "npm:^0.23.3"
     uglify-js: "npm:^3.14.0"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3254,7 +3254,6 @@ __metadata:
     "@babel/plugin-transform-parameters": "workspace:^"
     "@babel/plugin-transform-runtime": "workspace:^"
     babel-plugin-polyfill-regenerator: "npm:^1.0.0-rc.2"
-    mocha: "npm:^10.0.0"
     recast: "npm:^0.23.3"
     uglify-js: "npm:^3.14.0"
   peerDependencies:
@@ -7024,13 +7023,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-colors@npm:^4.1.3":
-  version: 4.1.3
-  resolution: "ansi-colors@npm:4.1.3"
-  checksum: 10/43d6e2fc7b1c6e4dc373de708ee76311ec2e0433e7e8bd3194e7ff123ea6a747428fc61afdcf5969da5be3a5f0fd054602bec56fc0ebe249ce2fcde6e649e3c2
-  languageName: node
-  linkType: hard
-
 "ansi-escapes@npm:^4.3.2":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
@@ -7149,13 +7141,6 @@ __metadata:
   dependencies:
     sprintf-js: "npm:~1.0.2"
   checksum: 10/c6a621343a553ff3779390bb5ee9c2263d6643ebcd7843227bdde6cc7adbed796eb5540ca98db19e3fd7b4714e1faa51551f8849b268bb62df27ddb15cbcd91e
-  languageName: node
-  linkType: hard
-
-"argparse@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "argparse@npm:2.0.1"
-  checksum: 10/18640244e641a417ec75a9bd38b0b2b6b95af5199aa241b131d4b2fb206f334d7ecc600bd194861610a5579084978bfcbb02baa399dbe442d56d0ae5e60dbaef
   languageName: node
   linkType: hard
 
@@ -7859,13 +7844,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browser-stdout@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "browser-stdout@npm:1.3.1"
-  checksum: 10/ac70a84e346bb7afc5045ec6f22f6a681b15a4057447d4cc1c48a25c6dedb302a49a46dd4ddfb5cdd9c96e0c905a8539be1b98ae7bc440512152967009ec7015
-  languageName: node
-  linkType: hard
-
 "browserify-aes@npm:^1.0.4, browserify-aes@npm:^1.2.0":
   version: 1.2.0
   resolution: "browserify-aes@npm:1.2.0"
@@ -8174,7 +8152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^6.0.0, camelcase@npm:^6.3.0":
+"camelcase@npm:^6.3.0":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 10/8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
@@ -8209,7 +8187,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -8811,7 +8789,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.5, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -8845,13 +8823,6 @@ __metadata:
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: 10/ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
-  languageName: node
-  linkType: hard
-
-"decamelize@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "decamelize@npm:4.0.0"
-  checksum: 10/b7d09b82652c39eead4d6678bb578e3bebd848add894b76d0f6b395bc45b2d692fb88d977e7cfb93c4ed6c119b05a1347cef261174916c2e75c0a8ca57da1809
   languageName: node
   linkType: hard
 
@@ -9025,13 +8996,6 @@ __metadata:
   version: 4.0.4
   resolution: "diff@npm:4.0.4"
   checksum: 10/5019b3f5ae124ea9e95137119e1a83a59c252c75ddac873cc967832fd7a834570a58a4d58b941bdbd07832ebf98dcb232b27c561b7f5584357da6dae59bcac62
-  languageName: node
-  linkType: hard
-
-"diff@npm:^5.2.0":
-  version: 5.2.2
-  resolution: "diff@npm:5.2.2"
-  checksum: 10/8a885b38113d96138d87f6cb474ee959b7e9ab33c0c4cb1b07dcf019ec544945a2309d53d721532af020de4b3a58fb89f1026f64f42f9421aa9c3ae48a36998b
   languageName: node
   linkType: hard
 
@@ -10894,7 +10858,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.3, glob@npm:^8.1.0":
+"glob@npm:^8.0.3":
   version: 8.1.0
   resolution: "glob@npm:8.1.0"
   dependencies:
@@ -11183,15 +11147,6 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10/619526379cda755409d856cbf3c65b82ea342151719a0a550920cf7d6a7f58f7cf079e5a78f3acd162324fc784a3d3d6f6f61aff613b47a0163c16fbe09ea89f
-  languageName: node
-  linkType: hard
-
-"he@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "he@npm:1.2.0"
-  bin:
-    he: bin/he
-  checksum: 10/d09b2243da4e23f53336e8de3093e5c43d2c39f8d0d18817abfa32ce3e9355391b2edb4bb5edc376aea5d4b0b59d6a0482aab4c52bc02ef95751e4b818e847f1
   languageName: node
   linkType: hard
 
@@ -11808,13 +11763,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "is-plain-obj@npm:2.1.0"
-  checksum: 10/cec9100678b0a9fe0248a81743041ed990c2d4c99f893d935545cfbc42876cbe86d207f3b895700c690ad2fa520e568c44afc1605044b535a7820c1d40e38daa
-  languageName: node
-  linkType: hard
-
 "is-plain-obj@npm:^4.1.0":
   version: 4.1.0
   resolution: "is-plain-obj@npm:4.1.0"
@@ -11948,13 +11896,6 @@ __metadata:
   dependencies:
     unc-path-regex: "npm:^0.1.2"
   checksum: 10/e8abfde203f7409f5b03a5f1f8636e3a41e78b983702ef49d9343eb608cdfe691429398e8815157519b987b739bcfbc73ae7cf4c8582b0ab66add5171088eab6
-  languageName: node
-  linkType: hard
-
-"is-unicode-supported@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "is-unicode-supported@npm:0.1.0"
-  checksum: 10/a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
   languageName: node
   linkType: hard
 
@@ -12702,17 +12643,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10/a52d0519f0f4ef5b4adc1cde466cb54c50d56e2b4a983b9d5c9c0f2f99462047007a6274d7e95617a21d3c91fde3ee6115536ed70991cd645ba8521058b78f77
-  languageName: node
-  linkType: hard
-
 "jsdoc-type-pratt-parser@npm:^7.0.0":
   version: 7.2.0
   resolution: "jsdoc-type-pratt-parser@npm:7.2.0"
@@ -13125,16 +13055,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log-symbols@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "log-symbols@npm:4.1.0"
-  dependencies:
-    chalk: "npm:^4.1.0"
-    is-unicode-supported: "npm:^0.1.0"
-  checksum: 10/fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
-  languageName: node
-  linkType: hard
-
 "log-update@npm:^6.1.0":
   version: 6.1.0
   resolution: "log-update@npm:6.1.0"
@@ -13460,7 +13380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^5.0.1, minimatch@npm:^5.1.6":
+"minimatch@npm:^5.0.1":
   version: 5.1.9
   resolution: "minimatch@npm:5.1.9"
   dependencies:
@@ -13585,37 +13505,6 @@ __metadata:
     pkg-types: "npm:^1.3.1"
     ufo: "npm:^1.6.3"
   checksum: 10/e13b79edb113ac9d3ce8b5998d490cd979e907d31b562b9c6630e59623d32710cc83be1da46755ccd3143c57d50debcf98a9903d55e6e07e57910dc3369d96c1
-  languageName: node
-  linkType: hard
-
-"mocha@npm:^10.0.0":
-  version: 10.8.2
-  resolution: "mocha@npm:10.8.2"
-  dependencies:
-    ansi-colors: "npm:^4.1.3"
-    browser-stdout: "npm:^1.3.1"
-    chokidar: "npm:^3.5.3"
-    debug: "npm:^4.3.5"
-    diff: "npm:^5.2.0"
-    escape-string-regexp: "npm:^4.0.0"
-    find-up: "npm:^5.0.0"
-    glob: "npm:^8.1.0"
-    he: "npm:^1.2.0"
-    js-yaml: "npm:^4.1.0"
-    log-symbols: "npm:^4.1.0"
-    minimatch: "npm:^5.1.6"
-    ms: "npm:^2.1.3"
-    serialize-javascript: "npm:^6.0.2"
-    strip-json-comments: "npm:^3.1.1"
-    supports-color: "npm:^8.1.1"
-    workerpool: "npm:^6.5.1"
-    yargs: "npm:^16.2.0"
-    yargs-parser: "npm:^20.2.9"
-    yargs-unparser: "npm:^2.0.0"
-  bin:
-    _mocha: bin/_mocha
-    mocha: bin/mocha.js
-  checksum: 10/903bbffcb195ef9d36b27db54e3462c5486de1397289e0953735b3530397a139336c452bcf5188c663496c660d2285bbb6c7213290d36d536ad647b6145cb917
   languageName: node
   linkType: hard
 
@@ -15858,15 +15747,6 @@ __metadata:
   dependencies:
     randombytes: "npm:^2.1.0"
   checksum: 10/df6809168973a84facade7d73e2d6dc418f5dee704d1e6cbe79e92fdb4c10af55237e99d2e67881ae3b29aa96ba596a0dfec4e609bd289ab8ec93c5ae78ede8e
-  languageName: node
-  linkType: hard
-
-"serialize-javascript@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "serialize-javascript@npm:6.0.2"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10/445a420a6fa2eaee4b70cbd884d538e259ab278200a2ededd73253ada17d5d48e91fb1f4cd224a236ab62ea7ba0a70c6af29fc93b4f3d3078bf7da1c031fde58
   languageName: node
   linkType: hard
 
@@ -18193,13 +18073,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workerpool@npm:^6.5.1":
-  version: 6.5.1
-  resolution: "workerpool@npm:6.5.1"
-  checksum: 10/b1b00139fe62f2ebec556a2af8085bf6e7502ad26cf2a4dcb34fb4408b2e68aa12c88b0a50cb463b24f2806d60fa491fc0da933b56ec3b53646aeec0025d14cb
-  languageName: node
-  linkType: hard
-
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
@@ -18375,13 +18248,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.2.9":
-  version: 20.2.9
-  resolution: "yargs-parser@npm:20.2.9"
-  checksum: 10/0188f430a0f496551d09df6719a9132a3469e47fe2747208b1dd0ab2bb0c512a95d0b081628bbca5400fb20dbf2fabe63d22badb346cecadffdd948b049f3fcc
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
@@ -18402,18 +18268,6 @@ __metadata:
   dependencies:
     camelcase: "npm:^4.1.0"
   checksum: 10/733a86e1547488b0c72aaef7dd68d3e1d85bbb278ee20a09b71637b57768b91971f6ff45a4879f6161f04694020aca0781e52e87c03ba5a6e99aa97db209d3cd
-  languageName: node
-  linkType: hard
-
-"yargs-unparser@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "yargs-unparser@npm:2.0.0"
-  dependencies:
-    camelcase: "npm:^6.0.0"
-    decamelize: "npm:^4.0.0"
-    flat: "npm:^5.0.2"
-    is-plain-obj: "npm:^2.1.0"
-  checksum: 10/68f9a542c6927c3768c2f16c28f71b19008710abd6b8f8efbac6dcce26bbb68ab6503bed1d5994bdbc2df9a5c87c161110c1dfe04c6a3fe5c6ad1b0e15d9a8a3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8368,14 +8368,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "cliui@npm:9.0.1"
+"cliui@npm:^7.0.2":
+  version: 7.0.4
+  resolution: "cliui@npm:7.0.4"
   dependencies:
-    string-width: "npm:^7.2.0"
-    strip-ansi: "npm:^7.1.0"
-    wrap-ansi: "npm:^9.0.0"
-  checksum: 10/df43d8d1c6e3254cbb64b1905310d5f6672c595496a3cbe76946c6d24777136886470686f2772ac9edfe547a74bb70e8017530b3554715aee119efd7752fc0d9
+    string-width: "npm:^4.2.0"
+    strip-ansi: "npm:^6.0.0"
+    wrap-ansi: "npm:^7.0.0"
+  checksum: 10/db858c49af9d59a32d603987e6fddaca2ce716cd4602ba5a2bb3a5af1351eebe82aba8dff3ef3e1b331f7fa9d40ca66e67bdf8e7c327ce0ea959747ead65c0ef
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "cliui@npm:8.0.1"
+  dependencies:
+    string-width: "npm:^4.2.0"
+    strip-ansi: "npm:^6.0.1"
+    wrap-ansi: "npm:^7.0.0"
+  checksum: 10/eaa5561aeb3135c2cddf7a3b3f562fc4238ff3b3fc666869ef2adf264be0f372136702f16add9299087fb1907c2e4ec5dbfe83bd24bce815c70a80c6c1a2e950
   languageName: node
   linkType: hard
 
@@ -16293,7 +16304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -16336,7 +16347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^7.0.0, string-width@npm:^7.2.0":
+"string-width@npm:^7.0.0":
   version: 7.2.0
   resolution: "string-width@npm:7.2.0"
   dependencies:
@@ -18073,7 +18084,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
   dependencies:
@@ -18248,17 +18259,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^20.2.2":
+  version: 20.2.9
+  resolution: "yargs-parser@npm:20.2.9"
+  checksum: 10/0188f430a0f496551d09df6719a9132a3469e47fe2747208b1dd0ab2bb0c512a95d0b081628bbca5400fb20dbf2fabe63d22badb346cecadffdd948b049f3fcc
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: 10/9dc2c217ea3bf8d858041252d43e074f7166b53f3d010a8c711275e09cd3d62a002969a39858b92bbda2a6a63a585c7127014534a560b9c69ed2d923d113406e
-  languageName: node
-  linkType: hard
-
-"yargs-parser@npm:^22.0.0":
-  version: 22.0.0
-  resolution: "yargs-parser@npm:22.0.0"
-  checksum: 10/f13c42bad6ebed1a587a72f2db5694f5fa772bcaf409a701691d13cf74eb5adfcf61a2611de08807e319b829d3e5e6e1578b16ebe174cae8e8be3bf7b8e7a19e
   languageName: node
   linkType: hard
 
@@ -18271,17 +18282,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:18.0.0":
-  version: 18.0.0
-  resolution: "yargs@npm:18.0.0"
+"yargs@npm:^16.2.0":
+  version: 16.2.0
+  resolution: "yargs@npm:16.2.0"
   dependencies:
-    cliui: "npm:^9.0.1"
+    cliui: "npm:^7.0.2"
     escalade: "npm:^3.1.1"
     get-caller-file: "npm:^2.0.5"
-    string-width: "npm:^7.2.0"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.0"
     y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^22.0.0"
-  checksum: 10/5af36234871390386b31cac99f00e79fcbc2ead858a61b30a8ca381c5fde5df8af0b407c36b000d3f774bcbe4aec5833f2f1c915f6ddc49ce97b78176b651801
+    yargs-parser: "npm:^20.2.2"
+  checksum: 10/807fa21211d2117135d557f95fcd3c3d390530cda2eca0c840f1d95f0f40209dcfeb5ec18c785a1f3425896e623e3b2681e8bb7b6600060eda1c3f4804e7957e
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.7.2":
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
+  dependencies:
+    cliui: "npm:^8.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.3"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^21.1.1"
+  checksum: 10/abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
   languageName: node
   linkType: hard
 
@@ -18315,20 +18342,6 @@ __metadata:
     decamelize: "npm:^1.0.0"
     window-size: "npm:0.1.0"
   checksum: 10/869fa54609d4575cae1df1e525e9a22a86fa13ed88c1c68759368af9b8e0af1775b1ea2fc91789a0007523461e1390946e22f65a6fb831eb5a06b7a52bdbf257
-  languageName: node
-  linkType: hard
-
-"yargs@patch:yargs@npm%3A18.0.0#~/.yarn/patches/yargs-npm-18.0.0-ec82bf7b61.patch":
-  version: 18.0.0
-  resolution: "yargs@patch:yargs@npm%3A18.0.0#~/.yarn/patches/yargs-npm-18.0.0-ec82bf7b61.patch::version=18.0.0&hash=a19fec"
-  dependencies:
-    cliui: "npm:^9.0.1"
-    escalade: "npm:^3.1.1"
-    get-caller-file: "npm:^2.0.5"
-    string-width: "npm:^7.2.0"
-    y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^22.0.0"
-  checksum: 10/740f44dee4dfef0f3d851fa837f17f37f03330b9ad79b3b8897c1ad09293b6f463e9627307850c6df7a5acfeeffe7d6172c5467da4aadb25f5c31cd4ddd1e0a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In this PR we migrate the test runner of regenerator tests, previously imported from the upstream repo, from `mocha` to `jest`. This should simplify the build pipeline

It will also unblock https://github.com/babel/babel/pull/18015 since only mocha 10 depends on `yargs@16` which is broken on Node.js 26. The v7 backport of this PR passes all the tests on my local machine.