### PR TITLE
ci: update agentscan

### DIFF
--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -8,6 +8,9 @@ on:
   issues:
     types:
       - opened
+  issue_comment:
+    types:
+      - created
 
 jobs:
   agentscan:
@@ -17,16 +20,11 @@ jobs:
       issues: write
       contents: read
     steps:
-      - name: Cache AgentScan analysis
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
-        with:
-          path: .agentscan-cache
-          key: agentscan-cache-${{ github.actor }}
-          restore-keys: agentscan-cache-
       - name: AgentScan
-        uses: MatteoGabriele/agentscan-action@2b7e598bd821bc0f4651e985688951930c2f60d0
+        uses: MatteoGabriele/agentscan-action@cf7615ba9f4fa86beab3323bc84b803ab430f8dc # v2.3.0
         with:
-          cache-path: ".agentscan-cache"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          skip-comment-on-organic: true
-          skip-members: "nicolo-ribaudo,JLHwung,liuxingbaoyu,babel-bot,fisker"
+          allowed-users: "nicolo-ribaudo,JLHwung,liuxingbaoyu,babel-bot,fisker"
+          trusted-author-associations: "owner,member,collaborator"
+          honeypot: true
+          scan-issues: true


### PR DESCRIPTION
Updated Agentscan with an improved detection library.

#### Skip trusted account associations
I've included owners, members, and collaborators: choose the best fit for your needs.
These are all the possible values: `collaborator`, `contributor`, `first_timer`, `first_time_contributor`, `member`, `owner`

#### Honeypot comments
Enabled honeypot comments (example [here](https://github.com/MatteoGabriele/agentscan/pull/285)) to attract automated accounts and reveal themselves. It may or may not work, but worst case, you'll get a free welcome message (or you can customize it as you like). There's also a dedicated message for first-time contributors that you can personalize. If it doesn't meet your specific needs, we can disable it and adjust it to better suit your repo.

#### Notes
I've removed `skip-comment-on-organic: true` because it is now the default behavior, along with the cache feature.

Reason for cache removal. 
Unfortunately, spammers might be caught later, or you might get 10 PRs at once. If the user doesn't turn out to be "automated" immediately, we might be able to identify them after a few scans. If the analysis is cached, we cannot actively scan all of them.
