### PR TITLE
fix(parser): disallow `declare module M {}`

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -116,6 +116,7 @@ export const TSErrorTemplates = {
   // https://github.com/microsoft/TypeScript/blob/main/src/compiler/types.ts#L2915
   EmptyHeritageClauseType: ({ token }: { token: "extends" | "implements" }) =>
     `'${token}' list cannot be empty.`,
+  EmptyNamespaceName: "Namespace must be given a name.",
   EmptyTypeArguments: "Type argument list cannot be empty.",
   EmptyTypeParameters: "Type parameter list cannot be empty.",
   ExpectedAmbientAfterExportDeclare:
@@ -173,6 +174,8 @@ export const TSErrorTemplates = {
     orderedModifiers: [TsModifier, TsModifier];
   }) =>
     `'${orderedModifiers[0]}' modifier must precede '${orderedModifiers[1]}' modifier.`,
+  InvalidNamespaceName: (value: string | number) =>
+    `Namespace name cannot be '${value}'.`,
   InvalidPropertyAccessAfterInstantiationExpression:
     "Invalid property access after an instantiation expression. " +
     "You can either wrap the instantiation expression in parentheses, or delete the type arguments.",
@@ -2096,7 +2099,22 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         node.id = this.parseIdentifier();
       } else {
         node.kind = "module";
-        node.id = super.parseStringLiteral(this.state.value);
+        const { type, value } = this.state;
+        if (type === tt.string) {
+          node.id = super.parseStringLiteral(value);
+        } else if (tokenIsIdentifier(type)) {
+          this.raise(
+            TSErrors.InlineModuleDeclarationMustUseString,
+            this.state.startLoc,
+          );
+          node.id = this.tsParseEntityName(tsParseEntityNameFlags.NONE);
+        } else if (type === tt.braceL) {
+          this.raise(TSErrors.EmptyNamespaceName, this.state.startLoc);
+        } else {
+          this.raise(TSErrors.InvalidNamespaceName, this.state.startLoc, value);
+          // @ts-expect-error Parse as an expression atom to recover from the error
+          node.id = super.parseExprAtom();
+        }
       }
       if (this.match(tt.braceL)) {
         if (!isGlobal) {

--- a/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-identifier/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-identifier/input.ts
@@ -1,0 +1,3 @@
+declare module M {}
+
+declare module M.P {}

--- a/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-identifier/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-identifier/output.json
@@ -1,0 +1,61 @@
+{
+  "type": "File",
+  "start":0,"end":42,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":21,"index":42}},
+  "errors": [
+    "SyntaxError: `module ... {}` declarations must have a string name. Use `namespace ... {}` instead. (1:15)",
+    "SyntaxError: `module ... {}` declarations must have a string name. Use `namespace ... {}` instead. (3:15)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":42,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":3,"column":21,"index":42}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSModuleDeclaration",
+        "start":0,"end":19,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":19,"index":19}},
+        "kind": "module",
+        "id": {
+          "type": "Identifier",
+          "start":15,"end":16,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":16,"index":16},"identifierName":"M"},
+          "name": "M"
+        },
+        "body": {
+          "type": "TSModuleBlock",
+          "start":17,"end":19,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":1,"column":19,"index":19}},
+          "body": []
+        },
+        "declare": true
+      },
+      {
+        "type": "TSModuleDeclaration",
+        "start":21,"end":42,"loc":{"start":{"line":3,"column":0,"index":21},"end":{"line":3,"column":21,"index":42}},
+        "kind": "module",
+        "id": {
+          "type": "TSQualifiedName",
+          "start":36,"end":39,"loc":{"start":{"line":3,"column":15,"index":36},"end":{"line":3,"column":18,"index":39}},
+          "left": {
+            "type": "Identifier",
+            "start":36,"end":37,"loc":{"start":{"line":3,"column":15,"index":36},"end":{"line":3,"column":16,"index":37},"identifierName":"M"},
+            "name": "M"
+          },
+          "right": {
+            "type": "Identifier",
+            "start":38,"end":39,"loc":{"start":{"line":3,"column":17,"index":38},"end":{"line":3,"column":18,"index":39},"identifierName":"P"},
+            "name": "P"
+          }
+        },
+        "body": {
+          "type": "TSModuleBlock",
+          "start":40,"end":42,"loc":{"start":{"line":3,"column":19,"index":40},"end":{"line":3,"column":21,"index":42}},
+          "body": []
+        },
+        "declare": true
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-number/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-number/input.ts
@@ -1,0 +1,1 @@
+declare module 0 {}

--- a/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-number/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-number/output.json
@@ -1,0 +1,39 @@
+{
+  "type": "File",
+  "start":0,"end":19,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":19,"index":19}},
+  "errors": [
+    "SyntaxError: Namespace name cannot be '0'. (1:15)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":19,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":19,"index":19}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSModuleDeclaration",
+        "start":0,"end":19,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":19,"index":19}},
+        "kind": "module",
+        "id": {
+          "type": "NumericLiteral",
+          "start":15,"end":16,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":16,"index":16}},
+          "extra": {
+            "rawValue": 0,
+            "raw": "0"
+          },
+          "value": 0
+        },
+        "body": {
+          "type": "TSModuleBlock",
+          "start":17,"end":19,"loc":{"start":{"line":1,"column":17,"index":17},"end":{"line":1,"column":19,"index":19}},
+          "body": []
+        },
+        "declare": true
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-without-name/input.ts
+++ b/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-without-name/input.ts
@@ -1,0 +1,1 @@
+declare module {}

--- a/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-without-name/output.json
+++ b/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-declare-module-without-name/output.json
@@ -1,0 +1,30 @@
+{
+  "type": "File",
+  "start":0,"end":17,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":17,"index":17}},
+  "errors": [
+    "SyntaxError: Namespace must be given a name. (1:15)"
+  ],
+  "program": {
+    "type": "Program",
+    "start":0,"end":17,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":17,"index":17}},
+    "sourceType": "module",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "TSModuleDeclaration",
+        "start":0,"end":17,"loc":{"start":{"line":1,"column":0,"index":0},"end":{"line":1,"column":17,"index":17}},
+        "kind": "module",
+        "body": {
+          "type": "TSModuleBlock",
+          "start":15,"end":17,"loc":{"start":{"line":1,"column":15,"index":15},"end":{"line":1,"column":17,"index":17}},
+          "body": []
+        },
+        "declare": true
+      }
+    ],
+    "directives": [],
+    "extra": {
+      "topLevelAwait": false
+    }
+  }
+}

--- a/packages/babel-parser/typings/babel-parser.d.ts
+++ b/packages/babel-parser/typings/babel-parser.d.ts
@@ -296,6 +296,7 @@ type ErrorInfoCompressed = {
   DuplicateAccessibilityModifier: [{ modifier: Accessibility }];
   DuplicateModifier: [{ modifier: TsModifier }];
   EmptyHeritageClauseType: [{ token: "extends" | "implements" }];
+  EmptyNamespaceName: [];
   EmptyTypeArguments: [];
   EmptyTypeParameters: [];
   ExpectedAmbientAfterExportDeclare: [];
@@ -336,6 +337,7 @@ type ErrorInfoCompressed = {
     | VarianceAnnotations,
   ];
   InvalidModifiersOrder: [{ orderedModifiers: [TsModifier, TsModifier] }];
+  InvalidNamespaceName: [string | number];
   InvalidPropertyAccessAfterInstantiationExpression: [];
   InvalidTupleMemberLabel: [];
   MissingInterfaceName: [];

--- a/packages/babel-plugin-transform-typescript/test/fixtures/declarations/erased/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/declarations/erased/input.ts
@@ -4,7 +4,6 @@ declare function f(): void;
 declare class C {}
 declare enum E {}
 declare module "m" {}
-declare module M {}
 declare namespace N {}
 export interface I {}
 export type T = number;

--- a/scripts/parser-tests/typescript/allowlist.md
+++ b/scripts/parser-tests/typescript/allowlist.md
@@ -32,7 +32,7 @@
 - [umdNamespaceMergedWithGlobalAugmentationIsNotCircular.ts](../../../build/typescript/tests/cases/compiler/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.ts) <!-- TS checks duplicate identifiers across related files, but babel-parser handles them separately -->
 - [uniqueSymbolJs.ts](../../../build/typescript/tests/cases/compiler/uniqueSymbolJs.ts) <!-- JSDoc syntax error. babel-parser does not parse JSDoc comments -->
 
-## 49 valid programs produced a parsing error
+## 47 valid programs produced a parsing error
 
 - [anyDeclare.ts](../../../build/typescript/tests/cases/compiler/anyDeclare.ts)
 - [augmentedTypesClass2a.ts](../../../build/typescript/tests/cases/compiler/augmentedTypesClass2a.ts)
@@ -64,7 +64,6 @@
 - [funClodule.ts](../../../build/typescript/tests/cases/compiler/funClodule.ts)
 - [functionCall15.ts](../../../build/typescript/tests/cases/compiler/functionCall15.ts)
 - [importAndVariableDeclarationConflict3.ts](../../../build/typescript/tests/cases/compiler/importAndVariableDeclarationConflict3.ts)
-- [importAssertionNonstring.ts](../../../build/typescript/tests/cases/compiler/importAssertionNonstring.ts)
 - [importDeclWithDeclareModifierInAmbientContext.ts](../../../build/typescript/tests/cases/compiler/importDeclWithDeclareModifierInAmbientContext.ts)
 - [jsFileCompilationBindDuplicateIdentifier.ts](../../../build/typescript/tests/cases/compiler/jsFileCompilationBindDuplicateIdentifier.ts)
 - [jsFileCompilationWithoutJsExtensions.ts](../../../build/typescript/tests/cases/compiler/jsFileCompilationWithoutJsExtensions.ts)
@@ -73,7 +72,6 @@
 - [letDeclarations-validContexts.ts](../../../build/typescript/tests/cases/compiler/letDeclarations-validContexts.ts)
 - [mismatchedClassConstructorVariable.ts](../../../build/typescript/tests/cases/compiler/mismatchedClassConstructorVariable.ts)
 - [moduleDuplicateIdentifiers.ts](../../../build/typescript/tests/cases/compiler/moduleDuplicateIdentifiers.ts)
-- [moduleKeywordDeprecated.ts](../../../build/typescript/tests/cases/compiler/moduleKeywordDeprecated.ts)
 - [modulePreserve2.ts](../../../build/typescript/tests/cases/compiler/modulePreserve2.ts)
 - [moduleSharesNameWithImportDeclarationInsideIt3.ts](../../../build/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt3.ts)
 - [moduleSharesNameWithImportDeclarationInsideIt5.ts](../../../build/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt5.ts)

--- a/scripts/parser-tests/typescript/error-codes.js
+++ b/scripts/parser-tests/typescript/error-codes.js
@@ -92,12 +92,19 @@ export default [
   "TS1246", // An interface property cannot have an initializer.
   "TS1247", // A type literal property cannot have an initializer.
   "TS1248", // A class member cannot have the 'const' keyword.
+  "TS1253", // Abstract properties can only appear within an abstract class.
+  "TS1255", // A definite assignment assertion '!' is not permitted in this context.
+  "TS1257", // A required element cannot follow an optional element.
   "TS1260", // Keywords cannot contain escape characters.
   "TS1263", // Declarations with initializers cannot also have definite assignment assertions.
   "TS1264", // Declarations with definite assignment assertions must also have type annotations.
+  "TS1275", // 'accessor' modifier can only appear on a property declaration.
+  "TS1276", // An 'accessor' property cannot be declared optional.
+  "TS1277", // '{0}' modifier can only appear on a type parameter of a function, method or class
   "TS1308", // 'await' expression is only allowed within an async function.
   "TS1312", // '=' can only be used in an object literal property inside a destructuring assignment.
   "TS1317", // A parameter property cannot be declared using a rest parameter.
+  "TS1318", // An abstract accessor cannot have an implementation.
   "TS1319", // A default export can only be used in an ECMAScript-style module.
   "TS1344", // A label is not allowed here.
   "TS1347", // 'use strict' directive cannot be used with non-simple parameter list.
@@ -114,6 +121,7 @@ export default [
   "TS1490", // File appears to be binary.
   "TS1499", // Unknown regular expression flag.
   "TS1500", // Duplicate regular expression flag.
+  "TS1540", // A 'namespace' declaration should not be declared using the 'module' keyword. Please use the 'namespace' keyword instead.
   // "TS2300", // Duplicate identifier '{0}'.
   "TS2335", // 'super' can only be referenced in a derived class.
   "TS2337", // Super calls are not permitted outside constructors or in nested functions inside constructors.
@@ -146,6 +154,7 @@ export default [
   "TS2754", // 'super' may not use type arguments.
   "TS2809", // Declaration or statement expected. This '=' follows a block of statements, so if you intended to write a destructuring assignment, you might need to wrap the the whole assignment in parentheses.
   "TS2815", // 'arguments' cannot be referenced in property initializers.
+  "TS2880", // Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
 
   "TS8002", // 'import ... =' can only be used in TypeScript files.
   "TS8003", // 'export =' can only be used in TypeScript files."


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Forbids `declare module M {}`
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we reused the error `InlineModuleDeclarationMustUseString` for such cases. Also added new tests and updated the parser test results.