### PR TITLE
fix(bugfix): bound check before array access

### DIFF
--- a/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/src/util.ts
+++ b/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/src/util.ts
@@ -35,7 +35,10 @@ export function shouldTransform(
 ): NodePath<t.Expression> | false {
   const elementPaths = path.get("elements");
   const elementPathsLength = elementPaths.length;
-  if (elementPaths[elementPathsLength - 1].isRestElement()) {
+  if (
+    elementPathsLength > 0 &&
+    elementPaths[elementPathsLength - 1].isRestElement()
+  ) {
     const { parentPath } = path;
     const rhsPath = parentPath.isVariableDeclarator()
       ? parentPath.get("init")

--- a/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/test/util.skip-bundled.js
+++ b/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/test/util.skip-bundled.js
@@ -61,6 +61,7 @@ describe("shouldTransform", () => {
     "var a = [0, 42]; var [_, ...rest] = a",
     "var [_, ...rest] = [0].concat(42)",
     "function foo([a, ...rest] = [1, 2]) { return rest }",
+    "[] = [];",
   ];
 
   const negativeNestedCases = [


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #18206
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
In this PR we fixed the bug reported in the #18206. Although that PR is closed due to violation to the AI policy, the bug revealed in that PR is genuine.