### PR TITLE
fix: only collapse the empty-object check when it targets the declared binding

### DIFF
--- a/packages/babel-plugin-transform-destructuring/src/util.ts
+++ b/packages/babel-plugin-transform-destructuring/src/util.ts
@@ -716,10 +716,8 @@ export function convertVariableDeclaration(
     t.isExpressionStatement(nodesOut[1]) &&
     t.isCallExpression(nodesOut[1].expression) &&
     nodesOut[0].declarations.length === 1 &&
-    t.isIdentifier(nodesOut[0].declarations[0].id) &&
-    nodesOut[1].expression.arguments.length === 1 &&
     t.isIdentifier(nodesOut[1].expression.arguments[0], {
-      name: nodesOut[0].declarations[0].id.name,
+      name: (nodesOut[0].declarations[0].id as t.Identifier).name,
     })
   ) {
     // This can only happen when we generate this code:

--- a/packages/babel-plugin-transform-destructuring/src/util.ts
+++ b/packages/babel-plugin-transform-destructuring/src/util.ts
@@ -715,7 +715,12 @@ export function convertVariableDeclaration(
     t.isVariableDeclaration(nodesOut[0]) &&
     t.isExpressionStatement(nodesOut[1]) &&
     t.isCallExpression(nodesOut[1].expression) &&
-    nodesOut[0].declarations.length === 1
+    nodesOut[0].declarations.length === 1 &&
+    t.isIdentifier(nodesOut[0].declarations[0].id) &&
+    nodesOut[1].expression.arguments.length === 1 &&
+    t.isIdentifier(nodesOut[1].expression.arguments[0], {
+      name: nodesOut[0].declarations[0].id.name,
+    })
   ) {
     // This can only happen when we generate this code:
     //    var _ref = DESTRUCTURED_VALUE;

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/regression/18210/input.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/regression/18210/input.js
@@ -1,0 +1,2 @@
+const [{ a }, {}] = [x, y];
+const [{}] = [null, {}];

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/regression/18210/options.json
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/regression/18210/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-destructuring"]
+}

--- a/packages/babel-plugin-transform-destructuring/test/fixtures/regression/18210/output.js
+++ b/packages/babel-plugin-transform-destructuring/test/fixtures/regression/18210/output.js
@@ -1,0 +1,4 @@
+const a = x.a;
+babelHelpers.objectDestructuringEmpty(y);
+const _ref = [null, {}];
+babelHelpers.objectDestructuringEmpty(_ref[0]);


### PR DESCRIPTION
Fixes #18210. The two-statement optimisation in convertVariableDeclaration only checks the shape of the statements, not that the call argument is the identifier that was just declared. When another two-statement pair matches that shape, the declaration gets dropped and the check points at the wrong value.

For const [{ a }, {}] = [x, y] the a binding disappears and the emptiness check runs on x.a instead of y. For const [{}] = [null, {}] it checks the array rather than element 0, so it doesn't throw where native code does.

I added the three conditions that make the collapse fire only on the pair the comment above it describes. New fixture in regression/18210, and I checked it fails without the change.