### PR TITLE
Fix `_arrayWithHoles` fast path bypassing custom `Symbol.iterator` on array-backed Proxies

### DIFF
--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -100,12 +100,12 @@ const helpers: Record<string, Helper> = {
       internal: false,
     },
   ),
-  // size: 57, gzip size: 71
+  // size: 142, gzip size: 130
   arrayWithHoles: helper(
     "7.0.0-beta.0",
-    "function _arrayWithHoles(r){if(Array.isArray(r))return r}",
+    'function _arrayWithHoles(r){if(Array.isArray(r)&&("undefined"==typeof Symbol||r[Symbol.iterator]===Array.prototype[Symbol.iterator]))return r}',
     {
-      globals: ["Array"],
+      globals: ["Array", "Symbol"],
       locals: { _arrayWithHoles: ["body.0.id"] },
       exportBindingAssignments: [],
       exportName: "_arrayWithHoles",

--- a/packages/babel-helpers/src/helpers/arrayWithHoles.ts
+++ b/packages/babel-helpers/src/helpers/arrayWithHoles.ts
@@ -1,5 +1,11 @@
 /* @minVersion 7.0.0-beta.0 */
 
 export default function _arrayWithHoles<T>(arr: T[]) {
-  if (Array.isArray(arr)) return arr;
+  if (
+    Array.isArray(arr) &&
+    (typeof Symbol === "undefined" ||
+      arr[Symbol.iterator] === Array.prototype[Symbol.iterator])
+  ) {
+    return arr;
+  }
 }

--- a/packages/babel-helpers/test/fixtures/behavior/array-with-holes/exec.js
+++ b/packages/babel-helpers/test/fixtures/behavior/array-with-holes/exec.js
@@ -1,0 +1,24 @@
+// A plain array keeps the fast path (returned by reference).
+const plain = [1, 2, 3];
+expect(HELPER_ARRAY_WITH_HOLES(plain)).toBe(plain);
+
+// An array-backed Proxy that does not override Symbol.iterator also keeps
+// the fast path: Array.isArray pierces the proxy and the iterator is inherited.
+const plainProxy = new Proxy(["a"], {});
+expect(HELPER_ARRAY_WITH_HOLES(plainProxy)).toBe(plainProxy);
+
+// An array-backed Proxy that overrides Symbol.iterator must NOT take the fast
+// path: native destructuring would use the custom iterator, so the helper has
+// to fall through to the iterator path instead of reading `proxy[0]`.
+const target = ["real-value"];
+const proxy = new Proxy(target, {
+  get(t, prop) {
+    if (prop === Symbol.iterator) {
+      return function* () {
+        yield "real-value";
+      };
+    }
+    return undefined;
+  },
+});
+expect(HELPER_ARRAY_WITH_HOLES(proxy)).toBe(undefined);

--- a/packages/babel-helpers/test/fixtures/behavior/array-with-holes/options.json
+++ b/packages/babel-helpers/test/fixtures/behavior/array-with-holes/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["./plugin.cjs"]
+}

--- a/packages/babel-helpers/test/fixtures/behavior/array-with-holes/plugin.cjs
+++ b/packages/babel-helpers/test/fixtures/behavior/array-with-holes/plugin.cjs
@@ -1,0 +1,12 @@
+module.exports = function() {
+  return {
+    visitor: {
+      Identifier(path) {
+        if (path.node.name === "HELPER_ARRAY_WITH_HOLES") {
+          const helper = this.addHelper("arrayWithHoles");
+          path.replaceWith(helper);
+        }
+      },
+    },
+  };
+};

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7199/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7199/output.js
@@ -7,7 +7,7 @@ function _nonIterableRest() { throw new TypeError("Invalid attempt to destructur
 function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
 function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function _iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t["return"] && (u = t["return"](), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
-function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
+function _arrayWithHoles(r) { if (Array.isArray(r) && ("undefined" == typeof Symbol || r[Symbol.iterator] === Array.prototype[Symbol.iterator])) return r; }
 const _bar = bar,
   _bar2 = _slicedToArray(_bar, 1),
   x = _bar2[0];

--- a/packages/babel-runtime-corejs3/helpers/esm/arrayWithHoles.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/arrayWithHoles.js
@@ -1,5 +1,7 @@
 import _Array$isArray from "core-js-pure/features/array/is-array.js";
+import _Symbol from "core-js-pure/features/symbol/index.js";
+import _getIteratorMethod from "core-js-pure/features/get-iterator-method.js";
 function _arrayWithHoles(r) {
-  if (_Array$isArray(r)) return r;
+  if (_Array$isArray(r) && ("undefined" == typeof _Symbol || _getIteratorMethod(r) === _getIteratorMethod(Array.prototype))) return r;
 }
 export { _arrayWithHoles as default };


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream main.
-->

| Q | A |
| --- | --- |
| Fixed Issues? | Fixes #18181 |
| Patch: Bug Fix? | Yes |
| Major: Breaking Change? | No |
| Minor: New Feature? | No |
| Tests Added + Pass? | Yes |
| Documentation PR Link | <!-- Only if adding new config options --> |
| Any Dependency Changes? | No |
| License | MIT |

## Description

`Array.isArray` pierces an array-backed `Proxy` and returns `true` even when the Proxy overrides `Symbol.iterator` in its `get` trap. The `_arrayWithHoles` helper therefore returned the proxy directly, causing `_slicedToArray` to read `proxy[0]` instead of going through the iterator protocol — diverging from native destructuring semantics.

This PR guards the fast path with:

```js
typeof Symbol === "undefined" || arr[Symbol.iterator] === Array.prototype[Symbol.iterator]
```

mirroring `_iterableToArrayLimit`, so plain arrays keep the fast path while a Proxy with a custom iterator falls through to the iterator path. The `typeof Symbol === "undefined"` guard keeps the fast path working in environments without `Symbol` (matching the other iterator helpers).

## Tests

Added a behavior fixture under `packages/babel-helpers/test/fixtures/behavior/array-with-holes/` covering:
- a plain array keeps the fast path (returned by reference);
- an array-backed Proxy without a `Symbol.iterator` override keeps the fast path;
- an array-backed Proxy overriding `Symbol.iterator` no longer takes the fast path (the helper returns `undefined` so `_slicedToArray` proceeds to the iterator path).

Also updated the `transform-modules-commonjs` regression fixture `T7199/output.js` to reflect the regenerated helper output.