### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/babel-plugin-transform-typescript/package.json
+++ b/packages/babel-plugin-transform-typescript/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@babel/plugin-transform-typescript",
   "version": "8.0.0-rc.6",
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "description": "Transform TypeScript into ES.next",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds missing `bugs, repository, homepage` metadata to `packages/babel-plugin-transform-typescript/package.json`.

Fixes npm tooling unable to resolve package metadata.