### PR TITLE
fix: set the prototype for __proto__ keys hoisted out of object literals

### DIFF
--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -1199,6 +1199,23 @@ const helpers: Record<string, Helper> = {
       internal: false,
     },
   ),
+  // size: 84, gzip size: 90
+  setObjectProto: helper(
+    "8.1.0",
+    "function _setObjectProto(t,e){return null!==e&&Object(e)!==e||setPrototypeOf(t,e),t}",
+    {
+      globals: ["Object"],
+      locals: { _setObjectProto: ["body.0.id"] },
+      exportBindingAssignments: [],
+      exportName: "_setObjectProto",
+      dependencies: {
+        setPrototypeOf: [
+          "body.0.body.body.0.argument.expressions.0.right.callee",
+        ],
+      },
+      internal: false,
+    },
+  ),
   // size: 163, gzip size: 102
   setPrototypeOf: helper(
     "7.0.0-beta.0",

--- a/packages/babel-helpers/src/helpers/setObjectProto.ts
+++ b/packages/babel-helpers/src/helpers/setObjectProto.ts
@@ -1,0 +1,13 @@
+/* @minVersion 8.1.0 */
+
+import setPrototypeOf from "./setPrototypeOf.ts";
+
+// A `__proto__` key in an object initializer updates the prototype only when
+// the value is an object or null, and never creates an own property:
+// https://tc39.es/ecma262/#sec-__proto__-property-names-in-object-initializers
+export default function _setObjectProto<T extends object>(obj: T, proto: any) {
+  if (proto === null || Object(proto) === proto) {
+    setPrototypeOf(obj, proto);
+  }
+  return obj;
+}

--- a/packages/babel-plugin-transform-computed-properties/src/index.ts
+++ b/packages/babel-plugin-transform-computed-properties/src/index.ts
@@ -54,6 +54,18 @@ export default declare((api, options: Options) => {
   }
 
   /**
+   * Whether `prop` is the `__proto__` form that sets the prototype rather than
+   * creating an own property.
+   */
+  function isProtoKey(prop: t.ObjectMember) {
+    return (
+      t.isObjectProperty(prop, { computed: false, shorthand: false }) &&
+      (t.isIdentifier(prop.key, { name: "__proto__" }) ||
+        t.isStringLiteral(prop.key, { value: "__proto__" }))
+    );
+  }
+
+  /**
    * Get value of an object member under object expression.
    * Returns a function expression if prop is a ObjectMethod.
    *
@@ -144,6 +156,11 @@ export default declare((api, options: Options) => {
           (prop.kind === "get" || prop.kind === "set")
         ) {
           node = buildDefineAccessor(info.state, node, prop);
+        } else if (isProtoKey(prop)) {
+          node = t.callExpression(state.addHelper("setObjectProto"), [
+            node,
+            getValue(prop)!,
+          ]);
         } else {
           node = t.callExpression(state.addHelper("defineProperty"), [
             node,

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/proto-after-computed/exec.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/proto-after-computed/exec.js
@@ -1,0 +1,32 @@
+var key = "a";
+var proto = { inherited: true };
+
+var obj = {
+  [key]: 1,
+  __proto__: proto,
+};
+expect(Object.getPrototypeOf(obj)).toBe(proto);
+expect(Object.hasOwn(obj, "__proto__")).toBe(false);
+expect(obj.inherited).toBe(true);
+
+var stringKey = {
+  [key]: 1,
+  "__proto__": proto,
+};
+expect(Object.getPrototypeOf(stringKey)).toBe(proto);
+
+var nullProto = {
+  [key]: 1,
+  __proto__: null,
+  other: 2,
+};
+expect(Object.getPrototypeOf(nullProto)).toBe(null);
+expect(nullProto.other).toBe(2);
+
+// Only an object or null updates the prototype.
+var primitiveProto = {
+  [key]: 1,
+  __proto__: 5,
+};
+expect(Object.getPrototypeOf(primitiveProto)).toBe(Object.prototype);
+expect(Object.hasOwn(primitiveProto, "__proto__")).toBe(false);

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/proto-after-computed/input.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/proto-after-computed/input.js
@@ -1,0 +1,20 @@
+var obj = {
+  [key]: 1,
+  __proto__: proto,
+};
+
+var stringKey = {
+  [key]: 1,
+  "__proto__": proto,
+};
+
+var nullProto = {
+  [key]: 1,
+  __proto__: null,
+  other: 2,
+};
+
+var primitiveProto = {
+  [key]: 1,
+  __proto__: 5,
+};

--- a/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/proto-after-computed/output.js
+++ b/packages/babel-plugin-transform-computed-properties/test/fixtures/spec/proto-after-computed/output.js
@@ -1,0 +1,5 @@
+function _setObjectProto(t, e) { return null !== e && Object(e) !== e || babelHelpers.setPrototypeOf(t, e), t; }
+var obj = _setObjectProto(babelHelpers.defineProperty({}, key, 1), proto);
+var stringKey = _setObjectProto(babelHelpers.defineProperty({}, key, 1), proto);
+var nullProto = babelHelpers.defineProperty(_setObjectProto(babelHelpers.defineProperty({}, key, 1), null), "other", 2);
+var primitiveProto = _setObjectProto(babelHelpers.defineProperty({}, key, 1), 5);

--- a/packages/babel-plugin-transform-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.ts
@@ -107,6 +107,18 @@ export default declare((api, opts: Options) => {
     return false;
   }
 
+  // Whether `prop` is the `__proto__` form that sets the prototype rather than
+  // creating an own property.
+  function isProtoKey(
+    prop: t.ObjectMember | t.SpreadElement,
+  ): prop is t.ObjectProperty {
+    return (
+      t.isObjectProperty(prop, { computed: false, shorthand: false }) &&
+      (t.isIdentifier(prop.key, { name: "__proto__" }) ||
+        t.isStringLiteral(prop.key, { value: "__proto__" }))
+    );
+  }
+
   // returns an array of all keys of an object, and a status flag indicating if all extracted keys
   // were converted to stringLiterals or not
   // e.g. extracts {keys: ["a", "b", "3", ++x], allPrimitives: false }
@@ -860,6 +872,8 @@ export default declare((api, opts: Options) => {
 
         let exp: t.CallExpression | null = null;
         let props: t.ObjectMember[] = [];
+        // Whether `exp` is a spread call we can still append arguments to.
+        let canAppend = false;
 
         function make() {
           const hadProps = props.length > 0;
@@ -868,12 +882,13 @@ export default declare((api, opts: Options) => {
 
           if (!exp) {
             exp = t.callExpression(helper, [obj]);
+            canAppend = true;
             return;
           }
 
           // When we can assume that getters are pure and don't depend on
           // the order of evaluation, we can avoid making multiple calls.
-          if (pureGetters) {
+          if (pureGetters && canAppend) {
             if (hadProps) {
               exp.arguments.push(obj);
             }
@@ -887,12 +902,23 @@ export default declare((api, opts: Options) => {
             // [[GetOwnProperty]]
             ...(hadProps ? [t.objectExpression([]), obj] : []),
           ]);
+          canAppend = true;
         }
 
         for (const prop of path.node.properties) {
           if (t.isSpreadElement(prop)) {
             make();
             exp!.arguments.push(prop.argument);
+          } else if (exp && isProtoKey(prop)) {
+            // The spread helpers copy own properties, so a `__proto__` key
+            // left in one of their source objects would be dropped instead of
+            // updating the prototype of the object being built.
+            if (props.length) make();
+            exp = t.callExpression(file.addHelper("setObjectProto"), [
+              exp,
+              prop.value as t.Expression,
+            ]);
+            canAppend = false;
           } else {
             props.push(prop);
           }

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/proto/exec.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/proto/exec.js
@@ -1,0 +1,40 @@
+var spread = { s: 1 };
+var proto = { inherited: true };
+
+var obj = {
+  ...spread,
+  __proto__: proto,
+};
+expect(Object.getPrototypeOf(obj)).toBe(proto);
+expect(Object.hasOwn(obj, "__proto__")).toBe(false);
+expect(obj.s).toBe(1);
+
+var mixed = {
+  ...spread,
+  a: 1,
+  __proto__: proto,
+  b: 2,
+};
+expect(Object.getPrototypeOf(mixed)).toBe(proto);
+expect(mixed).toMatchObject({ s: 1, a: 1, b: 2 });
+
+var nullProto = {
+  ...spread,
+  __proto__: null,
+};
+expect(Object.getPrototypeOf(nullProto)).toBe(null);
+expect(nullProto.s).toBe(1);
+
+var protoFirst = {
+  __proto__: proto,
+  ...spread,
+};
+expect(Object.getPrototypeOf(protoFirst)).toBe(proto);
+
+// A computed key never updates the prototype.
+var computed = {
+  ...spread,
+  ["__proto__"]: proto,
+};
+expect(Object.getPrototypeOf(computed)).toBe(Object.prototype);
+expect(Object.hasOwn(computed, "__proto__")).toBe(true);

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/proto/input.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/proto/input.js
@@ -1,0 +1,21 @@
+var obj = {
+  ...spread,
+  __proto__: proto,
+};
+
+var mixed = {
+  ...spread,
+  a: 1,
+  __proto__: proto,
+  b: 2,
+};
+
+var nullProto = {
+  ...spread,
+  __proto__: null,
+};
+
+var protoFirst = {
+  __proto__: proto,
+  ...spread,
+};

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/proto/output.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-spread/proto/output.js
@@ -1,0 +1,11 @@
+function _setObjectProto(t, e) { return null !== e && Object(e) !== e || babelHelpers.setPrototypeOf(t, e), t; }
+var obj = _setObjectProto(babelHelpers.objectSpread2({}, spread), proto);
+var mixed = babelHelpers.objectSpread2(_setObjectProto(babelHelpers.objectSpread2(babelHelpers.objectSpread2({}, spread), {}, {
+  a: 1
+}), proto), {}, {
+  b: 2
+});
+var nullProto = _setObjectProto(babelHelpers.objectSpread2({}, spread), null);
+var protoFirst = babelHelpers.objectSpread2({
+  __proto__: proto
+}, spread);

--- a/packages/babel-runtime-corejs3/helpers/esm/setObjectProto.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/setObjectProto.js
@@ -1,0 +1,5 @@
+import setPrototypeOf from "./setPrototypeOf.js";
+function _setObjectProto(t, e) {
+  return null !== e && Object(e) !== e || setPrototypeOf(t, e), t;
+}
+export { _setObjectProto as default };

--- a/packages/babel-runtime-corejs3/package.json
+++ b/packages/babel-runtime-corejs3/package.json
@@ -362,6 +362,11 @@
       "import": "./helpers/esm/setFunctionName.js",
       "default": "./helpers/setFunctionName.js"
     },
+    "./helpers/setObjectProto": {
+      "node": "./helpers/setObjectProto.js",
+      "import": "./helpers/esm/setObjectProto.js",
+      "default": "./helpers/setObjectProto.js"
+    },
     "./helpers/setPrototypeOf": {
       "node": "./helpers/setPrototypeOf.js",
       "import": "./helpers/esm/setPrototypeOf.js",

--- a/packages/babel-runtime/package.json
+++ b/packages/babel-runtime/package.json
@@ -360,6 +360,11 @@
       "import": "./helpers/esm/setFunctionName.js",
       "default": "./helpers/setFunctionName.js"
     },
+    "./helpers/setObjectProto": {
+      "node": "./helpers/setObjectProto.js",
+      "import": "./helpers/esm/setObjectProto.js",
+      "default": "./helpers/setObjectProto.js"
+    },
     "./helpers/setPrototypeOf": {
       "node": "./helpers/setPrototypeOf.js",
       "import": "./helpers/esm/setPrototypeOf.js",


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | Adds a `setObjectProto` runtime helper
| Tests Added + Pass?      | Yes
| Documentation PR Link    |
| Any Dependency Changes?  | No
| License                  | MIT

A non-computed, non-shorthand `__proto__` key runs `SetPrototypeOf` and creates no own property, but two lowering paths drop that meaning. `transform-computed-properties` sends every property that follows the first computed key through `defineProperty`, so `{ [k]: 1, __proto__: p }` becomes `_defineProperty(_defineProperty({}, k, 1), "__proto__", p)`, an own enumerable `__proto__` property with the prototype left untouched. `transform-object-rest-spread` keeps the key in a literal it then passes as a *source* to `objectSpread2`/`extends`, which copy own properties, so `{ ...s, __proto__: p }` loses the prototype entirely. I ran into it checking what `{ ...opts, __proto__: null }` compiles to: the result still inherits from `Object.prototype`, so `constructor`, `toString` and friends resolve again on an object written specifically not to have them.

Both paths now route that key through a new `setObjectProto` helper, which updates the prototype only when the value is an object or null, so `{ [k]: 1, __proto__: 5 }` stays a no-op like it does natively. The check belongs in the helper rather than at each call site because the value is only known at runtime. Computed and shorthand `__proto__` are untouched and keep creating own properties, and `setComputedProperties`/`setSpreadProperties` keep their documented `[[Set]]` behavior.
