### PR TITLE
fix: Remove `isTSX` from `babel-plugin-syntax-typescript` types

### DIFF
--- a/packages/babel-core/test/index.tst.ts
+++ b/packages/babel-core/test/index.tst.ts
@@ -254,7 +254,6 @@ describe("options of all packages", () => {
       | "optimizeConstEnums"
       | "disallowAmbiguousJSXLike"
       | "dts"
-      | "isTSX"
     >();
     expect<
       ExtractOptionsKeys<typeof pluginTransformUnicodePropertyRegex>

--- a/packages/babel-plugin-syntax-typescript/src/index.ts
+++ b/packages/babel-plugin-syntax-typescript/src/index.ts
@@ -3,7 +3,6 @@ import { declare } from "@babel/helper-plugin-utils";
 export interface Options {
   disallowAmbiguousJSXLike?: boolean;
   dts?: boolean;
-  isTSX?: boolean;
 }
 
 export default declare((api, opts: Options) => {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Found in https://github.com/vuejs/babel-plugin-jsx/pull/770