### PR TITLE
fix(register): do not inherit parent execArgv

### DIFF
--- a/packages/babel-cli/test/helpers/runner.js
+++ b/packages/babel-cli/test/helpers/runner.js
@@ -11,7 +11,7 @@ const rootDir = path.resolve(__dirname, "../../../..");
 
 const getPath = name => path.join(rootDir, "packages", name, "lib/index.js");
 
-const presetLocs = [getPath("babel-preset-react")];
+const presetLocs = ["babel-preset-react"].map(getPath).join(",");
 
 const pluginLocs = [
   "babel-plugin-transform-arrow-functions",

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -730,6 +730,11 @@ export function buildParallelProcessTests(name: string, tests: ProcessTest[]) {
   };
 }
 
+const rootDir = path.resolve(dirname, "../../..");
+function resolveRootDirToken(arg: string) {
+  return arg.replace("<rootDir>", rootDir);
+}
+
 export function buildProcessTests(
   dir: string | URL,
   beforeHook: ProcessTestBeforeHook,
@@ -844,19 +849,15 @@ export function buildProcessTests(
           try {
             beforeHook(test, tmpLoc);
 
-            if (test.binLoc === undefined) {
-              throw new Error("test.binLoc is undefined");
+            let args = [];
+            if (opts.executor) {
+              args.push("--require", path.join(dirname, "./exit-loader.cjs"));
+            }
+            if (test.binLoc) {
+              args.push(test.binLoc);
             }
 
-            let args = opts.executor
-              ? [
-                  "--require",
-                  path.join(dirname, "./exit-loader.cjs"),
-                  test.binLoc,
-                ]
-              : [test.binLoc];
-
-            args = args.concat(opts.args);
+            args = args.concat(opts.args).map(arg => resolveRootDirToken(arg));
             const env = {
               ...process.env,
               FORCE_COLOR: "false",

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -730,9 +730,16 @@ export function buildParallelProcessTests(name: string, tests: ProcessTest[]) {
   };
 }
 
-const rootDir = path.resolve(dirname, "../../..");
+const rootUrl = new URL("../../..", import.meta.url);
 function resolveRootDirToken(arg: string) {
-  return arg.replace("<rootDir>", rootDir);
+  if (arg.startsWith("<rootDir>")) {
+    if (process.platform === "win32") {
+      return arg.replace("<rootDir>", rootUrl.href.slice(0, -1));
+    } else {
+      return arg.replace("<rootDir>", fileURLToPath(rootUrl));
+    }
+  }
+  return arg;
 }
 
 export function buildProcessTests(

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -731,15 +731,10 @@ export function buildParallelProcessTests(name: string, tests: ProcessTest[]) {
 }
 
 const rootUrl = new URL("../../..", import.meta.url);
-function resolveRootDirToken(arg: string) {
-  if (arg.startsWith("<rootDir>")) {
-    if (process.platform === "win32") {
-      return arg.replace("<rootDir>", rootUrl.href.slice(0, -1));
-    } else {
-      return arg.replace("<rootDir>", fileURLToPath(rootUrl));
-    }
-  }
-  return arg;
+function resolveRootDirOrRootUrlToken(arg: string) {
+  return arg
+    .replace("<rootDir>", fileURLToPath(rootUrl))
+    .replace("<rootUrl>", rootUrl.href.slice(0, -1));
 }
 
 export function buildProcessTests(
@@ -864,7 +859,9 @@ export function buildProcessTests(
               args.push(test.binLoc);
             }
 
-            args = args.concat(opts.args).map(arg => resolveRootDirToken(arg));
+            args = args
+              .concat(opts.args)
+              .map(arg => resolveRootDirOrRootUrlToken(arg));
             const env = {
               ...process.env,
               FORCE_COLOR: "false",

--- a/packages/babel-register/package.json
+++ b/packages/babel-register/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@babel/core": "workspace:^",
+    "@babel/helper-transform-fixture-test-runner": "workspace:^",
     "@babel/plugin-transform-arrow-functions": "workspace:^",
     "@babel/plugin-transform-modules-commonjs": "workspace:^",
     "@babel/preset-typescript": "workspace:^",

--- a/packages/babel-register/src/worker-client.ts
+++ b/packages/babel-register/src/worker-client.ts
@@ -46,7 +46,13 @@ class Client implements IClient {
 class WorkerClient extends Client {
   #worker = new worker_threads.Worker(
     new URL("./worker/index.js", import.meta.url),
-    { env: markInRegisterWorker(process.env) },
+    {
+      env: markInRegisterWorker(process.env),
+      // Set execArgv to an empty array to prevent the worker from inheriting
+      // the command line flags.
+      // https://nodejs.org/api/worker_threads.html#launching-worker-threads-from-preload-scripts
+      execArgv: [],
+    },
   );
 
   constructor() {

--- a/packages/babel-register/test/batch-test-runner/0.js
+++ b/packages/babel-register/test/batch-test-runner/0.js
@@ -1,0 +1,3 @@
+import { runParallel } from "../helpers/runner.js";
+
+runParallel(parseInt(import.meta.url.split("/").pop().split(".")[0]), 8);

--- a/packages/babel-register/test/batch-test-runner/1.js
+++ b/packages/babel-register/test/batch-test-runner/1.js
@@ -1,0 +1,3 @@
+import { runParallel } from "../helpers/runner.js";
+
+runParallel(parseInt(import.meta.url.split("/").pop().split(".")[0]), 8);

--- a/packages/babel-register/test/batch-test-runner/2.js
+++ b/packages/babel-register/test/batch-test-runner/2.js
@@ -1,0 +1,3 @@
+import { runParallel } from "../helpers/runner.js";
+
+runParallel(parseInt(import.meta.url.split("/").pop().split(".")[0]), 8);

--- a/packages/babel-register/test/batch-test-runner/3.js
+++ b/packages/babel-register/test/batch-test-runner/3.js
@@ -1,0 +1,3 @@
+import { runParallel } from "../helpers/runner.js";
+
+runParallel(parseInt(import.meta.url.split("/").pop().split(".")[0]), 8);

--- a/packages/babel-register/test/batch-test-runner/4.js
+++ b/packages/babel-register/test/batch-test-runner/4.js
@@ -1,0 +1,3 @@
+import { runParallel } from "../helpers/runner.js";
+
+runParallel(parseInt(import.meta.url.split("/").pop().split(".")[0]), 8);

--- a/packages/babel-register/test/batch-test-runner/5.js
+++ b/packages/babel-register/test/batch-test-runner/5.js
@@ -1,0 +1,3 @@
+import { runParallel } from "../helpers/runner.js";
+
+runParallel(parseInt(import.meta.url.split("/").pop().split(".")[0]), 8);

--- a/packages/babel-register/test/batch-test-runner/6.js
+++ b/packages/babel-register/test/batch-test-runner/6.js
@@ -1,0 +1,3 @@
+import { runParallel } from "../helpers/runner.js";
+
+runParallel(parseInt(import.meta.url.split("/").pop().split(".")[0]), 8);

--- a/packages/babel-register/test/batch-test-runner/7.js
+++ b/packages/babel-register/test/batch-test-runner/7.js
@@ -1,0 +1,3 @@
+import { runParallel } from "../helpers/runner.js";
+
+runParallel(parseInt(import.meta.url.split("/").pop().split(".")[0]), 8);

--- a/packages/babel-register/test/fixtures/preload/--import/--input-type=commonjs -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--import/--input-type=commonjs -e/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--import", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=commonjs", "-e", "console.log(0)"],
+  "stdout": "0"
+}

--- a/packages/babel-register/test/fixtures/preload/--import/--input-type=commonjs -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--import/--input-type=commonjs -e/options.json
@@ -1,4 +1,4 @@
 {
-  "args": ["--import", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=commonjs", "-e", "console.log(0)"],
+  "args": ["--import", "<rootUrl>/packages/babel-register/lib/index.js", "--input-type=commonjs", "-e", "console.log(0)"],
   "stdout": "0"
 }

--- a/packages/babel-register/test/fixtures/preload/--import/--input-type=commonjs-typescript -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--import/--input-type=commonjs-typescript -e/options.json
@@ -1,4 +1,4 @@
 {
-  "args": ["--import", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=commonjs-typescript", "-e", "console!.log(0)"],
+  "args": ["--import", "<rootUrl>/packages/babel-register/lib/index.js", "--input-type=commonjs-typescript", "-e", "console!.log(0)"],
   "stdout": "0"
 }

--- a/packages/babel-register/test/fixtures/preload/--import/--input-type=commonjs-typescript -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--import/--input-type=commonjs-typescript -e/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--import", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=commonjs-typescript", "-e", "console!.log(0)"],
+  "stdout": "0"
+}

--- a/packages/babel-register/test/fixtures/preload/--import/--input-type=module -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--import/--input-type=module -e/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--import", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=module", "-e", "console.log(0)"],
+  "stdout": "0"
+}

--- a/packages/babel-register/test/fixtures/preload/--import/--input-type=module -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--import/--input-type=module -e/options.json
@@ -1,4 +1,4 @@
 {
-  "args": ["--import", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=module", "-e", "console.log(0)"],
+  "args": ["--import", "<rootUrl>/packages/babel-register/lib/index.js", "--input-type=module", "-e", "console.log(0)"],
   "stdout": "0"
 }

--- a/packages/babel-register/test/fixtures/preload/--import/--input-type=module-typescript -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--import/--input-type=module-typescript -e/options.json
@@ -1,4 +1,4 @@
 {
-  "args": ["--import", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=module-typescript", "-e", "console!.log(0)"],
+  "args": ["--import", "<rootUrl>/packages/babel-register/lib/index.js", "--input-type=module-typescript", "-e", "console!.log(0)"],
   "stdout": "0"
 }

--- a/packages/babel-register/test/fixtures/preload/--import/--input-type=module-typescript -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--import/--input-type=module-typescript -e/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--import", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=module-typescript", "-e", "console!.log(0)"],
+  "stdout": "0"
+}

--- a/packages/babel-register/test/fixtures/preload/--import/-e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--import/-e/options.json
@@ -1,4 +1,4 @@
 {
-  "args": ["--import", "<rootDir>/packages/babel-register/lib/index.js", "-e", "console.log(0)"],
+  "args": ["--import", "<rootUrl>/packages/babel-register/lib/index.js", "-e", "console.log(0)"],
   "stdout": "0"
 }

--- a/packages/babel-register/test/fixtures/preload/--import/-e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--import/-e/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--import", "<rootDir>/packages/babel-register/lib/index.js", "-e", "console.log(0)"],
+  "stdout": "0"
+}

--- a/packages/babel-register/test/fixtures/preload/--require/--input-type=commonjs -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--require/--input-type=commonjs -e/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--require", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=commonjs", "-e", "console.log(0)"],
+  "stdout": "0"
+}

--- a/packages/babel-register/test/fixtures/preload/--require/--input-type=commonjs-typescript -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--require/--input-type=commonjs-typescript -e/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--require", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=commonjs-typescript", "-e", "console!.log(0)"],
+  "stdout": "0"
+}

--- a/packages/babel-register/test/fixtures/preload/--require/--input-type=module -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--require/--input-type=module -e/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--require", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=module", "-e", "console.log(0)"],
+  "stdout": "0"
+}

