### PR TITLE
chore: add package bugs metadata

### DIFF
--- a/packages/babel-helper-check-duplicate-nodes/package.json
+++ b/packages/babel-helper-check-duplicate-nodes/package.json
@@ -18,6 +18,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-helper-check-duplicate-nodes"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-helper-compilation-targets"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "main": "./lib/index.js",
   "exports": {
     ".": {

--- a/packages/babel-helper-globals/package.json
+++ b/packages/babel-helper-globals/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-helper-globals"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/babel-helper-module-imports/package.json
+++ b/packages/babel-helper-module-imports/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-helper-module-imports"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/traverse": "workspace:^",

--- a/packages/babel-helper-module-transforms/package.json
+++ b/packages/babel-helper-module-transforms/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-helper-module-transforms"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/helper-module-imports": "workspace:^",

--- a/packages/babel-helper-plugin-utils/package.json
+++ b/packages/babel-helper-plugin-utils/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-helper-plugin-utils"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "main": "./lib/index.js",
   "engines": {
     "node": "^22.18.0 || >=24.11.0"

--- a/packages/babel-helper-string-parser/package.json
+++ b/packages/babel-helper-string-parser/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-helper-string-parser"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "homepage": "https://babel.dev/docs/en/next/babel-helper-string-parser",
   "license": "MIT",
   "publishConfig": {

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-helper-transform-fixture-test-runner"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "main": "./lib/index.js",
   "dependencies": {
     "@babel/code-frame": "workspace:^",

--- a/packages/babel-helper-validator-identifier/package.json
+++ b/packages/babel-helper-validator-identifier/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-helper-validator-identifier"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-helper-validator-option/package.json
+++ b/packages/babel-helper-validator-option/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-helper-validator-option"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-class-static-block/package.json
+++ b/packages/babel-plugin-transform-class-static-block/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-plugin-transform-class-static-block"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-dynamic-import/package.json
+++ b/packages/babel-plugin-transform-dynamic-import/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-plugin-transform-dynamic-import"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-modules-amd/package.json
+++ b/packages/babel-plugin-transform-modules-amd/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-plugin-transform-modules-amd"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "homepage": "https://babel.dev/docs/en/next/babel-plugin-transform-modules-amd",
   "license": "MIT",
   "publishConfig": {

--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-plugin-transform-modules-commonjs"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-modules-systemjs/package.json
+++ b/packages/babel-plugin-transform-modules-systemjs/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-plugin-transform-modules-systemjs"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-modules-umd/package.json
+++ b/packages/babel-plugin-transform-modules-umd/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-plugin-transform-modules-umd"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "homepage": "https://babel.dev/docs/en/next/babel-plugin-transform-modules-umd",
   "license": "MIT",
   "publishConfig": {

--- a/packages/babel-plugin-transform-optional-chaining/package.json
+++ b/packages/babel-plugin-transform-optional-chaining/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-plugin-transform-optional-chaining"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "homepage": "https://babel.dev/docs/en/next/babel-plugin-transform-optional-chaining",
   "license": "MIT",
   "publishConfig": {

--- a/packages/babel-plugin-transform-private-methods/package.json
+++ b/packages/babel-plugin-transform-private-methods/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/babel/babel.git",
     "directory": "packages/babel-plugin-transform-private-methods"
   },
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "homepage": "https://babel.dev/docs/en/next/babel-plugin-transform-private-methods",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | metadata-only
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | package metadata checks
| Documentation PR Link    | none
| Any Dependency Changes?  | no
| License                  | MIT

This adds npm `bugs.url` metadata for 18 Babel packages. The URL points to the Babel issue tracker.

Packages covered:

- `@babel/plugin-transform-modules-commonjs`
- `@babel/plugin-transform-private-methods`
- `@babel/plugin-transform-modules-umd`
- `@babel/plugin-transform-modules-amd`
- `@babel/plugin-transform-modules-systemjs`
- `@babel/helper-validator-option`
- `@babel/plugin-transform-dynamic-import`
- `@babel/plugin-transform-class-static-block`
- `@babel/plugin-transform-optional-chaining`
- `@babel/helper-module-imports`
- `@babel/helper-module-transforms`
- `@babel/helper-transform-fixture-test-runner`
- `@babel/helper-globals`
- `@babel/helper-compilation-targets`
- `@babel/helper-check-duplicate-nodes`
- `@babel/helper-validator-identifier`
- `@babel/helper-string-parser`
- `@babel/helper-plugin-utils`

This is metadata-only and does not change runtime code, dependencies, exports, generated files, package versioning, or build behavior.

Verification:

```sh
node - <<'NODE'
const dirs = [
'babel-plugin-transform-modules-commonjs','babel-plugin-transform-private-methods','babel-plugin-transform-modules-umd','babel-plugin-transform-modules-amd','babel-plugin-transform-modules-systemjs','babel-helper-validator-option','babel-plugin-transform-dynamic-import','babel-plugin-transform-class-static-block','babel-plugin-transform-optional-chaining','babel-helper-module-imports','babel-helper-module-transforms','babel-helper-transform-fixture-test-runner','babel-helper-globals','babel-helper-compilation-targets','babel-helper-check-duplicate-nodes','babel-helper-validator-identifier','babel-helper-string-parser','babel-helper-plugin-utils'
]
for (const dir of dirs) {
  const p = require(`./packages/${dir}/package.json`)
  if (p.bugs?.url !== 'https://github.com/babel/babel/issues') process.exit(1)
  console.log(`${p.name} metadata OK`)
}
NODE
for d in packages/babel-plugin-transform-modules-commonjs packages/babel-plugin-transform-private-methods packages/babel-plugin-transform-modules-umd packages/babel-plugin-transform-modules-amd packages/babel-plugin-transform-modules-systemjs packages/babel-helper-validator-option packages/babel-plugin-transform-dynamic-import packages/babel-plugin-transform-class-static-block packages/babel-plugin-transform-optional-chaining packages/babel-helper-module-imports packages/babel-helper-module-transforms packages/babel-helper-transform-fixture-test-runner packages/babel-helper-globals packages/babel-helper-compilation-targets packages/babel-helper-check-duplicate-nodes packages/babel-helper-validator-identifier packages/babel-helper-string-parser packages/babel-helper-plugin-utils; do (cd $d && npm pack --dry-run --ignore-scripts --json >/tmp/$(basename $d)-babel-pack.json); done
git diff --check
```
