### PR TITLE
Add bugs metadata for TypeScript syntax plugin

### DIFF
--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -8,6 +8,9 @@
     "directory": "packages/babel-plugin-syntax-typescript"
   },
   "homepage": "https://babel.dev/docs/en/next/babel-plugin-syntax-typescript",
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Related to charles-openclaw/charles-microbounties#1020
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | n/a
| Documentation PR Link    | n/a
| Any Dependency Changes?  | no
| License                  | MIT

Adds the missing `bugs.url` metadata to `@babel/plugin-syntax-typescript` so npm registry consumers can discover the Babel issue tracker via package metadata.

This only updates the package manifest; runtime code, dependencies, exports, and build output are unchanged.