### PR TITLE
fix: drop `parser` property which could not be cloned

### DIFF
--- a/eslint/babel-eslint-parser/src/configuration.ts
+++ b/eslint/babel-eslint-parser/src/configuration.ts
@@ -7,6 +7,8 @@ export default function normalizeESLintConfig(options: any) {
     ecmaVersion = "latest",
     sourceType = "module",
     requireConfigFile = true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    parser,
     ...otherOptions
   } = options;
 

--- a/eslint/babel-eslint-parser/test/index.js
+++ b/eslint/babel-eslint-parser/test/index.js
@@ -1,11 +1,11 @@
 import path from "node:path";
 import * as escope from "eslint-scope";
 import unpad from "dedent";
-import { parseForESLint as parseForESLintOriginal } from "../lib/index.js";
+import babelEslintParser from "../lib/index.js";
 import { commonJS } from "$repo-utils";
 
 function parseForESLint(code, options) {
-  return parseForESLintOriginal(code, {
+  return babelEslintParser.parseForESLint(code, {
     requireConfigFile: false,
     ...options,
     babelOptions: {
@@ -127,6 +127,17 @@ describe("Babel and Espree", () => {
           eslintScopeManager: true,
           eslintVisitorKeys: true,
           babelOptions: { filename: "test.js", ignore: [/./] },
+        });
+      expect(thunk).not.toThrow();
+    });
+
+    it("should not crash when `parser` is passed", () => {
+      const thunk = () =>
+        parseForESLint("`test`", {
+          eslintScopeManager: true,
+          eslintVisitorKeys: true,
+          babelOptions: BABEL_OPTIONS,
+          parser: babelEslintParser,
         });
       expect(thunk).not.toThrow();
     });


### PR DESCRIPTION
When use together with https://github.com/vuejs/vue-eslint-parser#parseroptionsparser, `parser: babelEslintParser` is passed into `parserOptions` which will be called at https://github.com/vuejs/vue-eslint-parser/blob/70e8d93ad3fe458abcea11428362eee266b37f16/src/script/index.ts#L585, an error `payload` `could not be cloned` at https://github.com/babel/babel/blob/2c055349327da8dfbc7a95068ec879c8d494d7e5/eslint/babel-eslint-parser/src/client.ts#L52

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
