### PR TITLE
fix: evaluate computed __proto__ object key as an own property

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -360,8 +360,19 @@ function _evaluate(path: NodePath, state: State): any {
         return;
       }
       value = value.value;
-      // @ts-expect-error key is any type
-      obj[key] = value;
+      if (prop.node.computed && key === "__proto__") {
+        // A computed `{ ["__proto__"]: value }` defines an own property and
+        // does not set the prototype, unlike `{ __proto__: value }`.
+        Object.defineProperty(obj, key, {
+          value,
+          configurable: true,
+          enumerable: true,
+          writable: true,
+        });
+      } else {
+        // @ts-expect-error key is any type
+        obj[key] = value;
+      }
     }
     return obj;
   }

--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -360,18 +360,21 @@ function _evaluate(path: NodePath, state: State): any {
         return;
       }
       value = value.value;
-      if (prop.node.computed && key === "__proto__") {
-        // A computed `{ ["__proto__"]: value }` defines an own property and
-        // does not set the prototype, unlike `{ __proto__: value }`.
+      if (!prop.node.computed && key === "__proto__") {
+        // A non-computed __proto__ key sets the prototype, unless the value
+        // is not an object or null, in which case it is ignored.
+        if (typeof value === "object" || typeof value === "function") {
+          Object.setPrototypeOf(obj, value);
+        }
+      } else {
+        // Define an own property, so a computed `["__proto__"]` key does not
+        // set the prototype and no setters on the prototype are triggered.
         Object.defineProperty(obj, key, {
           value,
           configurable: true,
           enumerable: true,
           writable: true,
         });
-      } else {
-        // @ts-expect-error key is any type
-        obj[key] = value;
       }
     }
     return obj;

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -488,6 +488,21 @@ describe("evaluation", function () {
       expect(Object.hasOwn(evalResult.value, "__proto__")).toBe(false);
       expect(evalResult.value.polluted).toBe(true);
     }
+
+    const nullProto = getPath("({ __proto__: null });")
+      .get("body.0.expression")
+      .evaluate();
+    expect(nullProto.confident).toBe(true);
+    expect(Object.getPrototypeOf(nullProto.value)).toBe(null);
+  });
+
+  it("should ignore a plain __proto__ key with a primitive value", function () {
+    const evalResult = getPath("({ __proto__: 5 });")
+      .get("body.0.expression")
+      .evaluate();
+    expect(evalResult.confident).toBe(true);
+    expect(Object.getPrototypeOf(evalResult.value)).toBe(Object.prototype);
+    expect(Object.hasOwn(evalResult.value, "__proto__")).toBe(false);
   });
 
   addDeoptTest("({a:{b}})", "ObjectExpression", "Identifier");

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -468,6 +468,28 @@ describe("evaluation", function () {
     expect(evalResult.value).toBe(1);
   });
 
+  it("should evaluate a computed __proto__ key as an own property", function () {
+    const computed = getPath("({ ['__proto__']: { polluted: true } });")
+      .get("body.0.expression")
+      .evaluate();
+    expect(computed.confident).toBe(true);
+    expect(Object.getPrototypeOf(computed.value)).toBe(Object.prototype);
+    expect(Object.hasOwn(computed.value, "__proto__")).toBe(true);
+    expect(computed.value.polluted).toBeUndefined();
+  });
+
+  it("should evaluate a plain __proto__ key as a prototype", function () {
+    for (const code of [
+      "({ __proto__: { polluted: true } });",
+      "({ '__proto__': { polluted: true } });",
+    ]) {
+      const evalResult = getPath(code).get("body.0.expression").evaluate();
+      expect(evalResult.confident).toBe(true);
+      expect(Object.hasOwn(evalResult.value, "__proto__")).toBe(false);
+      expect(evalResult.value.polluted).toBe(true);
+    }
+  });
+
   addDeoptTest("({a:{b}})", "ObjectExpression", "Identifier");
   addDeoptTest("({[a + 'b']: 1})", "ObjectExpression", "Identifier");
   addDeoptTest("[{a}]", "ArrayExpression", "Identifier");


### PR DESCRIPTION
| Q                       | A
| ----------------------- | ---
| Fixed Issues?           |
| Patch: Bug Fix?         | Yes
| Major: Breaking Change? | No
| Minor: New Feature?     | No
| Tests Added + Pass?     | Yes
| Documentation PR Link   |
| Any Dependency Changes? | No
| License                 | MIT

`path.evaluate` folds an object literal with `obj[key] = value`, so a computed `{ ["__proto__"]: x }` key hits the `__proto__` setter and mutates the evaluated object's prototype instead of adding an own property. Per spec only a plain `__proto__` key sets the prototype, so `evaluate` of `({ ["__proto__"]: { y: 1 } })` returns an object that inherits `y` rather than one with an own `__proto__` property. Found while auditing the `ObjectExpression` branch; `Object.defineProperty` keeps the computed case an own property and leaves the non-computed form unchanged.