### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/babel-plugin-transform-modules-commonjs/package.json
+++ b/packages/babel-plugin-transform-modules-commonjs/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@babel/plugin-transform-modules-commonjs",
   "version": "8.0.0-rc.6",
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "description": "This plugin transforms ES2015 modules to CommonJS",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/babel-plugin-transform-modules-commonjs/package.json`.