### PR TITLE
Fix initialization of nested for loop head declarations

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/index.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/index.ts
@@ -6,6 +6,7 @@ import {
   getLoopBodyBindings,
   getUsageInBody,
   isVarInLoopHead,
+  isVarInForStatementInit,
   wrapLoopBody,
 } from "./loop.ts";
 import { validateUsage } from "./validation.ts";
@@ -192,10 +193,13 @@ function transformBlockScopedVariable(
     binding.kind = "var";
   }
 
-  if (
-    (isInLoop(path) && !isVarInLoopHead(path)) ||
-    dynamicTDZNames.length > 0
-  ) {
+  const isLoopBodyDeclaration = isInLoop(path) && !isVarInLoopHead(path);
+  const isNestedForStatementInit =
+    isVarInForStatementInit(path) && isInLoop(path.parentPath);
+  const shouldInitLoopDeclaration =
+    isLoopBodyDeclaration || isNestedForStatementInit;
+
+  if (shouldInitLoopDeclaration || dynamicTDZNames.length > 0) {
     for (const decl of path.node.declarations) {
       // We explicitly add `void 0` to cases like
       //  for (;;) { let a; }

--- a/packages/babel-plugin-transform-block-scoping/src/loop.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/loop.ts
@@ -382,6 +382,10 @@ export function isVarInLoopHead(path: NodePath<t.VariableDeclaration>) {
   return false;
 }
 
+export function isVarInForStatementInit(path: NodePath<t.VariableDeclaration>) {
+  return path.parentPath.isForStatement() && path.key === "init";
+}
+
 function filterMap<T, U extends object>(list: T[], fn: (item: T) => U | null) {
   const result: U[] = [];
   for (const item of list) {

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087-indirect/exec.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087-indirect/exec.js
@@ -1,0 +1,11 @@
+let count = 0;
+
+for (let outer = 0; outer < 2; outer++) {
+  do {
+    for (let done; !done; done = true) {
+      count++;
+    }
+  } while (false);
+}
+
+expect(count).toBe(2);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087-indirect/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087-indirect/input.js
@@ -1,0 +1,11 @@
+let count = 0;
+
+for (let outer = 0; outer < 2; outer++) {
+  do {
+    for (let done; !done; done = true) {
+      count++;
+    }
+  } while (false);
+}
+
+expect(count).toBe(2);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087-indirect/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087-indirect/output.js
@@ -1,0 +1,9 @@
+var count = 0;
+for (var outer = 0; outer < 2; outer++) {
+  do {
+    for (var done = void 0; !done; done = true) {
+      count++;
+    }
+  } while (false);
+}
+expect(count).toBe(2);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087/exec.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087/exec.js
@@ -1,0 +1,9 @@
+let count = 0;
+
+for (let outer = 0; outer < 2; outer++) {
+  for (let done; !done; done = true) {
+    count++;
+  }
+}
+
+expect(count).toBe(2);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087/input.js
@@ -1,0 +1,9 @@
+let count = 0;
+
+for (let outer = 0; outer < 2; outer++) {
+  for (let done; !done; done = true) {
+    count++;
+  }
+}
+
+expect(count).toBe(2);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/issue-18087/output.js
@@ -1,0 +1,7 @@
+var count = 0;
+for (var outer = 0; outer < 2; outer++) {
+  for (var done = void 0; !done; done = true) {
+    count++;
+  }
+}
+expect(count).toBe(2);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #18087 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR fixes an issue in `@babel/plugin-transform-block-scoping` where an uninitialized `let` declaration in a nested `for` statement initializer could retain its value across outer loop iterations after being transformed to `var`.

For example:

```js
let count = 0;

for (let outer = 0; outer < 2; outer++) {
  for (let done; !done; done = true) {
    count++;
  }
}

expect(count).toBe(2);
```

Before this change, the inner done declaration was transformed without an initializer:

```js
for (var done; !done; done = true) {}
```

Because `var` is function-scoped, `done` could keep the value from the previous outer iteration. This PR initializes nested `for` statement initializers with `void 0` when needed:

```js
for (var done = void 0; !done; done = true) {}
```

The existing loop-body declaration initialization behavior is preserved, while top-level loop-head declarations are not unnecessarily initialized.

Added a regression fixture for #18087 covering both output and runtime behavior.