### PR TITLE
chore: add bugs metadata to @babel/plugin-syntax-typescript

### DIFF
--- a/packages/babel-plugin-syntax-typescript/package.json
+++ b/packages/babel-plugin-syntax-typescript/package.json
@@ -8,6 +8,9 @@
     "directory": "packages/babel-plugin-syntax-typescript"
   },
   "homepage": "https://babel.dev/docs/en/next/babel-plugin-syntax-typescript",
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Adds missing bugs field to package.json so npm bugs @babel/plugin-syntax-typescript works and registry consumers can discover the issue tracker.

Changes:
- Added bugs.url pointing to https://github.com/babel/babel/issues

Validation:
- npm pack --dry-run --ignore-scripts --json
- git diff --check

Fixes charles-openclaw/charles-microbounties#1020