### PR TITLE
fix(traverse): exclude ClassExpression id from outer binding identifiers

### DIFF
--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -593,7 +593,7 @@ function getBindingIdentifierPaths(
         search.push(id.get("id"));
         continue;
       }
-      if (id.isFunctionExpression()) {
+      if (id.isFunctionExpression() || id.isClassExpression()) {
         continue;
       }
     }

--- a/packages/babel-traverse/test/family.js
+++ b/packages/babel-traverse/test/family.js
@@ -57,6 +57,21 @@ describe("path/family", function () {
       });
     });
   });
+  describe("getOuterBindingIdentifiers", function () {
+    it("should not treat a ClassExpression id as an outer binding", function () {
+      const ast = parse("(class Foo {})");
+      let outerNodes = {},
+        outerPaths = {};
+      traverse(ast, {
+        ClassExpression(path) {
+          outerNodes = path.getOuterBindingIdentifiers();
+          outerPaths = path.getOuterBindingIdentifierPaths();
+        },
+      });
+      expect(Object.keys(outerNodes)).toEqual([]);
+      expect(Object.keys(outerPaths)).toEqual(Object.keys(outerNodes));
+    });
+  });
   describe("getSibling", function () {
     const ast = parse(
       "var a = 1, {b} = c, [d] = e; function f() {} function g() {}",


### PR DESCRIPTION
## What

`NodePath#getOuterBindingIdentifierPaths()` no longer reports a `ClassExpression`'s `id` as an outer binding. For `(class Foo {})` it now returns `{}`, matching `NodePath#getOuterBindingIdentifiers()`.

## Why

`getBindingIdentifierPaths` (which backs `getOuterBindingIdentifierPaths` via `outerOnly=true`) is a re-implementation of `@babel/types` `getBindingIdentifiers`. Under `outerOnly` the types version skips **both** `FunctionExpression` and `ClassExpression`:

```ts
if (isFunctionExpression(id) || isClassExpression(id)) continue;
```

The traverse version skipped `FunctionDeclaration` and `FunctionExpression` but omitted `ClassExpression`, so it descended via the `ClassExpression` keys (`["id"]`) and yielded the inner id. A class expression's id is bound only inside the class body, never in the enclosing scope, so it is not an outer binding. The result was that the two public APIs — `getOuterBindingIdentifiers()` (correct, returns `{}`) and `getOuterBindingIdentifierPaths()` (wrongly returned `Foo`) — disagreed.

## How

Add the `isClassExpression()` skip alongside the existing `FunctionExpression` skip, mirroring `@babel/types`:

```ts
if (id.isFunctionExpression() || id.isClassExpression()) {
  continue;
}
```

## Test

Added a parity test to `test/family.js`: traversing `(class Foo {})`, both `getOuterBindingIdentifiers()` and `getOuterBindingIdentifierPaths()` yield no keys and agree. Fails before the change (paths version returns `["Foo"]`), passes after.