### PR TITLE
chore: bump lru-cache to v11 and drop @types/lru-cache

### DIFF
--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -28,12 +28,11 @@
     "@babel/compat-data": "workspace:^",
     "@babel/helper-validator-option": "workspace:^",
     "browserslist": "^4.24.0",
-    "lru-cache": "^7.14.1",
+    "lru-cache": "^11.0.0",
     "semver": "catalog:"
   },
   "devDependencies": {
     "@babel/helper-plugin-test-runner": "workspace:^",
-    "@types/lru-cache": "^5.1.1",
     "@types/semver": "^5.5.0"
   },
   "engines": {

--- a/packages/babel-helper-compilation-targets/src/index.ts
+++ b/packages/babel-helper-compilation-targets/src/index.ts
@@ -1,7 +1,7 @@
 import browserslist from "browserslist";
 import { findSuggestion } from "@babel/helper-validator-option";
 import browserModulesData from "@babel/compat-data/native-modules" with { type: "json" };
-import LruCache from "lru-cache";
+import { LRUCache } from "lru-cache";
 
 import {
   semverify,
@@ -174,11 +174,11 @@ function resolveTargets(queries: Browsers, env?: string): Targets {
   return getLowestVersions(resolved);
 }
 
-const targetsCache = new LruCache({ max: 64 });
+const targetsCache = new LRUCache<string, Targets>({ max: 64 });
 
 function resolveTargetsCached(queries: Browsers, env?: string): Targets {
   const cacheKey = typeof queries === "string" ? queries : queries.join() + env;
-  let cached = targetsCache.get(cacheKey) as Targets | undefined;
+  let cached = targetsCache.get(cacheKey);
   if (!cached) {
     cached = resolveTargets(queries, env);
     targetsCache.set(cacheKey, cached);

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -21,7 +21,7 @@
     "@babel/helper-fixtures": "workspace:^",
     "@jridgewell/trace-mapping": "catalog:",
     "jest-diff": "^30.0.0",
-    "lru-cache": "^7.14.1",
+    "lru-cache": "^11.0.0",
     "resolve": "2.0.0-next.5"
   },
   "engines": {

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -19,7 +19,7 @@ import assert from "node:assert";
 import fs, { readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
 import vm from "node:vm";
-import LruCache from "lru-cache";
+import { LRUCache } from "lru-cache";
 import { fileURLToPath } from "node:url";
 import { diff } from "jest-diff";
 import type { ChildProcess } from "node:child_process";
@@ -41,7 +41,7 @@ type Module = {
 
 const EXTERNAL_HELPERS_VERSION = "7.100.0";
 
-const cachedScripts = new LruCache<
+const cachedScripts = new LRUCache<
   string,
   { code: string; cachedData?: Buffer }
 >({ max: 10 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,10 +688,9 @@ __metadata:
     "@babel/compat-data": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-validator-option": "workspace:^"
-    "@types/lru-cache": "npm:^5.1.1"
     "@types/semver": "npm:^5.5.0"
     browserslist: "npm:^4.24.0"
-    lru-cache: "npm:^7.14.1"
+    lru-cache: "npm:^11.0.0"
     semver: "catalog:"
   languageName: unknown
   linkType: soft
@@ -1115,7 +1114,7 @@ __metadata:
     "@babel/helper-fixtures": "workspace:^"
     "@jridgewell/trace-mapping": "catalog:"
     jest-diff: "npm:^30.0.0"
-    lru-cache: "npm:^7.14.1"
+    lru-cache: "npm:^11.0.0"
     resolve: "npm:2.0.0-next.5"
   languageName: unknown
   linkType: soft
@@ -6093,13 +6092,6 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 10/4e5aed58cabb2bbf6f725da13421aa50a49abb6bc17bfab6c31b8774b073fa7b50d557c61f961a09a85f6056151190f8ac95f13f5b48136ba5841f7d4484ec56
-  languageName: node
-  linkType: hard
-
-"@types/lru-cache@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "@types/lru-cache@npm:5.1.1"
-  checksum: 10/0afadefc983306684a8ef95b6337a0d9e3f687e7e89e1f1f3f2e1ce3fbab5b018bb84cf277d781f871175a2c8f0176762b69e58b6f4296ee1b816cea94d5ef06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
| Q                       | A
| ----------------------- | ---
| Fixed Issues?           | Fixes #18037
| Patch: Bug Fix?         | No
| Major: Breaking Change? | No
| Minor: New Feature?     | No
| Tests Added + Pass?     | Yes
| Documentation PR Link   | N/A
| Any Dependency Changes? | Yes — `lru-cache` `^7.14.1` → `^11.0.0`; remove `@types/lru-cache`
| License                 | MIT

### What

Modernizes `lru-cache` usage in the two packages that depend on it directly:

- `@babel/helper-compilation-targets`
- `@babel/helper-transform-fixture-test-runner`

Each package:
- bumps `lru-cache` from `^7.14.1` to `^11.0.0`
- switches the default import to the named export:
  `import LruCache from "lru-cache"` → `import { LRUCache } from "lru-cache"`
  (the class is exported as `LRUCache` since v8)

`@babel/helper-compilation-targets` additionally:
- **drops the `@types/lru-cache` devDependency** — `lru-cache` has shipped its own type definitions since v7, and `@types/lru-cache@^5` describes the long-gone v5 API, so it was already mistyped against the v7 runtime. v11 is self-typed, so no `@types` package is needed.
- removes a now-redundant `as Targets | undefined` cast on the cache `.get()` call, since v11's typed `.get()` already returns `Targets | undefined`.

### Why

- **Correct types.** Removes a stale `@types/lru-cache@5` whose shape no longer matches the installed runtime.
- **Bundler robustness.** The named `{ LRUCache }` export resolves correctly when a bundler inlines a v10/v11 copy of `lru-cache` into the helper. The old default import is what breaks in such setups — e.g. the `miniprogram-ci` / pnpm packaging crash reported in #18037.

This is not a deduplication change — multiple `lru-cache` majors still exist transitively in the lockfile, and that is unaffected.

### Verification

- `LRUCache` is used as a value (`new LRUCache({ max: 64 })`), which is valid in v11 (`max` alone satisfies the "max / ttl / maxSize" requirement); `.get()` / `.set()` are unchanged.
- `@babel/helper-transform-fixture-test-runner` keeps its explicit generics (`new LRUCache<string, { code: string; cachedData?: Buffer }>()`), type-checked against v11's bundled types.
- The engine range (`^22.18.0 || >=24.11.0`) already satisfies v11's `node: 20 || >=22`, so no `engines` change.
- `make tscheck`, `make build`, and `eslint` pass on the change; behavior is unchanged, so existing tests cover it.
