### PR TITLE
Evaluate TypeScript expression wrappers in NodePath#evaluate

### DIFF
--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -183,8 +183,14 @@ function _evaluate(path: NodePath, state: State): any {
     }
   }
 
-  if (path.isExpressionWrapper()) {
-    // TypeCastExpression, ExpressionStatement etc
+  if (
+    path.isExpressionWrapper() ||
+    path.isTSAsExpression() ||
+    path.isTSSatisfiesExpression() ||
+    path.isTSTypeAssertion() ||
+    path.isTSNonNullExpression()
+  ) {
+    // Runtime-transparent expression wrappers such as type assertions.
     return evaluateCached(path.get("expression"), state);
   }
 

--- a/packages/babel-traverse/src/path/evaluation.ts
+++ b/packages/babel-traverse/src/path/evaluation.ts
@@ -188,7 +188,8 @@ function _evaluate(path: NodePath, state: State): any {
     path.isTSAsExpression() ||
     path.isTSSatisfiesExpression() ||
     path.isTSTypeAssertion() ||
-    path.isTSNonNullExpression()
+    path.isTSNonNullExpression() ||
+    path.isTSInstantiationExpression()
   ) {
     // Runtime-transparent expression wrappers such as type assertions.
     return evaluateCached(path.get("expression"), state);

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -107,6 +107,17 @@ describe("evaluation", function () {
     expect(result.value).toBe(1);
   });
 
+  it("should evaluate TypeScript instantiation expressions", function () {
+    const result = getPath("const value = 1; value<number>;", {
+      plugins: ["typescript"],
+    })
+      .get("body.1.expression")
+      .evaluate();
+
+    expect(result.confident).toBe(true);
+    expect(result.value).toBe(1);
+  });
+
   it("should deopt when var is redeclared in the same scope", function () {
     expect(
       getPath("var x = 2; var y = x + 2; { var x = 3 }")

--- a/packages/babel-traverse/test/evaluation.js
+++ b/packages/babel-traverse/test/evaluation.js
@@ -2,8 +2,8 @@ import { parse } from "@babel/parser";
 
 import traverse from "../lib/index.js";
 
-function getPath(code) {
-  const ast = parse(code);
+function getPath(code, parserOptions) {
+  const ast = parse(code, parserOptions);
   let path;
   traverse(ast, {
     Program: function (_path) {
@@ -89,6 +89,22 @@ describe("evaluation", function () {
         .get("body")[1]
         .evaluateTruthy(),
     ).toBe(true);
+  });
+
+  it.each([
+    ["as expressions", "1 as number"],
+    ["satisfies expressions", "1 satisfies number"],
+    ["type assertions", "<number>1"],
+    ["non-null expressions", "1!"],
+  ])("should evaluate TypeScript %s", function (_name, expression) {
+    const result = getPath(`const value = ${expression}; value;`, {
+      plugins: ["typescript"],
+    })
+      .get("body.1.expression")
+      .evaluate();
+
+    expect(result.confident).toBe(true);
+    expect(result.value).toBe(1);
   });
 
   it("should deopt when var is redeclared in the same scope", function () {


### PR DESCRIPTION
| Q                        | A |
| ------------------------ | --- |
| Fixed Issues?            | Fixes #11712 |
| Patch: Bug Fix?          | Yes |
| Major: Breaking Change?  | No |
| Minor: New Feature?      | No |
| Tests Added + Pass?      | Yes |
| Documentation PR Link    | N/A |
| Any Dependency Changes?  | No |
| License                  | MIT |

Teach `NodePath#evaluate()` to unwrap runtime-transparent TypeScript assertion expressions, matching Babel's existing treatment of Flow casts and parenthesized expressions.

The regression coverage verifies `as`, `satisfies`, angle-bracket type assertions, and non-null assertions through a referenced binding.

Validation:
- `yarn node Makefile.js build-no-bundle`
- `yarn jest packages/babel-traverse/test/evaluation.js --runInBand` — 42 tests passed
- `yarn jest babel-traverse --runInBand` — 18 suites, 656 tests, and 57 snapshots passed; 1 test skipped
- `yarn eslint packages/babel-traverse/src/path/evaluation.ts packages/babel-traverse/test/evaluation.js`
- `git diff --check`
- Independent review: Approve, with no actionable findings