### PR TITLE
Fix computed object rest exclusions in loose mode

### DIFF
--- a/packages/babel-plugin-transform-object-rest-spread/src/index.ts
+++ b/packages/babel-plugin-transform-object-rest-spread/src/index.ts
@@ -226,7 +226,9 @@ export default declare((api, opts: Options) => {
       const bindingParentPath = bindings[bindingName].parentPath;
       if (
         path.scope.getBinding(bindingName)!.references > 0 ||
-        !bindingParentPath.isObjectProperty()
+        !bindingParentPath.isObjectProperty() ||
+        (bindingParentPath.node.computed &&
+          bindingParentPath.get("key").isAssignmentExpression())
       ) {
         return;
       }

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/remove-unused-computed-key-loose/exec.js
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/remove-unused-computed-key-loose/exec.js
@@ -1,0 +1,6 @@
+function omit(obj, spec) {
+  const { [spec.key]: unused, ...rest } = obj;
+  return rest;
+}
+
+expect(omit({ a: 1, b: 2 }, { key: "a" })).toEqual({ b: 2 });

--- a/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/remove-unused-computed-key-loose/options.json
+++ b/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/remove-unused-computed-key-loose/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-object-rest-spread", { "loose": true }]]
+}


### PR DESCRIPTION
Disclosure: This pull request description was drafted with AI assistance and reviewed by me.

## Summary

- Preserve assignment-bearing computed properties when removing unused object-rest bindings.
- Add an executable regression fixture for a computed exclusion whose local binding is unused.

## Root cause

In loose mode, an impure computed key can be memoized as an inline assignment. The unused-binding optimization removed that whole property, while the rest exclusion helper still referenced the temporary identifier.

Keeping the assignment-bearing property preserves the key evaluation and exclusion, and this is obviously going to solve the problem while leaving the existing optimization for static unused keys unchanged.

## Validation

- yarn jest babel-plugin-transform-object-rest-spread --runInBand
- BABEL_8_BREAKING=true yarn jest babel-plugin-transform-object-rest-spread --runInBand
- yarn jest: 276 suites and 36,789 tests passed
- make lint

Closes #18196.

Downstream report: https://github.com/expo/expo/issues/49232