### PR TITLE
chore: consolidate upwards traversal to empathic

### DIFF
--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -48,7 +48,7 @@
     "@babel/types": "workspace:^",
     "@types/gensync": "^1.0.5",
     "convert-source-map": "^2.0.0",
-    "find-up-simple": "^1.0.1",
+    "empathic": "^2.0.1",
     "gensync": "^1.0.0-beta.2",
     "import-meta-resolve": "^4.2.0",
     "json5": "^2.2.3",

--- a/packages/babel-core/src/transformation/read-input-source-map-file.ts
+++ b/packages/babel-core/src/transformation/read-input-source-map-file.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { findUpSync } from "find-up-simple";
+import { up as findPackageUp } from "empathic/package";
 import { createDebug } from "obug";
 import convertSourceMap from "convert-source-map";
 import type { SourceMapConverter } from "convert-source-map";
@@ -20,9 +20,9 @@ function getInputMapPath(
     relativeToInputFileDir.startsWith("..") ||
     path.isAbsolute(relativeToInputFileDir)
   ) {
-    const inputPackageJSONPath = findUpSync("package.json", {
+    const inputPackageJSONPath = findPackageUp({
       cwd: inputFileDir,
-      stopAt: root,
+      last: root,
     });
     const inputFileRoot = inputPackageJSONPath
       ? path.dirname(inputPackageJSONPath)

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -31,7 +31,9 @@
     "@babel/core": "workspace:^",
     "@babel/helper-plugin-test-runner": "workspace:^",
     "@babel/traverse": "workspace:^",
-    "babel-plugin-polyfill-es-shims": "^1.0.0-rc.2"
+    "array.prototype.concat": "^1.0.2",
+    "babel-plugin-polyfill-es-shims": "^1.0.0-rc.2",
+    "object.getownpropertydescriptors": "^2.1.1"
   },
   "engines": {
     "node": "^22.18.0 || >=24.11.0"

--- a/packages/babel-plugin-proposal-decorators/package.json
+++ b/packages/babel-plugin-proposal-decorators/package.json
@@ -31,9 +31,7 @@
     "@babel/core": "workspace:^",
     "@babel/helper-plugin-test-runner": "workspace:^",
     "@babel/traverse": "workspace:^",
-    "array.prototype.concat": "^1.0.2",
-    "babel-plugin-polyfill-es-shims": "^1.0.0-rc.2",
-    "object.getownpropertydescriptors": "^2.1.1"
+    "babel-plugin-polyfill-es-shims": "^1.0.0-rc.2"
   },
   "engines": {
     "node": "^22.18.0 || >=24.11.0"

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -18,7 +18,7 @@
     "@cspotcode/source-map-support": "^0.8.1",
     "cacache": "20.0.3",
     "clone-deep": "^4.0.1",
-    "find-cache-directory": "^6.0.0",
+    "empathic": "^2.0.1",
     "pirates": "^4.0.6"
   },
   "peerDependencies": {

--- a/packages/babel-register/src/worker/cache.ts
+++ b/packages/babel-register/src/worker/cache.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
-import findCacheDirectory from "find-cache-directory";
+import { cache as findCacheDirectory } from "empathic/package";
 import cacache from "cacache";
 import { gzipSync, unzipSync } from "node:zlib";
 
@@ -11,7 +11,7 @@ export default class Cache {
   enabled = false;
   cacheDir =
     process.env.BABEL_CACHE_PATH ||
-    findCacheDirectory({ name: "@babel/register" }) ||
+    findCacheDirectory("@babel/register") ||
     path.join(os.tmpdir() || os.homedir(), `.babel-register`);
   batched: { key: string; data: unknown }[] = [];
   batchedSize = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,7 +469,7 @@ __metadata:
     "@types/resolve": "npm:^1.3.2"
     "@types/semver": "npm:^5.4.0"
     convert-source-map: "npm:^2.0.0"
-    find-up-simple: "npm:^1.0.1"
+    empathic: "npm:^2.0.1"
     gensync: "npm:^1.0.0-beta.2"
     import-meta-resolve: "npm:^4.2.0"
     json5: "npm:^2.2.3"
@@ -1496,9 +1496,7 @@ __metadata:
     "@babel/helper-plugin-utils": "workspace:^"
     "@babel/plugin-syntax-decorators": "workspace:^"
     "@babel/traverse": "workspace:^"
-    array.prototype.concat: "npm:^1.0.2"
     babel-plugin-polyfill-es-shims: "npm:^1.0.0-rc.2"
-    object.getownpropertydescriptors: "npm:^2.1.1"
   peerDependencies:
     "@babel/core": "workspace:^"
   languageName: unknown
@@ -3842,7 +3840,7 @@ __metadata:
     "@types/cacache": "npm:^20.0.0"
     cacache: "npm:20.0.3"
     clone-deep: "npm:^4.0.1"
-    find-cache-directory: "npm:^6.0.0"
+    empathic: "npm:^2.0.1"
     pirates: "npm:^4.0.6"
   peerDependencies:
     "@babel/core": "workspace:^"
@@ -7235,21 +7233,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.concat@npm:^1.0.2":
-  version: 1.0.6
-  resolution: "array.prototype.concat@npm:1.0.6"
-  dependencies:
-    call-bind: "npm:^1.0.7"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.2"
-    es-constants: "npm:^1.0.1"
-    es-errors: "npm:^1.3.0"
-    es-object-atoms: "npm:^1.0.0"
-    is-string: "npm:^1.0.7"
-  checksum: 10/f133d0ef58e4cc4dfa5baef431b0fe805569c6804218d234220c9bdf6a5a5e72ae0ac7bf25c81517826786e97dd5102cb391fc13c51d212eb18a51c3b37900fb
-  languageName: node
-  linkType: hard
-
 "array.prototype.findlastindex@npm:^1.2.6":
   version: 1.2.6
   resolution: "array.prototype.findlastindex@npm:1.2.6"
@@ -7286,22 +7269,6 @@ __metadata:
     es-abstract: "npm:^1.23.5"
     es-shim-unscopables: "npm:^1.0.2"
   checksum: 10/473534573aa4b37b1d80705d0ce642f5933cccf5617c9f3e8a56686e9815ba93d469138e86a1f25d2fe8af999c3d24f54d703ec1fc2db2e6778d46d0f4ac951e
-  languageName: node
-  linkType: hard
-
-"array.prototype.reduce@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "array.prototype.reduce@npm:1.0.8"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.4"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.9"
-    es-array-method-boxes-properly: "npm:^1.0.0"
-    es-errors: "npm:^1.3.0"
-    es-object-atoms: "npm:^1.1.1"
-    is-string: "npm:^1.1.1"
-  checksum: 10/63f4af812f6322fcf1961c348a33a4d2504dbea26d0bde614e43708d02bcdbdb729d225bad69392e8c168803333f0438d6870eb579194a7f2e94fb471fa518bb
   languageName: node
   linkType: hard
 
@@ -8125,7 +8092,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.2, call-bind@npm:^1.0.7, call-bind@npm:^1.0.8, call-bind@npm:^1.0.9":
+"call-bind@npm:^1.0.7, call-bind@npm:^1.0.8, call-bind@npm:^1.0.9":
   version: 1.0.9
   resolution: "call-bind@npm:1.0.9"
   dependencies:
@@ -8541,13 +8508,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"common-path-prefix@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "common-path-prefix@npm:3.0.0"
-  checksum: 10/09c180e8d8495d42990d617f4d4b7522b5da20f6b236afe310192d401d1da8147a7835ae1ea37797ba0c2238ef3d06f3492151591451df34539fdb4b2630f2b3
-  languageName: node
-  linkType: hard
-
 "commondir@npm:^1.0.1":
   version: 1.0.1
   resolution: "commondir@npm:1.0.1"
@@ -8952,7 +8912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-properties@npm:^1.2.0, define-properties@npm:^1.2.1":
+"define-properties@npm:^1.2.1":
   version: 1.2.1
   resolution: "define-properties@npm:1.2.1"
   dependencies:
@@ -9183,6 +9143,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"empathic@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "empathic@npm:2.0.1"
+  checksum: 10/c5a37b78926e722c38779e5026342350098771fa1cacb52cb808e5329896ab39abb88cd2f1374671d6e5c98aa24cba2534f00da2938d04f11de1a2d012ee75c3
+  languageName: node
+  linkType: hard
+
 "end-of-stream@npm:^1.0.0, end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.4":
   version: 1.4.5
   resolution: "end-of-stream@npm:1.4.5"
@@ -9334,23 +9301,6 @@ __metadata:
     unbox-primitive: "npm:^1.1.0"
     which-typed-array: "npm:^1.1.19"
   checksum: 10/e2c97263d87b7faf65102d887074af421db7e48cd92b8b3cd308216cdd2547b647e8f61bf51429bdb13adc463bb7f421989544cbfd2e7f7469ef7a69ae8a4205
-  languageName: node
-  linkType: hard
-
-"es-array-method-boxes-properly@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "es-array-method-boxes-properly@npm:1.0.0"
-  checksum: 10/27a8a21acf20f3f51f69dce8e643f151e380bffe569e95dc933b9ded9fcd89a765ee21b5229c93f9206c93f87395c6b75f80be8ac8c08a7ceb8771e1822ff1fb
-  languageName: node
-  linkType: hard
-
-"es-constants@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "es-constants@npm:1.0.1"
-  dependencies:
-    call-bind: "npm:^1.0.2"
-    define-properties: "npm:^1.2.0"
-  checksum: 10/b69bce861d45b159a2bb906e155d3ccb950ecfd54efb0863385de0c19fb13a8b0269ac44255a1d34bd30a6b5132c4f29094d6ea3b936b979a49861fd62370fc5
   languageName: node
   linkType: hard
 
@@ -10372,17 +10322,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-cache-directory@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "find-cache-directory@npm:6.0.0"
-  dependencies:
-    common-path-prefix: "npm:^3.0.0"
-    pkg-dir: "npm:^8.0.0"
-  checksum: 10/d0864b74ac556e21b1b4dc09d37f0b85ba8620f8cecc08727e8b2348e94828595d7368095deb79e804234629db56900c0f953beecf3cf2373e615fb809cc2033
-  languageName: node
-  linkType: hard
-
-"find-up-simple@npm:^1.0.0, find-up-simple@npm:^1.0.1":
+"find-up-simple@npm:^1.0.1":
   version: 1.0.1
   resolution: "find-up-simple@npm:1.0.1"
   checksum: 10/6e374bffda9f8425314eab47ef79752b6e77dcc95c0ad17d257aef48c32fe07bbc41bcafbd22941c25bb94fffaaaa8e178d928867d844c58100c7fe19ec82f72
@@ -11930,7 +11870,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-string@npm:^1.0.7, is-string@npm:^1.1.1":
+"is-string@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-string@npm:1.1.1"
   dependencies:
@@ -14006,21 +13946,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.getownpropertydescriptors@npm:^2.1.1":
-  version: 2.1.9
-  resolution: "object.getownpropertydescriptors@npm:2.1.9"
-  dependencies:
-    array.prototype.reduce: "npm:^1.0.8"
-    call-bind: "npm:^1.0.8"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.24.0"
-    es-object-atoms: "npm:^1.1.1"
-    gopd: "npm:^1.2.0"
-    safe-array-concat: "npm:^1.1.3"
-  checksum: 10/e80dfbf8fcf9b4883db4738b669c184f1e0faea0c20cf01f610b5a022382f5b54d07fb3e3000e74a6d83b4019173a576ce666500e46d01e959245fac9ae05753
-  languageName: node
-  linkType: hard
-
 "object.groupby@npm:^1.0.3":
   version: 1.0.3
   resolution: "object.groupby@npm:1.0.3"
@@ -14685,15 +14610,6 @@ __metadata:
   dependencies:
     find-up: "npm:^4.0.0"
   checksum: 10/9863e3f35132bf99ae1636d31ff1e1e3501251d480336edb1c211133c8d58906bed80f154a1d723652df1fda91e01c7442c2eeaf9dc83157c7ae89087e43c8d6
-  languageName: node
-  linkType: hard
-
-"pkg-dir@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "pkg-dir@npm:8.0.0"
-  dependencies:
-    find-up-simple: "npm:^1.0.0"
-  checksum: 10/e589abebd1b76cbc3669a45df64f63cc1b041fd3a6588b45d4c692207df126f2a67478a804e5beeb729e75efea06cd405fb84445c879e7af346ba46a4a30b1ff
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1496,7 +1496,9 @@ __metadata:
     "@babel/helper-plugin-utils": "workspace:^"
     "@babel/plugin-syntax-decorators": "workspace:^"
     "@babel/traverse": "workspace:^"
+    array.prototype.concat: "npm:^1.0.2"
     babel-plugin-polyfill-es-shims: "npm:^1.0.0-rc.2"
+    object.getownpropertydescriptors: "npm:^2.1.1"
   peerDependencies:
     "@babel/core": "workspace:^"
   languageName: unknown
@@ -7233,6 +7235,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array.prototype.concat@npm:^1.0.2":
+  version: 1.0.6
+  resolution: "array.prototype.concat@npm:1.0.6"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.2"
+    es-constants: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.0.0"
+    is-string: "npm:^1.0.7"
+  checksum: 10/f133d0ef58e4cc4dfa5baef431b0fe805569c6804218d234220c9bdf6a5a5e72ae0ac7bf25c81517826786e97dd5102cb391fc13c51d212eb18a51c3b37900fb
+  languageName: node
+  linkType: hard
+
 "array.prototype.findlastindex@npm:^1.2.6":
   version: 1.2.6
   resolution: "array.prototype.findlastindex@npm:1.2.6"
@@ -7269,6 +7286,22 @@ __metadata:
     es-abstract: "npm:^1.23.5"
     es-shim-unscopables: "npm:^1.0.2"
   checksum: 10/473534573aa4b37b1d80705d0ce642f5933cccf5617c9f3e8a56686e9815ba93d469138e86a1f25d2fe8af999c3d24f54d703ec1fc2db2e6778d46d0f4ac951e
+  languageName: node
+  linkType: hard
+
+"array.prototype.reduce@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "array.prototype.reduce@npm:1.0.8"
+  dependencies:
+    call-bind: "npm:^1.0.8"
+    call-bound: "npm:^1.0.4"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.9"
+    es-array-method-boxes-properly: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.1.1"
+    is-string: "npm:^1.1.1"
+  checksum: 10/63f4af812f6322fcf1961c348a33a4d2504dbea26d0bde614e43708d02bcdbdb729d225bad69392e8c168803333f0438d6870eb579194a7f2e94fb471fa518bb
   languageName: node
   linkType: hard
 
@@ -8092,7 +8125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.7, call-bind@npm:^1.0.8, call-bind@npm:^1.0.9":
+"call-bind@npm:^1.0.2, call-bind@npm:^1.0.7, call-bind@npm:^1.0.8, call-bind@npm:^1.0.9":
   version: 1.0.9
   resolution: "call-bind@npm:1.0.9"
   dependencies:
@@ -8912,7 +8945,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-properties@npm:^1.2.1":
+"define-properties@npm:^1.2.0, define-properties@npm:^1.2.1":
   version: 1.2.1
   resolution: "define-properties@npm:1.2.1"
   dependencies:
@@ -9301,6 +9334,23 @@ __metadata:
     unbox-primitive: "npm:^1.1.0"
     which-typed-array: "npm:^1.1.19"
   checksum: 10/e2c97263d87b7faf65102d887074af421db7e48cd92b8b3cd308216cdd2547b647e8f61bf51429bdb13adc463bb7f421989544cbfd2e7f7469ef7a69ae8a4205
+  languageName: node
+  linkType: hard
+
+"es-array-method-boxes-properly@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "es-array-method-boxes-properly@npm:1.0.0"
+  checksum: 10/27a8a21acf20f3f51f69dce8e643f151e380bffe569e95dc933b9ded9fcd89a765ee21b5229c93f9206c93f87395c6b75f80be8ac8c08a7ceb8771e1822ff1fb
+  languageName: node
+  linkType: hard
+
+"es-constants@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "es-constants@npm:1.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.2.0"
+  checksum: 10/b69bce861d45b159a2bb906e155d3ccb950ecfd54efb0863385de0c19fb13a8b0269ac44255a1d34bd30a6b5132c4f29094d6ea3b936b979a49861fd62370fc5
   languageName: node
   linkType: hard
 
@@ -11870,7 +11920,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-string@npm:^1.1.1":
+"is-string@npm:^1.0.7, is-string@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-string@npm:1.1.1"
   dependencies:
@@ -13943,6 +13993,21 @@ __metadata:
     es-abstract: "npm:^1.23.2"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10/5b2e80f7af1778b885e3d06aeb335dcc86965e39464671adb7167ab06ac3b0f5dd2e637a90d8ebd7426d69c6f135a4753ba3dd7d0fe2a7030cf718dcb910fd92
+  languageName: node
+  linkType: hard
+
+"object.getownpropertydescriptors@npm:^2.1.1":
+  version: 2.1.9
+  resolution: "object.getownpropertydescriptors@npm:2.1.9"
+  dependencies:
+    array.prototype.reduce: "npm:^1.0.8"
+    call-bind: "npm:^1.0.8"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.24.0"
+    es-object-atoms: "npm:^1.1.1"
+    gopd: "npm:^1.2.0"
+    safe-array-concat: "npm:^1.1.3"
+  checksum: 10/e80dfbf8fcf9b4883db4738b669c184f1e0faea0c20cf01f610b5a022382f5b54d07fb3e3000e74a6d83b4019173a576ce666500e46d01e959245fac9ae05753
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Now that empathic has gained wide adoption (15M downloads/week - used by
storybook, sanity, vite, tsdown, etc), we could make the same move here.

This:
- Replaces `find-up-simple` with empathic/package
- Replaces `find-cache-directory` with empathic/package

While empathic is larger than find-up-simple (but still only ~20KB,
and mostly thanks to dual package), that is justified by the
fact it replaces _many_ modules in the wider ecosystem, not only
`find-up`. For example, storybook dropped ~8 dependencies for it.

Keep in mind, too, that the two deps being removed are a combined ~24KB which is larger than empathic.

This change will also help avoid ecosystem fragmentation. Given _for
this case_ the two packages do the same job (no better or worse), it
makes sense to use what the wider ecosystem uses (empathic).

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | :+1: 
| Major: Breaking Change?  | :-1:
| Minor: New Feature?      | :-1:
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | Introduces empathic
| License                  | MIT
