### PR TITLE
fix: disable npmMinimalAgeGate for angular-e2e test

### DIFF
--- a/scripts/integration-tests/e2e-angular-cli.sh
+++ b/scripts/integration-tests/e2e-angular-cli.sh
@@ -26,6 +26,8 @@ mkdir tmp && cd tmp
 npx -p @angular/cli ng new --defaults ngx --package-manager yarn --skip-git --skip-install
 cd ngx
 node "$dir"/utils/bump-babel-dependencies.js resolutions
+# Disable yarn minimal age gate because npx will fetch the latest version of Angular CLI
+echo "npmMinimalAgeGate: 0" >> .yarnrc.yml
 touch yarn.lock
 yarn set version stable
 export YARN_ENABLE_IMMUTABLE_INSTALLS=false


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | https://github.com/babel/babel/actions/runs/26548884016/job/78207635324
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
CI is failing because yarn quarantined the latest published `@angular/cli` package installed by `npx`. Here we disable this feature in the e2e test. This change does not affect the main repo.