### PR TITLE
fix(helpers): only take the array fast path when the iterator is the intrinsic one

### DIFF
--- a/packages/babel-helpers/src/helpers-generated.ts
+++ b/packages/babel-helpers/src/helpers-generated.ts
@@ -100,12 +100,12 @@ const helpers: Record<string, Helper> = {
       internal: false,
     },
   ),
-  // size: 57, gzip size: 71
+  // size: 142, gzip size: 130
   arrayWithHoles: helper(
     "7.0.0-beta.0",
-    "function _arrayWithHoles(r){if(Array.isArray(r))return r}",
+    'function _arrayWithHoles(r){if(Array.isArray(r)&&("undefined"==typeof Symbol||r[Symbol.iterator]===Array.prototype[Symbol.iterator]))return r}',
     {
-      globals: ["Array"],
+      globals: ["Array", "Symbol"],
       locals: { _arrayWithHoles: ["body.0.id"] },
       exportBindingAssignments: [],
       exportName: "_arrayWithHoles",

--- a/packages/babel-helpers/src/helpers/arrayWithHoles.ts
+++ b/packages/babel-helpers/src/helpers/arrayWithHoles.ts
@@ -1,5 +1,15 @@
 /* @minVersion 7.0.0-beta.0 */
 
 export default function _arrayWithHoles<T>(arr: T[]) {
-  if (Array.isArray(arr)) return arr;
+  if (Array.isArray(arr)) {
+    // Array destructuring goes through the iterator protocol, so this fast path is only
+    // equivalent when the iterator is the intrinsic one. Array.isArray sees through a
+    // Proxy to its array target, and an array can carry its own Symbol.iterator.
+    if (
+      typeof Symbol === "undefined" ||
+      arr[Symbol.iterator] === Array.prototype[Symbol.iterator]
+    ) {
+      return arr;
+    }
+  }
 }

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/array-with-custom-iterator/exec.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/destructuring/array-with-custom-iterator/exec.js
@@ -1,0 +1,47 @@
+function iteratorReturning(value) {
+  return function () {
+    var done = false;
+    return {
+      next: function () {
+        if (done) return { done: true, value: undefined };
+        done = true;
+        return { done: false, value: value };
+      },
+    };
+  };
+}
+
+// Array.isArray sees through a Proxy to its array target, but this Proxy serves its
+// element only through Symbol.iterator and answers no positional read.
+function makeProxy() {
+  return new Proxy(["never-read"], {
+    get: function (target, prop) {
+      if (prop === Symbol.iterator) return iteratorReturning("from-iterator");
+      return undefined;
+    },
+  });
+}
+
+var [fromProxy] = makeProxy();
+expect(fromProxy).toBe("from-iterator");
+
+// A real array carrying its own Symbol.iterator.
+function makeArrayWithOwnIterator() {
+  var arr = ["never-read"];
+  Object.defineProperty(arr, Symbol.iterator, {
+    value: iteratorReturning("from-iterator"),
+  });
+  return arr;
+}
+
+var [fromOwnIterator] = makeArrayWithOwnIterator();
+expect(fromOwnIterator).toBe("from-iterator");
+
+// A plain array keeps taking the fast path.
+function makePlainArray() {
+  return ["a", "b"];
+}
+
+var [a, b] = makePlainArray();
+expect(a).toBe("a");
+expect(b).toBe("b");

--- a/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7199/output.js
+++ b/packages/babel-plugin-transform-modules-commonjs/test/fixtures/regression/T7199/output.js
@@ -7,7 +7,7 @@ function _nonIterableRest() { throw new TypeError("Invalid attempt to destructur
 function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
 function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function _iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t["return"] && (u = t["return"](), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
-function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
+function _arrayWithHoles(r) { if (Array.isArray(r) && ("undefined" == typeof Symbol || r[Symbol.iterator] === Array.prototype[Symbol.iterator])) return r; }
 const _bar = bar,
   _bar2 = _slicedToArray(_bar, 1),
   x = _bar2[0];

--- a/packages/babel-runtime-corejs3/helpers/esm/arrayWithHoles.js
+++ b/packages/babel-runtime-corejs3/helpers/esm/arrayWithHoles.js
@@ -1,5 +1,7 @@
 import _Array$isArray from "core-js-pure/features/array/is-array.js";
+import _Symbol from "core-js-pure/features/symbol/index.js";
+import _getIteratorMethod from "core-js-pure/features/get-iterator-method.js";
 function _arrayWithHoles(r) {
-  if (_Array$isArray(r)) return r;
+  if (_Array$isArray(r) && ("undefined" == typeof _Symbol || _getIteratorMethod(r) === _getIteratorMethod(Array.prototype))) return r;
 }
 export { _arrayWithHoles as default };


### PR DESCRIPTION
Closes #18181.

`_arrayWithHoles` hands back the value untouched whenever `Array.isArray` says yes, but array destructuring always goes through the iterator protocol. `Array.isArray` sees through a Proxy to its array target, so a Proxy that serves its elements only from a custom `Symbol.iterator` takes the fast path and is then read positionally. An array carrying its own `Symbol.iterator` diverges the same way. Both return something different from the untransformed code.

The guard is the one @nicolo-ribaudo agreed to on the issue, with the `typeof Symbol` check the other iterator helpers use, so an environment without `Symbol` keeps the old behaviour, and `destructuring/array-symbol-unsupported`, which sets `global.Symbol` to undefined, covers exactly that path and still passes.

The new exec fixture `destructuring/array-with-custom-iterator` covers a Proxy, an array with an own iterator, and a plain array. Each value comes back from a function call, because the transform unpacks a locally created array literal positionally and doesn't reach the helper at all.

Checked both directions by reverting the helper to its parent commit and rebuilding. The fixture fails first with `Received: undefined`, and passes after. Running the whole suite before and after, the two runs differ by exactly one test, the new one. `T7199/output.js` is regenerated for the changed helper text, one line. Prettier, eslint and `tsc -p packages/babel-helpers/src/helpers/tsconfig.json` pass.

Not a security issue. The cost is one property read per destructuring of a real array.

What I didn't check: any performance impact beyond that read. `_arrayWithoutHoles` has the same divergence for spread, where `[...proxy]` gives `[undefined]` against `["from-iterator"]` untransformed. I left it alone to keep this to what the issue covers, and I'm happy to extend it if you'd rather have both.
