### PR TITLE
fix(systemjs): support __proto__ as an export name

### DIFF
--- a/packages/babel-plugin-transform-modules-systemjs/src/index.ts
+++ b/packages/babel-plugin-transform-modules-systemjs/src/index.ts
@@ -74,6 +74,8 @@ type ModuleMetadata = {
   exports: any[];
 };
 
+const protoKey = "__proto__";
+
 function constructExportCall(
   path: NodePath<t.Program>,
   exportIdent: t.Identifier,
@@ -97,11 +99,15 @@ function constructExportCall(
       const objectProperties = [];
       for (let i = 0; i < exportNames.length; i++) {
         const exportName = exportNames[i];
-        const exportNameNode = stringSpecifiers.has(exportName)
-          ? t.stringLiteral(exportName)
-          : t.identifier(exportName);
+        const computed = exportName === protoKey;
+        const exportNameNode =
+          stringSpecifiers.has(exportName) || computed
+            ? t.stringLiteral(exportName)
+            : t.identifier(exportName);
         const exportValue = exportValues[i];
-        objectProperties.push(t.objectProperty(exportNameNode, exportValue));
+        objectProperties.push(
+          t.objectProperty(exportNameNode, exportValue, computed),
+        );
       }
       statements.push(
         t.expressionStatement(
@@ -114,7 +120,12 @@ function constructExportCall(
 
     statements.push(
       t.variableDeclaration("var", [
-        t.variableDeclarator(t.identifier(exportObj), t.objectExpression([])),
+        t.variableDeclarator(
+          t.identifier(exportObj),
+          t.objectExpression([
+            t.objectProperty(t.identifier(protoKey), t.nullLiteral()),
+          ]),
+        ),
       ]),
     );
 

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-from-with-export-star/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-from-with-export-star/output.mjs
@@ -4,7 +4,9 @@ System.register(["./other.mjs"], function (_export, _context) {
   var foo, bar;
   return {
     setters: [function (_otherMjs) {
-      var _exportObj = {};
+      var _exportObj = {
+        __proto__: null
+      };
       for (var _key in _otherMjs) {
         if (_key !== "default" && _key !== "__esModule") _exportObj[_key] = _otherMjs[_key];
       }

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier-with-export-star/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/interop-module-string-names/export-named-string-can-be-identifier-with-export-star/output.mjs
@@ -4,7 +4,9 @@ System.register(["./other.mjs"], function (_export, _context) {
   var foo, bar;
   return {
     setters: [function (_otherMjs) {
-      var _exportObj = {};
+      var _exportObj = {
+        __proto__: null
+      };
       for (var _key in _otherMjs) {
         if (_key !== "default" && _key !== "__esModule") _exportObj[_key] = _otherMjs[_key];
       }

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-name-and-all/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-name-and-all/input.mjs
@@ -1,0 +1,2 @@
+export * from "foo";
+export { baz as default, __proto__} from "foo";

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-name-and-all/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-name-and-all/output.mjs
@@ -9,6 +9,8 @@ System.register(["foo"], function (_export, _context) {
       for (var _key in _foo) {
         if (_key !== "default" && _key !== "__esModule") _exportObj[_key] = _foo[_key];
       }
+      _exportObj.default = _foo.baz;
+      _exportObj.__proto__ = _foo.__proto__;
       _export(_exportObj);
     }],
     execute: function () {}

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-name/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-name/input.mjs
@@ -1,0 +1,1 @@
+export { baz as default, __proto__} from "foo";

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-name/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-name/output.mjs
@@ -1,0 +1,13 @@
+System.register(["foo"], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [function (_foo) {
+      _export({
+        default: _foo.baz,
+        ["__proto__"]: _foo.__proto__
+      });
+    }],
+    execute: function () {}
+  };
+});

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-string-and-all/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-string-and-all/input.mjs
@@ -1,0 +1,2 @@
+export * from "foo";
+export { baz as default, "__proto__" } from "foo";

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-string-and-all/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-string-and-all/output.mjs
@@ -9,6 +9,8 @@ System.register(["foo"], function (_export, _context) {
       for (var _key in _foo) {
         if (_key !== "default" && _key !== "__esModule") _exportObj[_key] = _foo[_key];
       }
+      _exportObj.default = _foo.baz;
+      _exportObj.__proto__ = _foo["__proto__"];
       _export(_exportObj);
     }],
     execute: function () {}

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-string/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-string/input.mjs
@@ -1,0 +1,1 @@
+export { baz as default, "__proto__" } from "foo";

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-string/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-default-and-proto-string/output.mjs
@@ -1,0 +1,13 @@
+System.register(["foo"], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [function (_foo) {
+      _export({
+        default: _foo.baz,
+        ["__proto__"]: _foo["__proto__"]
+      });
+    }],
+    execute: function () {}
+  };
+});

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-name-with-computed-properties-transform/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-name-with-computed-properties-transform/input.mjs
@@ -1,0 +1,1 @@
+export { foo, __proto__ } from "foo";

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-name-with-computed-properties-transform/options.json
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-name-with-computed-properties-transform/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-modules-systemjs", "transform-computed-properties"]
+}

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-name-with-computed-properties-transform/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-name-with-computed-properties-transform/output.mjs
@@ -1,0 +1,12 @@
+System.register(["foo"], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [function (_foo) {
+      _export(babelHelpers.defineProperty({
+        foo: _foo.foo
+      }, "__proto__", _foo.__proto__));
+    }],
+    execute: function () {}
+  };
+});

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-name/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-name/input.mjs
@@ -1,0 +1,1 @@
+export { foo, __proto__ } from "foo";

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-name/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-name/output.mjs
@@ -1,0 +1,13 @@
+System.register(["foo"], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [function (_foo) {
+      _export({
+        foo: _foo.foo,
+        ["__proto__"]: _foo.__proto__
+      });
+    }],
+    execute: function () {}
+  };
+});

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-string/input.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-string/input.mjs
@@ -1,0 +1,1 @@
+export { foo, baz as "__proto__" } from "foo";

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-string/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-from-proto-string/output.mjs
@@ -1,0 +1,13 @@
+System.register(["foo"], function (_export, _context) {
+  "use strict";
+
+  return {
+    setters: [function (_foo) {
+      _export({
+        foo: _foo.foo,
+        ["__proto__"]: _foo.baz
+      });
+    }],
+    execute: function () {}
+  };
+});

--- a/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-named-alongside-with-export-star/output.mjs
+++ b/packages/babel-plugin-transform-modules-systemjs/test/fixtures/systemjs/export-named-alongside-with-export-star/output.mjs
@@ -3,14 +3,18 @@ System.register(["foo", "bar"], function (_export, _context) {
 
   return {
     setters: [function (_foo) {
-      var _exportObj = {};
+      var _exportObj = {
+        __proto__: null
+      };
       for (var _key in _foo) {
         if (_key !== "default" && _key !== "__esModule") _exportObj[_key] = _foo[_key];
       }
       _exportObj.default = _foo.default;
       _export(_exportObj);
     }, function (_bar) {
-      var _exportObj2 = {};
+      var _exportObj2 = {
+        __proto__: null
+      };
       for (var _key2 in _bar) {
         if (_key2 !== "default" && _key2 !== "__esModule") _exportObj2[_key2] = _bar[_key2];
       }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | The systemjs transform does not correctly handle the export named `__proto__`.
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we implemented two output changes:
- Initialize `exportObj` with `{ __proto__: null }` when transforming `export *` 
- Convert `export { __proto__ }` to `_exports({ ["__proto__"]: ... })`

These changes ensure that the `__proto__` will be assigned as a normal object property of the namespace object.