### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/babel-plugin-syntax-jsx/package.json
+++ b/packages/babel-plugin-syntax-jsx/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@babel/plugin-syntax-jsx",
   "version": "8.0.0-rc.6",
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "description": "Allow parsing of jsx",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/babel-plugin-syntax-jsx/package.json`.