### PR TITLE
fix: assign closure body after handling return

### DIFF
--- a/packages/babel-plugin-transform-block-scoping/src/loop.ts
+++ b/packages/babel-plugin-transform-block-scoping/src/loop.ts
@@ -202,11 +202,7 @@ export function wrapLoopBody(
   }
 
   const id = loopPath.scope.generateUid("loop");
-  const fn = t.functionExpression(
-    null,
-    closureParams,
-    t.toBlock(loopNode.body),
-  );
+  const fn = t.functionExpression(null, closureParams, t.blockStatement([]));
   let call: t.Expression = t.callExpression(t.identifier(id), callArgs);
 
   const fnParent = loopPath.findParent(p => p.isFunction());
@@ -222,7 +218,6 @@ export function wrapLoopBody(
     updater.length > 0
       ? t.expressionStatement(t.sequenceExpression(updater))
       : null;
-  if (updaterNode) fn.body.body.push(updaterNode);
 
   // NOTE: Calling .insertBefore on the loop path might cause the
   // loop to be moved in the AST. For example, in
@@ -371,7 +366,13 @@ export function wrapLoopBody(
     }
   }
 
+  // Assign loop closure body after the original loop body was manipulated by
+  // the completion record handling above. Doing so also avoids duplicate AST
+  // nodes during the transform
+  const loopBlockBody = t.toBlock(loopNode.body);
   loopNode.body = t.blockStatement(bodyStmts);
+  fn.body = loopBlockBody;
+  if (updaterNode) loopBlockBody.body.push(updaterNode);
 
   return varPath;
 }

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/for-body-return/exec.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/for-body-return/exec.js
@@ -1,0 +1,6 @@
+function run() {
+  for (let i = 0; i < 2; i++) return () => i;
+}
+
+const reader = run();
+expect(reader()).toBe(0);

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/for-body-return/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/for-body-return/input.js
@@ -1,0 +1,5 @@
+function run() {
+  for (let i = 0; i < 2; i++) return () => i;
+}
+
+const reader = run();

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/general/for-body-return/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/general/for-body-return/output.js
@@ -1,0 +1,15 @@
+function run() {
+  var _loop = function (i) {
+      return {
+        v: function () {
+          return i;
+        }
+      };
+    },
+    _ret;
+  for (var i = 0; i < 2; i++) {
+    _ret = _loop(i);
+    if (_ret) return _ret.v;
+  }
+}
+var reader = run();

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/issue-18192/input.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/issue-18192/input.js
@@ -1,0 +1,5 @@
+function run() {
+  for (let i = 0; i < 2; i++) return () => i;
+}
+
+const reader = run();

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/issue-18192/options.json
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/issue-18192/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-block-scoping"]
+}

--- a/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/issue-18192/output.js
+++ b/packages/babel-plugin-transform-block-scoping/test/fixtures/regression/issue-18192/output.js
@@ -1,0 +1,13 @@
+function run() {
+  var _loop = function (i) {
+      return {
+        v: () => i
+      };
+    },
+    _ret;
+  for (var i = 0; i < 2; i++) {
+    _ret = _loop(i);
+    if (_ret) return _ret.v;
+  }
+}
+var reader = run();


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #18192 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
The root cause of #18192 is data inconsistency: When `returnNum > 0`, we wrap the return statement collected in `state.returns` within the `{ v: ... }` object wrapper. However, the `state.returns` is a NodePath collected at the start of `wrapLoopBody`, while the emit output is from the loop body assigned to the loop closure body _after_ the NodePath is collected: Therefore, changes to the NodePath here does not sync to the closure body and we see unwrapped return statement in the final output.

The `wrapLoopBody` essentially moves the loop body to the loop closure body. To avoid duplicate nodes during the transform, we move the loop body reassigning step to the end of the `wrapLoopBody` transform, in order to ensure that any AST changes in the loop body will be reflected on the loop closure.