### PR TITLE
fix(generator): improve new callee parens check

### DIFF
--- a/packages/babel-generator/src/node/index.ts
+++ b/packages/babel-generator/src/node/index.ts
@@ -38,15 +38,28 @@ for (const type of Object.keys(parens) as (keyof typeof parens)[]) {
   }
 }
 
-function isOrHasLeadingCallExpression(node: t.Node): boolean {
-  switch (node.type) {
-    case "CallExpression":
-    case "ImportExpression":
-      return true;
-    case "MemberExpression":
-      return isOrHasLeadingCallExpression(node.object);
+function newCalleeNeedsParens(node: t.Node): boolean {
+  let current: t.Node = node;
+  while (true) {
+    switch (current.type) {
+      case "CallExpression":
+      case "ImportExpression":
+      case "OptionalCallExpression":
+      case "OptionalMemberExpression":
+        return true;
+      case "MemberExpression":
+        current = current.object;
+        break;
+      case "TaggedTemplateExpression":
+        current = current.tag;
+        break;
+      case "TSNonNullExpression":
+        current = current.expression;
+        break;
+      default:
+        return false;
+    }
   }
-  return false;
 }
 
 export function parentNeedsParens(
@@ -57,12 +70,7 @@ export function parentNeedsParens(
   switch (parentId) {
     case __node("NewExpression"):
       if (parent.callee === node) {
-        if (
-          isOrHasLeadingCallExpression(node) ||
-          node.type === "OptionalCallExpression" ||
-          node.type === "OptionalMemberExpression"
-        )
-          return true;
+        return newCalleeNeedsParens(node);
       }
       break;
     case __node("Decorator"):

--- a/packages/babel-generator/test/fixtures/parentheses/new-callee/input.js
+++ b/packages/babel-generator/test/fixtures/parentheses/new-callee/input.js
@@ -5,12 +5,23 @@ new (g?.())();
 new (f.g?.h)();
 new (f?.g.h)();
 
+new (f().g)();
+new (f?.().g)();
+
+new (f()?.g)();
+new (f?.()?.g)();
+
+new (f()`g`)();
+
 new (import("foo"))();
 new (import("foo").bar)();
+new (import("foo")`bar`)();
 
 new (super())();
 new (super().foo)();
+new (super()`foo`)();
 
 // The following outer parentheses can be removed
 new (f[g()])();
 new ((f?.g).h)();
+new (new f())();

--- a/packages/babel-generator/test/fixtures/parentheses/new-callee/output.js
+++ b/packages/babel-generator/test/fixtures/parentheses/new-callee/output.js
@@ -3,11 +3,19 @@ new (f())();
 new (g?.())();
 new (f.g?.h)();
 new (f?.g.h)();
+new (f().g)();
+new (f?.().g)();
+new (f()?.g)();
+new (f?.()?.g)();
+new (f()`g`)();
 new (import("foo"))();
 new (import("foo").bar)();
+new (import("foo")`bar`)();
 new (super())();
 new (super().foo)();
+new (super()`foo`)();
 
 // The following outer parentheses can be removed
 new f[g()]();
-new (f?.g).h();
+new ((f?.g).h)();
+new new f()();

--- a/packages/babel-generator/test/fixtures/parentheses/ts-new-callee/input.js
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-new-callee/input.js
@@ -1,0 +1,26 @@
+// The following parentheses should be kept
+new (f()!)();
+new (g?.()!)();
+
+new (f!.g?.h)();
+new (f?.g!.h)();
+
+new (f().g!)();
+new (f?.().g!)();
+
+new (f!()?.g)();
+new (f?.()?.g!)();
+
+new (f!()`g`)();
+
+new (import("foo")!)();
+new (import("foo")!.bar)();
+new (import("foo")!`bar`)();
+
+new (super()!)();
+new (super()!.foo)();
+new (super()!`foo`)();
+
+// The following outer parentheses can be removed
+new (f![g()])();
+new ((f?.g!).h)();

--- a/packages/babel-generator/test/fixtures/parentheses/ts-new-callee/options.json
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-new-callee/options.json
@@ -1,0 +1,9 @@
+{
+  "sourceType": "module",
+  "parserOpts": {
+    "allowSuperOutsideMethod": true
+  },
+  "plugins": [
+    "typescript"
+  ]
+}

--- a/packages/babel-generator/test/fixtures/parentheses/ts-new-callee/output.js
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-new-callee/output.js
@@ -1,0 +1,20 @@
+// The following parentheses should be kept
+new (f()!)();
+new (g?.()!)();
+new (f!.g?.h)();
+new (f?.g!.h)();
+new (f().g!)();
+new (f?.().g!)();
+new (f!()?.g)();
+new (f?.()?.g!)();
+new (f!()`g`)();
+new (import("foo")!)();
+new (import("foo")!.bar)();
+new (import("foo")!`bar`)();
+new (super()!)();
+new (super()!.foo)();
+new (super()!`foo`)();
+
+// The following outer parentheses can be removed
+new f![g()]();
+new (f?.g!.h)();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #18045 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we improve the new callee `needsParens` logic: It now covers the tagged template and the TS non-null expressions as well. The recursive call has been replaced by plain loop as well.