### PR TITLE
fix(parser): remove unused importMeta from Plugin type (#18158)

### DIFF
--- a/packages/babel-parser/src/typings.d.ts
+++ b/packages/babel-parser/src/typings.d.ts
@@ -11,7 +11,6 @@ export type Plugin =
   | "flowComments"
   | "functionBind"
   | "functionSent"
-  | "importMeta"
   | "jsx"
   | "moduleBlocks"
   | "placeholders"


### PR DESCRIPTION
Fixes #18158\n\nRemoves the unused `importMeta` property from the `Plugin` type in the parser, which was leftover from an earlier iteration and is no longer referenced anywhere.