### PR TITLE
perf: Improve `@babel/parser`

### DIFF
--- a/packages/babel-parser/src/parser/expression.ts
+++ b/packages/babel-parser/src/parser/expression.ts
@@ -228,21 +228,27 @@ export default abstract class ExpressionParser extends LValParser {
   parseMaybeAssignDisallowIn(
     this: Parser,
     refExpressionErrors?: ExpressionErrors | null,
-    afterLeftParse?: Function,
   ) {
-    return this.disallowInAnd(() =>
-      this.parseMaybeAssign(refExpressionErrors, afterLeftParse),
-    );
+    return this.disallowInAnd(() => this.parseMaybeAssign(refExpressionErrors));
   }
 
   // Set [+In] parameter for assignment expression
   parseMaybeAssignAllowIn(
     this: Parser,
+    refExpressionErrors: ExpressionErrors | null | undefined,
+    isParenItem: boolean | undefined,
+  ): N.Expression | N.TSTypeCastExpression;
+  parseMaybeAssignAllowIn(
+    this: Parser,
     refExpressionErrors?: ExpressionErrors | null,
-    afterLeftParse?: Function,
+  ): N.Expression;
+  parseMaybeAssignAllowIn(
+    this: Parser,
+    refExpressionErrors?: ExpressionErrors | null,
+    isParenItem?: boolean,
   ) {
     return this.allowInAnd(() =>
-      this.parseMaybeAssign(refExpressionErrors, afterLeftParse),
+      this.parseMaybeAssign(refExpressionErrors, isParenItem),
     );
   }
 
@@ -257,17 +263,27 @@ export default abstract class ExpressionParser extends LValParser {
   // https://tc39.es/ecma262/#prod-AssignmentExpression
   parseMaybeAssign(
     this: Parser,
+    refExpressionErrors: ExpressionErrors | null | undefined,
+    isParenItem: boolean | undefined,
+  ): N.Expression | N.TSTypeCastExpression;
+  parseMaybeAssign(
+    this: Parser,
     refExpressionErrors?: ExpressionErrors | null,
-    afterLeftParse?: Function,
-  ): N.Expression {
+  ): N.Expression;
+  parseMaybeAssign(
+    this: Parser,
+    refExpressionErrors?: ExpressionErrors | null,
+    isParenItem?: boolean,
+  ): N.Expression | N.TSTypeCastExpression {
     const startLoc = this.state.startLoc;
     const isYield = this.isContextual(tt._yield);
     if (isYield) {
       if (this.prodParam.hasYield) {
         this.next();
-        let left = this.parseYield(startLoc);
-        if (afterLeftParse) {
-          left = afterLeftParse.call(this, left, startLoc);
+        let left: N.Expression | N.TSTypeCastExpression =
+          this.parseYield(startLoc);
+        if (isParenItem) {
+          left = this.parseParenItem(left, startLoc);
         }
         return left;
       }
@@ -282,9 +298,10 @@ export default abstract class ExpressionParser extends LValParser {
     }
 
     this.state.canStartArrow = true;
-    let left = this.parseMaybeConditional(refExpressionErrors);
-    if (afterLeftParse) {
-      left = afterLeftParse.call(this, left, startLoc);
+    let left: N.Expression | N.TSTypeCastExpression =
+      this.parseMaybeConditional(refExpressionErrors);
+    if (isParenItem) {
+      left = this.parseParenItem(left, startLoc);
     }
     if (tokenIsAssignment(this.state.type)) {
       const node = this.startNodeAt<N.AssignmentExpression>(startLoc);
@@ -322,7 +339,7 @@ export default abstract class ExpressionParser extends LValParser {
           refExpressionErrors.voidPatternLoc = null;
         }
       } else {
-        node.left = left as unknown as N.Assignable; // checked a few lines further down
+        node.left = left as N.Assignable; // checked a few lines further down
       }
 
       this.next();
@@ -336,8 +353,7 @@ export default abstract class ExpressionParser extends LValParser {
         undefined,
         operator === "||=" || operator === "&&=" || operator === "??=",
       );
-      // @ts-expect-error todo(flow->ts) improve node types
-      return node;
+      return node as N.AssignmentExpression;
     } else if (ownExpressionErrors) {
       this.checkExpressionErrors(refExpressionErrors, true);
     }
@@ -1698,7 +1714,6 @@ export default abstract class ExpressionParser extends LValParser {
       | N.VoidPattern
       | N.AssignmentPattern
       | N.TSTypeCastExpression
-      | N.TypeCastExpression
     )[] = [];
     const refExpressionErrors = new ExpressionErrors();
     let first = true;
@@ -1736,7 +1751,7 @@ export default abstract class ExpressionParser extends LValParser {
           this.parseMaybeAssignAllowInOrVoidPattern(
             tt.parenR,
             refExpressionErrors,
-            this.parseParenItem,
+            true,
           ),
         );
       }
@@ -1821,11 +1836,7 @@ export default abstract class ExpressionParser extends LValParser {
 
   parseParenItem<
     T extends
-      | N.Expression
-      | N.RestElement
-      | N.SpreadElement
-      | N.TSTypeCastExpression
-      | N.TypeCastExpression,
+      N.Expression | N.RestElement | N.SpreadElement | N.TSTypeCastExpression,
   >(
     node: T,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -2330,10 +2341,10 @@ export default abstract class ExpressionParser extends LValParser {
             break;
           }
           default:
-            this.unexpected();
+            throw this.unexpected();
         }
       }
-      (prop as any).key = key;
+      prop.key = key;
       if (type !== tt.privateName) {
         // @ts-expect-error todo: computed is not defined on TSPropertySignature
         // ClassPrivateProperty is never computed, so we don't assign in that case.
@@ -2411,7 +2422,6 @@ export default abstract class ExpressionParser extends LValParser {
           | N.VoidPattern
           | N.AssignmentPattern
           | N.ArgumentPlaceholder
-          | N.TypeCastExpression
           | N.TSTypeCastExpression
         )[]
       | (
@@ -2420,7 +2430,6 @@ export default abstract class ExpressionParser extends LValParser {
           | N.VoidPattern
           | N.AssignmentPattern
           | N.ArgumentPlaceholder
-          | N.TypeCastExpression
           | N.TSTypeCastExpression
         )[]
       | null
@@ -2461,7 +2470,6 @@ export default abstract class ExpressionParser extends LValParser {
           | N.VoidPattern
           | N.AssignmentPattern
           | N.ArgumentPlaceholder
-          | N.TypeCastExpression
           | N.TSTypeCastExpression
         )[]
       | (
@@ -2470,7 +2478,6 @@ export default abstract class ExpressionParser extends LValParser {
           | N.VoidPattern
           | N.AssignmentPattern
           | N.ArgumentPlaceholder
-          | N.TypeCastExpression
           | N.TSTypeCastExpression
         )[],
     trailingCommaLoc?: Position | null,
@@ -2701,7 +2708,7 @@ export default abstract class ExpressionParser extends LValParser {
       elt = this.parseMaybeAssignAllowInOrVoidPattern(
         close,
         refExpressionErrors,
-        this.parseParenItem,
+        true,
       );
     }
     return elt;
@@ -3109,7 +3116,18 @@ export default abstract class ExpressionParser extends LValParser {
     this: Parser,
     close: TokenType,
     refExpressionErrors: ExpressionErrors | null | undefined,
-    afterLeftParse?: Function,
+    isParenItem: boolean | undefined,
+  ): N.Expression | N.TSTypeCastExpression;
+  parseMaybeAssignAllowInOrVoidPattern(
+    this: Parser,
+    close: TokenType,
+    refExpressionErrors?: ExpressionErrors | null,
+  ): N.Expression;
+  parseMaybeAssignAllowInOrVoidPattern(
+    this: Parser,
+    close: TokenType,
+    refExpressionErrors: ExpressionErrors | null | undefined,
+    isParenItem?: boolean,
   ) {
     if (refExpressionErrors != null && this.match(tt._void)) {
       const nextCode = this.lookaheadCharCode();
@@ -3131,7 +3149,7 @@ export default abstract class ExpressionParser extends LValParser {
         );
       }
     }
-    return this.parseMaybeAssignAllowIn(refExpressionErrors, afterLeftParse);
+    return this.parseMaybeAssignAllowIn(refExpressionErrors, isParenItem);
   }
 
   // Used in Flow plugin

--- a/packages/babel-parser/src/parser/lval.ts
+++ b/packages/babel-parser/src/parser/lval.ts
@@ -24,7 +24,6 @@ import type {
   VoidPattern,
   ArgumentPlaceholder,
   TSTypeCastExpression,
-  TypeCastExpression,
 } from "../types.ts";
 import type { Position } from "../util/location.ts";
 import {
@@ -53,16 +52,6 @@ export const enum ParseBindingListFlags {
 export default abstract class LValParser extends NodeUtils {
   // Forward-declaration: defined in expression.js
   abstract parseIdentifier(liberal?: boolean): Identifier;
-  abstract parseMaybeAssign(
-    refExpressionErrors?: ExpressionErrors | null,
-    afterLeftParse?: Function,
-  ): Expression;
-
-  abstract parseMaybeAssignAllowIn(
-    refExpressionErrors?: ExpressionErrors | null,
-    afterLeftParse?: Function,
-  ): Expression;
-
   abstract parseObjectLike<T extends ObjectPattern | ObjectExpression>(
     close: TokenType,
     isPattern: boolean,
@@ -260,7 +249,6 @@ export default abstract class LValParser extends NodeUtils {
       | AssignmentPattern
       | ArgumentPlaceholder
       | TSTypeCastExpression
-      | TypeCastExpression
       | null
     )[],
     trailingCommaLoc: Position | undefined | null,
@@ -376,7 +364,6 @@ export default abstract class LValParser extends NodeUtils {
           | AssignmentPattern
           | ArgumentPlaceholder
           | TSTypeCastExpression
-          | TypeCastExpression
           | null
         )[]
       | readonly (
@@ -385,7 +372,6 @@ export default abstract class LValParser extends NodeUtils {
           | VoidPattern
           | AssignmentPattern
           | TSTypeCastExpression
-          | TypeCastExpression
           | null
         )[],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -398,7 +384,6 @@ export default abstract class LValParser extends NodeUtils {
         | AssignmentPattern
         | ArgumentPlaceholder
         | TSTypeCastExpression
-        | TypeCastExpression
         | null
       )[]
     | readonly (
@@ -407,7 +392,6 @@ export default abstract class LValParser extends NodeUtils {
         | VoidPattern
         | AssignmentPattern
         | TSTypeCastExpression
-        | TypeCastExpression
         | null
       )[] {
     return exprList;
@@ -421,10 +405,7 @@ export default abstract class LValParser extends NodeUtils {
   ): SpreadElement {
     const node = this.startNode<SpreadElement>();
     this.next();
-    node.argument = this.parseMaybeAssignAllowIn(
-      refExpressionErrors,
-      undefined,
-    );
+    node.argument = this.parseMaybeAssignAllowIn(refExpressionErrors);
     return this.finishNode(node, "SpreadElement");
   }
 
@@ -732,7 +713,12 @@ export default abstract class LValParser extends NodeUtils {
 
   checkLVal(
     expression:
-      Expression | ObjectMember | RestElement | Pattern | TSParameterProperty,
+      | Expression
+      | ObjectMember
+      | RestElement
+      | Pattern
+      | TSParameterProperty
+      | TSTypeCastExpression,
     ancestor: LValAncestor,
     binding: BindingFlag = BindingFlag.TYPE_NONE,
     checkClashes: Set<string> | false = false,

--- a/packages/babel-parser/src/parser/statement.ts
+++ b/packages/babel-parser/src/parser/statement.ts
@@ -559,7 +559,7 @@ export default abstract class StatementParser extends ExpressionParser {
     ) {
       return this.parseLabeledStatement(node, maybeName, expr, flags);
     } else {
-      return this.parseExpressionStatement(node, expr, decorators);
+      return this.parseExpressionStatement(node, expr);
     }
   }
 
@@ -832,11 +832,7 @@ export default abstract class StatementParser extends ExpressionParser {
           (isForIn || this.isContextual(tt._of)) &&
           init.declarations.length === 1
         ) {
-          return this.parseForIn(
-            node as Undone<N.ForXStatement>,
-            init,
-            awaitAt,
-          );
+          return this.parseForX(node as Undone<N.ForXStatement>, init, awaitAt);
         }
         if (awaitAt !== null) {
           this.unexpected(awaitAt);
@@ -876,10 +872,9 @@ export default abstract class StatementParser extends ExpressionParser {
       this.toAssignable(init, /* isLHS */ true);
       const type = isForOf ? "ForOfStatement" : "ForInStatement";
       this.checkLVal(init, { type });
-      return this.parseForIn(
-        node as Undone<N.ForInStatement | N.ForOfStatement>,
-        // @ts-expect-error init has been transformed to an assignable
-        init,
+      return this.parseForX(
+        node as Undone<N.ForXStatement>,
+        init as N.Identifier | N.MemberExpression,
         awaitAt,
       );
     } else {
@@ -945,7 +940,7 @@ export default abstract class StatementParser extends ExpressionParser {
   parseSwitchStatement(this: Parser, node: Undone<N.SwitchStatement>) {
     this.next();
     node.discriminant = this.parseHeaderExpression();
-    const cases: N.SwitchStatement["cases"] = (node.cases = []);
+    const cases: Undone<N.SwitchCase>[] = (node.cases = []);
     this.expect(tt.braceL);
     this.state.labels.push(switchLabel);
     this.scope.enter(ScopeFlag.SWITCH);
@@ -959,7 +954,6 @@ export default abstract class StatementParser extends ExpressionParser {
       if (this.match(tt._case) || this.match(tt._default)) {
         const isCase = this.match(tt._case);
         if (cur) this.finishNode(cur, "SwitchCase");
-        // @ts-expect-error Fixme
         cases.push((cur = this.startNode<N.SwitchCase>()));
         cur.consequent = [];
         this.next();
@@ -1161,8 +1155,6 @@ export default abstract class StatementParser extends ExpressionParser {
   parseExpressionStatement(
     node: Undone<N.ExpressionStatement>,
     expr: N.Expression,
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars -- used in TypeScript parser */
-    decorators: N.Decorator[] | null | undefined,
   ) {
     node.expression = expr;
     this.semicolon();
@@ -1307,10 +1299,14 @@ export default abstract class StatementParser extends ExpressionParser {
   // Parse a `for`/`in` and `for`/`of` loop, which are almost
   // same from parser's perspective.
 
-  parseForIn(
+  parseForX(
     this: Parser,
     node: Undone<N.ForXStatement>,
-    init: N.VariableDeclaration | N.AssignmentPattern,
+    init:
+      | N.VariableDeclaration
+      | N.AssignmentPattern
+      | N.Identifier
+      | N.MemberExpression,
     awaitAt?: Position | null,
   ): N.ForXStatement {
     const isForIn = this.match(tt._in);
@@ -1517,8 +1513,7 @@ export default abstract class StatementParser extends ExpressionParser {
     this.expressionScope.exit();
   }
 
-  registerFunctionStatementId(node: N.Function): void {
-    // @ts-expect-error Fixme: id is not defined in ArrowFunctionExpression
+  registerFunctionStatementId(node: N.NormalFunction): void {
     if (!node.id) return;
 
     // If it is a regular function declaration in sloppy mode, then it is
@@ -1526,15 +1521,13 @@ export default abstract class StatementParser extends ExpressionParser {
     // mode depends on properties of the current scope (see
     // treatFunctionsAsVar).
     this.scope.declareName(
-      // @ts-expect-error Fixme: id is not defined in ArrowFunctionExpression
       node.id.name,
       !this.options.annexB || this.state.strict || node.generator || node.async
         ? this.scope.treatFunctionsAsVar
           ? BindingFlag.TYPE_VAR
           : BindingFlag.TYPE_LEXICAL
         : BindingFlag.TYPE_FUNCTION,
-      // @ts-expect-error Fixme: id is not defined in ArrowFunctionExpression
-      node.id.start,
+      node.id.start!,
     );
   }
 
@@ -1657,7 +1650,7 @@ export default abstract class StatementParser extends ExpressionParser {
     const key = this.parseIdentifier(true); // eats the modifier
 
     if (this.isClassMethod()) {
-      const method: N.ClassMethod = member as any;
+      const method = member as Undone<N.ClassMethod>;
 
       // a method named like the modifier
       method.kind = "method";
@@ -1674,7 +1667,7 @@ export default abstract class StatementParser extends ExpressionParser {
       );
       return true;
     } else if (this.isClassProperty()) {
-      const prop: N.ClassProperty = member as any;
+      const prop = member as Undone<N.ClassProperty>;
 
       // a property named like the modifier
       prop.computed = false;
@@ -2218,7 +2211,7 @@ export default abstract class StatementParser extends ExpressionParser {
 
     if (isFromRequired || hasSpecifiers || hasDeclaration) {
       const node2 = node as Undone<N.ExportNamedDeclaration>;
-      this.checkExport(node2, true, false, !!node2.source);
+      this.checkNamedExport(node2, !!node2.source);
       if (node2.declaration?.type === "ClassDeclaration") {
         this.maybeTakeDecorators(decorators, node2.declaration, node2);
       } else if (decorators) {
@@ -2240,7 +2233,19 @@ export default abstract class StatementParser extends ExpressionParser {
         throw this.raise(Errors.UnsupportedDecoratorExport, node);
       }
 
-      this.checkExport(node2, true, true);
+      this.checkDuplicateExports(node, "default");
+      if (this.hasPlugin("exportDefaultFrom")) {
+        if (
+          decl.type === "Identifier" &&
+          decl.name === "from" &&
+          // eslint-disable-next-line @typescript-eslint/no-confusing-non-null-assertion
+          decl.end! - decl.start! === 4 && // does not contain escape
+          !decl.extra?.parenthesized
+        ) {
+          this.raise(Errors.ExportDefaultFromAsIdentifier, decl);
+        }
+      }
+
       this.sawUnambiguousESM = true;
       return this.finishNode(node2, "ExportDefaultDeclaration");
     }
@@ -2466,7 +2471,6 @@ export default abstract class StatementParser extends ExpressionParser {
   ): void {
     if (this.eatContextual(tt._from)) {
       node.source = this.parseImportSource();
-      this.checkExport(node);
       this.maybeParseImportAttributes(node);
     } else if (expect) {
       this.unexpected();
@@ -2504,73 +2508,47 @@ export default abstract class StatementParser extends ExpressionParser {
     );
   }
 
-  checkExport(
-    node: Undone<
-      | N.ExportNamedDeclaration
-      | N.ExportAllDeclaration
-      | N.ExportDefaultDeclaration
-    >,
-    checkNames?: boolean,
-    isDefault?: boolean,
+  // Check for duplicate exports
+  checkNamedExport(
+    node: Undone<N.ExportNamedDeclaration>,
     isFrom?: boolean,
   ): void {
-    if (checkNames) {
-      // Check for duplicate exports
-      if (isDefault) {
-        // Default exports
-        this.checkDuplicateExports(node, "default");
-        if (this.hasPlugin("exportDefaultFrom")) {
-          const declaration = (node as any as N.ExportDefaultDeclaration)
-            .declaration;
-          if (
-            declaration.type === "Identifier" &&
-            declaration.name === "from" &&
-            // eslint-disable-next-line @typescript-eslint/no-confusing-non-null-assertion
-            declaration.end! - declaration.start! === 4 && // does not contain escape
-            !declaration.extra?.parenthesized
-          ) {
-            this.raise(Errors.ExportDefaultFromAsIdentifier, declaration);
+    if (node.specifiers?.length) {
+      // Named exports
+      for (const specifier of node.specifiers) {
+        const { exported } = specifier;
+        const exportName =
+          exported.type === "Identifier" ? exported.name : exported.value;
+        this.checkDuplicateExports(specifier, exportName);
+        if (!isFrom && specifier.type === "ExportSpecifier") {
+          const { local } = specifier;
+          if (local.type !== "Identifier") {
+            this.raise(Errors.ExportBindingIsString, specifier, {
+              localName: local.value,
+              exportName,
+            });
+          } else {
+            // check for keywords used as local names
+            this.checkReservedWord(local.name, local.start!, true, false);
+            // check if export is defined
+            this.scope.checkLocalExport(local);
           }
         }
-        // @ts-expect-error node.specifiers may not exist
-      } else if (node.specifiers?.length) {
-        // Named exports
-        // @ts-expect-error node.specifiers may not exist
-        for (const specifier of node.specifiers) {
-          const { exported } = specifier;
-          const exportName =
-            exported.type === "Identifier" ? exported.name : exported.value;
-          this.checkDuplicateExports(specifier, exportName);
-          if (!isFrom && specifier.local) {
-            const { local } = specifier;
-            if (local.type !== "Identifier") {
-              this.raise(Errors.ExportBindingIsString, specifier, {
-                localName: local.value,
-                exportName,
-              });
-            } else {
-              // check for keywords used as local names
-              this.checkReservedWord(local.name, local.start, true, false);
-              // check if export is defined
-              this.scope.checkLocalExport(local);
-            }
-          }
-        }
-      } else if ((node as Undone<N.ExportNamedDeclaration>).declaration) {
-        const decl = (node as Undone<N.ExportNamedDeclaration>).declaration!;
-        // Exported declarations
-        if (
-          decl.type === "FunctionDeclaration" ||
-          decl.type === "ClassDeclaration"
-        ) {
-          const { id } = decl;
-          if (!id) throw new Error("Assertion failure");
+      }
+    } else if (node.declaration) {
+      const decl = node.declaration;
+      // Exported declarations
+      if (
+        decl.type === "FunctionDeclaration" ||
+        decl.type === "ClassDeclaration"
+      ) {
+        const { id } = decl;
+        if (!id) throw new Error("Assertion failure");
 
-          this.checkDuplicateExports(node, id.name);
-        } else if (decl.type === "VariableDeclaration") {
-          for (const declaration of decl.declarations) {
-            this.checkDeclaration(declaration.id);
-          }
+        this.checkDuplicateExports(node, id.name);
+      } else if (decl.type === "VariableDeclaration") {
+        for (const declaration of decl.declarations) {
+          this.checkDeclaration(declaration.id);
         }
       }
     }
@@ -2656,18 +2634,19 @@ export default abstract class StatementParser extends ExpressionParser {
   }
 
   parseExportSpecifier(
-    node: any,
+    node: Undone<N.ExportSpecifier>,
     isString: boolean,
     /* eslint-disable @typescript-eslint/no-unused-vars -- used in TypeScript parser */
     isInTypeExport: boolean,
-    isMaybeTypeOnly /* eslint-enable @typescript-eslint/no-unused-vars */ : boolean,
+    isMaybeTypeOnly: boolean,
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): N.ExportSpecifier {
     if (this.eatContextual(tt._as)) {
       node.exported = this.parseModuleExportName();
     } else if (isString) {
-      node.exported = this.cloneStringLiteral(node.local);
+      node.exported = this.cloneStringLiteral(node.local as N.StringLiteral);
     } else if (!node.exported) {
-      node.exported = this.cloneIdentifier(node.local);
+      node.exported = this.cloneIdentifier(node.local as N.Identifier);
     }
     return this.finishNode<N.ExportSpecifier>(node, "ExportSpecifier");
   }
@@ -2842,7 +2821,7 @@ export default abstract class StatementParser extends ExpressionParser {
     this: Parser,
     node: Undone<N.ImportDeclaration>,
     maybeDefaultIdentifier: N.Identifier | null,
-  ): N.AnyImport {
+  ): N.ImportDeclaration {
     node.specifiers = [];
 
     // check if we have a default import like
@@ -2872,7 +2851,7 @@ export default abstract class StatementParser extends ExpressionParser {
   parseImportSourceAndAttributes(
     this: Parser,
     node: Undone<N.ImportDeclaration>,
-  ): N.AnyImport {
+  ): N.ImportDeclaration {
     node.specifiers ??= [];
     node.source = this.parseImportSource();
     this.maybeParseImportAttributes(node);

--- a/packages/babel-parser/src/plugins/flow/index.ts
+++ b/packages/babel-parser/src/plugins/flow/index.ts
@@ -2032,7 +2032,6 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     parseExpressionStatement(
       node: Undone<N.ExpressionStatement>,
       expr: N.Expression,
-      decorators: N.Decorator[] | null,
     ): N.ExpressionStatement {
       if (expr.type === "Identifier") {
         if (expr.name === "declare") {
@@ -2063,7 +2062,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         }
       }
 
-      return super.parseExpressionStatement(node, expr, decorators);
+      return super.parseExpressionStatement(node, expr);
     }
 
     // export type
@@ -2165,7 +2164,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       node.test = expr;
       node.consequent = consequent;
       node.alternate = this.forwardNoArrowParamsConversionAt(node, () =>
-        this.parseMaybeAssign(undefined, undefined),
+        this.parseMaybeAssign(),
       );
 
       return this.finishNode(node, "ConditionalExpression");
@@ -2265,11 +2264,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
     parseParenItem<
       T extends
-        | N.Expression
-        | N.RestElement
-        | N.SpreadElement
-        | N.TSTypeCastExpression
-        | N.TypeCastExpression,
+        N.Expression | N.RestElement | N.SpreadElement | N.TSTypeCastExpression,
     >(
       node: T,
       startLoc: Position,
@@ -2516,7 +2511,6 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
             | N.AssignmentPattern
             | N.ArgumentPlaceholder
             | N.TSTypeCastExpression
-            | N.TypeCastExpression
             | null
           )[]
         | readonly (
@@ -2525,7 +2519,6 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
             | N.VoidPattern
             | N.AssignmentPattern
             | N.TSTypeCastExpression
-            | N.TypeCastExpression
             | null
           )[],
       isParenthesizedExpr?: boolean,
@@ -2537,7 +2530,6 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           | N.AssignmentPattern
           | N.ArgumentPlaceholder
           | N.TSTypeCastExpression
-          | N.TypeCastExpression
           | null
         )[]
       | readonly (
@@ -2546,7 +2538,6 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           | N.VoidPattern
           | N.AssignmentPattern
           | N.TSTypeCastExpression
-          | N.TypeCastExpression
           | null
         )[] {
       for (let i = 0; i < exprList.length; i++) {
@@ -3035,9 +3026,16 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     //    there
     // 3. This is neither. Just call the super method
     parseMaybeAssign(
+      refExpressionErrors: ExpressionErrors | null | undefined,
+      isParenItem: boolean | undefined,
+    ): N.Expression | N.TSTypeCastExpression;
+    parseMaybeAssign(
       refExpressionErrors?: ExpressionErrors | null,
-      afterLeftParse?: Function,
-    ): N.Expression {
+    ): N.Expression;
+    parseMaybeAssign(
+      refExpressionErrors?: ExpressionErrors | null,
+      isParenItem?: boolean,
+    ): N.Expression | N.TSTypeCastExpression {
       let state = null;
 
       let jsx;
@@ -3049,7 +3047,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         state = this.state.clone();
 
         jsx = this.tryParse(
-          () => super.parseMaybeAssign(refExpressionErrors, afterLeftParse),
+          () => super.parseMaybeAssign(refExpressionErrors, isParenItem),
           state,
         );
 
@@ -3080,7 +3078,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
             () => {
               const result = super.parseMaybeAssign(
                 refExpressionErrors,
-                afterLeftParse,
+                isParenItem,
               );
 
               this.resetStartLocationFromNode(result, typeParameters);
@@ -3160,7 +3158,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         );
       }
 
-      return super.parseMaybeAssign(refExpressionErrors, afterLeftParse);
+      return super.parseMaybeAssign(refExpressionErrors, isParenItem);
     }
 
     // handle return types for arrow functions

--- a/packages/babel-parser/src/plugins/jsx/index.ts
+++ b/packages/babel-parser/src/plugins/jsx/index.ts
@@ -633,7 +633,7 @@ export default (superClass: typeof Parser) =>
       super.getTokenFromCode(code);
     }
 
-    updateContext(prevType: TokenType): void {
+    updateContext(prevType?: TokenType): void {
       const { context, type } = this.state;
       if (type === tt.slash && prevType === tt.jsxTagStart) {
         // do not consider JSX expr -> JSX open tag -> ... anymore

--- a/packages/babel-parser/src/plugins/placeholders.ts
+++ b/packages/babel-parser/src/plugins/placeholders.ts
@@ -372,16 +372,17 @@ export default (superClass: typeof Parser) =>
       );
     }
 
-    checkExport(node: N.ExportNamedDeclaration): void {
-      const { specifiers } = node;
-      if (specifiers?.length) {
-        node.specifiers = specifiers.filter(
-          // @ts-expect-error placeholder typings
-          node => node.exported.type === "Placeholder",
-        );
-      }
-      super.checkExport(node);
-      node.specifiers = specifiers;
+    // TODO: Enable this
+    checkNamedExport(): void {
+      // const { specifiers } = node;
+      // if (specifiers?.length) {
+      //   node.specifiers = specifiers.filter(
+      //     // @ts-expect-error placeholder typings
+      //     node => node.exported.type === "Placeholder",
+      //   );
+      // }
+      // super.checkNamedExport(node);
+      // node.specifiers = specifiers;
     }
 
     parseImport(

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -1,3 +1,5 @@
+/* eslint sort-keys: "error" */
+
 import type State from "../../tokenizer/state.ts";
 import {
   tokenIsIdentifier,
@@ -68,7 +70,6 @@ type ModifierBase = {
   accessibility?: N.Accessibility;
 } & Partial<Record<TsModifier, boolean | undefined | null>>;
 
-/* eslint sort-keys: "error" */
 export const TSErrorTemplates = {
   AbstractMethodHasImplementation: ({ methodName }: { methodName: string }) =>
     `Method '${methodName}' cannot have an implementation because it is marked abstract.`,
@@ -252,7 +253,6 @@ export const TSErrorTemplates = {
   UsingDeclarationInAmbientContext: (kind: "using" | "await using") =>
     `'${kind}' declarations are not allowed in ambient contexts.`,
 } satisfies ParseErrorTemplates;
-/* eslint-disable sort-keys */
 
 const TSErrors = ParseErrorEnum`typescript`(TSErrorTemplates);
 
@@ -321,6 +321,47 @@ export const enum tsParseEntityNameFlags {
   LEADING_THIS_AS_IDENTIFIER = 0b10,
 }
 
+const ClassMemberModifiers = buildModifiersMap(
+  [
+    "declare",
+    "private",
+    "public",
+    "protected",
+    "override",
+    "abstract",
+    "readonly",
+    "static",
+  ],
+  ["in", "out"],
+);
+
+const IndexSignatureModifiers = buildModifiersMap(
+  ["readonly"],
+  [
+    "declare",
+    "abstract",
+    "private",
+    "protected",
+    "public",
+    "static",
+    "override",
+  ],
+);
+
+const BindingElementModifiers = buildModifiersMap([
+  "public",
+  "private",
+  "protected",
+  "override",
+  "readonly",
+]);
+
+const AccessModifiers = buildModifiersMap([
+  "private",
+  "public",
+  "protected",
+]) as Map<N.Accessibility, boolean>;
+
 export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
   class TypeScriptParserMixin extends superClass implements Parser {
     declare scope: TypeScriptScopeHandler;
@@ -366,7 +407,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
 
     /** Parses a modifier matching one the given modifier names. */
     tsParseModifier<T extends TsModifier>(
-      allowedModifiers: T[],
+      modifiers: Map<T, boolean>,
       stopOnStartOfClassStaticBlock?: boolean,
       hasSeenStaticModifier?: boolean | null,
     ): T | undefined | null {
@@ -379,7 +420,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       }
 
       const modifier = this.state.value;
-      if (allowedModifiers.includes(modifier)) {
+      if (modifiers.has(modifier)) {
         if (hasSeenStaticModifier && this.match(tt._static)) {
           return undefined;
         }
@@ -399,18 +440,10 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
      *    this.tsParseModifiers({ modified: node, allowedModifiers: ["abstract", "readonly"] });
      */
     tsParseModifiers<N extends ModifierBase>(
-      {
-        allowedModifiers,
-        disallowedModifiers,
-        stopOnStartOfClassStaticBlock,
-        errorTemplate = TSErrors.InvalidModifierOnTypeMember,
-      }: {
-        allowedModifiers: readonly TsModifier[];
-        disallowedModifiers?: TsModifier[];
-        stopOnStartOfClassStaticBlock?: boolean;
-        errorTemplate?: typeof TSErrors.InvalidModifierOnTypeMember;
-      },
+      modifiers: Map<TsModifier, boolean>,
+      errorTemplate: typeof TSErrors.InvalidModifierOnTypeMember = TSErrors.InvalidModifierOnTypeMember,
       modified: N,
+      stopOnStartOfClassStaticBlock: boolean = false,
     ): void {
       const enforceOrder = (
         loc: Position,
@@ -443,7 +476,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       for (;;) {
         const { startLoc } = this.state;
         const modifier: TsModifier | undefined | null = this.tsParseModifier(
-          allowedModifiers.concat(disallowedModifiers ?? []),
+          modifiers,
           stopOnStartOfClassStaticBlock,
           modified.static,
         );
@@ -484,7 +517,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           modified[modifier] = true;
         }
 
-        if (disallowedModifiers?.includes(modifier)) {
+        if (!modifiers.get(modifier)) {
           this.raise(errorTemplate, startLoc, {
             modifier,
           });
@@ -766,41 +799,46 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       return this.finishNode(node, "TSTypeQuery");
     }
 
-    tsParseInOutModifiers = this.tsParseModifiers.bind(this, {
-      allowedModifiers: ["in", "out"],
-      disallowedModifiers: [
-        "const",
-        "public",
-        "private",
-        "protected",
-        "readonly",
-        "declare",
-        "abstract",
-        "override",
-      ],
-      errorTemplate: TSErrors.InvalidModifierOnTypeParameter,
-    });
+    tsParseInOutModifiers = this.tsParseModifiers.bind(
+      this,
+      buildModifiersMap(
+        ["in", "out"],
+        [
+          "const",
+          "public",
+          "private",
+          "protected",
+          "readonly",
+          "declare",
+          "abstract",
+          "override",
+        ],
+      ),
+      TSErrors.InvalidModifierOnTypeParameter,
+    );
 
-    tsParseConstModifier = this.tsParseModifiers.bind(this, {
-      allowedModifiers: ["const"],
-      // for better error recovery
-      disallowedModifiers: ["in", "out"],
-      errorTemplate: TSErrors.InvalidModifierOnTypeParameterPositions,
-    });
+    tsParseConstModifier = this.tsParseModifiers.bind(
+      this,
+      buildModifiersMap(["const"], ["in", "out"]),
+      TSErrors.InvalidModifierOnTypeParameterPositions,
+    );
 
-    tsParseInOutConstModifiers = this.tsParseModifiers.bind(this, {
-      allowedModifiers: ["in", "out", "const"],
-      disallowedModifiers: [
-        "public",
-        "private",
-        "protected",
-        "readonly",
-        "declare",
-        "abstract",
-        "override",
-      ],
-      errorTemplate: TSErrors.InvalidModifierOnTypeParameter,
-    });
+    tsParseInOutConstModifiers = this.tsParseModifiers.bind(
+      this,
+      buildModifiersMap(
+        ["in", "out", "const"],
+        [
+          "public",
+          "private",
+          "protected",
+          "readonly",
+          "declare",
+          "abstract",
+          "override",
+        ],
+      ),
+      TSErrors.InvalidModifierOnTypeParameter,
+    );
 
     tsParseTypeParameter(
       parseModifiers: (node: Undone<N.TSTypeParameter>) => void,
@@ -1052,21 +1090,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         }
       }
 
-      this.tsParseModifiers(
-        {
-          allowedModifiers: ["readonly"],
-          disallowedModifiers: [
-            "declare",
-            "abstract",
-            "private",
-            "protected",
-            "public",
-            "static",
-            "override",
-          ],
-        },
-        node,
-      );
+      this.tsParseModifiers(IndexSignatureModifiers, undefined, node);
 
       const idx = this.tsTryParseIndexSignature(node);
       if (idx) {
@@ -2446,18 +2470,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       const startLoc = decorators.length ? null : this.state.startLoc;
 
       const modified: ModifierBase = {};
-      this.tsParseModifiers(
-        {
-          allowedModifiers: [
-            "public",
-            "private",
-            "protected",
-            "override",
-            "readonly",
-          ],
-        },
-        modified,
-      );
+      this.tsParseModifiers(BindingElementModifiers, undefined, modified);
       const accessibility = modified.accessibility;
       const override = modified.override;
       const readonly = modified.readonly;
@@ -2594,12 +2607,10 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       return super.parseFunctionBodyAndFinish(node, type, isMethod);
     }
 
-    registerFunctionStatementId(node: N.Function): void {
-      // @ts-expect-error Fixme: id is not defined in ArrowFunctionExpression
+    registerFunctionStatementId(node: N.NormalFunction): void {
       if (!node.body && node.id) {
         // Function ids are validated after parsing their body.
         // For bodiless function, we need to do it here.
-        // @ts-expect-error Fixme: id is not defined in ArrowFunctionExpression
         this.checkIdentifier(node.id, BindingFlag.TYPE_TS_AMBIENT);
       } else {
         super.registerFunctionStatementId(node);
@@ -2946,16 +2957,16 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
           );
         }
       } else {
-        importNode = super.parseImport(node as Undone<N.ImportDeclaration>);
+        importNode = super.parseImport(
+          node as Undone<N.ImportDeclaration>,
+        ) as N.ImportDeclaration;
       }
 
       // `import type` can only be used on imports with named imports or with a
       // default import - but not both
       if (
         importNode.importKind === "type" &&
-        // @ts-expect-error refine typings
         importNode.specifiers.length > 1 &&
-        // @ts-expect-error refine typings
         importNode.specifiers[0].type === "ImportDefaultSpecifier"
       ) {
         this.raise(TSErrors.TypeImportCannotSpecifyDefaultAndNamed, importNode);
@@ -3250,7 +3261,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     }
 
     parseAccessModifier(): N.Accessibility | undefined | null {
-      return this.tsParseModifier(["public", "protected", "private"]);
+      return this.tsParseModifier(AccessModifiers);
     }
 
     tsHasSomeModifiers(member: any, modifiers: readonly TsModifier[]): boolean {
@@ -3274,31 +3285,29 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       member: any,
       state: N.ParseClassMemberState,
     ): void {
-      const modifiers = [
-        "declare",
-        "private",
-        "public",
-        "protected",
-        "override",
-        "abstract",
-        "readonly",
-        "static",
-      ] as const;
       this.tsParseModifiers(
-        {
-          allowedModifiers: modifiers,
-          disallowedModifiers: ["in", "out"],
-          stopOnStartOfClassStaticBlock: true,
-          errorTemplate: TSErrors.InvalidModifierOnTypeParameterPositions,
-        },
+        ClassMemberModifiers,
+        TSErrors.InvalidModifierOnTypeParameterPositions,
         member,
+        true,
       );
 
       const callParseClassMemberWithIsStatic = () => {
         if (this.tsIsStartOfStaticBlocks()) {
           this.next(); // eat "static"
           this.next(); // eat "{"
-          if (this.tsHasSomeModifiers(member, modifiers)) {
+          if (
+            this.tsHasSomeModifiers(member, [
+              "declare",
+              "private",
+              "public",
+              "protected",
+              "override",
+              "abstract",
+              "readonly",
+              "static",
+            ])
+          ) {
             this.raise(
               TSErrors.StaticBlockCannotHaveModifier,
               this.state.curPosition(),
@@ -3464,11 +3473,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     // But we parse them here and change them when completing the arrow function.
     parseParenItem<
       T extends
-        | N.Expression
-        | N.RestElement
-        | N.SpreadElement
-        | N.TSTypeCastExpression
-        | N.TypeCastExpression,
+        N.Expression | N.RestElement | N.SpreadElement | N.TSTypeCastExpression,
     >(node: T, startLoc: Position): T | N.TSTypeCastExpression {
       const newNode = super.parseParenItem(node, startLoc);
       if (this.eat(tt.question)) {
@@ -3760,8 +3765,8 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       const typeParameters = this.tsTryParseTypeParameters(
         this.tsParseConstModifier,
       );
-      // @ts-expect-error typeParameters is not defined on ObjectProperty
-      if (typeParameters) prop.typeParameters = typeParameters;
+      if (typeParameters)
+        (prop as Undone<N.ObjectMethod>).typeParameters = typeParameters;
 
       return super.parseObjPropValue(
         prop,
@@ -3819,9 +3824,16 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     }
 
     parseMaybeAssign(
+      refExpressionErrors: ExpressionErrors | null | undefined,
+      isParenItem: boolean | undefined,
+    ): N.Expression | N.TSTypeCastExpression;
+    parseMaybeAssign(
       refExpressionErrors?: ExpressionErrors | null,
-      afterLeftParse?: Function,
-    ): N.Expression {
+    ): N.Expression;
+    parseMaybeAssign(
+      refExpressionErrors?: ExpressionErrors | null,
+      isParenItem?: boolean,
+    ): N.Expression | N.TSTypeCastExpression {
       // Note: When the JSX plugin is on, type assertions (`<T> x`) aren't valid syntax.
 
       let state: State | undefined | null;
@@ -3836,7 +3848,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         state = this.state.clone();
 
         jsx = this.tryParse(
-          () => super.parseMaybeAssign(refExpressionErrors, afterLeftParse),
+          () => super.parseMaybeAssign(refExpressionErrors, isParenItem),
           state,
         );
 
@@ -3855,7 +3867,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       }
 
       if (!jsx?.error && !this.match(tt.lt)) {
-        return super.parseMaybeAssign(refExpressionErrors, afterLeftParse);
+        return super.parseMaybeAssign(refExpressionErrors, isParenItem);
       }
 
       // Either way, we're looking at a '<': tt.jsxTagStart or relational.
@@ -3870,10 +3882,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       const arrow = this.tryParse((abort: () => never) => {
         // This is similar to TypeScript's `tryParseParenthesizedArrowFunctionExpression`.
         typeParameters = this.tsParseTypeParameters(this.tsParseConstModifier);
-        const expr = super.parseMaybeAssign(
-          refExpressionErrors,
-          afterLeftParse,
-        );
+        const expr = super.parseMaybeAssign(refExpressionErrors, isParenItem);
 
         if (
           expr.type !== "ArrowFunctionExpression" ||
@@ -3931,7 +3940,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
         // This will start with a type assertion (via parseMaybeUnary).
         // But don't directly call `this.tsParseTypeAssertion` because we want to handle any binary after it.
         typeCast = this.tryParse(
-          () => super.parseMaybeAssign(refExpressionErrors, afterLeftParse),
+          () => super.parseMaybeAssign(refExpressionErrors, isParenItem),
           state,
         );
         /*:: invariant(!typeCast.aborted) */
@@ -3962,7 +3971,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       throw jsx?.error || arrow.error || typeCast?.error;
     }
 
-    reportReservedArrowTypeParam(node: any) {
+    reportReservedArrowTypeParam(node: N.TSTypeParameterDeclaration) {
       if (
         node.params.length === 1 &&
         !node.params[0].constraint &&
@@ -4016,7 +4025,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       param: T,
     ): T {
       if (this.eat(tt.question)) {
-        (param as any as N.Identifier).optional = true;
+        (param as N.Identifier).optional = true;
       }
       const type = this.tsTryParseTypeAnnotation();
       // @ts-expect-error typeAnnotation is not defined on VoidPattern
@@ -4474,11 +4483,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       isMaybeTypeOnly: boolean,
     ) {
       if (!isString && isMaybeTypeOnly) {
-        this.parseTypeOnlyImportExportSpecifier(
-          node,
-          /* isImport */ false,
-          isInTypeExport,
-        );
+        this.parseTypeOnlyExportSpecifier(node, isInTypeExport);
         return this.finishNode<N.ExportSpecifier>(node, "ExportSpecifier");
       }
       node.exportKind = "value";
@@ -4499,11 +4504,7 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       bindingType: BindingFlag | undefined,
     ): N.ImportSpecifier {
       if (!importedIsString && isMaybeTypeOnly) {
-        this.parseTypeOnlyImportExportSpecifier(
-          specifier,
-          /* isImport */ true,
-          isInTypeOnlyImport,
-        );
+        this.parseTypeOnlyImportSpecifier(specifier, isInTypeOnlyImport);
         return this.finishNode<N.ImportSpecifier>(specifier, "ImportSpecifier");
       }
       specifier.importKind = "value";
@@ -4518,21 +4519,13 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       );
     }
 
-    parseTypeOnlyImportExportSpecifier(
-      node: any,
-      isImport: boolean,
-      isInTypeOnlyImportExport: boolean,
-    ): void {
-      const leftOfAsKey = isImport ? "imported" : "local";
-      const rightOfAsKey = isImport ? "local" : "exported";
-
-      let leftOfAs = node[leftOfAsKey];
-      let rightOfAs;
+    parseTypeOnlyImportSpecifier(
+      node: Undone<N.ImportSpecifier>,
+      isInTypeOnly: boolean,
+    ) {
+      let leftOfAs = node.imported;
 
       let hasTypeSpecifier = false;
-      let canParseAsKeyword = true;
-
-      const loc = leftOfAs.start;
 
       // https://github.com/microsoft/TypeScript/blob/fc4f9d83d5939047aa6bb2a43965c6e9bbfbc35b/src/compiler/parser.ts#L7411-L7456
       // import { type } from "mod";          - hasTypeSpecifier: false, leftOfAs: type
@@ -4549,21 +4542,14 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
             // { type as as something }
             hasTypeSpecifier = true;
             leftOfAs = firstAs;
-            rightOfAs = isImport
-              ? this.parseIdentifier()
-              : this.parseModuleExportName();
-            canParseAsKeyword = false;
+            node.local = this.parseIdentifier();
           } else {
             // { type as as }
-            rightOfAs = secondAs;
-            canParseAsKeyword = false;
+            node.local = secondAs;
           }
         } else if (tokenIsKeywordOrIdentifier(this.state.type)) {
           // { type as something }
-          canParseAsKeyword = false;
-          rightOfAs = isImport
-            ? this.parseIdentifier()
-            : this.parseModuleExportName();
+          node.local = this.parseIdentifier();
         } else {
           // { type as }
           hasTypeSpecifier = true;
@@ -4572,46 +4558,79 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       } else if (tokenIsKeywordOrIdentifier(this.state.type)) {
         // { type something ...? }
         hasTypeSpecifier = true;
-        if (isImport) {
-          leftOfAs = this.parseIdentifier(true);
-          if (!this.isContextual(tt._as)) {
-            this.checkReservedWord(leftOfAs.name, leftOfAs.start, true, true);
-          }
-        } else {
-          leftOfAs = this.parseModuleExportName();
+        leftOfAs = this.parseIdentifier(true);
+        if (!this.isContextual(tt._as)) {
+          this.checkReservedWord(leftOfAs.name, leftOfAs.start!, true, true);
         }
       }
-      if (hasTypeSpecifier && isInTypeOnlyImportExport) {
-        this.raise(
-          isImport
-            ? TSErrors.TypeModifierIsUsedInTypeImports
-            : TSErrors.TypeModifierIsUsedInTypeExports,
-          loc,
-        );
+      if (hasTypeSpecifier && isInTypeOnly) {
+        this.raise(TSErrors.TypeModifierIsUsedInTypeImports, node.imported);
       }
 
-      node[leftOfAsKey] = leftOfAs;
-      node[rightOfAsKey] = rightOfAs;
+      node.imported = leftOfAs;
 
-      const kindKey = isImport ? "importKind" : "exportKind";
-      node[kindKey] = hasTypeSpecifier ? "type" : "value";
+      node.importKind = hasTypeSpecifier ? "type" : "value";
 
-      if (canParseAsKeyword && this.eatContextual(tt._as)) {
-        node[rightOfAsKey] = isImport
+      this.checkIdentifier(
+        (node.local ??= this.eatContextual(tt._as)
           ? this.parseIdentifier()
-          : this.parseModuleExportName();
+          : this.cloneIdentifier(node.imported as N.Identifier)),
+        hasTypeSpecifier
+          ? BindingFlag.TYPE_TS_TYPE_IMPORT
+          : BindingFlag.TYPE_TS_VALUE_IMPORT,
+      );
+    }
+
+    parseTypeOnlyExportSpecifier(
+      node: Undone<N.ExportSpecifier>,
+      isInTypeOnly: boolean,
+    ): void {
+      const local = node.local;
+
+      let hasTypeSpecifier = false;
+
+      // https://github.com/microsoft/TypeScript/blob/fc4f9d83d5939047aa6bb2a43965c6e9bbfbc35b/src/compiler/parser.ts#L7411-L7456
+      // import { type } from "mod";          - hasTypeSpecifier: false, leftOfAs: type
+      // import { type as } from "mod";       - hasTypeSpecifier: true,  leftOfAs: as
+      // import { type as as } from "mod";    - hasTypeSpecifier: false, leftOfAs: type, rightOfAs: as
+      // import { type as as as } from "mod"; - hasTypeSpecifier: true,  leftOfAs: as,   rightOfAs: as
+      if (this.isContextual(tt._as)) {
+        // { type as ...? }
+        const firstAs = this.parseIdentifier();
+        if (this.isContextual(tt._as)) {
+          // { type as as ...? }
+          const secondAs = this.parseIdentifier();
+          if (tokenIsKeywordOrIdentifier(this.state.type)) {
+            // { type as as something }
+            hasTypeSpecifier = true;
+            node.local = firstAs;
+            node.exported = this.parseModuleExportName();
+          } else {
+            // { type as as }
+            node.exported = secondAs;
+          }
+        } else if (tokenIsKeywordOrIdentifier(this.state.type)) {
+          // { type as something }
+          node.exported = this.parseModuleExportName();
+        } else {
+          // { type as }
+          hasTypeSpecifier = true;
+          node.local = firstAs;
+        }
+      } else if (tokenIsKeywordOrIdentifier(this.state.type)) {
+        // { type something ...? }
+        hasTypeSpecifier = true;
+        node.local = this.parseModuleExportName();
       }
-      if (!node[rightOfAsKey]) {
-        node[rightOfAsKey] = this.cloneIdentifier(node[leftOfAsKey]);
+      if (hasTypeSpecifier && isInTypeOnly) {
+        this.raise(TSErrors.TypeModifierIsUsedInTypeExports, local);
       }
-      if (isImport) {
-        this.checkIdentifier(
-          node[rightOfAsKey],
-          hasTypeSpecifier
-            ? BindingFlag.TYPE_TS_TYPE_IMPORT
-            : BindingFlag.TYPE_TS_VALUE_IMPORT,
-        );
-      }
+
+      node.exportKind = hasTypeSpecifier ? "type" : "value";
+
+      node.exported ??= this.eatContextual(tt._as)
+        ? this.parseModuleExportName()
+        : this.cloneIdentifier(node.local as N.Identifier);
     }
 
     /**
@@ -4880,4 +4899,15 @@ function isUncomputedMemberExpressionChain(
   }
 
   return isUncomputedMemberExpressionChain(expression.object);
+}
+
+function buildModifiersMap(allowed: TsModifier[], disallow: TsModifier[] = []) {
+  const map = new Map<TsModifier, boolean>();
+  for (const modifier of allowed) {
+    map.set(modifier, true);
+  }
+  for (const modifier of disallow) {
+    map.set(modifier, false);
+  }
+  return map;
 }

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -390,8 +390,8 @@ export default abstract class Tokenizer extends CommentsParser {
 
   skipSpace(): void {
     const spaceStart = this.state.pos;
-    const comments: N.Comment[] | null =
-      this.optionFlags & OptionFlags.AttachComment ? [] : null;
+    const attachComment = (this.optionFlags & OptionFlags.AttachComment) > 0;
+    let comments: N.Comment[] | undefined;
     loop: while (this.state.pos < this.length) {
       const ch = this.input.charCodeAt(this.state.pos);
       switch (ch) {
@@ -421,7 +421,9 @@ export default abstract class Tokenizer extends CommentsParser {
               const comment = this.skipBlockComment("*/");
               if (comment !== undefined) {
                 this.addComment(comment);
-                comments?.push(comment);
+                if (attachComment) {
+                  (comments ??= []).push(comment);
+                }
               }
               break;
             }
@@ -430,7 +432,9 @@ export default abstract class Tokenizer extends CommentsParser {
               const comment = this.skipLineComment(2);
               if (comment !== undefined) {
                 this.addComment(comment);
-                comments?.push(comment);
+                if (attachComment) {
+                  (comments ??= []).push(comment);
+                }
               }
               break;
             }
@@ -458,7 +462,9 @@ export default abstract class Tokenizer extends CommentsParser {
               const comment = this.skipLineComment(3);
               if (comment !== undefined) {
                 this.addComment(comment);
-                comments?.push(comment);
+                if (attachComment) {
+                  (comments ??= []).push(comment);
+                }
               }
             } else {
               break loop;
@@ -478,7 +484,9 @@ export default abstract class Tokenizer extends CommentsParser {
               const comment = this.skipLineComment(4);
               if (comment !== undefined) {
                 this.addComment(comment);
-                comments?.push(comment);
+                if (attachComment) {
+                  (comments ??= []).push(comment);
+                }
               }
             } else {
               break loop;
@@ -489,13 +497,12 @@ export default abstract class Tokenizer extends CommentsParser {
       }
     }
 
-    // @ts-expect-error comparing undefined and number
-    if (comments?.length > 0) {
+    if (comments?.length) {
       const end = this.state.pos;
       const commentWhitespace: CommentWhitespace = {
         start: this.sourceToOffsetPos(spaceStart),
         end: this.sourceToOffsetPos(end),
-        comments: comments!,
+        comments: comments,
         leadingNode: null,
         trailingNode: null,
         containingNode: null,
@@ -523,8 +530,6 @@ export default abstract class Tokenizer extends CommentsParser {
 
   replaceToken(type: TokenType): void {
     this.state.type = type;
-    // @ts-expect-error the prevType of updateContext is required
-    // only when the new type is tt.slash/tt.jsxTagEnd
     this.updateContext();
   }
 
@@ -1483,7 +1488,7 @@ export default abstract class Tokenizer extends CommentsParser {
 
   // updateContext is used by the jsx plugin
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  updateContext(prevType: TokenType): void {}
+  updateContext(prevType?: TokenType): void {}
 
   // Raise an unexpected token error. Can take the expected token type.
   unexpected(loc?: Position | number | null, type?: TokenType): any {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This PR mainly focuses on some type improvements.
```
PS F:\babel> node benchmark\babel-parser\real-case.mjs
Recommend running with --expose-gc.
babel-parser/real-case.mjs babel-parser-express.ts @ current: 390 ops/sec ±1.17% 1903 runs (2.628ms)
babel-parser/real-case.mjs babel-parser-express.ts @ baseline: 352 ops/sec ±1.48% 1713 runs (2.92ms)
babel-parser/real-case.mjs jquery-3.6.js @ current: 125 ops/sec ±1.07% 620 runs (8.071ms)
babel-parser/real-case.mjs jquery-3.6.js @ baseline: 118 ops/sec ±1.11% 584 runs (8.566ms)
babel-parser/real-case.mjs ts-checker.mjs @ current: 13.71 ops/sec ±1.9% 69 runs (73ms)
babel-parser/real-case.mjs ts-checker.mjs @ baseline: 12.97 ops/sec ±1.91% 65 runs (78ms)
babel-parser/real-case.mjs ts-checker.ts @ current: 9.88 ops/sec ±1.76% 64 runs (102ms)
babel-parser/real-case.mjs ts-checker.ts @ baseline: 9.67 ops/sec ±1.35% 64 runs (104ms)
babel-parser/real-case.mjs ts-parser.mjs @ current: 117 ops/sec ±0.81% 580 runs (8.625ms)
babel-parser/real-case.mjs ts-parser.mjs @ baseline: 110 ops/sec ±0.79% 546 runs (9.166ms)
babel-parser/real-case.mjs ts-parser.ts @ current: 73.49 ops/sec ±0.41% 367 runs (14ms)
babel-parser/real-case.mjs ts-parser.ts @ baseline: 70.95 ops/sec ±0.94% 354 runs (14ms)
babel-parser/real-case.mjs typescript-5.6.2.js @ current: 2.99 ops/sec ±1.15% 64 runs (336ms)
babel-parser/real-case.mjs typescript-5.6.2.js @ baseline: 2.89 ops/sec ±1.23% 64 runs (346ms)
```