### PR TITLE
chore: Cleanup `inherit` in `@babel/types`

### DIFF
--- a/packages/babel-types/src/utils/inherit.ts
+++ b/packages/babel-types/src/utils/inherit.ts
@@ -1,14 +1,26 @@
 import type * as t from "../index.ts";
 
+type MaybeArray = unknown[] | null | undefined;
+
+type ArrayKeys<C> = {
+  [K in keyof C]: C[K] extends MaybeArray ? K : never;
+}[keyof C];
+
 export default function inherit<C extends t.Node, P extends t.Node>(
-  key: keyof C & keyof P,
+  key: ArrayKeys<C> & ArrayKeys<P>,
   child: C,
   parent: P,
 ): void {
   if (child && parent) {
-    // @ts-expect-error Could further refine key definitions
-    child[key] = Array.from(
-      new Set(([] as any[]).concat(child[key], parent[key]).filter(Boolean)),
+    const parentVal = parent[key] as MaybeArray;
+    if (!parentVal) return;
+
+    const childVal = child[key] as MaybeArray;
+
+    (child[key] as MaybeArray) = Array.from(
+      childVal
+        ? new Set([...childVal, ...parentVal].filter(Boolean))
+        : parentVal,
     );
   }
 }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In many cases only one of the two objects has the property, so we can avoid creating the set when that happens. This PR also refines the type.