### PR TITLE
fix: avoid removable fields as decorator evaluation hosts

### DIFF
--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -1858,6 +1858,15 @@ function transformClass(
     let firstPublicElement:
       NodePath<t.ClassProperty | t.ClassMethod> | undefined;
     for (const path of elements) {
+      // Other transforms can remove declaration fields and fields without
+      // initializers in a later visitor, so they cannot host decorator
+      // evaluations that must run while the class is being defined.
+      if (
+        path.isClassProperty() &&
+        (path.node.value == null || path.node.declare || path.node.abstract)
+      ) {
+        continue;
+      }
       if (
         (path.isClassProperty() || path.isClassMethod()) &&
         (path.node as t.ClassMethod).kind !== "constructor"

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-declare-field/exec.ts
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-declare-field/exec.ts
@@ -1,0 +1,25 @@
+const lib = {
+  zUI: () => (_value: unknown, context: { name: string | symbol }) => {
+    seen.push(String(context.name));
+  },
+  zObserve: (fn: unknown) => (
+    _value: unknown,
+    context: { name: string | symbol },
+  ) => {
+    seen.push(String(context.name));
+  },
+};
+
+const seen: string[] = [];
+
+class Example {
+  declare untouched: string;
+
+  @lib.zUI()
+  @lib.zObserve((value: number, instance: Example) => value)
+  target = 2;
+}
+
+new Example();
+
+expect(seen).toEqual(["target", "target"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-declare-field/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-declare-field/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": [["proposal-decorators", { "version": "2023-11" }]],
+  "presets": [["typescript"]]
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-field-order/exec.ts
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-field-order/exec.ts
@@ -1,0 +1,22 @@
+const lib = {
+  zUI: () => (_value: unknown, context: { name: string | symbol }) => {
+    seen.push(String(context.name));
+  },
+  zObserve: (fn: unknown) => (_value: unknown, context: { name: string | symbol }) => {
+    seen.push(String(context.name));
+  },
+};
+
+const seen: string[] = [];
+
+class Example {
+  untouched: string;
+
+  @lib.zUI()
+  @lib.zObserve((value: number, instance: Example) => value)
+  target = 2;
+}
+
+new Example();
+
+expect(seen).toEqual(["target", "target"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-field-order/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-field-order/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["proposal-decorators", { "version": "2023-11" }],
+    "./remove-uninitialized-fields.cjs"
+  ],
+  "presets": [["typescript"]]
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-field-order/remove-uninitialized-fields.cjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-field-order/remove-uninitialized-fields.cjs
@@ -1,0 +1,9 @@
+// Simulate a later transform removing an uninitialized field after
+// decorators have attached evaluation work to it.
+module.exports = () => ({
+  visitor: {
+    ClassProperty(path) {
+      if (path.node.value == null) path.remove();
+    },
+  },
+});

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-multiple-fields/exec.ts
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-multiple-fields/exec.ts
@@ -1,0 +1,27 @@
+const seen: string[] = [];
+
+const lib = {
+  zComponent: () => {
+    seen.push("class");
+    return (target: unknown) => target;
+  },
+  zUI: () => (_value: unknown, context: { name: string | symbol }) => {
+    seen.push(String(context.name));
+  },
+  zObserve: (fn: unknown) => (_value: unknown, context: { name: string | symbol }) => {
+    seen.push(String(context.name));
+  },
+};
+
+@lib.zComponent()
+class Example {
+  untouched: string;
+
+  @lib.zUI()
+  @lib.zObserve((v: number, _instance: Example) => v)
+  target = 2;
+}
+
+new Example();
+
+expect(seen).toEqual(["class", "target", "target"]);

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-multiple-fields/options.json
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-multiple-fields/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["proposal-decorators", { "version": "2023-11" }],
+    "./remove-uninitialized-fields.cjs"
+  ],
+  "presets": [["typescript"]]
+}

--- a/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-multiple-fields/remove-uninitialized-fields.cjs
+++ b/packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-typescript/member-expression-decorator-multiple-fields/remove-uninitialized-fields.cjs
@@ -1,0 +1,9 @@
+// Simulate a later transform removing an uninitialized field after
+// decorators have attached evaluation work to it.
+module.exports = () => ({
+  visitor: {
+    ClassProperty(path) {
+      if (path.node.value == null) path.remove();
+    },
+  },
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #18223 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | N/A <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

Decorator memoization can be attached to a class field that a later transform removes, causing the generated class to throw `TypeError: A decorator must be a function`.

This skips removable fields when selecting a host and uses the existing temporary computed field when necessary, and this is obviously going to solve the problem without changing decorator evaluation order.

Regression tests cover uninitialized and declaration fields.
