### PR TITLE
Fix: pin @vitest/browser-playwright to the last Vitest-4-compatible release in the script

### DIFF
--- a/scripts/integration-tests/e2e-angular-cli.sh
+++ b/scripts/integration-tests/e2e-angular-cli.sh
@@ -33,7 +33,10 @@ yarn set version stable
 export YARN_ENABLE_IMMUTABLE_INSTALLS=false
 yarn install
 # Install browser-playwright for ChromiumHeadless testing
-yarn add playwright @vitest/browser-playwright --dev
+# Pinned to 4.x: @angular/build's vitest peer dep is still ^4.0.8, while
+# @vitest/browser-playwright@5 requires vitest@5.0.0 exactly, which breaks
+# @angular/build's "ng test" (missing BrowserConnectionError export etc).
+yarn add playwright @vitest/browser-playwright@4.1.11 --dev
 yarn playwright install --with-deps
 yarn run build
 yarn run ng test --watch=false --browsers ChromiumHeadless

--- a/scripts/integration-tests/e2e-angular-cli.sh
+++ b/scripts/integration-tests/e2e-angular-cli.sh
@@ -33,10 +33,7 @@ yarn set version stable
 export YARN_ENABLE_IMMUTABLE_INSTALLS=false
 yarn install
 # Install browser-playwright for ChromiumHeadless testing
-# Pinned to 4.x: @angular/build's vitest peer dep is still ^4.0.8, while
-# @vitest/browser-playwright@5 requires vitest@5.0.0 exactly, which breaks
-# @angular/build's "ng test" (missing BrowserConnectionError export etc).
-yarn add playwright @vitest/browser-playwright@4.1.11 --dev
+yarn add playwright @vitest/browser-playwright --dev
 yarn playwright install --with-deps
 yarn run build
 yarn run ng test --watch=false --browsers ChromiumHeadless

--- a/scripts/integration-tests/e2e-angular-cli.sh
+++ b/scripts/integration-tests/e2e-angular-cli.sh
@@ -36,7 +36,7 @@ yarn install
 # Pinned to 4.x: @angular/build's vitest peer dep is still ^4.0.8, while
 # @vitest/browser-playwright@5 requires vitest@5.0.0 exactly, which breaks
 # @angular/build's "ng test" (missing BrowserConnectionError export etc).
-yarn add playwright @vitest/browser-playwright@4.1.11 --dev
+yarn add playwright @vitest/browser-playwright@4 --dev
 yarn playwright install --with-deps
 yarn run build
 yarn run ng test --watch=false --browsers ChromiumHeadless


### PR DESCRIPTION
pin @vitest/browser-playwright to the last Vitest-4-compatible release in the script, since @angular/build hasn't caught up to Vitest 5 yet:

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
