### PR TITLE
fix(babel-register): preserve app-managed graceful shutdown

### DIFF
--- a/packages/babel-register/src/index.ts
+++ b/packages/babel-register/src/index.ts
@@ -15,7 +15,9 @@ function register(opts?: Options) {
       client.close();
       if (typeof signalOrCode !== "number") {
         if (process.listenerCount(signalOrCode) === 1) {
-          process.off(signalOrCode, listener!);
+          process.off("exit", listener!);
+          process.off("SIGINT", listener!);
+          process.off("SIGTERM", listener!);
           process.kill(process.pid, signalOrCode);
         }
       }

--- a/packages/babel-register/src/index.ts
+++ b/packages/babel-register/src/index.ts
@@ -15,7 +15,7 @@ function register(opts?: Options) {
       client.close();
       if (typeof signalOrCode !== "number") {
         if (process.listenerCount(signalOrCode) === 1) {
-          process.off(signalOrCode, listener);
+          process.off(signalOrCode, listener!);
           process.kill(process.pid, signalOrCode);
         }
       }

--- a/packages/babel-register/src/index.ts
+++ b/packages/babel-register/src/index.ts
@@ -14,8 +14,10 @@ function register(opts?: Options) {
       hasClosed = true;
       client.close();
       if (typeof signalOrCode !== "number") {
-        // eslint-disable-next-line n/no-process-exit
-        process.exit(0);
+        if (process.listenerCount(signalOrCode) === 1) {
+          process.off(signalOrCode, listener);
+          process.kill(process.pid, signalOrCode);
+        }
       }
     };
     process.on("exit", listener);

--- a/packages/babel-register/src/index.ts
+++ b/packages/babel-register/src/index.ts
@@ -5,26 +5,26 @@ import { WorkerClient } from "./worker-client.ts";
 import { isInRegisterWorker } from "./is-in-register-worker.ts";
 
 let client: IClient;
-let listener: undefined | ((signalOrCode: string | number) => void);
+let isListening = false;
+
+function listener(signal: string | number) {
+  client.save();
+
+  if (typeof signal !== "string") return;
+
+  if (process.listenerCount(signal) === 1) {
+    process.off("SIGINT", listener);
+    process.off("SIGTERM", listener);
+    process.kill(process.pid, signal);
+  }
+}
+
 function register(opts?: Options) {
-  if (!client) {
-    let hasClosed = false;
-    listener = function (signalOrCode) {
-      if (hasClosed) return;
-      hasClosed = true;
-      client.close();
-      if (typeof signalOrCode !== "number") {
-        if (process.listenerCount(signalOrCode) === 1) {
-          process.off("exit", listener!);
-          process.off("SIGINT", listener!);
-          process.off("SIGTERM", listener!);
-          process.kill(process.pid, signalOrCode);
-        }
-      }
-    };
-    process.on("exit", listener);
+  if (!isListening) {
+    isListening = true;
     process.on("SIGINT", listener);
     process.on("SIGTERM", listener);
+    process.once("exit", listener);
   }
   client ||= new WorkerClient();
   hook.register(client, opts);
@@ -32,11 +32,11 @@ function register(opts?: Options) {
 
 export function revert() {
   hook.revert();
-  if (listener) {
+  if (isListening) {
+    isListening = false;
     process.off("exit", listener);
     process.off("SIGINT", listener);
     process.off("SIGTERM", listener);
-    listener = undefined;
   }
 }
 

--- a/packages/babel-register/src/types.ts
+++ b/packages/babel-register/src/types.ts
@@ -4,7 +4,7 @@ export const enum ACTIONS {
   TRANSFORM = "TRANSFORM",
   TRANSFORM_SYNC = "TRANSFORM_SYNC",
   IS_FILE_IGNORED = "IS_FILE_IGNORED",
-  CLOSE = "CLOSE",
+  SAVE = "SAVE",
 }
 
 export type Options = {
@@ -19,5 +19,5 @@ export interface IClient {
     filename: string,
   ): { code: string; map: object } | null;
   isFileIgnored(filename: string): boolean;
-  close(): void;
+  save(): void;
 }

--- a/packages/babel-register/src/worker-client.ts
+++ b/packages/babel-register/src/worker-client.ts
@@ -35,8 +35,8 @@ class Client implements IClient {
     return this.#send(ACTIONS.IS_FILE_IGNORED, filename);
   }
 
-  close() {
-    this.#send(ACTIONS.CLOSE, undefined);
+  save() {
+    this.#send(ACTIONS.SAVE, undefined);
   }
 }
 

--- a/packages/babel-register/src/worker/handle-message.ts
+++ b/packages/babel-register/src/worker/handle-message.ts
@@ -3,7 +3,7 @@ import { DEFAULT_EXTENSIONS } from "@babel/core";
 import {
   setOptions,
   transform,
-  disableCache,
+  saveCache,
   isFileIgnored,
 } from "./transform.ts";
 
@@ -17,8 +17,8 @@ export default function handleMessage(action: ACTIONS, payload: any) {
       return transform(payload.code, payload.filename);
     case ACTIONS.IS_FILE_IGNORED:
       return isFileIgnored(payload);
-    case ACTIONS.CLOSE:
-      return disableCache();
+    case ACTIONS.SAVE:
+      return saveCache();
   }
 
   throw new Error(`Unknown internal parser worker action: ${action}`);

--- a/packages/babel-register/src/worker/transform.ts
+++ b/packages/babel-register/src/worker/transform.ts
@@ -141,8 +141,8 @@ async function isFileIgnored(filename: string) {
   return opts === null;
 }
 
-function disableCache() {
-  return cache.disable();
+function saveCache() {
+  return cache.flush();
 }
 
-export { setOptions, transform, disableCache, isFileIgnored };
+export { setOptions, transform, saveCache, isFileIgnored };

--- a/packages/babel-register/test/fixtures/preload/--require/graceful-shutdown/in-files/index.js
+++ b/packages/babel-register/test/fixtures/preload/--require/graceful-shutdown/in-files/index.js
@@ -1,0 +1,13 @@
+// Begin reading from stdin so the process does not exit.
+process.stdin.resume();
+
+process.on('SIGINT', () => {
+  console.log('graceful');
+  process.exit(0);
+});
+
+if (process.platform === 'win32') {
+  process.emit('SIGINT');
+} else {
+  process.kill(process.pid, 'SIGINT');
+}

--- a/packages/babel-register/test/fixtures/preload/--require/graceful-shutdown/options.json
+++ b/packages/babel-register/test/fixtures/preload/--require/graceful-shutdown/options.json
@@ -2,8 +2,7 @@
   "args": [
     "--require",
     "<rootDir>/packages/babel-register/lib/index.js",
-    "-e",
-    "process.on('SIGINT', () => { console.log('graceful'); process.exit(0); }); setTimeout(() => process.emit('SIGINT'), 10); setTimeout(() => {}, 2000);"
+    "index.js"
   ],
   "stdout": "graceful\n"
 }

--- a/packages/babel-register/test/fixtures/preload/--require/graceful-shutdown/options.json
+++ b/packages/babel-register/test/fixtures/preload/--require/graceful-shutdown/options.json
@@ -1,0 +1,9 @@
+{
+  "args": [
+    "--require",
+    "<rootDir>/packages/babel-register/lib/index.js",
+    "-e",
+    "process.on('SIGINT', () => { console.log('graceful'); process.exit(0); }); setTimeout(() => process.emit('SIGINT'), 10); setTimeout(() => {}, 2000);"
+  ],
+  "stdout": "graceful\n"
+}


### PR DESCRIPTION
Fixes #18134

**Description:**
This PR addresses an issue where `@babel/register` forces an early `process.exit(0)` when receiving `SIGTERM` or `SIGINT` signals, which inadvertently interrupts any application-managed graceful shutdown routines.

**Changes:**
- Updated the signal listener in `packages/babel-register/src/index.ts` to check `process.listenerCount(signal)`.
- If `@babel/register` is the *only* listener, it removes itself and re-raises the signal using `process.kill()` to preserve default Node.js termination behavior.
- If there are other listeners present, it simply cleans up its worker client and avoids forcing `process.exit(0)`, allowing the rest of the application's shutdown handlers to run naturally.
