### PR TITLE
refactor: replace `semver` with `verkit`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,7 +6,7 @@ catalog:
   babel-plugin-polyfill-corejs3: ^1.0.0
   core-js: ^3.48.0
   core-js-compat: ^3.48.0
-  semver: ^7.7.3
+  verkit: ^0.1.0
 
 catalogs:
   dev:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,7 +6,7 @@ catalog:
   babel-plugin-polyfill-corejs3: ^1.0.0
   core-js: ^3.48.0
   core-js-compat: ^3.48.0
-  verkit: ^0.1.0
+  verkit: ^0.3.2
 
 catalogs:
   dev:

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,9 +11,6 @@ import pluginUnicorn from "eslint-plugin-unicorn";
 import pluginBabelDevelopment from "@babel/eslint-plugin-development";
 import pluginBabelDevelopmentInternal from "@babel/eslint-plugin-development-internal";
 import typescriptEslint from "typescript-eslint";
-import { commonJS } from "$repo-utils";
-
-const { require } = commonJS(import.meta.url);
 
 const cjsGlobals = ["__dirname", "__filename", "require", "module", "exports"];
 
@@ -351,22 +348,6 @@ export default defineConfig([
     files: [...sourceFiles("js,ts,mjs"), ...testFiles, "test/**/*.js"],
     rules: {
       "no-restricted-globals": ["error", ...cjsGlobals],
-      "no-restricted-imports": [
-        "error",
-        {
-          paths: [
-            {
-              name: "semver",
-              message:
-                "semver's named exports are not recognized by the Node.js ESM-CJS interop.",
-              importNames: Object.keys(require("semver")).filter(
-                // We use it as a type import.
-                name => name !== "SemVer"
-              ),
-            },
-          ],
-        },
-      ],
     },
   },
   {

--- a/eslint/babel-eslint-parser/package.json
+++ b/eslint/babel-eslint-parser/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "eslint-scope": "^9.1.0",
     "eslint-visitor-keys": "^5.0.0",
-    "semver": "catalog:"
+    "verkit": "catalog:"
   },
   "devDependencies": {
     "@babel/core": "workspace:^",

--- a/eslint/babel-eslint-parser/src/parse.ts
+++ b/eslint/babel-eslint-parser/src/parse.ts
@@ -1,4 +1,4 @@
-import semver from "semver";
+import { satisfies } from "verkit";
 import type { Options } from "./types";
 import { version } from "@babel/core";
 import { WorkerClient, type Client } from "./client.ts";
@@ -24,7 +24,7 @@ export default function parse(code: string, options: Options) {
   const minSupportedCoreVersion = REQUIRED_VERSION("^7.2.0 || ^8.0.0");
 
   if (typeof isRunningMinSupportedCoreVersion !== "boolean") {
-    isRunningMinSupportedCoreVersion = semver.satisfies(
+    isRunningMinSupportedCoreVersion = satisfies(
       version,
       minSupportedCoreVersion,
     );

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "rollup": "^4.18.0",
     "rollup-plugin-dts": "patch:rollup-plugin-dts@npm%3A6.1.0#~/.yarn/patches/rollup-plugin-dts-npm-6.1.0-6d41e665a7.patch",
     "rollup-plugin-polyfill-node": "^0.13.0",
-    "semver": "catalog:",
     "shelljs": "^0.10.0",
     "terser": "catalog:dev",
     "test262-stream": "^1.4.0",

--- a/packages/babel-cli/package.json
+++ b/packages/babel-cli/package.json
@@ -36,8 +36,7 @@
   },
   "devDependencies": {
     "@babel/core": "workspace:^",
-    "@babel/helper-transform-fixture-test-runner": "workspace:^",
-    "semver": "catalog:"
+    "@babel/helper-transform-fixture-test-runner": "workspace:^"
   },
   "bin": {
     "babel": "./bin/babel.js"

--- a/packages/babel-core/package.json
+++ b/packages/babel-core/package.json
@@ -53,7 +53,7 @@
     "import-meta-resolve": "^4.2.0",
     "json5": "^2.2.3",
     "obug": "^2.1.1",
-    "semver": "catalog:"
+    "verkit": "catalog:"
   },
   "devDependencies": {
     "@babel/helper-transform-fixture-test-runner": "workspace:^",
@@ -67,7 +67,6 @@
     "@jridgewell/trace-mapping": "catalog:",
     "@types/convert-source-map": "^2.0.0",
     "@types/resolve": "^1.3.2",
-    "@types/semver": "^5.4.0",
     "ts-node": "^11.0.0-beta.1",
     "tsx": "^4.20.3"
   },

--- a/packages/babel-core/src/config/helpers/config-api.ts
+++ b/packages/babel-core/src/config/helpers/config-api.ts
@@ -1,4 +1,4 @@
-import semver from "semver";
+import { satisfies } from "verkit";
 import type { Targets } from "@babel/helper-compilation-targets";
 
 import { version as coreVersion } from "../../index.ts";
@@ -132,9 +132,9 @@ function assertVersion(range: string | number): void {
   }
 
   // We want "*" to also allow any pre-release, but we do not pass
-  // the includePrerelease option to semver.satisfies because we
+  // the includePrerelease option to satisfies because we
   // do not want ^7.0.0 to match 8.0.0-alpha.1.
-  if (range === "*" || semver.satisfies(coreVersion, range)) return;
+  if (range === "*" || satisfies(coreVersion, range)) return;
 
   const message =
     `Requires Babel "${range}", but was loaded with "${coreVersion}". ` +

--- a/packages/babel-core/src/transformation/file/file.ts
+++ b/packages/babel-core/src/transformation/file/file.ts
@@ -4,7 +4,7 @@ import type { HubInterface, Scope } from "@babel/traverse";
 import { codeFrameColumns } from "@babel/code-frame";
 import { cloneNode, interpreterDirective, traverseFast } from "@babel/types";
 import type * as t from "@babel/types";
-import semver from "semver";
+import { isValid, rangesIntersect } from "verkit";
 
 import type { NormalizedFile } from "../normalize-file.ts";
 
@@ -102,28 +102,17 @@ export default class File {
 
     if (typeof versionRange !== "string") return true;
 
-    // semver.intersects() has some surprising behavior with comparing ranges
-    // with pre-release versions. We add '^' to ensure that we are always
-    // comparing ranges with ranges, which sidesteps this logic.
-    // For example:
-    //
-    //   semver.intersects(`<7.0.1`, "7.0.0-beta.0") // false - surprising
-    //   semver.intersects(`<7.0.1`, "^7.0.0-beta.0") // true - expected
-    //
-    // This is because the first falls back to
-    //
-    //   semver.satisfies("7.0.0-beta.0", `<7.0.1`) // false - surprising
-    //
-    // and this fails because a prerelease version can only satisfy a range
-    // if it is a prerelease within the same major/minor/patch range.
+    // Treat a concrete version as its compatible range. This ensures that a
+    // helper introduced after a prerelease is not considered available for
+    // that prerelease, while preserving the existing behavior for ranges.
     //
     // Note: If this is found to have issues, please also revisit the logic in
     // transform-runtime's definitions.js file.
-    if (semver.valid(versionRange)) versionRange = `^${versionRange}`;
+    if (isValid(versionRange)) versionRange = `^${versionRange}`;
 
     return (
-      !semver.intersects(`<${minVersion}`, versionRange) &&
-      !semver.intersects(`>=9.0.0`, versionRange)
+      !rangesIntersect(`<${minVersion}`, versionRange) &&
+      !rangesIntersect(`>=9.0.0`, versionRange)
     );
   }
 

--- a/packages/babel-core/test/config-ts-integration-tsx.js
+++ b/packages/babel-core/test/config-ts-integration-tsx.js
@@ -1,6 +1,6 @@
 import { loadPartialConfigSync } from "../lib/index.js";
 import path from "node:path";
-import semver from "semver";
+import { isLess } from "verkit";
 import { commonJS } from "$repo-utils";
 
 const { __dirname, require } = commonJS(import.meta.url);
@@ -8,7 +8,7 @@ const { __dirname, require } = commonJS(import.meta.url);
 // We skip older versions of node testing for two reasons.
 // 1. tsx and ts don't support the old version of node.
 // 2. In the old version of node, jest has been registered in `require.extensions`, which will cause babel to disable the transforming as expected.
-const shouldSkip = semver.lt(process.version, "18.0.0");
+const shouldSkip = isLess(process.version, "18.0.0");
 
 (shouldSkip ? describe : describe.skip)(
   "@babel/core config with ts [dummy]",

--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -29,11 +29,10 @@
     "@babel/helper-validator-option": "workspace:^",
     "browserslist": "^4.24.0",
     "lru-cache": "^11.0.0",
-    "semver": "catalog:"
+    "verkit": "catalog:"
   },
   "devDependencies": {
-    "@babel/helper-plugin-test-runner": "workspace:^",
-    "@types/semver": "^5.5.0"
+    "@babel/helper-plugin-test-runner": "workspace:^"
   },
   "engines": {
     "node": "^22.18.0 || >=24.11.0"

--- a/packages/babel-helper-compilation-targets/src/debug.ts
+++ b/packages/babel-helper-compilation-targets/src/debug.ts
@@ -1,4 +1,4 @@
-import semver from "semver";
+import { isLess } from "verkit";
 import { prettifyVersion } from "./pretty.ts";
 import {
   semverify,
@@ -28,7 +28,7 @@ export function getInclusionReasons(
         if (
           !targetIsUnreleased &&
           (minIsUnreleased ||
-            semver.lt(targetVersion.toString(), semverify(minVersion)))
+            isLess(targetVersion.toString(), semverify(minVersion)))
         ) {
           result[env] = prettifyVersion(targetVersion);
         }

--- a/packages/babel-helper-compilation-targets/src/filter-items.ts
+++ b/packages/babel-helper-compilation-targets/src/filter-items.ts
@@ -1,4 +1,4 @@
-import semver from "semver";
+import { isGreater, isValid } from "verkit";
 
 import pluginsCompatData from "@babel/compat-data/plugins" with { type: "json" };
 
@@ -39,14 +39,14 @@ export function targetsSupported(target: Targets, support: Targets) {
       return true;
     }
 
-    if (!semver.valid(lowestTargetedVersion.toString())) {
+    if (!isValid(lowestTargetedVersion.toString())) {
       throw new Error(
         `Invalid version passed for target "${environment}": "${lowestTargetedVersion}". ` +
           "Versions must be in semver format (major.minor.patch)",
       );
     }
 
-    return semver.gt(
+    return isGreater(
       semverify(lowestImplementedVersion),
       lowestTargetedVersion.toString(),
     );

--- a/packages/babel-helper-compilation-targets/src/pretty.ts
+++ b/packages/babel-helper-compilation-targets/src/pretty.ts
@@ -1,4 +1,4 @@
-import semver from "semver";
+import { parse } from "verkit";
 import { unreleasedLabels } from "./targets.ts";
 import type { Targets, Target } from "./types.d.ts";
 
@@ -7,7 +7,7 @@ export function prettifyVersion(version: string) {
     return version;
   }
 
-  const { major, minor, patch } = semver.parse(version)!;
+  const { major, minor, patch } = parse(version);
 
   const parts = [major];
 

--- a/packages/babel-helper-compilation-targets/src/utils.ts
+++ b/packages/babel-helper-compilation-targets/src/utils.ts
@@ -1,4 +1,4 @@
-import semver from "semver";
+import { isLess, isValid } from "verkit";
 import { OptionValidator } from "@babel/helper-validator-option";
 import { unreleasedLabels } from "./targets.ts";
 import type { Target, Targets } from "./types.d.ts";
@@ -12,13 +12,13 @@ export function semverMin(
   first: string | undefined | null,
   second: string,
 ): string {
-  return first && semver.lt(first, second) ? first : second;
+  return first && isLess(first, second) ? first : second;
 }
 
 // Convert version to a semver value.
 // 2.5 -> 2.5.0; 1 -> 1.0.0;
 export function semverify(version: number | string): string {
-  if (typeof version === "string" && semver.valid(version)) {
+  if (typeof version === "string" && isValid(version)) {
     return version;
   }
 

--- a/packages/babel-helper-create-class-features-plugin/package.json
+++ b/packages/babel-helper-create-class-features-plugin/package.json
@@ -24,7 +24,7 @@
     "@babel/helper-replace-supers": "workspace:^",
     "@babel/helper-skip-transparent-expression-wrappers": "workspace:^",
     "@babel/traverse": "workspace:^",
-    "semver": "catalog:"
+    "verkit": "catalog:"
   },
   "peerDependencies": {
     "@babel/core": "^8.0.0"

--- a/packages/babel-helper-create-class-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/index.ts
@@ -1,7 +1,7 @@
 import { types as t } from "@babel/core";
 import type { PluginAPI, PluginObject, NodePath } from "@babel/core";
 
-import semver from "semver";
+import { isLess } from "verkit";
 
 import {
   buildPrivateNamesNodes,
@@ -113,7 +113,7 @@ export function createClassFeaturePlugin({
 
       if (
         !file.get(versionKey) ||
-        semver.lt(file.get(versionKey), PACKAGE_JSON.version)
+        isLess(file.get(versionKey), PACKAGE_JSON.version)
       ) {
         file.set(versionKey, PACKAGE_JSON.version);
       }

--- a/packages/babel-helper-create-regexp-features-plugin/package.json
+++ b/packages/babel-helper-create-regexp-features-plugin/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@babel/helper-annotate-as-pure": "workspace:^",
     "regexpu-core": "^6.3.1",
-    "semver": "catalog:"
+    "verkit": "catalog:"
   },
   "peerDependencies": {
     "@babel/core": "^8.0.0"

--- a/packages/babel-helper-create-regexp-features-plugin/src/index.ts
+++ b/packages/babel-helper-create-regexp-features-plugin/src/index.ts
@@ -2,7 +2,7 @@ import rewritePattern from "regexpu-core";
 import { types as t, type PluginObject, type NodePath } from "@babel/core";
 import annotateAsPure from "@babel/helper-annotate-as-pure";
 
-import semver from "semver";
+import { isLess } from "verkit";
 
 import {
   featuresKey,
@@ -66,7 +66,7 @@ export function createRegExpFeaturePlugin({
 
       if (
         !file.get(versionKey) ||
-        semver.lt(file.get(versionKey), PACKAGE_JSON.version)
+        isLess(file.get(versionKey), PACKAGE_JSON.version)
       ) {
         file.set(versionKey, PACKAGE_JSON.version);
       }

--- a/packages/babel-helper-fixtures/package.json
+++ b/packages/babel-helper-fixtures/package.json
@@ -16,11 +16,10 @@
   "main": "./lib/index.js",
   "dependencies": {
     "@jridgewell/gen-mapping": "catalog:",
-    "semver": "catalog:"
+    "verkit": "catalog:"
   },
   "devDependencies": {
-    "@babel/core": "workspace:^",
-    "@types/semver": "^7.3.4"
+    "@babel/core": "workspace:^"
   },
   "peerDependencies": {
     "@babel/core": "^8.0.0"

--- a/packages/babel-helper-fixtures/src/index.ts
+++ b/packages/babel-helper-fixtures/src/index.ts
@@ -1,4 +1,4 @@
-import semver from "semver";
+import { clean, isLess } from "verkit";
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -8,7 +8,7 @@ import type { EncodedSourceMap } from "@jridgewell/gen-mapping";
 
 const require = createRequire(import.meta.url);
 
-const nodeVersion = semver.clean(process.version.slice(1))!;
+const nodeVersion = clean(process.version.slice(1))!;
 
 function humanize(val: string, noext?: boolean) {
   if (noext) val = path.basename(val, path.extname(val));
@@ -265,7 +265,7 @@ function pushTask(
 
   // If there's node requirement, check it before pushing task
   if (taskOpts.minNodeVersion) {
-    const minimumVersion = semver.clean(taskOpts.minNodeVersion);
+    const minimumVersion = clean(taskOpts.minNodeVersion);
 
     if (minimumVersion == null) {
       throw new Error(
@@ -273,7 +273,7 @@ function pushTask(
       );
     }
 
-    if (semver.lt(nodeVersion, minimumVersion)) {
+    if (isLess(nodeVersion, minimumVersion)) {
       if (test.actual.code) {
         test.exec.code = undefined;
       } else {
@@ -286,7 +286,7 @@ function pushTask(
   }
 
   if (taskOpts.minNodeVersionTransform) {
-    const minimumVersion = semver.clean(taskOpts.minNodeVersionTransform);
+    const minimumVersion = clean(taskOpts.minNodeVersionTransform);
 
     if (minimumVersion == null) {
       throw new Error(
@@ -294,7 +294,7 @@ function pushTask(
       );
     }
 
-    if (semver.lt(nodeVersion, minimumVersion)) {
+    if (isLess(nodeVersion, minimumVersion)) {
       return;
     }
 

--- a/packages/babel-preset-env/package.json
+++ b/packages/babel-preset-env/package.json
@@ -80,7 +80,7 @@
     "@babel/preset-modules": "^0.2.0",
     "babel-plugin-polyfill-corejs3": "catalog:",
     "core-js-compat": "catalog:",
-    "semver": "catalog:"
+    "verkit": "catalog:"
   },
   "peerDependencies": {
     "@babel/core": "^8.0.0"

--- a/packages/babel-preset-env/src/filter-items.ts
+++ b/packages/babel-preset-env/src/filter-items.ts
@@ -1,4 +1,4 @@
-import semver from "semver";
+import { isLess } from "verkit";
 import { minVersions } from "./available-plugins.ts";
 
 export function addProposalSyntaxPlugins(
@@ -24,7 +24,7 @@ export function removeUnsupportedItems(
   items.forEach(item => {
     if (
       Object.hasOwn(minVersions, item) &&
-      semver.lt(
+      isLess(
         babelVersion,
         // @ts-expect-error we have checked minVersions[item] in has call
         minVersions[item],

--- a/packages/babel-preset-env/src/index.ts
+++ b/packages/babel-preset-env/src/index.ts
@@ -1,4 +1,4 @@
-import semver, { type SemVer } from "semver";
+import { isLess, normalize, type SemVer } from "verkit";
 import { logPlugin } from "./debug.ts";
 import {
   addProposalSyntaxPlugins,
@@ -141,7 +141,7 @@ const getCoreJSOptions = ({
   debug: boolean;
 }) => ({
   method: `${useBuiltIns}-global`,
-  version: corejs ? corejs.toString() : undefined,
+  version: corejs ? normalize(corejs)! : undefined,
   targets: polyfillTargets,
   include,
   exclude,
@@ -223,7 +223,7 @@ export default declarePreset((api, opts: Options) => {
     // @babel/core < 7.13.0 doesn't load targets (api.targets() always
     // returns {} thanks to @babel/helper-plugin-utils), so we always want
     // to fallback to the old targets behavior in this case.
-    semver.lt(api.version, "7.13.0") ||
+    isLess(api.version, "7.13.0") ||
     // If any browserslist-related option is specified, fallback to the old
     // behavior of not using the targets specified in the top-level options.
     opts.targets ||

--- a/packages/babel-preset-env/src/normalize-options.ts
+++ b/packages/babel-preset-env/src/normalize-options.ts
@@ -1,4 +1,4 @@
-import semver, { type SemVer } from "semver";
+import { coerce, parse, type SemVer } from "verkit";
 import corejs3Polyfills from "core-js-compat/data.json" with { type: "json" };
 import {
   plugins as pluginsList,
@@ -172,7 +172,8 @@ export function normalizeCoreJSOption(
     rawVersion = corejs;
   }
 
-  const version = rawVersion ? semver.coerce(String(rawVersion)) : false;
+  const coercedVersion = rawVersion ? coerce(String(rawVersion)) : null;
+  const version = coercedVersion ? parse(coercedVersion) : false;
 
   if (version) {
     if (useBuiltIns) {

--- a/scripts/repo-utils/index.cjs
+++ b/scripts/repo-utils/index.cjs
@@ -6,7 +6,7 @@
 const path = require("path");
 const { fileURLToPath } = require("url");
 const { createRequire } = require("module");
-const semver = require("semver");
+const { isGreaterOrEqual, isLess, satisfies } = require("verkit");
 
 // env vars from the cli are always strings, so !!ENV_VAR returns true for "false"
 function bool(value) {
@@ -25,13 +25,13 @@ if (typeof jest !== "undefined") {
   exports.itBabel8 = bool(process.env.BABEL_9_BREAKING) ? dummy : it;
   exports.itBabel9 = bool(process.env.BABEL_9_BREAKING) ? it : dummy;
   exports.itGte = function (version) {
-    return semver.gte(process.version, version) ? it : dummy;
+    return isGreaterOrEqual(process.version, version) ? it : dummy;
   };
   exports.itLt = function (version) {
-    return semver.lt(process.version, version) ? it : dummy;
+    return isLess(process.version, version) ? it : dummy;
   };
   exports.itSatisfies = function (version) {
-    return semver.satisfies(process.version, version) ? it : dummy;
+    return satisfies(process.version, version) ? it : dummy;
   };
   exports.itNegate = function (jestIt) {
     return jestIt === dummy ? it : dummy;
@@ -44,12 +44,12 @@ if (typeof jest !== "undefined") {
     ? describe
     : dummy;
   exports.describeGte = function (version) {
-    return semver.gte(process.version, version) ? describe : describe.skip;
-  };
-  exports.describeSatisfies = function (version) {
-    return semver.satisfies(process.version, version)
+    return isGreaterOrEqual(process.version, version)
       ? describe
       : describe.skip;
+  };
+  exports.describeSatisfies = function (version) {
+    return satisfies(process.version, version) ? describe : describe.skip;
   };
   exports.describeNoCITGM = __dirname.includes("citgm_tmp")
     ? describe.skip

--- a/scripts/repo-utils/package.json
+++ b/scripts/repo-utils/package.json
@@ -8,7 +8,7 @@
     "./babel-top-level": "./babel.js"
   },
   "dependencies": {
-    "semver": "catalog:",
+    "verkit": "catalog:",
     "@babel/core": "workspace:^",
     "@babel/preset-typescript": "workspace:^"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,7 +296,6 @@ __metadata:
     commander: "npm:^14.0.2"
     convert-source-map: "npm:^2.0.0"
     glob: "npm:^13.0.0"
-    semver: "catalog:"
     slash: "npm:^5.1.0"
   peerDependencies:
     "@babel/core": ^8.0.0
@@ -464,16 +463,15 @@ __metadata:
     "@types/convert-source-map": "npm:^2.0.0"
     "@types/gensync": "npm:^1.0.5"
     "@types/resolve": "npm:^1.3.2"
-    "@types/semver": "npm:^5.4.0"
     convert-source-map: "npm:^2.0.0"
     empathic: "npm:^2.0.1"
     gensync: "npm:^1.0.0-beta.2"
     import-meta-resolve: "npm:^4.2.0"
     json5: "npm:^2.2.3"
     obug: "npm:^2.1.1"
-    semver: "catalog:"
     ts-node: "npm:^11.0.0-beta.1"
     tsx: "npm:^4.20.3"
+    verkit: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -488,8 +486,8 @@ __metadata:
     eslint: "npm:^10.0.0"
     eslint-scope: "npm:^9.1.0"
     eslint-visitor-keys: "npm:^5.0.0"
-    semver: "catalog:"
     typescript-eslint: "npm:8.60.0"
+    verkit: "catalog:"
   peerDependencies:
     "@babel/core": ^8.0.0
     eslint: ^9.0.0 || ^10.0.0
@@ -685,10 +683,9 @@ __metadata:
     "@babel/compat-data": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-validator-option": "workspace:^"
-    "@types/semver": "npm:^5.5.0"
     browserslist: "npm:^4.24.0"
     lru-cache: "npm:^11.0.0"
-    semver: "catalog:"
+    verkit: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -724,7 +721,7 @@ __metadata:
     "@babel/traverse": "workspace:^"
     "@types/charcodes": "npm:^0.2.0"
     charcodes: "npm:^0.2.0"
-    semver: "catalog:"
+    verkit: "catalog:"
   peerDependencies:
     "@babel/core": ^8.0.0
   languageName: unknown
@@ -751,7 +748,7 @@ __metadata:
     "@babel/helper-annotate-as-pure": "workspace:^"
     "@babel/helper-plugin-test-runner": "workspace:^"
     regexpu-core: "npm:^6.3.1"
-    semver: "catalog:"
+    verkit: "catalog:"
   peerDependencies:
     "@babel/core": ^8.0.0
   languageName: unknown
@@ -785,8 +782,7 @@ __metadata:
   dependencies:
     "@babel/core": "workspace:^"
     "@jridgewell/gen-mapping": "catalog:"
-    "@types/semver": "npm:^7.3.4"
-    semver: "catalog:"
+    verkit: "catalog:"
   peerDependencies:
     "@babel/core": ^8.0.0
   languageName: unknown
@@ -3750,7 +3746,7 @@ __metadata:
     "@babel/traverse": "workspace:^"
     babel-plugin-polyfill-corejs3: "catalog:"
     core-js-compat: "catalog:"
-    semver: "catalog:"
+    verkit: "catalog:"
   peerDependencies:
     "@babel/core": ^8.0.0
   languageName: unknown
@@ -6166,20 +6162,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^5.4.0, @types/semver@npm:^5.5.0":
-  version: 5.5.0
-  resolution: "@types/semver@npm:5.5.0"
-  checksum: 10/ed79e6806dd6228f953294460a8d9194e307150bbaaa91e2abfa39cbd74d77e1ddfa59e598721ef90845f41e780b69311b3badb9341b124aa2ec14e13222f306
-  languageName: node
-  linkType: hard
-
-"@types/semver@npm:^7.3.4":
-  version: 7.7.1
-  resolution: "@types/semver@npm:7.7.1"
-  checksum: 10/8f09e7e6ca3ded67d78ba7a8f7535c8d9cf8ced83c52e7f3ac3c281fe8c689c3fe475d199d94390dc04fc681d51f2358b430bb7b2e21c62de24f2bee2c719068
-  languageName: node
-  linkType: hard
-
 "@types/shelljs@npm:^0.10.0":
   version: 0.10.0
   resolution: "@types/shelljs@npm:0.10.0"
@@ -7667,7 +7649,6 @@ __metadata:
     rollup: "npm:^4.18.0"
     rollup-plugin-dts: "patch:rollup-plugin-dts@npm%3A6.1.0#~/.yarn/patches/rollup-plugin-dts-npm-6.1.0-6d41e665a7.patch"
     rollup-plugin-polyfill-node: "npm:^0.13.0"
-    semver: "catalog:"
     shelljs: "npm:^0.10.0"
     terser: "catalog:dev"
     test262-stream: "npm:^1.4.0"
@@ -17667,6 +17648,13 @@ __metadata:
   version: 4.0.0
   resolution: "value-or-function@npm:4.0.0"
   checksum: 10/16b6aed84b8f9732a7eb7a5035a1480be3689d097a73b1154fb827caf021d5f2b6f60c0dfe694bfc8c9605f06cfc093dc428efdc3d24cb2768fbe202ffd42ae1
+  languageName: node
+  linkType: hard
+
+"verkit@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "verkit@npm:0.1.0"
+  checksum: 10/5f9fc7191c049a2294b160b6e1424cf5b06eb473dfd88a5887b0351dd902e29dd6e56ecf457fc834ce19669252510669fdf85e60c99099258bd6e401b310e3b6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17651,10 +17651,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"verkit@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "verkit@npm:0.1.0"
-  checksum: 10/5f9fc7191c049a2294b160b6e1424cf5b06eb473dfd88a5887b0351dd902e29dd6e56ecf457fc834ce19669252510669fdf85e60c99099258bd6e401b310e3b6
+"verkit@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "verkit@npm:0.3.2"
+  checksum: 10/23e57c28094da170e381e27c020cddde0543fbac377b111c325a18440da4502d21c58446ef25794ecc1f2434df1d6297edf760910245ac5b90199a9bb18d8634
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
| Q                        | A |
| ------------------------ | --- |
| Fixed Issues?            | N/A |
| Patch: Bug Fix?          | No |
| Major: Breaking Change?  | No |
| Minor: New Feature?      | No |
| Tests Added + Pass?      | Existing tests pass |
| Documentation PR Link    | N/A |
| Any Dependency Changes?  | Replaces `semver` with `verkit` |
| License                  | MIT |

## Summary

This PR replaces Babel's direct usage of [`semver`](https://github.com/npm/node-semver) with [`verkit`](https://github.com/sxzz/verkit).

`verkit` provides:

- pure ESM with zero runtime dependencies;
- first-class TypeScript declarations;
- functional, tree-shakeable named exports;
- smaller bundles and faster operations in its upstream benchmarks.

The migration also removes `@types/semver` and Babel's ESLint workaround for `semver`'s CommonJS exports. Existing version, range, coercion, and prerelease behavior is preserved.

## Motivation

`node-semver` does not appear to have an active ESM migration plan. The related request in [semver/semver#1123](https://github.com/semver/semver/issues/1123) was closed as **not planned**. A direct dual-format ESM proposal in [npm/node-semver#844](https://github.com/npm/node-semver/pull/844) was also closed; maintainers noted that ESM is on their radar but is not currently being worked on. https://github.com/npm/node-semver/issues/712

That said, `verkit` is still young and currently at `v0.2.0`. There is no urgency to adopt it—the Babel community may prefer to observe its stability and adoption before merging this change.

## Validation

- `yarn lint`
- 17 focused test suites and 878 tests passed
- Development build
- `@babel/standalone` build
