### PR TITLE
Fix import path for babel-node.js

### DIFF
--- a/packages/babel-node/bin/babel-node.js
+++ b/packages/babel-node/bin/babel-node.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-import "../lib/babel-node";
+import "../lib/babel-node.js";

--- a/packages/babel-node/test/helpers/runner.js
+++ b/packages/babel-node/test/helpers/runner.js
@@ -8,7 +8,7 @@ import {
 
 const { require, __dirname } = commonJS(import.meta.url);
 
-const binLoc = path.join(__dirname, "../../lib/babel-node.js");
+const binLoc = path.join(__dirname, "../../bin/babel-node.js");
 
 export const runParallel = buildParallelProcessTests(
   "babel-node",

--- a/packages/babel-node/test/helpers/runner.js
+++ b/packages/babel-node/test/helpers/runner.js
@@ -8,7 +8,7 @@ import {
 
 const { require, __dirname } = commonJS(import.meta.url);
 
-const binLoc = path.join(__dirname, "../../lib/babel-node");
+const binLoc = path.join(__dirname, "../../lib/babel-node.js");
 
 export const runParallel = buildParallelProcessTests(
   "babel-node",


### PR DESCRIPTION
The import path was missing the `.js` extension, trying to run `babel-node` resulted in:

```
npm notice run babel-node -x ".ts" src
node:internal/modules/esm/resolve:272
    throw new ERR_MODULE_NOT_FOUND(
          ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/xxx/node_modules/@babel/node/lib/babel-node' imported from /Users/xxx/node_modules/@babel/node/bin/babel-node.js
    at finalizeResolution (node:internal/modules/esm/resolve:272:11)
    at moduleResolve (node:internal/modules/esm/resolve:879:10)
    at defaultResolve (node:internal/modules/esm/resolve:1006:11)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:705:20)
    at #resolveAndMaybeBlockOnLoaderThread (node:internal/modules/esm/loader:725:38)
    at ModuleLoader.resolveSync (node:internal/modules/esm/loader:763:56)
    at #resolve (node:internal/modules/esm/loader:687:17)
    at ModuleLoader.getOrCreateModuleJob (node:internal/modules/esm/loader:607:35)
    at ModuleJob.syncLink (node:internal/modules/esm/module_job:276:33)
    at ModuleJob.link (node:internal/modules/esm/module_job:381:17) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///Users/xxx/node_modules/@babel/node/lib/babel-node'
}

Node.js v24.20.0
```

This PR should fix the problem.