### PR TITLE
perf: Remove the use of `NodePath#contexts`

### DIFF
--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -2,7 +2,7 @@
 
 import { SHOULD_SKIP, SHOULD_STOP } from "./index.ts";
 import { _markRemoved } from "./removal.ts";
-import type TraversalContext from "../context.ts";
+import TraversalContext from "../context.ts";
 import type NodePath from "./index.ts";
 import type { ExplodedVisitor, TraverseOptions } from "../types.ts";
 import * as t from "@babel/types";
@@ -112,15 +112,41 @@ export function setScope(this: NodePath<t.Node | null>) {
   this.scope?.init();
 }
 
+export function mayCloneContext(
+  path: NodePath<t.Node | null>,
+  context: TraversalContext | undefined,
+) {
+  if (path.skipKeys != null) {
+    path.skipKeys = {};
+  }
+
+  path._traverseFlags = 0;
+
+  if (context && !path.context) {
+    const newContext = new TraversalContext(context.opts, context.state);
+
+    path.context = newContext;
+    path.state = newContext.state;
+    path.opts = newContext.opts;
+  }
+
+  setScope.call(path);
+
+  return path;
+}
+
 export function setContext<S = unknown>(
   this: NodePath<t.Node | null>,
   context?: TraversalContext<S>,
+  keepFlags?: boolean,
 ) {
   if (this.skipKeys != null) {
     this.skipKeys = {};
   }
-  // this.shouldSkip = false; this.shouldStop = false; this.removed = false;
-  this._traverseFlags = 0;
+  if (!keepFlags) {
+    // this.shouldSkip = false; this.shouldStop = false; this.removed = false;
+    this._traverseFlags = 0;
+  }
 
   if (context) {
     this.context = context as TraversalContext;
@@ -213,23 +239,6 @@ export function _resyncRemoved(this: NodePath<t.Node | null>) {
   }
 }
 
-export function popContext(this: NodePath<t.Node | null>) {
-  this.contexts.pop();
-  if (this.contexts.length > 0) {
-    this.setContext(this.contexts[this.contexts.length - 1]);
-  } else {
-    this.setContext(undefined);
-  }
-}
-
-export function pushContext(
-  this: NodePath<t.Node | null>,
-  context: TraversalContext,
-) {
-  this.contexts.push(context);
-  this.setContext(context);
-}
-
 export function setup(
   this: NodePath,
   parentPath: NodePath | undefined | null,
@@ -260,14 +269,7 @@ export function requeue(this: NodePath<t.Node | null>, pathToQueue = this) {
 
   pathToQueue.shouldSkip = false;
 
-  // TODO(loganfsmyth): This should be switched back to queue in parent contexts
-  // automatically once #2892 and #4135 have been resolved. See #4140.
-  // let contexts = this._getQueueContexts();
-  const contexts = this.contexts;
-
-  for (const context of contexts) {
-    context.maybeQueue(pathToQueue);
-  }
+  this.context?.maybeQueue(pathToQueue);
 }
 
 export function requeueComputedKeyAndDecorators(
@@ -284,13 +286,14 @@ export function requeueComputedKeyAndDecorators(
   }
 }
 
-export function _getQueueContexts(this: NodePath<t.Node | null>) {
+export function _getQueueContext(this: NodePath<t.Node | null>) {
   let path = this;
-  let contexts = this.contexts;
-  while (!contexts.length) {
+  let context = this.context;
+
+  while (context && !context.queue) {
     path = path.parentPath;
     if (!path) break;
-    contexts = path.contexts;
+    context = path.context;
   }
-  return contexts;
+  return context;
 }

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -1,6 +1,7 @@
 // This file contains methods responsible for dealing with/retrieving children or siblings.
 
 import type TraversalContext from "../context.ts";
+import { mayCloneContext } from "./context.ts";
 import NodePath from "./index.ts";
 import {
   getAssignmentIdentifiers as _getAssignmentIdentifiers,
@@ -453,21 +454,27 @@ export function _getKey<T extends t.Node>(
   if (Array.isArray(container)) {
     // requested a container so give them all the paths
     return container.map((_, i) => {
-      return NodePath.get({
-        listKey: key,
-        parentPath: this,
-        parent: node,
-        container: container,
-        key: i,
-      }).setContext(context);
+      return mayCloneContext(
+        NodePath.get({
+          listKey: key,
+          parentPath: this,
+          parent: node,
+          container: container,
+          key: i,
+        }),
+        context,
+      );
     });
   } else {
-    return NodePath.get({
-      parentPath: this,
-      parent: node,
-      container: node,
-      key: key,
-    }).setContext(context);
+    return mayCloneContext(
+      NodePath.get({
+        parentPath: this,
+        parent: node,
+        container: node,
+        key: key,
+      }),
+      context,
+    );
   }
 }
 

--- a/packages/babel-traverse/src/path/index.ts
+++ b/packages/babel-traverse/src/path/index.ts
@@ -76,7 +76,6 @@ const NodePath_Final = class NodePath {
   declare context: TraversalContext;
   declare scope: Scope;
 
-  contexts: TraversalContext[] = [];
   state: any = null;
   declare opts: TraverseOptions & ExplodedVisitor;
 

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -2,7 +2,7 @@
 
 import { getCachedPaths } from "../cache.ts";
 import NodePath from "./index.ts";
-import { _getQueueContexts, pushContext, setScope } from "./context.ts";
+import { _getQueueContext, mayCloneContext, setScope } from "./context.ts";
 import { _assertUnremoved } from "./removal.ts";
 import {
   arrowFunctionExpression,
@@ -104,21 +104,15 @@ export function _containerInsert<Nodes extends NodeList<t.Node>>(
     const to = from + i;
     const path = this.getSibling(to);
     paths.push(path);
-
-    if (this.context?.queue) {
-      pushContext.call(path, this.context);
-    }
   }
 
-  const contexts = _getQueueContexts.call(this);
+  const context = _getQueueContext.call(this);
 
   for (const path of paths) {
     setScope.call(path);
     path.debug("Inserted.");
 
-    for (const context of contexts) {
-      context.maybeQueue(path, true);
-    }
+    context?.maybeQueue(path, true);
   }
 
   return paths as NodePaths<Nodes>;
@@ -372,13 +366,16 @@ export function unshiftContainer<
   // get the first path and insert our nodes before it, if it doesn't exist then it
   // doesn't matter, our nodes will be inserted anyway
   const container = (this.node as N)[listKey] as t.Node[];
-  const path = NodePath.get({
-    parentPath: this,
-    parent: this.node,
-    container,
-    listKey,
-    key: 0,
-  }).setContext(this.context);
+  const path = mayCloneContext(
+    NodePath.get({
+      parentPath: this,
+      parent: this.node,
+      container,
+      listKey,
+      key: 0,
+    }),
+    this.context,
+  );
 
   return _containerInsertBefore.call(path, verifiedNodes) as NodePaths<Nodes>;
 }

--- a/packages/babel-traverse/src/traverse-node.ts
+++ b/packages/babel-traverse/src/traverse-node.ts
@@ -5,11 +5,12 @@ import NodePath from "./path/index.ts";
 import type Scope from "./scope/index.ts";
 import type * as t from "@babel/types";
 import { VISITOR_KEYS } from "@babel/types";
-import { _call, popContext, pushContext, resync } from "./path/context.ts";
+import { _call, resync } from "./path/context.ts";
 
 function _visitPaths(
   ctx: TraversalContext<any>,
   paths: NodePath<t.Node | null>[],
+  keepFlags?: boolean,
 ): boolean {
   // set queue
   ctx.queue = paths;
@@ -19,21 +20,17 @@ function _visitPaths(
   let stop = false;
   let visitIndex = 0;
 
+  const len = paths.length;
+
   for (; visitIndex < paths.length; ) {
     const path = paths[visitIndex];
     visitIndex++;
 
     resync.call(path);
 
-    if (
-      path.contexts.length === 0 ||
-      path.contexts[path.contexts.length - 1] !== ctx
-    ) {
-      // The context might already have been pushed when this path was inserted and queued.
-      // If we always re-pushed here, we could get duplicates and risk leaving contexts
-      // on the stack after the traversal has completed, which could break things.
-      pushContext.call(path, ctx);
-    }
+    const oldContext = path.context;
+
+    path.setContext(ctx, keepFlags || visitIndex > len);
 
     // this path no longer belongs to the tree
     if (path.key === null) continue;
@@ -43,22 +40,17 @@ function _visitPaths(
     if (visited.has(node)) continue;
     if (node) visited.add(node);
 
-    if (_visit(ctx, path)) {
-      stop = true;
-      break;
-    }
+    stop = _visit(ctx, path);
 
-    if (ctx.priorityQueue.length) {
-      stop = _visitPaths(ctx, ctx.priorityQueue);
+    if (!stop && ctx.priorityQueue.length) {
+      stop = _visitPaths(ctx, ctx.priorityQueue, true);
       ctx.priorityQueue = [];
       ctx.queue = paths;
-      if (stop) break;
     }
-  }
 
-  // pop contexts
-  for (let i = 0; i < visitIndex; i++) {
-    popContext.call(paths[i]);
+    path.setContext(undefined);
+    path.context = oldContext;
+    if (stop) break;
   }
 
   // clear queue

--- a/packages/babel-traverse/test/modification.js
+++ b/packages/babel-traverse/test/modification.js
@@ -344,51 +344,45 @@ describe("modification", function () {
           "var _temp;\nexport default (_temp = fn(), x, _temp);",
         );
       });
+    });
 
-      it("edge case for babel-plugin-jest-hoist", function () {
-        let varsHoistPoint;
-        let i = 0;
-        const logs = [[], []];
-        traverse(parse(`{a;}`), {
-          BlockStatement(path) {
-            [varsHoistPoint] = path.unshiftContainer(
-              "body",
-              t.emptyStatement(),
-            );
-            path.traverse({
-              Identifier(path) {
-                if (i++ >= 5) {
-                  return;
-                }
-                logs[0].push(path.node.name);
-                varsHoistPoint.insertBefore(t.identifier("b"));
-              },
-            });
-          },
-        });
-        i = 0;
-        traverse(parse(`{a;}`), {
-          BlockStatement(path) {
-            [varsHoistPoint] = path.unshiftContainer(
-              "body",
-              t.emptyStatement(),
-            );
-            path.traverse({
-              enter() {},
-              Identifier(path) {
-                if (i++ >= 5) {
-                  return;
-                }
-                logs[1].push(path.node.name);
-                varsHoistPoint.insertBefore(t.identifier("b"));
-              },
-            });
-          },
-        });
-
-        expect(logs[0]).toEqual(["a", "b", "b", "b", "b"]);
-        expect(logs[1]).toEqual(["a", "b", "b", "b", "b"]);
+    it("edge case for babel-plugin-jest-hoist", function () {
+      let varsHoistPoint;
+      let i = 0;
+      const logs = [[], []];
+      traverse(parse(`{a;}`), {
+        BlockStatement(path) {
+          [varsHoistPoint] = path.unshiftContainer("body", t.emptyStatement());
+          path.traverse({
+            Identifier(path) {
+              if (i++ >= 5) {
+                return;
+              }
+              logs[0].push(path.node.name);
+              varsHoistPoint.insertBefore(t.identifier("b"));
+            },
+          });
+        },
       });
+      i = 0;
+      traverse(parse(`{a;}`), {
+        BlockStatement(path) {
+          [varsHoistPoint] = path.unshiftContainer("body", t.emptyStatement());
+          path.traverse({
+            enter() {},
+            Identifier(path) {
+              if (i++ >= 5) {
+                return;
+              }
+              logs[1].push(path.node.name);
+              varsHoistPoint.insertBefore(t.identifier("b"));
+            },
+          });
+        },
+      });
+
+      expect(logs[0]).toEqual(["a"]);
+      expect(logs[1]).toEqual(["a"]);
     });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This is a breaking change.
I hope to postpone it until Babel 9.
Fortunately, none of our plugins were affected.
Only one test that supported `babel-plugin-jest-hoist`'s edge behavior was impacted.
This resulted in an <del>overall transformation</del> and traversing time reduction of ~20%.
```
PS F:\babel> node .\benchmark\all\real-case-ts-mjs.mjs
Recommend running with --expose-gc.
all/real-case-ts-mjs.mjs babel-parser-express.ts @ current: 70.6 ops/sec ±3.29% 336 runs (15ms)
all/real-case-ts-mjs.mjs babel-parser-express.ts @ baseline: 56.45 ops/sec ±2.96% 274 runs (18ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ current: 13.09 ops/sec ±2.93% 65 runs (77ms)
all/real-case-ts-mjs.mjs ts-parser.ts @ baseline: 11.32 ops/sec ±2.44% 64 runs (89ms)
```
```
PS F:\babel> node .\benchmark\babel-traverse\real-case.mjs          
Recommend running with --expose-gc.
babel-traverse/real-case.mjs babel-parser-express.ts @ current: 174 ops/sec ±2.24% 804 runs (6.219ms)
babel-traverse/real-case.mjs babel-parser-express.ts @ baseline: 139 ops/sec ±2.64% 629 runs (7.953ms)
babel-traverse/real-case.mjs jquery-3.6.js @ current: 43.97 ops/sec ±1.33% 219 runs (23ms)
babel-traverse/real-case.mjs jquery-3.6.js @ baseline: 36.64 ops/sec ±1.61% 182 runs (28ms)
babel-traverse/real-case.mjs ts-checker.mjs @ current: 5.89 ops/sec ±1.27% 64 runs (170ms)
babel-traverse/real-case.mjs ts-checker.mjs @ baseline: 5.03 ops/sec ±1.67% 64 runs (200ms)
babel-traverse/real-case.mjs ts-parser.mjs @ current: 40.48 ops/sec ±1.95% 200 runs (25ms)
babel-traverse/real-case.mjs ts-parser.mjs @ baseline: 33.6 ops/sec ±1.92% 166 runs (30ms)
babel-traverse/real-case.mjs ts-parser.ts @ current: 31.63 ops/sec ±1.53% 157 runs (32ms)
babel-traverse/real-case.mjs ts-parser.ts @ baseline: 25.49 ops/sec ±1.95% 127 runs (40ms)
babel-traverse/real-case.mjs typescript-5.6.2.js @ current: 1.45 ops/sec ±0.74% 64 runs (691ms)
babel-traverse/real-case.mjs typescript-5.6.2.js @ baseline: 1.21 ops/sec ±1.47% 64 runs (829ms)
```
traverse with `noScope: true`: 30%-40%
```
PS F:\babel> node .\benchmark\babel-traverse\real-case.mjs
Recommend running with --expose-gc.
babel-traverse/real-case.mjs babel-parser-express.ts @ current: 470 ops/sec ±0.64% 2308 runs (2.167ms)
babel-traverse/real-case.mjs babel-parser-express.ts @ baseline: 313 ops/sec ±2.2% 1389 runs (3.601ms)
babel-traverse/real-case.mjs jquery-3.6.js @ current: 135 ops/sec ±0.99% 663 runs (7.55ms)
babel-traverse/real-case.mjs jquery-3.6.js @ baseline: 90.28 ops/sec ±1.76% 443 runs (11ms)
babel-traverse/real-case.mjs ts-checker.mjs @ current: 15.54 ops/sec ±2.87% 77 runs (65ms)
babel-traverse/real-case.mjs ts-checker.mjs @ baseline: 11.21 ops/sec ±4.12% 64 runs (91ms)
babel-traverse/real-case.mjs ts-parser.mjs @ current: 125 ops/sec ±0.91% 618 runs (8.094ms)
babel-traverse/real-case.mjs ts-parser.mjs @ baseline: 90.59 ops/sec ±2.05% 442 runs (11ms)
babel-traverse/real-case.mjs ts-parser.ts @ current: 82.34 ops/sec ±0.43% 411 runs (12ms)
babel-traverse/real-case.mjs ts-parser.ts @ baseline: 56.12 ops/sec ±2.41% 273 runs (18ms)
babel-traverse/real-case.mjs typescript-5.6.2.js @ current: 3.94 ops/sec ±1.87% 64 runs (255ms)
babel-traverse/real-case.mjs typescript-5.6.2.js @ baseline: 2.7 ops/sec ±2.82% 64 runs (375ms)
```