### PR TITLE
perf: Improve the performance of `make prepublish-build`

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -470,20 +470,22 @@ function buildRollup(packages: PackageInfo[], buildStandalone?: boolean) {
                 "packages/babel-compat-data/scripts/data/legacy-plugin-aliases.js",
                 "packages/*/src/**/*.cjs",
               ],
-              dynamicRequireTargets: [
-                // https://github.com/mathiasbynens/regexpu-core/blob/ffd8fff2e31f4597f6fdfee75d5ac1c5c8111ec3/rewrite-pattern.js#L48
-                path
-                  .relative(
-                    monorepoRoot,
-                    resolveChain(
-                      import.meta.url,
-                      "./packages/babel-helper-create-regexp-features-plugin",
-                      "regexpu-core",
-                      "regenerate-unicode-properties"
-                    )
-                  )
-                  .replace(/\\/g, "/") + "/**/*.js", // Must be posix path in rollup 3
-              ],
+              dynamicRequireTargets: buildStandalone
+                ? [
+                    // https://github.com/mathiasbynens/regexpu-core/blob/ffd8fff2e31f4597f6fdfee75d5ac1c5c8111ec3/rewrite-pattern.js#L48
+                    path
+                      .relative(
+                        monorepoRoot,
+                        resolveChain(
+                          import.meta.url,
+                          "./packages/babel-helper-create-regexp-features-plugin",
+                          "regexpu-core",
+                          "regenerate-unicode-properties"
+                        )
+                      )
+                      .replace(/\\/g, "/") + "/**/*.js", // Must be posix path in rollup 3
+                  ]
+                : undefined,
               // Never delegate to the native require()
               ignoreDynamicRequires: false,
               // Align with the Node.js behavior


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
before: 
`Finished 'build' after 2.75 min`
after: 
`Finished 'build' after 9.15 s`

I'm surprised `dynamicRequireTargets` is so slow.