--- a/packages/babel-register/test/fixtures/preload/--require/--input-type=module-typescript -e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--require/--input-type=module-typescript -e/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--require", "<rootDir>/packages/babel-register/lib/index.js", "--input-type=module-typescript", "-e", "console!.log(0)"],
+  "stdout": "0"
+}

--- a/packages/babel-register/test/fixtures/preload/--require/-e/options.json
+++ b/packages/babel-register/test/fixtures/preload/--require/-e/options.json
@@ -1,0 +1,4 @@
+{
+  "args": ["--require", "<rootDir>/packages/babel-register/lib/index.js", "-e", "console.log(0)"],
+  "stdout": "0"
+}

--- a/packages/babel-register/test/helpers/runner.js
+++ b/packages/babel-register/test/helpers/runner.js
@@ -1,0 +1,14 @@
+import {
+  buildProcessTests,
+  buildParallelProcessTests,
+} from "@babel/helper-transform-fixture-test-runner";
+
+export const runParallel = buildParallelProcessTests(
+  "babel-register",
+  buildProcessTests(
+    new URL("../fixtures/preload", import.meta.url),
+    function (test) {
+      test.opts.env = { ...test.opts.env, BABEL_DISABLE_CACHE: true };
+    },
+  ),
+);

--- a/packages/babel-register/test/package.json
+++ b/packages/babel-register/test/package.json
@@ -1,1 +1,0 @@
-{ "type": "module" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3850,6 +3850,7 @@ __metadata:
   resolution: "@babel/register@workspace:packages/babel-register"
   dependencies:
     "@babel/core": "workspace:^"
+    "@babel/helper-transform-fixture-test-runner": "workspace:^"
     "@babel/plugin-transform-arrow-functions": "workspace:^"
     "@babel/plugin-transform-modules-commonjs": "workspace:^"
     "@babel/preset-typescript": "workspace:^"


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #18130
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

In this PR we avoid inheriting command line arguments for the babel-register worker, per the best practise mentioned in https://nodejs.org/api/worker_threads.html#launching-worker-threads-from-preload-scripts. 

A new Worker threads will inherit command line flags, including `-r`, but will discard the `-e` flag, when the `--input-type` flag is passed down without `-e` flag, an error is thrown from the module loader, and the signal does not have a chance to change so the `Atomics.wait` will block event loop indefinitely.

We also add a new feature to the process fixture test: The test will now resolve the special `<rootDir>` / `<rootUrl>` token into the root of the monorepo. With the new feature, we can properly test the behaviour of Node.js when `@babel/register` is preloaded via `--require` or `--import`.