### PR TITLE
Replace `lru-cache` with `flru`

### DIFF
--- a/packages/babel-helper-compilation-targets/package.json
+++ b/packages/babel-helper-compilation-targets/package.json
@@ -28,7 +28,7 @@
     "@babel/compat-data": "workspace:^",
     "@babel/helper-validator-option": "workspace:^",
     "browserslist": "^4.24.0",
-    "lru-cache": "^11.0.0",
+    "flru": "1.0.2",
     "verkit": "catalog:"
   },
   "devDependencies": {

--- a/packages/babel-helper-compilation-targets/src/index.ts
+++ b/packages/babel-helper-compilation-targets/src/index.ts
@@ -1,7 +1,7 @@
 import browserslist from "browserslist";
 import { findSuggestion } from "@babel/helper-validator-option";
 import browserModulesData from "@babel/compat-data/native-modules" with { type: "json" };
-import { LRUCache } from "lru-cache";
+import flru from "flru";
 
 import {
   semverify,
@@ -174,7 +174,7 @@ function resolveTargets(queries: Browsers, env?: string): Targets {
   return getLowestVersions(resolved);
 }
 
-const targetsCache = new LRUCache<string, Targets>({ max: 64 });
+const targetsCache = flru<Targets>(64);
 
 function resolveTargetsCached(queries: Browsers, env?: string): Targets {
   const cacheKey = typeof queries === "string" ? queries : queries.join() + env;

--- a/packages/babel-helper-transform-fixture-test-runner/package.json
+++ b/packages/babel-helper-transform-fixture-test-runner/package.json
@@ -20,8 +20,8 @@
     "@babel/helper-check-duplicate-nodes": "workspace:^",
     "@babel/helper-fixtures": "workspace:^",
     "@jridgewell/trace-mapping": "catalog:",
+    "flru": "1.0.2",
     "jest-diff": "^30.0.0",
-    "lru-cache": "^11.0.0",
     "resolve": "2.0.0-next.5"
   },
   "engines": {

--- a/packages/babel-helper-transform-fixture-test-runner/src/index.ts
+++ b/packages/babel-helper-transform-fixture-test-runner/src/index.ts
@@ -19,7 +19,7 @@ import assert from "node:assert";
 import fs, { readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
 import vm from "node:vm";
-import { LRUCache } from "lru-cache";
+import flru from "flru";
 import { fileURLToPath } from "node:url";
 import { diff } from "jest-diff";
 import type { ChildProcess } from "node:child_process";
@@ -41,10 +41,9 @@ type Module = {
 
 const EXTERNAL_HELPERS_VERSION = "7.100.0";
 
-const cachedScripts = new LRUCache<
-  string,
-  { code: string; cachedData?: Buffer }
->({ max: 10 });
+const cachedScripts = flru<{ code: string; cachedData: Buffer | undefined }>(
+  10,
+);
 const contextModuleCache = new WeakMap();
 
 // We never want our tests to accidentally load the root

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,7 +684,7 @@ __metadata:
     "@babel/helper-plugin-test-runner": "workspace:^"
     "@babel/helper-validator-option": "workspace:^"
     browserslist: "npm:^4.24.0"
-    lru-cache: "npm:^11.0.0"
+    flru: "npm:1.0.2"
     verkit: "catalog:"
   languageName: unknown
   linkType: soft
@@ -1106,8 +1106,8 @@ __metadata:
     "@babel/helper-check-duplicate-nodes": "workspace:^"
     "@babel/helper-fixtures": "workspace:^"
     "@jridgewell/trace-mapping": "catalog:"
+    flru: "npm:1.0.2"
     jest-diff: "npm:^30.0.0"
-    lru-cache: "npm:^11.0.0"
     resolve: "npm:2.0.0-next.5"
   languageName: unknown
   linkType: soft
@@ -10471,6 +10471,13 @@ __metadata:
   version: 3.4.2
   resolution: "flatted@npm:3.4.2"
   checksum: 10/a9e78fe5c2c1fcd98209a015ccee3a6caa953e01729778e83c1fe92e68601a63e1e69cd4e573010ca99eaf585a581b80ccf1018b99283e6cbc2117bcba1e030f
+  languageName: node
+  linkType: hard
+
+"flru@npm:1.0.2":
+  version: 1.0.2
+  resolution: "flru@npm:1.0.2"
+  checksum: 10/eb83ad671537f0f42fc658704d1f137bcb7bd65c1c41cb01ddc1dcf298fe601e06a9dc93f6f492e0c761a2c027ddd2a9c267b503af66da663937ed4d17db61b7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

I was looking at https://npmx.dev/package-timeline/@babel/core/v/8.0.1 and notice that the install size of `@babel/core` increased from 11MB to 12MB in Babel 8:

The reason seems to be `lru-cache`, which is a whole 2.7MB:
<img width="1161" height="654" alt="image" src="https://github.com/user-attachments/assets/33623e05-a486-45b8-aa59-48f59525d285" />

We have a very simple usage of it, and this PR replaces with with a much smaller and faster library that does the same thing, `flru`: https://github.com/lukeed/flru

This is the first dependency we have from that author and repository has not been touched in years (also, it probably doesn't need to, it's a 20 lines long file), so just in case I'm pinning its version to avoid potential problems.

Note that `lru-cache` is still pulled in as a transitive dependency of `@babel/cli` and `@babel/register`, but most users don't use those.