### PR TITLE
Fix optional chain tagged template output

### DIFF
--- a/packages/babel-generator/src/node/parentheses.ts
+++ b/packages/babel-generator/src/node/parentheses.ts
@@ -520,6 +520,8 @@ export function OptionalMemberExpression(
   parentId: number,
 ): boolean {
   switch (parentId) {
+    case __node("TaggedTemplateExpression"):
+      return parent.tag === node;
     case __node("CallExpression"):
       return parent.callee === node;
     case __node("MemberExpression"):

--- a/packages/babel-generator/test/fixtures/regression/18199/input.js
+++ b/packages/babel-generator/test/fixtures/regression/18199/input.js
@@ -1,0 +1,1 @@
+((false ? void 0 : String)?.raw)`f${1}`;

--- a/packages/babel-generator/test/fixtures/regression/18199/output.js
+++ b/packages/babel-generator/test/fixtures/regression/18199/output.js
@@ -1,0 +1,1 @@
+((false ? void 0 : String)?.raw)`f${1}`;


### PR DESCRIPTION
This pull request description was generated with LLM assistance.

| Q | A |
| --- | --- |
| Fixed Issues? | Fixes #18199 |
| Patch: Bug Fix? | Yes |
| Major: Breaking Change? | No |
| Minor: New Feature? | No |
| Tests Added + Pass? | Yes |
| Documentation PR Link | N/A |
| Any Dependency Changes? | No |
| License | MIT |

An optional member or call expression is not valid as an unparenthesized tagged-template tag. The generator currently drops the original parentheses and can emit syntax that cannot be parsed.

The generator now keeps parentheses when an optional expression is the tag of a `TaggedTemplateExpression`, and this is obviously going to solve the problem by preserving valid grammar without affecting unrelated expression positions.

A regression fixture covers the reported input. The Babel generator test suites pass.