### PR TITLE
fix(types): dedupe bare TSTypeReferences in createTSUnionType

### DIFF
--- a/packages/babel-types/src/modifications/typescript/removeTypeDuplicates.ts
+++ b/packages/babel-types/src/modifications/typescript/removeTypeDuplicates.ts
@@ -62,17 +62,19 @@ export default function removeTypeDuplicates(
 
     // todo: support merging tuples: number[]
     const typeArgumentsKey = "typeArguments";
-    if (isTSTypeReference(node) && node[typeArgumentsKey]) {
-      const typeArguments = node[typeArgumentsKey];
+    if (isTSTypeReference(node)) {
       const name = getQualifiedName(node.typeName);
 
       if (generics.has(name)) {
         const existingTypeArguments = generics.get(name)![typeArgumentsKey];
         if (existingTypeArguments) {
-          existingTypeArguments.params.push(...typeArguments.params);
-          existingTypeArguments.params = removeTypeDuplicates(
-            existingTypeArguments.params,
-          );
+          const typeArguments = node[typeArgumentsKey];
+          if (typeArguments) {
+            existingTypeArguments.params.push(...typeArguments.params);
+            existingTypeArguments.params = removeTypeDuplicates(
+              existingTypeArguments.params,
+            );
+          }
         }
       } else {
         generics.set(name, node);

--- a/packages/babel-types/test/builders/typescript/createTSUnionType.js
+++ b/packages/babel-types/test/builders/typescript/createTSUnionType.js
@@ -1,0 +1,25 @@
+import * as t from "../../../lib/index.js";
+
+describe("builders", function () {
+  describe("typescript", function () {
+    describe("createTSUnionType", function () {
+      it("dedupes bare type references without type arguments", function () {
+        const union = t.createTSUnionType([
+          t.tsTypeReference(t.identifier("A")),
+          t.tsTypeReference(t.identifier("A")),
+        ]);
+        expect(union.type).toBe("TSTypeReference");
+        expect(union.typeName.name).toBe("A");
+      });
+
+      it("matches Flow parity for bare generic annotations", function () {
+        const union = t.createFlowUnionType([
+          t.genericTypeAnnotation(t.identifier("A")),
+          t.genericTypeAnnotation(t.identifier("A")),
+        ]);
+        expect(union.type).toBe("GenericTypeAnnotation");
+        expect(union.id.name).toBe("A");
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What

`t.createTSUnionType([A, A])` (and the underlying `removeTypeDuplicates`) now collapses structurally-identical bare `TSTypeReference` nodes, so `A | A` reduces to `A`. Previously only references that carried type arguments were deduped.

## Why

`removeTypeDuplicates` routes generic references into a name-keyed map so duplicates merge. The check was:

```ts
if (isTSTypeReference(node) && node.typeArguments) {
```

The `&& node.typeArguments` half was only meant to protect the type-argument merge below it, but on the outer `if` it also excluded bare references (no `<...>`) from the map entirely. Those fell through to `types.push(node)`, and the only other dedup for them is an identity check, so two distinct AST nodes both representing `A` were both kept — producing a redundant `A | A`.

The Flow implementation (`src/modifications/flow/removeTypeDuplicates.ts`) has no such guard on its outer `isGenericTypeAnnotation` check, so it already reduces `A | A` to `A`. This was an accidental asymmetry between the two.

## How

Route every `TSTypeReference` through the name-keyed map and guard only the type-argument merge, mirroring the Flow implementation:

```ts
if (isTSTypeReference(node)) {
  const name = getQualifiedName(node.typeName);
  if (generics.has(name)) {
    const existingTypeArguments = generics.get(name)![typeArgumentsKey];
    if (existingTypeArguments) {
      const typeArguments = node[typeArgumentsKey];
      if (typeArguments) { /* merge + dedupe params */ }
    }
  } else {
    generics.set(name, node);
  }
  continue;
}
```

Note this also makes `A<X> | A` collapse to `A<X>`, matching Flow.

## Test

Added `test/builders/typescript/createTSUnionType.js`: two separate `t.tsTypeReference(t.identifier("A"))` nodes now produce a single `TSTypeReference`, and a parallel assertion confirms Flow parity for `genericTypeAnnotation`. Fails before the change (returns `TSUnionType`), passes after.