### PR TITLE
Remove `--all` from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: This release will publish the following packages
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            yarn release-tool version --dry --all ${{ github.event.inputs.version }}
+            yarn release-tool version --dry ${{ github.event.inputs.version }}
           else
             git diff --name-only HEAD^..HEAD
           fi;
@@ -78,7 +78,7 @@ jobs:
       - name: Create new version
         run: |
           make new-version-checklist
-          yarn release-tool version -f @babel/standalone --all --yes ${{ github.event.inputs.version }}
+          yarn release-tool version -f @babel/standalone --yes ${{ github.event.inputs.version }}
 
       - name: Compute temporary branch name
         id: branch-name


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Follow up to https://github.com/babel/babel/pull/18071. `--all` was needed to keep all pre-releases in sync, but for stable versions we only publish the changed packages to avoid npm caching problems.