### PR TITLE
fix(generator): keep parens for ?. chain in tag

### DIFF
--- a/packages/babel-generator/src/node/index.ts
+++ b/packages/babel-generator/src/node/index.ts
@@ -53,6 +53,24 @@ function newCalleeNeedsParens(node: t.Node): boolean {
       case "TaggedTemplateExpression":
         current = current.tag;
         break;
+      case "TSInstantiationExpression":
+      case "TSNonNullExpression":
+        current = current.expression;
+        break;
+      default:
+        return false;
+    }
+  }
+}
+
+function templateTagNeedsParens(node: t.Node): boolean {
+  let current: t.Node = node;
+  while (true) {
+    switch (current.type) {
+      case "OptionalCallExpression":
+      case "OptionalMemberExpression":
+        return true;
+      case "TSInstantiationExpression":
       case "TSNonNullExpression":
         current = current.expression;
         break;
@@ -71,6 +89,11 @@ export function parentNeedsParens(
     case __node("NewExpression"):
       if (parent.callee === node) {
         return newCalleeNeedsParens(node);
+      }
+      break;
+    case __node("TaggedTemplateExpression"):
+      if (parent.tag === node) {
+        return templateTagNeedsParens(node);
       }
       break;
     case __node("Decorator"):

--- a/packages/babel-generator/test/fixtures/parentheses/tagged-template-expression/input.js
+++ b/packages/babel-generator/test/fixtures/parentheses/tagged-template-expression/input.js
@@ -6,3 +6,6 @@ function* fn() {
   (yield)`foo`;
   (yield f)`foo`;
 }
+
+((false ? void 0 : String)?.raw)`f${ 1 }`;
+(a?.b())`foo`;

--- a/packages/babel-generator/test/fixtures/parentheses/tagged-template-expression/output.js
+++ b/packages/babel-generator/test/fixtures/parentheses/tagged-template-expression/output.js
@@ -5,3 +5,5 @@ function* fn() {
   (yield)`foo`;
   (yield f)`foo`;
 }
+((false ? void 0 : String)?.raw)`f${1}`;
+(a?.b())`foo`;

--- a/packages/babel-generator/test/fixtures/parentheses/ts-new-callee/input.js
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-new-callee/input.js
@@ -13,6 +13,8 @@ new (f?.()?.g!)();
 
 new (f!()`g`)();
 
+new (f?.g<h>)();
+
 new (import("foo")!)();
 new (import("foo")!.bar)();
 new (import("foo")!`bar`)();

--- a/packages/babel-generator/test/fixtures/parentheses/ts-new-callee/output.js
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-new-callee/output.js
@@ -8,6 +8,7 @@ new (f?.().g!)();
 new (f!()?.g)();
 new (f?.()?.g!)();
 new (f!()`g`)();
+new (f?.g<h>)();
 new (import("foo")!)();
 new (import("foo")!.bar)();
 new (import("foo")!`bar`)();

--- a/packages/babel-generator/test/fixtures/parentheses/ts-tagged-template-expression/input.ts
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-tagged-template-expression/input.ts
@@ -1,0 +1,7 @@
+// These parentheses should be reserved
+(a?.b()!)`foo`;
+(a?.b<c>)`foo`;
+
+// These parentheses can be stripped
+(a.b()!)`foo`;
+(a.b<c>)`foo`;

--- a/packages/babel-generator/test/fixtures/parentheses/ts-tagged-template-expression/options.json
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-tagged-template-expression/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["typescript"]
+}

--- a/packages/babel-generator/test/fixtures/parentheses/ts-tagged-template-expression/output.js
+++ b/packages/babel-generator/test/fixtures/parentheses/ts-tagged-template-expression/output.js
@@ -1,0 +1,7 @@
+// These parentheses should be reserved
+(a?.b()!)`foo`;
+(a?.b<c>)`foo`;
+
+// These parentheses can be stripped
+a.b()!`foo`;
+a.b<c>`foo`;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #18199, closes #18201
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we improve the parentheses rules for a template tag. Similar to how we handle the new callee, we have to unwrap the TS non-null expression before we check if we have met an optional chain.

This PR also improves the new callee parentheses rules, previously the `TSInstantiationExpression` is missed.