### PR TITLE
fix: warn instead of throw for removed `bugfixes` option in preset-env

### DIFF
--- a/packages/babel-preset-env/src/normalize-options.ts
+++ b/packages/babel-preset-env/src/normalize-options.ts
@@ -199,11 +199,20 @@ export function normalizeCoreJSOption(
 }
 
 export default function normalizeOptions(opts: Partial<Options>) {
-  v.invariant(
-    !Object.hasOwn(opts, "bugfixes"),
-    "The 'bugfixes' option has been removed, and now bugfix plugins are" +
-      " always enabled. Please remove it from your config.",
-  );
+  if (Object.hasOwn(opts, "bugfixes")) {
+    console.warn(
+      "\nWARNING (@babel/preset-env): The 'bugfixes' option has been removed, and now bugfix plugins are" +
+        " always enabled. Please remove it from your config.\n",
+    );
+
+    const optsWithoutBugfixes = {
+      ...opts,
+    } as Partial<Options> & {
+      bugfixes?: unknown;
+    };
+    delete optsWithoutBugfixes.bugfixes;
+    opts = optsWithoutBugfixes;
+  }
 
   v.validateTopLevelOptions(opts, TopLevelOptions);
 

--- a/packages/babel-preset-env/test/normalize-options.skip-bundled.js
+++ b/packages/babel-preset-env/test/normalize-options.skip-bundled.js
@@ -6,6 +6,26 @@ import normalizeOptions, {
 
 describe("normalize-options", () => {
   describe("normalizeOptions", () => {
+    it("warns but accepts the removed `bugfixes` option", () => {
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      const options = { bugfixes: true };
+      const normalized = normalizeOptions(options);
+      expect(normalized).not.toHaveProperty("bugfixes");
+      expect(options).toHaveProperty("bugfixes", true);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("'bugfixes' option has been removed"),
+      );
+
+      expect(() => normalizeOptions({ bugfixes: false })).not.toThrow();
+      expect(warn).toHaveBeenCalledTimes(2);
+
+      normalizeOptions({});
+      expect(warn).toHaveBeenCalledTimes(2);
+
+      warn.mockRestore();
+    });
+
     it("should return normalized `include` and `exclude`", () => {
       const normalized = normalizeOptions({
         include: [


### PR DESCRIPTION
## Summary

`@babel/preset-env` currently throws a hard error when the removed `bugfixes` option is passed. This turns a harmless leftover config key into a build-breaking crash. This PR downgrades it to a `console.warn`, as suggested in the issue thread.

## Background

`bugfixes` was removed in Babel 8 because bugfix plugins are now always enabled, so the option is a no-op. But configs carried over from Babel 7 (or shared presets that still set it) commonly include `bugfixes: true`. On Babel 8 those configs fail outright at `normalizeOptions`:

```js
v.invariant(
  !Object.hasOwn(opts, "bugfixes"),
  "The 'bugfixes' option has been removed, ...",
);
```

Since the option no longer does anything, a hard error is stricter than necessary. In the issue, a core maintainer noted that downgrading it to a `console.warn` is reasonable, matching how the `corejs`-without-`useBuiltIns` case is already handled in this same file.

## Fix

When `bugfixes` is present, emit a `console.warn` (same message, same newline-wrapped `WARNING (@babel/preset-env):` style as the existing `corejs` warning) instead of throwing.

There is one subtlety: `bugfixes` is not in `TopLevelOptions`, and the very next line calls `v.validateTopLevelOptions`, which throws on any unknown top-level key. So simply swapping the `invariant` for a warning would still crash. To avoid that, the option is stripped from a shallow copy of the input before validation runs. The caller's original options object is left untouched (only the local reference is reassigned), and configs that never pass `bugfixes` are completely unaffected.

## Testing

Added a focused case to `packages/babel-preset-env/test/normalize-options.skip-bundled.js` that spies on `console.warn` and asserts: passing `bugfixes: true`/`false` no longer throws, a warning mentioning `bugfixes` is emitted, the caller's options object is not mutated, and no warning fires when the option is absent. The `babel-preset-env` normalize-options suite passes (30 tests) and `make tscheck` is clean across the monorepo.

Closes #18096

AI was used for assistance.
