### PR TITLE
fix(parser): emit decimal bigint for zero-valued non-decimal literals in ESTree

### DIFF
--- a/packages/babel-parser/src/plugins/estree.ts
+++ b/packages/babel-parser/src/plugins/estree.ts
@@ -59,7 +59,7 @@ export default (superClass: typeof Parser) =>
         bigInt = null;
       }
       const node = this.estreeParseLiteral<N.EstreeBigIntLiteral>(bigInt);
-      node.bigint = String(node.value || value);
+      node.bigint = node.value == null ? value : String(node.value);
 
       return node;
     }

--- a/packages/babel-parser/test/fixtures/estree/bigInt/hex-nonzero/input.js
+++ b/packages/babel-parser/test/fixtures/estree/bigInt/hex-nonzero/input.js
@@ -1,0 +1,1 @@
+const a = 0xFFn;

--- a/packages/babel-parser/test/fixtures/estree/bigInt/hex-nonzero/output.extended.json
+++ b/packages/babel-parser/test/fixtures/estree/bigInt/hex-nonzero/output.extended.json
@@ -1,0 +1,38 @@
+{
+  "type": "File",
+  "start":0,"end":16,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":16}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":16,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":16}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":16,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":16}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":6,"end":15,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":15}},
+            "id": {
+              "type": "Identifier",
+              "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"a"},
+              "name": "a"
+            },
+            "init": {
+              "type": "Literal",
+              "start":10,"end":15,"loc":{"start":{"line":1,"column":10},"end":{"line":1,"column":15}},
+              "value": {
+                "$$ babel internal serialized type": "bigint",
+                "value": "255"
+              },
+              "raw": "0xFFn",
+              "bigint": "255"
+            }
+          }
+        ],
+        "kind": "const"
+      }
+    ]
+  }
+}

--- a/packages/babel-parser/test/fixtures/estree/bigInt/hex-zero/input.js
+++ b/packages/babel-parser/test/fixtures/estree/bigInt/hex-zero/input.js
@@ -1,0 +1,1 @@
+const a = 0x0n;

--- a/packages/babel-parser/test/fixtures/estree/bigInt/hex-zero/output.extended.json
+++ b/packages/babel-parser/test/fixtures/estree/bigInt/hex-zero/output.extended.json
@@ -1,0 +1,38 @@
+{
+  "type": "File",
+  "start":0,"end":15,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":15}},
+  "program": {
+    "type": "Program",
+    "start":0,"end":15,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":15}},
+    "sourceType": "script",
+    "interpreter": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start":0,"end":15,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":15}},
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start":6,"end":14,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":14}},
+            "id": {
+              "type": "Identifier",
+              "start":6,"end":7,"loc":{"start":{"line":1,"column":6},"end":{"line":1,"column":7},"identifierName":"a"},
+              "name": "a"
+            },
+            "init": {
+              "type": "Literal",
+              "start":10,"end":14,"loc":{"start":{"line":1,"column":10},"end":{"line":1,"column":14}},
+              "value": {
+                "$$ babel internal serialized type": "bigint",
+                "value": "0"
+              },
+              "raw": "0x0n",
+              "bigint": "0"
+            }
+          }
+        ],
+        "kind": "const"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

Fix the `bigint` field produced by the ESTree plugin for zero-valued BigInt literals written in a non-decimal radix (hex/octal/binary). `0x0n` now yields `bigint: "0"` instead of `"0x0"`.

## Why

`parseBigIntLiteral` computed the field with:

```js
node.bigint = String(node.value || value);
```

The `|| value` fallback exists only for environments where the BigInt could not be constructed (`node.value === null`), in which case the raw source string is used. But `0n` is falsy, so any zero-valued BigInt — regardless of radix — also fell through to the raw source string, which still carries the radix prefix. As a result `0x0n` serialized to `"0x0"` while `0xFFn` correctly serialized to `"255"`, and the [ESTree spec](https://github.com/estree/estree/blob/master/es2020.md#bigintliteral) defines `bigint` as the string representation of the value in base 10.

## How

Replace the falsy check with an explicit null check so real BigInt values (including `0n`) always go through the decimal `String(node.value)` path, and only the unsupported-BigInt case uses the raw source string:

```js
node.bigint = node.value == null ? value : String(node.value);
```

## Test

Added two ESTree fixtures under `test/fixtures/estree/bigInt/`: `hex-zero` (`0x0n` → `bigint: "0"`, the regression) and `hex-nonzero` (`0xFFn` → `bigint: "255"`, showing consistency). The `hex-zero` fixture fails before the change (`"0x0" != "0"`) and passes after.