### PR TITLE
fix(plugin-transform-typescript): merge enums across re-opened namespaces

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/enum.ts
+++ b/packages/babel-plugin-transform-typescript/src/enum.ts
@@ -40,7 +40,24 @@ export default function transpileEnum(
       const isSeen = seen(parentPath);
 
       let init: t.Expression = t.objectExpression([]);
-      if (isSeen || isGlobal) {
+      // When an enum is exported from a namespace, the namespace transform
+      // emits `_N.E = E;` right after the enum. Initialize the enum from that
+      // member (`_N.E || (_N.E = {})`) and drop the redundant assignment, so
+      // that re-opened namespaces merge into the same object instead of
+      // resetting it to a fresh one (which would drop earlier members).
+      const namespaceMember = getNamespaceMember(path, name, t);
+      if (namespaceMember) {
+        init = t.logicalExpression(
+          "||",
+          t.cloneNode(namespaceMember.member),
+          t.assignmentExpression(
+            "=",
+            t.cloneNode(namespaceMember.member),
+            init,
+          ),
+        );
+        namespaceMember.assignment.remove();
+      } else if (isSeen || isGlobal) {
         init = t.logicalExpression("||", t.cloneNode(fill.ID), init);
       }
       const enumIIFE = buildEnumWrapper({ ...fill, INIT: init });
@@ -82,6 +99,55 @@ export default function transpileEnum(
       return false;
     }
   }
+}
+
+/**
+ * Detect an enum that lives inside a namespace IIFE and is followed by the
+ * `_N.E = E;` assignment inserted by the namespace transform, e.g.
+ *
+ *   (function (_N) {
+ *     enum E { ... }       // <- `path`
+ *     _N.E = E;            // <- returned as `assignment`
+ *   })(...);
+ *
+ * Returns the `_N.E` member expression (as `member`) and the path of the
+ * assignment statement, or `null` when the enum is not exported this way.
+ */
+function getNamespaceMember(
+  path: NodePath<t.TSEnumDeclaration>,
+  name: string,
+  t: t,
+): { member: t.MemberExpression; assignment: NodePath } | null {
+  const { parentPath } = path;
+  if (!parentPath.isBlockStatement() || typeof path.key !== "number") {
+    return null;
+  }
+  // The block must be the body of the namespace IIFE `(function (_N) { … })`.
+  const fnPath = parentPath.parentPath;
+  if (!fnPath.isFunctionExpression() || fnPath.node.params.length !== 1) {
+    return null;
+  }
+  const param = fnPath.node.params[0];
+  if (!t.isIdentifier(param)) return null;
+
+  const assignment = path.getSibling(path.key + 1);
+  const stmt = assignment.node;
+  if (
+    !t.isExpressionStatement(stmt) ||
+    !t.isAssignmentExpression(stmt.expression, { operator: "=" })
+  ) {
+    return null;
+  }
+  const { left, right } = stmt.expression;
+  if (
+    t.isMemberExpression(left, { computed: false }) &&
+    t.isIdentifier(left.object, { name: param.name }) &&
+    t.isIdentifier(left.property, { name }) &&
+    t.isIdentifier(right, { name })
+  ) {
+    return { member: left, assignment };
+  }
+  return null;
 }
 
 const buildStringAssignment = template.statement(`

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/exported-enum-merged-across-namespaces/exec.js
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/exported-enum-merged-across-namespaces/exec.js
@@ -1,0 +1,22 @@
+// https://github.com/babel/babel/issues/16833
+// Enums exported from a namespace must merge when the namespace is re-opened,
+// rather than the later declaration resetting the enum to a fresh object.
+namespace Foo {
+  export namespace Bar {
+    export enum E {
+      x = 1,
+    }
+  }
+}
+
+namespace Foo {
+  export namespace Bar {
+    export enum E {
+      y = 2,
+    }
+  }
+}
+
+expect(Foo.Bar.E.x).toBe(1);
+expect(Foo.Bar.E.y).toBe(2);
+expect(Foo.Bar.E).toEqual({ 1: "x", 2: "y", x: 1, y: 2 });

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-namespace/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-namespace/output.mjs
@@ -3,6 +3,5 @@ export let A;
   let G = /*#__PURE__*/function (G) {
     G[G["H"] = 0] = "H";
     return G;
-  }({});
-  _A.G = G;
+  }(_A.G || (_A.G = {}));
 })(A || (A = {}));

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested/output.mjs
@@ -19,8 +19,7 @@ class A {}
       H[H["J"] = 13] = "J";
       H[H["K"] = 17] = "K";
       return H;
-    }({});
-    _D.H = H;
+    }(_D.H || (_D.H = {}));
   })(D || (D = _A.D || (_A.D = {})));
   class F {}
   (function (_F) {

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/same-name/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/same-name/output.mjs
@@ -16,7 +16,6 @@ let N;
   (function (_N9) {
     let _N = /*#__PURE__*/function (_N) {
       return _N;
-    }({});
-    _N9._N = _N;
+    }(_N9._N || (_N9._N = {}));
   })(N || (N = _N2.N || (_N2.N = {})));
 })(N || (N = {}));


### PR DESCRIPTION
### What & why

Non-const TypeScript enums are not merged across re-opened namespaces (#16833). When an enum is exported from a namespace, Babel initialized the enum IIFE with a fresh `{}` and attached it via a separate `_N.E = E;`. Re-opening the namespace resets the enum to a brand-new object, so members declared in an earlier block are lost at runtime:

```ts
namespace Foo { export namespace Bar { export enum E { x = 1 } } }
namespace Foo { export namespace Bar { export enum E { y = 2 } } }
// Foo.Bar.E.x === undefined  (tsc: 1)
```

`tsc` merges these, and Babel already merges plain namespaces the same way — so enum merging is consistent with existing design. (Issue filed by an swc maintainer, with the fix approach proposed in-thread.)

### Fix (`packages/babel-plugin-transform-typescript/src/enum.ts`)

Added `getNamespaceMember(...)` to detect the namespace-transform-generated `_N.E = E;` sibling assignment, then initialize the enum from `_N.E || (_N.E = {})` and drop the now-redundant assignment. Single-file logic change; `namespace.ts` untouched. Output matches `tsc` and is cleaner for the single-declaration case.

### Tests

Added exec fixture `test/fixtures/namespace/exported-enum-merged-across-namespaces/` asserting the runtime merge; regenerated 3 existing namespace fixtures to the improved output (reviewed each diff). Verified red→green (before: `Expected 1, Received undefined`). `jest packages/babel-plugin-transform-typescript` → 177 passed, eslint clean.

Closes #16833
