### PR TITLE
Use the `@babel/core` version when asserting version in `@babel/standalone`

### DIFF
--- a/babel.config.ts
+++ b/babel.config.ts
@@ -12,6 +12,7 @@ import {
   type ConfigAPI,
 } from "@babel/core";
 import packageJson from "./package.json" with { type: "json" };
+import babelCorePackageJson from "./packages/babel-core/package.json" with { type: "json" };
 import pluginToggleBooleanFlag from "./scripts/babel-plugin-toggle-boolean-flag/plugin.ts";
 import pluginBitDecorator from "./scripts/babel-plugin-bit-decorator/plugin.ts";
 import pluginTransformNodeProtocolImport from "./scripts/babel-plugin-transform-node-protocol-import/plugin.ts";
@@ -237,9 +238,12 @@ export default function (api: ConfigAPI) {
                 if (!process.env.IS_PUBLISH || env === "standalone") {
                   if (bool(process.env.BABEL_9_BREAKING)) {
                     // Match packages/babel-core/src/index.ts
-                    return packageJson.version.replace(/0*$/, "999999999");
+                    return babelCorePackageJson.version.replace(
+                      /0*$/,
+                      "999999999"
+                    );
                   }
-                  return packageJson.version;
+                  return babelCorePackageJson.version;
                 }
                 if (packageJson.version.includes("-")) {
                   // for pre-releases


### PR DESCRIPTION
…alone`

<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes https://github.com/babel/babel/issues/18082
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The problem is that the top-level version can be ahead of the actual `@babel/core` version.