### PR TITLE
Add bugs.url package metadata

### DIFF
--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -8,6 +8,9 @@
     "directory": "packages/babel-plugin-transform-block-scoped-functions"
   },
   "homepage": "https://babel.dev/docs/en/next/babel-plugin-transform-block-scoped-functions",
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `@babel/plugin-transform-block-scoped-functions`
- updates only `packages/babel-plugin-transform-block-scoped-functions/package.json`

## Metadata added
- `bugs.url`: `https://github.com/babel/babel/issues`

## Validation
- parsed `packages/babel-plugin-transform-block-scoped-functions/package.json` as JSON after the change
- confirmed the changed manifest still has `name: @babel/plugin-transform-block-scoped-functions`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package point users to the project README and/or public issue tracker once the package is next released.