### PR TITLE
Add bugs.url package metadata

### DIFF
--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -33,6 +33,9 @@
     "@babel/types": "workspace:^"
   },
   "homepage": "https://babel.dev/docs/en/next/babel-plugin-transform-typescript",
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "engines": {
     "node": "^22.18.0 || >=24.11.0"
   },


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `@babel/plugin-transform-typescript`
- updates only `packages/babel-plugin-transform-typescript/package.json`

## Metadata added
- `bugs.url`: `https://github.com/babel/babel/issues`

## Validation
- parsed `packages/babel-plugin-transform-typescript/package.json` as JSON after the change
- confirmed the changed manifest still has `name: @babel/plugin-transform-typescript`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package point users to the project README and/or public issue tracker once the package is next released.