### PR TITLE
Fix top-level enter and exit visitor types

### DIFF
--- a/packages/babel-core/test/index.tst.ts
+++ b/packages/babel-core/test/index.tst.ts
@@ -1,5 +1,6 @@
 import { expect, it, describe } from "tstyche";
-import { transformSync } from "../src/index.ts";
+import { transformSync, traverse } from "../src/index.ts";
+import type { NodePath, types as t } from "../src/index.ts";
 import type presetEnv from "@babel/preset-env";
 import type presetReact from "@babel/preset-react";
 import type presetTypescript from "@babel/preset-typescript";
@@ -47,6 +48,20 @@ describe("core", () => {
           return {};
         },
       ],
+    });
+  });
+
+  it("re-exports traverse with top-level enter and exit visitor types", () => {
+    traverse({} as t.Program, {
+      enter(path) {
+        expect(path).type.toBe<NodePath<t.Node>>();
+        expect(path.type).type.toBe<t.Node["type"]>();
+      },
+      exit(path) {
+        expect(path).type.toBe<NodePath<t.Node>>();
+        expect(path.type).type.toBe<t.Node["type"]>();
+      },
+      noScope: true,
     });
   });
 });

--- a/packages/babel-core/test/index.tst.ts
+++ b/packages/babel-core/test/index.tst.ts
@@ -1,6 +1,5 @@
 import { expect, it, describe } from "tstyche";
-import { transformSync, traverse } from "../src/index.ts";
-import type { NodePath, types as t } from "../src/index.ts";
+import { transformSync } from "../src/index.ts";
 import type presetEnv from "@babel/preset-env";
 import type presetReact from "@babel/preset-react";
 import type presetTypescript from "@babel/preset-typescript";
@@ -48,20 +47,6 @@ describe("core", () => {
           return {};
         },
       ],
-    });
-  });
-
-  it("re-exports traverse with top-level enter and exit visitor types", () => {
-    traverse({} as t.Program, {
-      enter(path) {
-        expect(path).type.toBe<NodePath<t.Node>>();
-        expect(path.type).type.toBe<t.Node["type"]>();
-      },
-      exit(path) {
-        expect(path).type.toBe<NodePath<t.Node>>();
-        expect(path.type).type.toBe<t.Node["type"]>();
-      },
-      noScope: true,
     });
   });
 });

--- a/packages/babel-traverse/src/types.ts
+++ b/packages/babel-traverse/src/types.ts
@@ -85,9 +85,13 @@ type ToNode<S extends string, N = Split<S>> = N extends keyof t.Aliases
 
 type OptionKeys = keyof TraverseOptions;
 
+type VisitNodeObjectKeys = keyof VisitNodeObject<unknown, t.Node>;
+
 export type VisitorProp<S, K extends string> = K extends OptionKeys
   ? TraverseOptions[K]
-  : VisitNode<S, ToNode<K>>;
+  : K extends VisitNodeObjectKeys
+    ? VisitNodeObject<S, t.Node>[K]
+    : VisitNode<S, ToNode<K>>;
 
 export type TraverseOptions = {
   scope?: Scope;

--- a/packages/babel-traverse/test/index.tst.ts
+++ b/packages/babel-traverse/test/index.tst.ts
@@ -95,6 +95,20 @@ describe("traverse", () => {
   });
 
   describe("Visitor", () => {
+    it("top-level enter and exit", () => {
+      traverse({} as t.Node, {
+        enter(path) {
+          expect(path).type.toBe<NodePath<t.Node>>();
+          expect(path.type).type.toBe<t.Node["type"]>();
+        },
+        exit(path) {
+          expect(path).type.toBe<NodePath<t.Node>>();
+          expect(path.type).type.toBe<t.Node["type"]>();
+        },
+        noScope: true,
+      });
+    });
+
     describe("Union types", () => {
       it("traverse", () => {
         traverse({} as t.Node, {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #18128
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes — `yarn tstyche`
| Documentation PR Link    | 
| Any Dependency Changes?  | No
| License                  | MIT

This fixes the contextual type for top-level `enter` and `exit` visitor methods. Those keys are now treated as root visitor callbacks rather than node-type visitor keys, avoiding `NodePath<never>` inference.

Added TSTyche coverage for both `@babel/traverse` and the `@babel/core` re-export.
