### PR TITLE
Handle null in `getAll{Prev,Next}Siblings`

### DIFF
--- a/benchmark/babel-traverse/get-all-next-siblings/bench.mjs
+++ b/benchmark/babel-traverse/get-all-next-siblings/bench.mjs
@@ -1,0 +1,48 @@
+import {
+  Benchmark,
+  baselineParser,
+  baselineTraverse,
+  currentTraverse,
+} from "../../util.mjs";
+
+function createInput(length, traverseImpl) {
+  const ast = baselineParser.parse(
+    Array(length)
+      .fill(0)
+      .map((_, i) => `${i};`)
+      .join("\n")
+  );
+  let programPath;
+  traverseImpl(ast, {
+    Program(path) {
+      programPath = path;
+      path.stop();
+    },
+  });
+  const body = programPath.get("body");
+  return {
+    0: body[0],
+    50: body[Math.floor(length / 2)],
+    75: body[Math.floor((length * 3) / 4)],
+    100: body[length - 1],
+  };
+}
+
+function benchCases(name, implementation) {
+  for (const length of [256, 512, 1024, 2048]) {
+    const inputs = createInput(length, implementation);
+    const benchmark = new Benchmark();
+    for (const [index, input] of Object.entries(inputs)) {
+      benchmark.add(
+        `${name} getAllNextSiblings from the ${index}% percentile within ${length} statements`,
+        () => {
+          input.getAllNextSiblings();
+        }
+      );
+    }
+    benchmark.run();
+  }
+}
+
+benchCases("baseline", baselineTraverse.default.default);
+benchCases("current", currentTraverse.default);

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -326,13 +326,15 @@ export function getNextSibling(
 export function getAllNextSiblings(
   this: NodePath<t.Node | null>,
 ): NodePath<t.Node | null>[] {
-  // @ts-expect-error todo(flow->ts) this.key could be a string
-  let _key: number = this.key;
-  let sibling = this.getSibling(++_key);
-  const siblings = [];
-  while (sibling.node) {
-    siblings.push(sibling);
-    sibling = this.getSibling(++_key);
+  // @ts-expect-error the Number.isFinite check ensures that this.key is a number
+  const _key: number = this.key;
+  if (!Number.isInteger(_key)) {
+    return [];
+  }
+  const siblings = [],
+    containerLength = (this.container as t.Node[]).length;
+  for (let key = _key + 1; key < containerLength; key++) {
+    siblings.push(this.getSibling(key));
   }
   return siblings;
 }
@@ -340,13 +342,14 @@ export function getAllNextSiblings(
 export function getAllPrevSiblings(
   this: NodePath<t.Node | null>,
 ): NodePath<t.Node | null>[] {
-  // @ts-expect-error todo(flow->ts) this.key could be a string
-  let _key: number = this.key;
-  let sibling = this.getSibling(--_key);
+  // @ts-expect-error the Number.isFinite check ensures that this.key is a number
+  const _key: number = this.key;
+  if (!Number.isInteger(_key)) {
+    return [];
+  }
   const siblings = [];
-  while (sibling.node) {
-    siblings.push(sibling);
-    sibling = this.getSibling(--_key);
+  for (let key = _key - 1; key >= 0; key--) {
+    siblings.push(this.getSibling(key));
   }
   return siblings;
 }

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -326,7 +326,7 @@ export function getNextSibling(
 export function getAllNextSiblings(
   this: NodePath<t.Node | null>,
 ): NodePath<t.Node | null>[] {
-  // @ts-expect-error the Number.isFinite check ensures that this.key is a number
+  // @ts-expect-error the Number.isInteger check ensures that this.key is a number
   const _key: number = this.key;
   if (!Number.isInteger(_key)) {
     return [];
@@ -342,7 +342,7 @@ export function getAllNextSiblings(
 export function getAllPrevSiblings(
   this: NodePath<t.Node | null>,
 ): NodePath<t.Node | null>[] {
-  // @ts-expect-error the Number.isFinite check ensures that this.key is a number
+  // @ts-expect-error the Number.isInteger check ensures that this.key is a number
   const _key: number = this.key;
   if (!Number.isInteger(_key)) {
     return [];

--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -77,11 +77,81 @@ describe("path/family", function () {
       expect(lastSibling.getNextSibling().node).toBeFalsy();
     });
 
-    it("should return all preceding and succeeding sibling nodes", function () {
-      expect(sibling.getAllNextSiblings().length).toBeTruthy();
-      expect(lastSibling.getAllPrevSiblings().length).toBeTruthy();
-      expect(sibling.getAllNextSiblings()).toHaveLength(2);
-      expect(lastSibling.getAllPrevSiblings()).toHaveLength(2);
+    describe("getAllPrevSiblings and getAllNextSiblings", function () {
+      it("should return all preceding and succeeding sibling nodes", function () {
+        expect(sibling.getAllNextSiblings().length).toBeTruthy();
+        expect(lastSibling.getAllPrevSiblings().length).toBeTruthy();
+        expect(sibling.getAllNextSiblings()).toHaveLength(2);
+        expect(lastSibling.getAllPrevSiblings()).toHaveLength(2);
+      });
+
+      it("should handle a non-numeric key", function () {
+        const ast = parse("var a = 1");
+        let sibling;
+        traverse(ast, {
+          Identifier(path) {
+            sibling = path;
+          },
+        });
+        expect(sibling).toBeDefined();
+        expect(sibling.key).toBe("id");
+        expect(sibling.getAllPrevSiblings()).toHaveLength(0);
+        expect(sibling.getAllNextSiblings()).toHaveLength(0);
+      });
+
+      it.each([NaN, Infinity, -Infinity, 0.1, -0.1])(
+        "should handle a non-integer numeric key %s due to corrupted AST",
+        function (nonIntegerKey) {
+          const ast = parse("var a = ['prev', 0, 'next']");
+          let sibling;
+          traverse(ast, {
+            NumericLiteral(path) {
+              sibling = path;
+              // Manipulate the key to be non-integer
+              sibling.key = nonIntegerKey;
+            },
+          });
+          expect(sibling).toBeDefined();
+          expect(sibling.key).toBe(nonIntegerKey);
+          expect(sibling.getAllPrevSiblings()).toHaveLength(0);
+          expect(sibling.getAllNextSiblings()).toHaveLength(0);
+        },
+      );
+
+      it("should handle null nodes", function () {
+        const ast = parse(
+          "const InuktitutSeasons = [ukiuq, /* upirngaksaaq */, upirngaaq, /* aujaq */, ukiaqsaaq, /* ukiaq */]",
+        );
+        let sibling;
+        traverse(ast, {
+          Identifier(path) {
+            if (path.node.name === "upirngaaq") {
+              sibling = path;
+            }
+          },
+        });
+        expect(sibling).toBeDefined();
+        expect(sibling.getAllPrevSiblings()).toHaveLength(2); // ukiuq and the null node (upirngaksaaq)
+        expect(sibling.getAllNextSiblings()).toHaveLength(2); // the null node (aujaq) and ukiaqsaaq
+      });
+
+      it("should handle removed nodes", function () {
+        const ast = parse("var arr = [1, 2, 3, 4, 5]");
+        let sibling;
+        traverse(ast, {
+          ArrayExpression(path) {
+            const elementsPaths = path.get("elements");
+            elementsPaths[0].remove();
+            elementsPaths[elementsPaths.length - 1].remove();
+            sibling = path.get("elements")[1];
+          },
+        });
+        expect(sibling).toBeDefined();
+        expect(sibling.node.type).toBe("NumericLiteral");
+        expect(sibling.node.value).toBe(3);
+        expect(sibling.getAllPrevSiblings()).toHaveLength(1);
+        expect(sibling.getAllNextSiblings()).toHaveLength(1);
+      });
     });
 
     it("should initialize path.scope when needed", function () {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `getAll{Prev,Next}Siblings` stops at null node
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we handle the null node in `getAll{Prev,Next}Siblings`: Previously they will stop the sibling enumeration, 
 in this PR the enumeration will continue upto the first/last element within the container.
 
 We also implement the bound check to avoid the out-of-bound access in `NodePath.get`. However, the benchmark shows no significant improvement due to other operations involved in `getAll{Prev,Next}Siblings`