### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/babel-plugin-transform-block-scoped-functions/package.json
+++ b/packages/babel-plugin-transform-block-scoped-functions/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@babel/plugin-transform-block-scoped-functions",
   "version": "8.0.0-rc.6",
+  "bugs": {
+    "url": "https://github.com/babel/babel/issues"
+  },
   "description": "Babel plugin to ensure function declarations at the block level are block scoped",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds missing `bugs, repository, homepage` metadata to `packages/babel-plugin-transform-block-scoped-functions/package.json`.

Fixes npm tooling unable to resolve package metadata.