### PR TITLE
fix(remove): unwrap single sequence expression

### DIFF
--- a/packages/babel-traverse/src/path/lib/removal-hooks.ts
+++ b/packages/babel-traverse/src/path/lib/removal-hooks.ts
@@ -36,11 +36,11 @@ export const hooks = [
   },
 
   function (self: NodePath, parent: NodePath) {
-    if (parent.isSequenceExpression() && parent.node.expressions.length === 1) {
+    if (parent.isSequenceExpression() && parent.node.expressions.length === 2) {
       // (node, NODE);
-      // we've just removed the second element of a sequence expression so let's turn that sequence
+      // we will remove the other element of a sequence expression so let's turn that sequence
       // expression into a regular expression
-      parent.replaceWith(parent.node.expressions[0]);
+      parent.replaceWith(parent.node.expressions[self.key === 0 ? 1 : 0]);
       return true;
     }
   },
@@ -49,7 +49,7 @@ export const hooks = [
     if (parent.isBinary()) {
       // left + NODE;
       // NODE + right;
-      // we're in a binary expression, better remove it and replace it with the last expression
+      // we're in a binary expression, better remove it and replace it with the other expression
       if (self.key === "left") {
         parent.replaceWith(parent.node.right);
       } else {

--- a/packages/babel-traverse/src/path/lib/removal-hooks.ts
+++ b/packages/babel-traverse/src/path/lib/removal-hooks.ts
@@ -38,8 +38,8 @@ export const hooks = [
   function (self: NodePath, parent: NodePath) {
     if (parent.isSequenceExpression() && parent.node.expressions.length === 2) {
       // (node, NODE);
-      // we will remove the other element of a sequence expression so let's turn that sequence
-      // expression into a regular expression
+      // we're removing one element from a 2-element sequence expression, so replace the sequence
+      // expression with the remaining expression
       parent.replaceWith(parent.node.expressions[self.key === 0 ? 1 : 0]);
       return true;
     }

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -326,7 +326,7 @@ describe("Removal", function () {
         'Property consequent of ConditionalExpression expected node to be of a type ["Expression"] but instead got undefined',
       );
     });
-    it("should throw when removing the expression property of an AwaitExpression", function () {
+    it("should throw when removing the argument property of an AwaitExpression", function () {
       const rootPath = getPath("async function foo() { await bar(); }");
       const path = rootPath.get("body.0.body.body.0.expression");
       expect(() => {

--- a/packages/babel-traverse/test/removal.js
+++ b/packages/babel-traverse/test/removal.js
@@ -3,8 +3,8 @@ import { parse } from "@babel/parser";
 import traverse from "../lib/index.js";
 import generate from "@babel/generator";
 
-function getPath(code) {
-  const ast = parse(code);
+function getPath(code, parserOpts = {}) {
+  const ast = parse(code, parserOpts);
   let path;
   traverse(ast, {
     Program: function (_path) {
@@ -20,7 +20,7 @@ function generateCode(path) {
   return generate(path.node).code;
 }
 
-describe("removal", function () {
+describe("Removal", function () {
   describe("ArrowFunction", function () {
     it("remove body", function () {
       const rootPath = getPath("x = () => b;");
@@ -162,5 +162,274 @@ describe("removal", function () {
     });
 
     expect(ast.elements.length).toBe(0);
+  });
+
+  it("should throw if the node path has already been removed", function () {
+    const rootPath = getPath("var x");
+    const path = rootPath.get("body.0");
+    path.remove();
+    expect(() => path.remove()).toThrow(
+      "NodePath has been removed so is read-only.",
+    );
+  });
+
+  describe("Removal hooks", function () {
+    describe("Remove parent when child is removed", function () {
+      it("should remove the parent WhileStatement when the test property is removed", function () {
+        const rootPath = getPath("while (true) { foo(); }");
+        const path = rootPath.get("body.0");
+        path.get("test").remove();
+        expect(path.removed).toBe(true);
+      });
+
+      it("should remove the parent DoWhileStatement when the test property is removed", function () {
+        const rootPath = getPath("do { foo(); } while (true);");
+        const path = rootPath.get("body.0");
+        path.get("test").remove();
+        expect(path.removed).toBe(true);
+      });
+
+      it("should remove the parent SwitchCase when the test property is removed", function () {
+        const rootPath = getPath("switch (x) { case 1: foo(); }");
+        const path = rootPath.get("body.0.cases.0");
+        path.get("test").remove();
+        expect(path.removed).toBe(true);
+      });
+
+      it("should remove the parent ExportNamedDeclaration when the declaration property is removed", function () {
+        const rootPath = getPath("export const x = 1;", {
+          sourceType: "module",
+        });
+        const path = rootPath.get("body.0");
+        path.get("declaration").remove();
+        expect(path.removed).toBe(true);
+      });
+
+      it("should remove the parent ExportDefaultDeclaration when the declaration property is removed", function () {
+        const rootPath = getPath("export default function foo() {}", {
+          sourceType: "module",
+        });
+        const path = rootPath.get("body.0");
+        path.get("declaration").remove();
+        expect(path.removed).toBe(true);
+      });
+
+      it("should remove the parent LabeledStatement when the body property is removed", function () {
+        const rootPath = getPath("label: foo();");
+        const path = rootPath.get("body.0");
+        path.get("body").remove();
+        expect(path.removed).toBe(true);
+      });
+
+      it("should remove the parent VariableDeclaration when there are no declarators left", function () {
+        const rootPath = getPath("var x = 1;");
+        const path = rootPath.get("body.0");
+        path.get("declarations.0").remove();
+        expect(path.removed).toBe(true);
+      });
+
+      it("should remove the parent ExpressionStatement when the expression property is removed", function () {
+        const rootPath = getPath("foo();");
+        const path = rootPath.get("body.0");
+        path.get("expression").remove();
+        expect(path.removed).toBe(true);
+      });
+    });
+    describe("Unwrap parent when child is removed", function () {
+      it("should unwrap single sequence expressions after the first child is removed", function () {
+        const rootPath = getPath("foo(), bar();");
+        const path = rootPath.get("body.0.expression");
+        path.get("expressions.0").remove();
+        expect(generateCode(rootPath)).toBe("bar();");
+        expect(rootPath.get("body.0.expression").node.type).toBe(
+          "CallExpression",
+        );
+      });
+      it("should unwrap single sequence expressions after the second child is removed", function () {
+        const rootPath = getPath("foo(), bar();");
+        const path = rootPath.get("body.0.expression");
+        path.get("expressions.1").remove();
+        expect(generateCode(rootPath)).toBe("foo();");
+        expect(rootPath.get("body.0.expression").node.type).toBe(
+          "CallExpression",
+        );
+      });
+
+      it("should unwrap binary expression after the left child is removed", function () {
+        const rootPath = getPath("foo() + bar();");
+        const path = rootPath.get("body.0.expression");
+        path.get("left").remove();
+        expect(generateCode(rootPath)).toBe("bar();");
+      });
+      it("should unwrap binary expression after the right child is removed", function () {
+        const rootPath = getPath("foo() + bar();");
+        const path = rootPath.get("body.0.expression");
+        path.get("right").remove();
+        expect(generateCode(rootPath)).toBe("foo();");
+      });
+
+      it("should unwrap logical expression after the left child is removed", function () {
+        const rootPath = getPath("foo() && bar();");
+        const path = rootPath.get("body.0.expression");
+        path.get("left").remove();
+        expect(generateCode(rootPath)).toBe("bar();");
+      });
+      it("should unwrap logical expression after the right child is removed", function () {
+        const rootPath = getPath("foo() && bar();");
+        const path = rootPath.get("body.0.expression");
+        path.get("right").remove();
+        expect(generateCode(rootPath)).toBe("foo();");
+      });
+    });
+    describe("Ensure valid code is generated after removal", function () {
+      it("should generate valid code after the consequent property of an IfStatement is removed", function () {
+        const rootPath = getPath("if (x) foo(); else bar();");
+        const path = rootPath.get("body.0");
+        path.get("consequent").remove();
+        expect(generateCode(rootPath)).toBe("if (x) {} else bar();");
+      });
+
+      it("should generate valid code after the body property of a ForStatement is removed", function () {
+        const rootPath = getPath("for (let i = 0; i < 10; i++) foo();");
+        const path = rootPath.get("body.0");
+        path.get("body").remove();
+        expect(generateCode(rootPath)).toBe("for (let i = 0; i < 10; i++) {}");
+      });
+      it("should generate valid code after the body property of a WhileStatement is removed", function () {
+        const rootPath = getPath("while (x) foo();");
+        const path = rootPath.get("body.0");
+        path.get("body").remove();
+        expect(generateCode(rootPath)).toBe("while (x) {}");
+      });
+      it("should generate valid code after the body property of a DoWhileStatement is removed", function () {
+        const rootPath = getPath("do foo(); while (x);");
+        const path = rootPath.get("body.0");
+        path.get("body").remove();
+        expect(generateCode(rootPath)).toBe("do {} while (x);");
+      });
+
+      it("should generate valid code after the body property of an ArrowExpression is removed", function () {
+        const rootPath = getPath("const foo = () => bar();");
+        const path = rootPath.get("body.0.declarations.0.init");
+        path.get("body").remove();
+        expect(generateCode(rootPath)).toBe("const foo = () => {};");
+      });
+    });
+  });
+  describe("Invalid removal cases", function () {
+    it("should throw when removing the consequent property of a ConditionalExpression", function () {
+      const rootPath = getPath("x ? foo() : bar();");
+      const path = rootPath.get("body.0.expression");
+      expect(() => {
+        path.get("consequent").remove();
+      }).toThrow(
+        'Property consequent of ConditionalExpression expected node to be of a type ["Expression"] but instead got undefined',
+      );
+    });
+    it("should throw when removing the expression property of an AwaitExpression", function () {
+      const rootPath = getPath("async function foo() { await bar(); }");
+      const path = rootPath.get("body.0.body.body.0.expression");
+      expect(() => {
+        path.get("argument").remove();
+      }).toThrow(
+        'Property argument of AwaitExpression expected node to be of a type ["Expression"] but instead got undefined',
+      );
+    });
+    it("should throw when removing the right property of an AssignmentExpression", function () {
+      const rootPath = getPath("x &&= foo();");
+      const path = rootPath.get("body.0.expression");
+      expect(() => {
+        path.get("right").remove();
+      }).toThrow(
+        'Property right of AssignmentExpression expected node to be of a type ["Expression"] but instead got undefined',
+      );
+    });
+  });
+  describe("scope updates", function () {
+    it("should remove the binding information when a VariableDeclarator is removed", function () {
+      const rootPath = getPath("var x = 1, y = 2;");
+      expect(rootPath.scope.hasBinding("x")).toBe(true);
+      expect(rootPath.scope.hasBinding("y")).toBe(true);
+      const path = rootPath.get("body.0");
+      path.get("declarations.0").remove();
+      expect(rootPath.scope.hasBinding("x")).toBe(false);
+      expect(rootPath.scope.hasBinding("y")).toBe(true);
+    });
+  });
+  describe("comments handling", function () {
+    it("should preserve comments when a statement with leading comments is removed and it has leading siblings", function () {
+      const rootPath = getPath("var x = 0; // comment\nvar y = 1;\nvar z = 2;");
+      const path = rootPath.get("body.1");
+      path.remove();
+      expect(generateCode(rootPath)).toMatchInlineSnapshot(`
+        "var x = 0; // comment
+
+        var z = 2;"
+      `);
+
+      const xPath = rootPath.get("body.0");
+      const zPath = rootPath.get("body.1");
+      expect(xPath.node.trailingComments).toHaveLength(1);
+      expect(xPath.node.trailingComments[0].value).toBe(" comment");
+      expect(zPath.node.leadingComments).toBeUndefined();
+    });
+    it("should preserve comments when a statement with leading comments is removed and it has trailing siblings", function () {
+      const rootPath = getPath("// comment\nvar y = 1;\nvar z = 2;");
+      const path = rootPath.get("body.0");
+      path.remove();
+      expect(generateCode(rootPath)).toMatchInlineSnapshot(`
+        "// comment
+
+        var z = 2;"
+      `);
+      const zPath = rootPath.get("body.0");
+      expect(zPath.node.leadingComments).toHaveLength(1);
+      expect(zPath.node.leadingComments[0].value).toBe(" comment");
+    });
+    it("should preserve comments when a statement with trailing comments is removed and it has leading siblings", function () {
+      const rootPath = getPath("var x = 0; var y = 1;// comment");
+      const path = rootPath.get("body.1");
+      path.remove();
+      expect(generateCode(rootPath)).toMatchInlineSnapshot(
+        `"var x = 0; // comment"`,
+      );
+
+      const xPath = rootPath.get("body.0");
+      expect(xPath.node.trailingComments).toHaveLength(1);
+      expect(xPath.node.trailingComments[0].value).toBe(" comment");
+    });
+    it("should preserve comments when a statement with trailing comments is removed and it has trailing siblings", function () {
+      const rootPath = getPath("var x = 0; var y = 1;// comment\nvar z = 2;");
+      const path = rootPath.get("body.1");
+      path.remove();
+      expect(generateCode(rootPath)).toMatchInlineSnapshot(`
+        "var x = 0;
+        // comment
+        var z = 2;"
+      `);
+
+      const xPath = rootPath.get("body.0");
+      const zPath = rootPath.get("body.1");
+      expect(xPath.node.trailingComments).toBeUndefined();
+      expect(zPath.node.leadingComments).toHaveLength(1);
+      expect(zPath.node.leadingComments[0].value).toBe(" comment");
+    });
+    it("does not preserve comments when a statement with leading comments is removed and it has no siblings", function () {
+      const rootPath = getPath("{ // comment\nvar y = 1; }");
+      const path = rootPath.get("body.0");
+      path.get("body.0").remove();
+      expect(generateCode(rootPath)).toMatchInlineSnapshot(`"{}"`);
+      expect(path.node.innerComments).toBeUndefined();
+    });
+    it("does not preserve comments when a statement with leading comments is removed and it is not an element of a list container", function () {
+      const rootPath = getPath("function *gen(x) { yield /* comment */x }");
+      const path = rootPath.get("body.0");
+      path.get("body.body.0.expression.argument").remove();
+      expect(generateCode(rootPath)).toMatchInlineSnapshot(`
+        "function* gen(x) {
+          yield;
+        }"
+      `);
+    });
   });
 });


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `path.remove()` does not unwrap single sequence expression as [the code](https://github.com/babel/babel/blob/1eac4481473df52fbbcb452c4dca8d79039dbb63/packages/babel-traverse/src/path/lib/removal-hooks.ts#L38-L46) intended.
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we add more tests for the `NodePath#remove` method. The new tests reveal a bug in the removal hooks: The single sequence expression unwrapping logic never work as intended because the removal hooks are called _before_ the node has been removed.