### PR TITLE
[ts] Allow merging `enum` into a `namespace`

### DIFF
--- a/packages/babel-plugin-transform-typescript/src/enum.ts
+++ b/packages/babel-plugin-transform-typescript/src/enum.ts
@@ -37,7 +37,13 @@ export default function transpileEnum(
       // todo: Consider exclude program with import/export
       // && !path.parent.body.some(n => t.isImportDeclaration(n) || t.isExportDeclaration(n));
       const isGlobal = t.isProgram(path.parent);
-      const isSeen = seen(parentPath);
+      // If the enum merges with a namespace that comes before it, the
+      // variable for this binding has already been declared by the
+      // namespace transform: assign to it instead of re-declaring it.
+      const existingBinding = path.scope.getOwnBinding(name);
+      const isSeen =
+        seen(parentPath) ||
+        (existingBinding != null && existingBinding.identifier !== node.id);
 
       let init: t.Expression = t.objectExpression([]);
       if (isSeen || isGlobal) {

--- a/packages/babel-plugin-transform-typescript/src/enum.ts
+++ b/packages/babel-plugin-transform-typescript/src/enum.ts
@@ -37,13 +37,12 @@ export default function transpileEnum(
       // todo: Consider exclude program with import/export
       // && !path.parent.body.some(n => t.isImportDeclaration(n) || t.isExportDeclaration(n));
       const isGlobal = t.isProgram(path.parent);
-      // If the enum merges with a namespace that comes before it, the
-      // variable for this binding has already been declared by the
-      // namespace transform: assign to it instead of re-declaring it.
+      // If the enum merges with an enum or namespace that comes before it,
+      // the variable for this binding has already been declared by that
+      // declaration's transform: assign to it instead of re-declaring it.
       const existingBinding = path.scope.getOwnBinding(name);
       const isSeen =
-        seen(parentPath) ||
-        (existingBinding != null && existingBinding.identifier !== node.id);
+        existingBinding != null && existingBinding.identifier !== node.id;
 
       let init: t.Expression = t.objectExpression([]);
       if (isSeen || isGlobal) {
@@ -74,19 +73,6 @@ export default function transpileEnum(
 
     default:
       throw new Error(`Unexpected enum parent '${path.parent.type}`);
-  }
-
-  function seen(parentPath: NodePath<t.Node>): boolean {
-    if (parentPath.isExportDeclaration()) {
-      return seen(parentPath.parentPath);
-    }
-
-    if (parentPath.getData(name)) {
-      return true;
-    } else {
-      parentPath.setData(name, true);
-      return false;
-    }
   }
 }
 

--- a/packages/babel-plugin-transform-typescript/test/fixtures/enum/enum-after-const-fail/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/enum/enum-after-const-fail/input.ts
@@ -1,0 +1,4 @@
+const N = 1;
+enum N {
+  A = 2,
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/enum/enum-after-const-fail/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/enum/enum-after-const-fail/options.json
@@ -1,4 +1,3 @@
 {
-  "plugins": ["transform-typescript"],
   "throws": "Identifier 'N' has already been declared."
 }

--- a/packages/babel-plugin-transform-typescript/test/fixtures/enum/enum-after-const-fail/options.json
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/enum/enum-after-const-fail/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["transform-typescript"],
+  "throws": "Identifier 'N' has already been declared."
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/enum-after-namespace/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/enum-after-namespace/input.ts
@@ -1,0 +1,6 @@
+export namespace N {
+  export const a = 2;
+}
+export enum N {
+  A = 1,
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/enum-after-namespace/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/enum-after-namespace/output.mjs
@@ -1,0 +1,8 @@
+export let N;
+(function (_N) {
+  const a = _N.a = 2;
+})(N || (N = {}));
+N = /*#__PURE__*/function (N) {
+  N[N["A"] = 1] = "A";
+  return N;
+}(N || {});

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-enum-after-namespace/input.ts
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-enum-after-namespace/input.ts
@@ -1,0 +1,8 @@
+namespace Outer {
+  export namespace N {
+    export const a = 2;
+  }
+  export enum N {
+    A = 1,
+  }
+}

--- a/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-enum-after-namespace/output.mjs
+++ b/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-enum-after-namespace/output.mjs
@@ -1,0 +1,12 @@
+let Outer;
+(function (_Outer) {
+  let N;
+  (function (_N) {
+    const a = _N.a = 2;
+  })(N || (N = _Outer.N || (_Outer.N = {})));
+  N = /*#__PURE__*/function (N) {
+    N[N["A"] = 1] = "A";
+    return N;
+  }(N || {});
+  _Outer.N = N;
+})(Outer || (Outer = {}));


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Before this PR Babel correctly allows merging an enum and a namespace if the enum comes first, but not if the enum comes last.

Note that we still disallow merging e.g. an enum into a `const`, because that throws about the duplicate declaration at the parser level.