### PR TITLE
fix: handle empty array pattern in safari-rest-destructuring-rhs-array bugfix plugin

### DIFF
--- a/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/src/util.ts
+++ b/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/src/util.ts
@@ -35,6 +35,9 @@ export function shouldTransform(
 ): NodePath<t.Expression> | false {
   const elementPaths = path.get("elements");
   const elementPathsLength = elementPaths.length;
+  if (elementPathsLength === 0) {
+    return false;
+  }
   if (elementPaths[elementPathsLength - 1].isRestElement()) {
     const { parentPath } = path;
     const rhsPath = parentPath.isVariableDeclarator()

--- a/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/test/util.skip-bundled.js
+++ b/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/test/util.skip-bundled.js
@@ -61,9 +61,12 @@ describe("shouldTransform", () => {
     "var a = [0, 42]; var [_, ...rest] = a",
     "var [_, ...rest] = [0].concat(42)",
     "function foo([a, ...rest] = [1, 2]) { return rest }",
+    "const [] = [];",
+    "[] = [];",
   ];
 
   const negativeNestedCases = [
+    "const [[]] = [[]];",
     "const [[a, ...rest]] = [[1]]",
     "[[a, ...rest]] = [1, 2]",
     "const [[...rest]] = [[1]]",


### PR DESCRIPTION
## What

`shouldTransform` in `@babel/plugin-bugfix-safari-rest-destructuring-rhs-array` no longer crashes on an empty array pattern (`const [] = arr`, `[] = arr`, nested `const [[]] = [[]]`). It now correctly returns `false` for them.

## Why

The `ArrayPattern` visitor calls `shouldTransform` for every `ArrayPattern`, including empty ones. `shouldTransform` did:

```ts
const elementPaths = path.get("elements");
const elementPathsLength = elementPaths.length;
if (elementPaths[elementPathsLength - 1].isRestElement()) {
```

For an empty pattern `elementPathsLength` is 0, so `elementPaths[-1]` is `undefined` and `.isRestElement()` throws `TypeError: Cannot read properties of undefined (reading 'isRestElement')`, aborting compilation of otherwise-valid code. Empty array patterns are legal JavaScript and have no trailing rest element.

## How

Guard the empty case before the index access:

```ts
if (elementPathsLength === 0) {
  return false;
}
```

## Test

Added `const [] = [];` and `[] = [];` to `negativeCases`, and nested `const [[]] = [[]];` to `negativeNestedCases`, in `test/util.skip-bundled.js` — all expect `shouldTransform(...) === false`. These throw a `TypeError` before the change and pass after.