### PR TITLE
Remove unused internal exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jest-light-runner": "^0.7.12",
     "jest-worker": "^30.4.1",
     "json5": "^2.2.3",
-    "knip": "^6.14.2",
+    "knip": "^6.35.1",
     "lint-staged": "^17.0.0",
     "mergeiterator": "^1.4.4",
     "open": "^11.0.0",

--- a/packages/babel-code-frame/src/common.ts
+++ b/packages/babel-code-frame/src/common.ts
@@ -38,7 +38,7 @@ export interface Options {
  * RegExp to test for newlines in terminal.
  */
 
-export const NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
+const NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
 
 /**
  * Extract what lines should be marked and highlighted.
@@ -46,7 +46,7 @@ export const NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
 
 type MarkerLines = Record<number, true | [number, number]>;
 
-export function getMarkerLines(
+function getMarkerLines(
   loc: NodeLocation,
   source: string[],
   opts: Options,

--- a/packages/babel-core/src/config/cache-contexts.ts
+++ b/packages/babel-core/src/config/cache-contexts.ts
@@ -4,8 +4,6 @@ import type {
   TargetsListOrObject,
 } from "./validation/options.ts";
 
-export type { ConfigContext as FullConfig };
-
 export type FullPreset = {
   targets: TargetsListOrObject;
 } & ConfigContext;

--- a/packages/babel-core/src/config/caching.ts
+++ b/packages/babel-core/src/config/caching.ts
@@ -21,7 +21,7 @@ export type SimpleCacheConfigurator = {
   invalidate: <T extends SimpleType>(handler: () => T) => T;
 };
 
-export type CacheEntry<ResultT, SideChannel> = {
+type CacheEntry<ResultT, SideChannel> = {
   value: ResultT;
   valid: (channel: SideChannel) => Handler<boolean>;
 }[];

--- a/packages/babel-core/src/config/config-chain.ts
+++ b/packages/babel-core/src/config/config-chain.ts
@@ -86,7 +86,7 @@ export function* buildPresetChain(
   };
 }
 
-export const buildPresetChainWalker = makeChainWalker<PresetInstance>({
+const buildPresetChainWalker = makeChainWalker<PresetInstance>({
   root: preset => loadPresetDescriptors(preset),
   env: (preset, envName) => loadPresetEnvDescriptors(preset)(envName),
   overrides: (preset, index) => loadPresetOverridesDescriptors(preset)(index),

--- a/packages/babel-core/src/config/full.ts
+++ b/packages/babel-core/src/config/full.ts
@@ -53,8 +53,7 @@ export type ResolvedConfig = {
 };
 
 export type { Plugin };
-export type PluginPassList = Plugin[];
-export type PluginPasses = PluginPassList[];
+export type PluginPasses = Plugin[][];
 
 export default gensync(function* loadFullConfig(
   inputOpts: InputOptions | null | undefined,

--- a/packages/babel-core/src/config/validation/options.ts
+++ b/packages/babel-core/src/config/validation/options.ts
@@ -150,6 +150,8 @@ type Assumptions = {
 
 export type AssumptionName = keyof Assumptions;
 
+type EnvSet<T> = Record<string, T>;
+
 export type InputOptions = {
   cwd?: string;
   filename?: string;
@@ -257,7 +259,6 @@ export type CallerMetadata = {
   supportsTopLevelAwait?: boolean;
   supportsExportNamespaceFrom?: boolean;
 };
-export type EnvSet<T> = Record<string, T>;
 export type MatchItem =
   | string
   | RegExp
@@ -270,7 +271,7 @@ export type MatchItem =
       },
     ) => unknown);
 
-export type MaybeDefaultProperty<T> = T | { default: T };
+type MaybeDefaultProperty<T> = T | { default: T };
 
 export type PluginTarget<Option = object> =
   | string

--- a/packages/babel-generator/src/printer.ts
+++ b/packages/babel-generator/src/printer.ts
@@ -110,12 +110,6 @@ export type Format = {
   topicToken?: GeneratorOptions["topicToken"];
 };
 
-interface PrintSequenceOptions {
-  statement?: boolean;
-  indent?: boolean;
-  trailingCommentsLineOffset?: number;
-}
-
 interface PrintListOptions {
   separator?: (this: Printer, occurrenceCount: number, last: boolean) => void;
   statement?: boolean;
@@ -123,7 +117,6 @@ interface PrintListOptions {
   printTrailingSeparator?: boolean;
 }
 
-export type PrintJoinOptions = PrintListOptions & PrintSequenceOptions;
 class Printer {
   constructor(
     format: Format,
@@ -943,7 +936,7 @@ class Printer {
     nodes: t.Node[] | undefined | null,
     statement?: boolean,
     indent?: boolean,
-    separator?: PrintJoinOptions["separator"] | null,
+    separator?: PrintListOptions["separator"] | null,
     printTrailingSeparator?: boolean | null,
     resetTokenContext?: boolean,
     trailingCommentsLineOffset?: number,

--- a/packages/babel-helper-create-class-features-plugin/src/decorators.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/decorators.ts
@@ -14,10 +14,6 @@ export function hasOwnDecorators(node: t.Class | t.ClassBody["body"][number]) {
   return !!node.decorators?.length;
 }
 
-export function hasDecorators(node: t.Class) {
-  return hasOwnDecorators(node) || node.body.body.some(hasOwnDecorators);
-}
-
 import * as charCodes from "charcodes";
 
 type ClassDecoratableElement =

--- a/packages/babel-helper-create-class-features-plugin/src/fields.ts
+++ b/packages/babel-helper-create-class-features-plugin/src/fields.ts
@@ -1202,12 +1202,12 @@ function replaceThisContext(
   return state.needsClassRef;
 }
 
-export type PropNode =
+export type PropPath = NodePath<
   | t.ClassProperty
   | t.ClassPrivateMethod
   | t.ClassPrivateProperty
-  | t.StaticBlock;
-export type PropPath = NodePath<PropNode>;
+  | t.StaticBlock
+>;
 
 function isNameOrLength({ key, computed }: t.ClassProperty) {
   if (key.type === "Identifier") {

--- a/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
+++ b/packages/babel-helper-module-transforms/src/normalize-and-load-metadata.ts
@@ -53,7 +53,7 @@ export interface SourceModuleMetadata {
   referenced: boolean;
 }
 
-export interface LocalExportMetadata {
+interface LocalExportMetadata {
   names: string[]; // names of exports,
   kind: "import" | "hoisted" | "block" | "var";
 }

--- a/packages/babel-parser/src/parse-error.ts
+++ b/packages/babel-parser/src/parse-error.ts
@@ -36,7 +36,7 @@ interface ParseErrorSpecification<ErrorDetails> {
   pos: number;
 }
 
-export type ParseErrorGeneric<ErrorDetails> = SyntaxError &
+type ParseErrorGeneric<ErrorDetails> = SyntaxError &
   ParseErrorSpecification<ErrorDetails>;
 
 export type ParseError = SyntaxError & {

--- a/packages/babel-parser/src/plugin-utils.ts
+++ b/packages/babel-parser/src/plugin-utils.ts
@@ -1,11 +1,6 @@
-import type Parser from "./parser/index.ts";
 import type { PluginConfig } from "./typings.d.ts";
 
 export type Plugin = PluginConfig;
-
-export type MixinPlugin = (
-  superClass: new (...args: any) => Parser,
-) => new (...args: any) => Parser;
 
 const PIPELINE_PROPOSALS = ["fsharp", "hack"];
 const TOPIC_TOKENS = ["^^", "@@", "^", "%", "#"];

--- a/packages/babel-parser/src/tokenizer/index.ts
+++ b/packages/babel-parser/src/tokenizer/index.ts
@@ -80,7 +80,7 @@ export class Token {
   declare loc: SourceLocation;
 }
 
-export let locDataCache: Uint32Array | undefined;
+let locDataCache: Uint32Array | undefined;
 
 // ## Tokenizer
 

--- a/packages/babel-parser/src/tokenizer/types.ts
+++ b/packages/babel-parser/src/tokenizer/types.ts
@@ -86,7 +86,7 @@ function createBinop(name: string, binop: number) {
 }
 
 let tokenTypeCounter = -1;
-export const tokenTypes: ExportedTokenType[] = [];
+const tokenTypes: ExportedTokenType[] = [];
 const tokenLabels: string[] = [];
 const tokenBinops: number[] = [];
 const tokenBeforeExprs: boolean[] = [];
@@ -405,10 +405,6 @@ export function tokenOperatorPrecedence(token: TokenType): number {
   return tokenBinops[token];
 }
 
-export function tokenIsBinaryOperator(token: TokenType): boolean {
-  return tokenBinops[token] !== -1;
-}
-
 export function tokenIsRightAssociative(token: TokenType): boolean {
   return token === tt.exponent;
 }
@@ -419,8 +415,4 @@ export function tokenIsTemplate(token: TokenType): boolean {
 
 export function getExportedToken(token: TokenType): ExportedTokenType {
   return tokenTypes[token];
-}
-
-export function isTokenType(obj: any): boolean {
-  return typeof obj === "number";
 }

--- a/packages/babel-parser/src/types.ts
+++ b/packages/babel-parser/src/types.ts
@@ -23,16 +23,6 @@ export interface CommentLine extends CommentBase {
 
 export type Comment = CommentBlock | CommentLine;
 
-// A whitespace containing comments
-export interface CommentWhitespace {
-  start: number;
-  end: number;
-  comments: Comment[];
-  leadingNode: N.Node | null;
-  trailingNode: N.Node | null;
-  containerNode: N.Node | null;
-}
-
 export type ExportedToken = Omit<Token, "type"> & { type: ExportedTokenType };
 
 export interface ParserOutput {
@@ -57,7 +47,7 @@ export interface BaseNode {
 // JSX
 // ================
 
-export type JSXElementTag = N.JSXOpeningElement | N.JSXClosingElement;
+type JSXElementTag = N.JSXOpeningElement | N.JSXClosingElement;
 export type JSXFragmentTag = N.JSXOpeningFragment | N.JSXClosingFragment;
 export type JSXTag = JSXElementTag | JSXFragmentTag;
 
@@ -168,14 +158,14 @@ export interface ParseClassMemberState {
 // ESTree
 // ================
 
-export type ESTreeNode =
+type ESTreeNode =
   | ESTreeClassElement
   | ESTreeExpression
   | EstreePrivateIdentifier
   | EstreeProperty
   | EstreeRegExpLiteral;
 
-export type ESTreeClassElement =
+type ESTreeClassElement =
   | EstreeAccessorProperty
   | EstreeMethodDefinition
   | EstreePropertyDefinition
@@ -183,7 +173,7 @@ export type ESTreeClassElement =
   | EstreeTSAbstractPropertyDefinition
   | EstreeTSAbstractAccessorProperty;
 
-export type ESTreeLiteral = EstreeLiteral | EstreeBigIntLiteral;
+type ESTreeLiteral = EstreeLiteral | EstreeBigIntLiteral;
 
 export type ESTreeExpression =
   EstreeChainExpression | ESTreeLiteral | EstreeTSEmptyBodyFunctionExpression;
@@ -309,21 +299,21 @@ export interface EstreeChainExpression extends BaseNode {
   expression: N.Expression;
 }
 
-export interface DeclarationBase extends BaseNode {
+interface DeclarationBase extends BaseNode {
   // TypeScript allows declarations to be prefixed by `declare`.
   //TODO: a FunctionDeclaration is never "declare", because it's a TSDeclareFunction instead.
   declare?: boolean;
 }
 
-export interface HasDecorators extends BaseNode {
+interface HasDecorators extends BaseNode {
   decorators?: N.Decorator[];
 }
 
-export interface TypeParameterDeclarationBase extends BaseNode {
+interface TypeParameterDeclarationBase extends BaseNode {
   params: (N.TypeParameter | N.TSTypeParameter)[];
 }
 
-export interface TypeAnnotationBase extends BaseNode {
+interface TypeAnnotationBase extends BaseNode {
   typeAnnotation: N.Node;
 }
 

--- a/packages/babel-parser/src/util/identifier.ts
+++ b/packages/babel-parser/src/util/identifier.ts
@@ -11,8 +11,6 @@ export {
   isKeyword,
 } from "@babel/helper-validator-identifier";
 
-export const keywordRelationalOperator = /^in(stanceof)?$/;
-
 // Test whether a current state character code and next character code is @
 
 export function isIteratorStart(

--- a/packages/babel-parser/src/util/whitespace.ts
+++ b/packages/babel-parser/src/util/whitespace.ts
@@ -1,9 +1,7 @@
 import * as charCodes from "charcodes";
 
-// Matches a whole line break (where CRLF is considered a single
-// line break). Used to count lines.
-export const lineBreak = /\r\n|[\r\n\u2028\u2029]/;
-export const lineBreakG = new RegExp(lineBreak.source, "g");
+// Matches a whole line break (where CRLF is considered a single line break).
+export const lineBreakG = /\r\n|[\r\n\u2028\u2029]/g;
 
 // https://tc39.github.io/ecma262/#sec-line-terminators
 export function isNewLine(code: number): boolean {

--- a/packages/babel-parser/test/unit/util/identifier.skip-bundled.js
+++ b/packages/babel-parser/test/unit/util/identifier.skip-bundled.js
@@ -1,7 +1,4 @@
-import {
-  isKeyword,
-  keywordRelationalOperator,
-} from "../../../lib/util/identifier.js";
+import { isKeyword } from "../../../lib/util/identifier.js";
 
 describe("identifier", () => {
   describe("isKeyword", () => {
@@ -19,24 +16,6 @@ describe("identifier", () => {
     });
     it("abc is not a keyword", () => {
       expect(isKeyword("abc")).toBe(false);
-    });
-  });
-
-  describe("keywordRelationalOperator", () => {
-    it("in is true", () => {
-      expect(keywordRelationalOperator.test("in")).toBe(true);
-    });
-    it("instanceof is true", () => {
-      expect(keywordRelationalOperator.test("instanceof")).toBe(true);
-    });
-    it("stanceof is false", () => {
-      expect(keywordRelationalOperator.test("stanceof")).toBe(false);
-    });
-    it("instance is false", () => {
-      expect(keywordRelationalOperator.test("instance")).toBe(false);
-    });
-    it("abc is false", () => {
-      expect(keywordRelationalOperator.test("abc")).toBe(false);
     });
   });
 });

--- a/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/src/util.ts
+++ b/packages/babel-plugin-bugfix-safari-rest-destructuring-rhs-array/src/util.ts
@@ -3,9 +3,9 @@ import { skipTransparentExprWrappers } from "@babel/helper-skip-transparent-expr
 
 /**
  * Check whether a path is an ArrayExpression with exactly N non-spread & non-hole elements and no trailing comma
- * @param path
- * @param N
- * @returns
+ *
+ * NOTE: When running `yarn knip`, this export is marked as unused. It's actually used
+ * in ../../test/util.skip-bundled.js.
  */
 export function isPathSimpleArrayWithLength(
   path: NodePath,

--- a/packages/babel-plugin-proposal-destructuring-private/src/util.ts
+++ b/packages/babel-plugin-proposal-destructuring-private/src/util.ts
@@ -202,8 +202,9 @@ type StackItem = {
  * - ObjectPattern
  * - ObjectProperty
  * - RestElement
- * @param root
- * @param visitor
+ *
+ * NOTE: When running `yarn knip`, this export is marked as unused. It's actually used
+ * in ../../test/normalize-options.skip-bundled.js.
  */
 export function* traversePattern(
   root:
@@ -299,8 +300,8 @@ export function hasPrivateClassElement(node: t.ClassBody): boolean {
  * A private key path is analogous to an array of `key` from the pattern NodePath
  * to the private key NodePath. See also test/util.skip-bundled.js for an example output
  *
- * @export
- * @param {t.LVal} pattern
+ * NOTE: When running `yarn knip`, this export is marked as unused. It's actually used
+ * in ../../test/util.skip-bundled.js.
  */
 export function* privateKeyPathIterator(pattern: t.LVal | t.PatternLike) {
   const indexPath: number[] = [];

--- a/packages/babel-plugin-proposal-discard-binding/src/utils.ts
+++ b/packages/babel-plugin-proposal-discard-binding/src/utils.ts
@@ -144,7 +144,7 @@ export function removeTrailingVoidPatternsFromParams(
 }
 
 // https://tc39.es/ecma262/#sec-isanonymousfunctiondefinition
-export function isAnonymousFunctionDefinition(
+function isAnonymousFunctionDefinition(
   node: t.Node | null,
 ): node is
   t.ClassExpression | t.ArrowFunctionExpression | t.FunctionExpression {

--- a/packages/babel-plugin-transform-regenerator/src/regenerator/emit.ts
+++ b/packages/babel-plugin-transform-regenerator/src/regenerator/emit.ts
@@ -974,7 +974,7 @@ export class Emitter {
     // break statement), then any sibling subexpressions will almost
     // certainly have to be exploded in order to maintain the order of their
     // side effects relative to the leaping child(ren).
-    const hasLeapingChildren = meta.containsLeap.onlyChildren(expr);
+    const hasLeapingChildren = meta.containsLeapInChildren(expr);
 
     // If ignoreResult is true, then we must take full responsibility for
     // emitting the expression with all its side effects, and we should not

--- a/packages/babel-plugin-transform-regenerator/src/regenerator/leap.ts
+++ b/packages/babel-plugin-transform-regenerator/src/regenerator/leap.ts
@@ -4,7 +4,7 @@ import type { types as t } from "@babel/core";
 
 export class Entry {}
 
-export class FunctionEntry extends Entry {
+class FunctionEntry extends Entry {
   returnLoc: t.NumericLiteral;
 
   constructor(returnLoc: t.NumericLiteral) {

--- a/packages/babel-plugin-transform-regenerator/src/regenerator/meta.ts
+++ b/packages/babel-plugin-transform-regenerator/src/regenerator/meta.ts
@@ -1,84 +1,59 @@
-import assert from "node:assert";
 import { types as t } from "@babel/core";
 
-const mMap = new WeakMap();
-function m(node: t.Node) {
-  if (!mMap.has(node)) {
-    mMap.set(node, {});
-  }
-  return mMap.get(node);
-}
-
-function makePredicate(
-  propertyName: string,
-  knownTypes: Record<string, boolean>,
-) {
-  function onlyChildren(node: t.Node): boolean {
-    t.assertNode(node);
-
-    // Assume no side effects until we find out otherwise.
-    let result = false;
-
-    function check(child: any) {
-      if (result) {
-        // Do nothing.
-      } else if (Array.isArray(child)) {
-        child.some(check);
-      } else if (t.isNode(child)) {
-        assert.strictEqual(result, false);
-        result = predicate(child);
-      }
-      return result;
-    }
-
-    const keys = t.VISITOR_KEYS[node.type];
-    if (keys) {
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
-        const child = node[key as keyof typeof node];
-        check(child);
-      }
-    }
-
-    return result;
-  }
-
-  function predicate(node: t.Node) {
-    t.assertNode(node);
-
-    const meta = m(node);
-    if (Object.hasOwn(meta, propertyName)) return meta[propertyName];
-
-    // Certain types are "opaque," which means they have no side
-    // effects or leaps and we don't care about their subexpressions.
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    if (Object.hasOwn(opaqueTypes, node.type))
-      return (meta[propertyName] = false);
-
-    if (Object.hasOwn(knownTypes, node.type))
-      return (meta[propertyName] = true);
-
-    return (meta[propertyName] = onlyChildren(node));
-  }
-
-  predicate.onlyChildren = onlyChildren;
-
-  return predicate;
-}
-
-const opaqueTypes = {
-  FunctionExpression: true,
-  ArrowFunctionExpression: true,
-};
-
 // These types are the direct cause of all leaps in control flow.
-const leapTypes = {
-  YieldExpression: true,
-  AwaitExpression: true,
-  BreakStatement: true,
-  ContinueStatement: true,
-  ReturnStatement: true,
-  ThrowStatement: true,
-};
+const leapTypes = new Set([
+  "YieldExpression",
+  "AwaitExpression",
+  "BreakStatement",
+  "ContinueStatement",
+  "ReturnStatement",
+  "ThrowStatement",
+]);
 
-export const containsLeap = makePredicate("containsLeap", leapTypes);
+export function containsLeap(node: t.Node | null): boolean {
+  if (!node) return false;
+
+  // Functions are "opaque" which means they have no leaps and we don't care
+  // about their subexpressions.
+  if (
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  ) {
+    return false;
+  }
+
+  if (leapTypes.has(node.type)) return true;
+
+  return containsLeapInChildren(node);
+}
+
+const containsLeapInChildrenCache = new WeakMap<t.Node, boolean>();
+
+export function containsLeapInChildren(node: t.Node): boolean {
+  if (containsLeapInChildrenCache.has(node)) {
+    return containsLeapInChildrenCache.get(node)!;
+  }
+
+  const keys = t.VISITOR_KEYS[node.type];
+  if (keys) {
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const child = node[key as keyof typeof node] as unknown as
+        t.Node | t.Node[];
+      if (Array.isArray(child)) {
+        if (child.some(containsLeap)) {
+          containsLeapInChildrenCache.set(node, true);
+          return true;
+        }
+      } else if (t.isNode(child)) {
+        if (containsLeap(child)) {
+          containsLeapInChildrenCache.set(node, true);
+          return true;
+        }
+      }
+    }
+  }
+
+  containsLeapInChildrenCache.set(node, false);
+  return false;
+}

--- a/packages/babel-plugin-transform-regenerator/src/regenerator/meta.ts
+++ b/packages/babel-plugin-transform-regenerator/src/regenerator/meta.ts
@@ -71,18 +71,6 @@ const opaqueTypes = {
   ArrowFunctionExpression: true,
 };
 
-// These types potentially have side effects regardless of what side
-// effects their subexpressions have.
-const sideEffectTypes = {
-  CallExpression: true, // Anything could happen!
-  ForInStatement: true, // Modifies the key variable.
-  UnaryExpression: true, // Think delete.
-  BinaryExpression: true, // Might invoke .toString() or .valueOf().
-  AssignmentExpression: true, // Side-effecting by definition.
-  UpdateExpression: true, // Updates are essentially assignments.
-  NewExpression: true, // Similar to CallExpression.
-};
-
 // These types are the direct cause of all leaps in control flow.
 const leapTypes = {
   YieldExpression: true,
@@ -93,13 +81,4 @@ const leapTypes = {
   ThrowStatement: true,
 };
 
-// All leap types are also side effect types.
-for (const type in leapTypes) {
-  if (Object.hasOwn(leapTypes, type)) {
-    sideEffectTypes[type as keyof typeof sideEffectTypes] =
-      leapTypes[type as keyof typeof leapTypes];
-  }
-}
-
-export const hasSideEffects = makePredicate("hasSideEffects", sideEffectTypes);
 export const containsLeap = makePredicate("containsLeap", leapTypes);

--- a/packages/babel-plugin-transform-typescript/src/enum.ts
+++ b/packages/babel-plugin-transform-typescript/src/enum.ts
@@ -121,7 +121,7 @@ function enumFill(path: NodePath<t.TSEnumDeclaration>, t: t, id: t.Identifier) {
   };
 }
 
-export function isSyntacticallyString(expr: t.Expression): boolean {
+function isSyntacticallyString(expr: t.Expression): boolean {
   expr = skipTransparentExprWrapperNodes(expr);
   switch (expr.type) {
     case "BinaryExpression": {

--- a/packages/babel-preset-env/src/normalize-options.ts
+++ b/packages/babel-preset-env/src/normalize-options.ts
@@ -48,6 +48,10 @@ const getValidIncludesAndExcludes = (
   return Array.from(set);
 };
 
+/*
+ * NOTE: When running `yarn knip`, this export is marked as unused. It's actually used
+ * in ../../test/normalize-options.skip-bundled.js.
+ */
 export const normalizePluginName = (plugin: string) =>
   plugin.replace(/^(?:@babel\/|babel-)(?:plugin-)?/, "");
 
@@ -91,6 +95,10 @@ const expandIncludesAndExcludes = (
   return selectedPlugins;
 };
 
+/*
+ * NOTE: When running `yarn knip`, this export is marked as unused. It's actually used
+ * in ../../test/normalize-options.skip-bundled.js.
+ */
 export const checkDuplicateIncludeExcludes = (
   include: string[] = [],
   exclude: string[] = [],
@@ -116,6 +124,10 @@ const normalizeTargets = (
   return { ...targets };
 };
 
+/*
+ * NOTE: When running `yarn knip`, this export is marked as unused. It's actually used
+ * in ../../test/normalize-options.skip-bundled.js.
+ */
 export const validateModulesOption = (
   modulesOpt: ModuleOption = ModulesOption.auto,
 ) => {
@@ -132,9 +144,7 @@ export const validateModulesOption = (
   return modulesOpt;
 };
 
-export const validateUseBuiltInsOption = (
-  builtInsOpt: BuiltInsOption = false,
-) => {
+const validateUseBuiltInsOption = (builtInsOpt: BuiltInsOption = false) => {
   v.invariant(
     // @ts-expect-error we have provided fallback for undefined keys
     UseBuiltInsOption[builtInsOpt.toString()] ||
@@ -153,7 +163,7 @@ export type NormalizedCorejsOption = {
   version: SemVer | null | false;
 };
 
-export function normalizeCoreJSOption(
+function normalizeCoreJSOption(
   corejs: CorejsOption | undefined | null,
   useBuiltIns: BuiltInsOption,
 ): NormalizedCorejsOption {

--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -1,7 +1,6 @@
 // This file contains methods responsible for maintaining a TraversalContext.
 
 import { SHOULD_SKIP, SHOULD_STOP } from "./index.ts";
-import { _markRemoved } from "./removal.ts";
 import type TraversalContext from "../context.ts";
 import type NodePath from "./index.ts";
 import type { ExplodedVisitor, TraverseOptions } from "../types.ts";
@@ -146,16 +145,15 @@ export function resync(this: NodePath<t.Node | null>) {
   _resyncParent.call(this);
   _resyncList.call(this);
   _resyncKey.call(this);
-  //this._resyncRemoved();
 }
 
-export function _resyncParent(this: NodePath<t.Node | null>) {
+function _resyncParent(this: NodePath<t.Node | null>) {
   if (this.parentPath) {
     this.parent = this.parentPath.node;
   }
 }
 
-export function _resyncKey(this: NodePath<t.Node | null>) {
+function _resyncKey(this: NodePath<t.Node | null>) {
   if (!this.container) return;
 
   if (
@@ -172,7 +170,7 @@ export function _resyncKey(this: NodePath<t.Node | null>) {
   if (Array.isArray(this.container)) {
     for (let i = 0; i < this.container.length; i++) {
       if (this.container[i] === this.node) {
-        setKey.call(this, i);
+        _setKey.call(this, i);
         return;
       }
     }
@@ -180,7 +178,7 @@ export function _resyncKey(this: NodePath<t.Node | null>) {
     for (const key of Object.keys(this.container)) {
       // @ts-expect-error this.key should present in this.container
       if (this.container[key] === this.node) {
-        setKey.call(this, key);
+        _setKey.call(this, key);
         return;
       }
     }
@@ -190,7 +188,7 @@ export function _resyncKey(this: NodePath<t.Node | null>) {
   this.key = null;
 }
 
-export function _resyncList(this: NodePath<t.Node | null>) {
+function _resyncList(this: NodePath<t.Node | null>) {
   if (!this.parent || !this.inList) return;
 
   const newContainer =
@@ -200,17 +198,6 @@ export function _resyncList(this: NodePath<t.Node | null>) {
 
   // container is out of sync. this is likely the result of it being reassigned
   this.container = newContainer || null;
-}
-
-export function _resyncRemoved(this: NodePath<t.Node | null>) {
-  if (
-    this.key == null ||
-    !this.container ||
-    // @ts-expect-error this.key should present in this.container
-    this.container[this.key] !== this.node
-  ) {
-    _markRemoved.call(this);
-  }
 }
 
 export function popContext(this: NodePath<t.Node | null>) {
@@ -241,10 +228,10 @@ export function setup(
   this.container = container;
 
   this.parentPath = parentPath || this.parentPath;
-  setKey.call(this, key);
+  _setKey.call(this, key);
 }
 
-export function setKey(this: NodePath<t.Node | null>, key: string | number) {
+function _setKey(this: NodePath<t.Node | null>, key: string | number) {
   this.key = key;
   this.node =
     // @ts-expect-error this.key must present in this.container

--- a/packages/babel-traverse/src/path/context.ts
+++ b/packages/babel-traverse/src/path/context.ts
@@ -142,62 +142,43 @@ export function setContext<S = unknown>(
 export function resync(this: NodePath<t.Node | null>) {
   if (this.removed) return;
 
-  _resyncParent.call(this);
-  _resyncList.call(this);
-  _resyncKey.call(this);
-}
-
-function _resyncParent(this: NodePath<t.Node | null>) {
   if (this.parentPath) {
     this.parent = this.parentPath.node;
   }
-}
 
-function _resyncKey(this: NodePath<t.Node | null>) {
-  if (!this.container) return;
+  if (this.parent && this.inList) {
+    // @ts-expect-error this.listKey should present in this.parent
+    const newContainer = this.parent[this.listKey] as t.Node;
+    if (this.container !== newContainer) {
+      // container is out of sync. this is likely the result of it being reassigned
+      this.container = newContainer || null;
+    }
+  }
 
   if (
-    this.node ===
-    // @ts-expect-error this.key should present in this.container
-    this.container[this.key]
+    this.container &&
+    this.node !== this.container[this.key as keyof typeof this.container]
   ) {
-    return;
-  }
+    // grrr, path key is out of sync. this is likely due to a modification to the AST
+    // not done through our path APIs
 
-  // grrr, path key is out of sync. this is likely due to a modification to the AST
-  // not done through our path APIs
-
-  if (Array.isArray(this.container)) {
-    for (let i = 0; i < this.container.length; i++) {
-      if (this.container[i] === this.node) {
-        _setKey.call(this, i);
-        return;
+    let key: string | number = -1;
+    if (Array.isArray(this.container)) {
+      key = this.container.indexOf(this.node!);
+    } else {
+      for (key of Object.keys(this.container)) {
+        if (this.container[key as keyof typeof this.container] === this.node) {
+          break;
+        }
       }
     }
-  } else {
-    for (const key of Object.keys(this.container)) {
-      // @ts-expect-error this.key should present in this.container
-      if (this.container[key] === this.node) {
-        _setKey.call(this, key);
-        return;
-      }
+    if (key === -1) {
+      // ¯\_(ツ)_/¯ who knows where it's gone lol
+      this.key = null;
+    } else {
+      _setKey.call(this, key);
     }
   }
-
-  // ¯\_(ツ)_/¯ who knows where it's gone lol
-  this.key = null;
-}
-
-function _resyncList(this: NodePath<t.Node | null>) {
-  if (!this.parent || !this.inList) return;
-
-  const newContainer =
-    // @ts-expect-error this.listKey should present in this.parent
-    this.parent[this.listKey];
-  if (this.container === newContainer) return;
-
-  // container is out of sync. this is likely the result of it being reassigned
-  this.container = newContainer || null;
 }
 
 export function popContext(this: NodePath<t.Node | null>) {

--- a/packages/babel-traverse/src/path/family.ts
+++ b/packages/babel-traverse/src/path/family.ts
@@ -445,7 +445,7 @@ function get(
 
 export { get };
 
-export function _getKey<T extends t.Node>(
+function _getKey<T extends t.Node>(
   this: NodePath<T>,
   key: keyof T & string,
   context?: TraversalContext,
@@ -474,7 +474,7 @@ export function _getKey<T extends t.Node>(
   }
 }
 
-export function _getPattern(
+function _getPattern(
   this: NodePath,
   parts: string[],
   context?: TraversalContext,

--- a/packages/babel-traverse/src/path/inference/index.ts
+++ b/packages/babel-traverse/src/path/inference/index.ts
@@ -52,7 +52,7 @@ const typeAnnotationInferringNodes = new WeakSet();
  * todo: split up this method
  */
 
-export function _getTypeAnnotation(this: NodePath<t.Node | null>): any {
+function _getTypeAnnotation(this: NodePath<t.Node | null>): any {
   const node = this.node;
 
   if (!node) {

--- a/packages/babel-traverse/src/path/introspection.ts
+++ b/packages/babel-traverse/src/path/introspection.ts
@@ -506,7 +506,7 @@ export function resolve(
   return _resolve.call(this, dangerous, resolved) || this;
 }
 
-export function _resolve(
+function _resolve(
   this: NodePath,
   dangerous?: boolean,
   resolved?: NodePath[],

--- a/packages/babel-traverse/src/path/introspection.ts
+++ b/packages/babel-traverse/src/path/introspection.ts
@@ -502,18 +502,10 @@ export function resolve(
   this: NodePath,
   dangerous?: boolean,
   resolved?: NodePath[],
-) {
-  return _resolve.call(this, dangerous, resolved) || this;
-}
-
-function _resolve(
-  this: NodePath,
-  dangerous?: boolean,
-  resolved?: NodePath[],
-): NodePath | undefined | null {
+): NodePath {
   // detect infinite recursion
   // todo: possibly have a max length on this just to be safe
-  if (resolved?.includes(this)) return;
+  if (resolved?.includes(this)) return this;
 
   // we store all the paths we've "resolved" in this array to prevent infinite recursion
   resolved = resolved || [];
@@ -528,18 +520,18 @@ function _resolve(
     }
   } else if (this.isReferencedIdentifier()) {
     const binding = this.scope.getBinding(this.node.name);
-    if (!binding) return;
+    if (!binding) return this;
 
     // reassigned so we can't really resolve it
-    if (!binding.constant) return;
+    if (!binding.constant) return this;
 
     // todo - lookup module in dependency graph
-    if (binding.kind === "module") return;
+    if (binding.kind === "module") return this;
 
     if (binding.path !== this) {
       const ret = binding.path.resolve(dangerous, resolved);
       // If the identifier resolves to parent node then we can't really resolve it.
-      if (this.find(parent => parent.node === ret.node)) return;
+      if (this.find(parent => parent.node === ret.node)) return this;
       return ret;
     }
   } else if (this.isTypeCastExpression()) {
@@ -550,7 +542,7 @@ function _resolve(
     // making this resolution inaccurate
 
     const targetKey = toComputedKey(this.node);
-    if (!isLiteral(targetKey)) return;
+    if (!isLiteral(targetKey)) return this;
 
     // @ts-expect-error todo(flow->ts): NullLiteral
     const targetName = targetKey.value;
@@ -580,6 +572,8 @@ function _resolve(
       if (elem) return elem.resolve(dangerous, resolved);
     }
   }
+
+  return this;
 }
 
 export function isConstantExpression(this: NodePath<t.Node | null>): boolean {

--- a/packages/babel-traverse/src/path/lib/removal-hooks.ts
+++ b/packages/babel-traverse/src/path/lib/removal-hooks.ts
@@ -1,9 +1,9 @@
-// this file contains hooks that handle ancestry cleanup of parent nodes when removing children
-
 import type NodePath from "../index.ts";
 import type * as t from "@babel/types";
+
 /**
- * Pre hooks should be used for either rejecting removal or delegating removal
+ * Hooks for custom removal logic for specific node types, that handle
+ * ancestry cleanup of parent nodes when removing children.
  */
 
 export const hooks = [

--- a/packages/babel-traverse/src/path/modification.ts
+++ b/packages/babel-traverse/src/path/modification.ts
@@ -89,7 +89,7 @@ export function insertBefore<Nodes extends NodeOrNodeList<t.Node>>(
   }
 }
 
-export function _containerInsert<Nodes extends NodeList<t.Node>>(
+function _containerInsert<Nodes extends NodeList<t.Node>>(
   this: NodePath<t.Node | null>,
   from: number,
   nodes: Nodes,
@@ -124,7 +124,7 @@ export function _containerInsert<Nodes extends NodeList<t.Node>>(
   return paths as NodePaths<Nodes>;
 }
 
-export function _containerInsertBefore<Nodes extends NodeList<t.Node>>(
+function _containerInsertBefore<Nodes extends NodeList<t.Node>>(
   this: NodePath<t.Node | null>,
   nodes: Nodes,
 ): NodePaths<Nodes> {

--- a/packages/babel-traverse/src/path/removal.ts
+++ b/packages/babel-traverse/src/path/removal.ts
@@ -28,13 +28,13 @@ export function remove(this: NodePath<t.Node | null>) {
   _markRemoved.call(this);
 }
 
-export function _removeFromScope(this: NodePath<t.Node | null>) {
+function _removeFromScope(this: NodePath<t.Node | null>) {
   if (!this.node) return;
   const bindings = t.getBindingIdentifiers(this.node, false, false, true);
   Object.keys(bindings).forEach(name => this.scope.removeBinding(name));
 }
 
-export function _callRemovalHooks(this: NodePath<t.Node | null>) {
+function _callRemovalHooks(this: NodePath<t.Node | null>) {
   if (this.parentPath) {
     for (const fn of hooks) {
       if (fn(this as NodePath<t.Node>, this.parentPath)) return true;
@@ -42,7 +42,7 @@ export function _callRemovalHooks(this: NodePath<t.Node | null>) {
   }
 }
 
-export function _remove(this: NodePath<t.Node | null>) {
+function _remove(this: NodePath<t.Node | null>) {
   if (Array.isArray(this.container)) {
     this.container.splice(this.key as number, 1);
     updateSiblingKeys.call(this, this.key as number, -1);

--- a/packages/babel-traverse/src/path/removal.ts
+++ b/packages/babel-traverse/src/path/removal.ts
@@ -14,49 +14,31 @@ export function remove(this: NodePath<t.Node | null>) {
 
   resync.call(this);
 
-  if (_callRemovalHooks.call(this)) {
-    _markRemoved.call(this);
-    return;
-  }
+  const handledByHook =
+    this.parentPath &&
+    hooks.some(fn => fn(this as NodePath<t.Node>, this.parentPath));
 
-  if (!this.opts?.noScope) {
-    _removeFromScope.call(this);
-  }
+  if (!handledByHook) {
+    if (this.node && !this.opts?.noScope) {
+      // Remove scope information relative to this node
+      const bindings = t.getBindingIdentifiers(this.node, false, false, true);
+      Object.keys(bindings).forEach(name => this.scope.removeBinding(name));
+    }
 
-  this.shareCommentsWithSiblings();
-  _remove.call(this);
-  _markRemoved.call(this);
-}
+    this.shareCommentsWithSiblings();
 
-function _removeFromScope(this: NodePath<t.Node | null>) {
-  if (!this.node) return;
-  const bindings = t.getBindingIdentifiers(this.node, false, false, true);
-  Object.keys(bindings).forEach(name => this.scope.removeBinding(name));
-}
-
-function _callRemovalHooks(this: NodePath<t.Node | null>) {
-  if (this.parentPath) {
-    for (const fn of hooks) {
-      if (fn(this as NodePath<t.Node>, this.parentPath)) return true;
+    if (Array.isArray(this.container)) {
+      this.container.splice(this.key as number, 1);
+      updateSiblingKeys.call(this, this.key as number, -1);
+    } else {
+      _replaceWith.call(this, null);
     }
   }
-}
 
-function _remove(this: NodePath<t.Node | null>) {
-  if (Array.isArray(this.container)) {
-    this.container.splice(this.key as number, 1);
-    updateSiblingKeys.call(this, this.key as number, -1);
-  } else {
-    _replaceWith.call(this, null);
-  }
-}
-
-export function _markRemoved(this: NodePath<t.Node | null>) {
-  // this.shouldSkip = true; this.removed = true;
+  // Mark the path as removed.
   this._traverseFlags |= SHOULD_SKIP | REMOVED;
   if (this.parent) {
-    // @ts-expect-error TODO: better types
-    getCachedPaths(this)?.delete(this.node);
+    getCachedPaths(this)?.delete(this.node!);
   }
   this.node = null;
 }

--- a/packages/babel-types/src/definitions/core.ts
+++ b/packages/babel-types/src/definitions/core.ts
@@ -71,7 +71,7 @@ export const classMethodOrPropertyUnionShapeCommon = (
   },
 });
 
-export const memberExpressionUnionShapeCommon = {
+const memberExpressionUnionShapeCommon = {
   unionShape: {
     discriminator: "computed",
     shapes: [
@@ -428,7 +428,7 @@ defineType("ForStatement", {
   },
 });
 
-export const functionCommon = () => ({
+const functionCommon = () => ({
   params: validateArrayOfType("FunctionParameter"),
   generator: {
     default: false,
@@ -438,7 +438,7 @@ export const functionCommon = () => ({
   },
 });
 
-export const functionTypeAnnotationCommon = () => ({
+const functionTypeAnnotationCommon = () => ({
   returnType: {
     validate: assertNodeType("TypeAnnotation", "TSTypeAnnotation"),
 

--- a/packages/babel-types/src/definitions/utils.ts
+++ b/packages/babel-types/src/definitions/utils.ts
@@ -56,25 +56,25 @@ export type ValidatorImpl<T extends t.Node> = (
   val: any,
 ) => void;
 
-export type ValidatorType<T extends t.Node> = {
+type ValidatorType<T extends t.Node> = {
   type: PrimitiveTypes;
 } & ValidatorImpl<T>;
-export type ValidatorEach<T extends t.Node> = {
+type ValidatorEach<T extends t.Node> = {
   each: Validator<T>;
 } & ValidatorImpl<T>;
-export type ValidatorChainOf<T extends t.Node> = {
+type ValidatorChainOf<T extends t.Node> = {
   chainOf: readonly Validator<T>[];
 } & ValidatorImpl<T>;
-export type ValidatorOneOf<T extends t.Node> = {
+type ValidatorOneOf<T extends t.Node> = {
   oneOf: readonly any[];
 } & ValidatorImpl<T>;
-export type ValidatorOneOfNodeTypes<T extends t.Node> = {
+type ValidatorOneOfNodeTypes<T extends t.Node> = {
   oneOfNodeTypes: readonly NodeTypes[];
 } & ValidatorImpl<T>;
-export type ValidatorOneOfNodeOrValueTypes<T extends t.Node> = {
+type ValidatorOneOfNodeOrValueTypes<T extends t.Node> = {
   oneOfNodeOrValueTypes: readonly (NodeTypes | PrimitiveTypes)[];
 } & ValidatorImpl<T>;
-export type ValidatorShapeOf<T extends t.Node> = {
+type ValidatorShapeOf<T extends t.Node> = {
   shapeOf: Record<string, FieldOptions<T>>;
 } & ValidatorImpl<T>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4138,31 +4138,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:1.10.0, @emnapi/core@npm:^1.4.3":
-  version: 1.10.0
-  resolution: "@emnapi/core@npm:1.10.0"
+"@emnapi/core@npm:1.11.2, @emnapi/core@npm:^1.4.3":
+  version: 1.11.2
+  resolution: "@emnapi/core@npm:1.11.2"
   dependencies:
-    "@emnapi/wasi-threads": "npm:1.2.1"
+    "@emnapi/wasi-threads": "npm:1.2.2"
     tslib: "npm:^2.4.0"
-  checksum: 10/d32f386084e64deaf2609aabb8295d1ad5af6144d0f46d2060b76cc53f1f3b486df54bec9b0f33c37d85a3822e1193ebcd4e3deb4a5f0e4cd650aa2ffc631715
+  checksum: 10/b3e9693f79ca1d8bb90cb8a950150c7738f54eca0ae1849d3d5103a87ce4e388c2669fb253cc123d3449ad2ae12583435455dbdc0270b1e9efb0cfd502c952b4
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:1.10.0, @emnapi/runtime@npm:^1.4.3":
-  version: 1.10.0
-  resolution: "@emnapi/runtime@npm:1.10.0"
+"@emnapi/runtime@npm:1.11.2, @emnapi/runtime@npm:^1.4.3":
+  version: 1.11.2
+  resolution: "@emnapi/runtime@npm:1.11.2"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10/d21083d07fa0c2da171c142e78ef986b66b07d45b06accc0bcaf49fcc61bb4dbc10e1c1760813070165b9f49b054376a931045347f21c0f42ff1eb2d2040faac
+  checksum: 10/280a219d3bf302615dabaaa248223b0e5fe9c49bacf0987dd958ca37ab425b62cf05287053cb188e711681418aaa5e447eaed6b62a0848c0a1303b2707864600
   languageName: node
   linkType: hard
 
-"@emnapi/wasi-threads@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@emnapi/wasi-threads@npm:1.2.1"
+"@emnapi/wasi-threads@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@emnapi/wasi-threads@npm:1.2.2"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10/57cd4292be81c05d26aa886d68a9e4c449ff666e8503fed6463dfc6b64a4e4213f03c152d53296b7cda32840271e38cd33347332070658f01befeb9bf4e59f36
+  checksum: 10/297fb6b1d89744bd0b41d5fec32bade05dc8dcf1f70eba86527226609fb3f6ad3fa96b3b2377b7449709715b3bd1569654c9def1dbbc85fb6b9cb0cff5bc5ebf
   languageName: node
   linkType: hard
 
@@ -4932,15 +4932,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^1.1.1, @napi-rs/wasm-runtime@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
+"@napi-rs/wasm-runtime@npm:^1.1.6":
+  version: 1.2.4
+  resolution: "@napi-rs/wasm-runtime@npm:1.2.4"
   dependencies:
-    "@tybys/wasm-util": "npm:^0.10.1"
+    "@tybys/wasm-util": "npm:^0.10.3"
   peerDependencies:
-    "@emnapi/core": ^1.7.1
-    "@emnapi/runtime": ^1.7.1
-  checksum: 10/1db3dc7eeb981306b09360487bd8ce4dfa5588d273bd8ea9f07dccca1b4ade57b675414180fc9bb66966c6c50b17208b0263194993e2f7f92cc7af28bda4d1af
+    "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.4
+    "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.4
+  checksum: 10/5cda52f943c67eba1875d95dc7ea0dbe2c1581edb25660d3b0d780d7d87600bdaf92b4f4395e3cde82a9ccfb540da55567452e6e6d61fb13b7f51da7a3ad9151
   languageName: node
   linkType: hard
 
@@ -5235,295 +5235,279 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-android-arm-eabi@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-android-arm-eabi@npm:0.130.0"
+"@oxc-parser/binding-android-arm-eabi@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-android-arm-eabi@npm:0.148.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-android-arm64@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-android-arm64@npm:0.130.0"
+"@oxc-parser/binding-android-arm64@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-android-arm64@npm:0.148.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-darwin-arm64@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-darwin-arm64@npm:0.130.0"
+"@oxc-parser/binding-darwin-arm64@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-darwin-arm64@npm:0.148.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-darwin-x64@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-darwin-x64@npm:0.130.0"
+"@oxc-parser/binding-darwin-x64@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-darwin-x64@npm:0.148.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-freebsd-x64@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-freebsd-x64@npm:0.130.0"
+"@oxc-parser/binding-freebsd-x64@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-freebsd-x64@npm:0.148.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-arm-gnueabihf@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-linux-arm-gnueabihf@npm:0.130.0"
+"@oxc-parser/binding-linux-arm-gnueabihf@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-linux-arm-gnueabihf@npm:0.148.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-arm-musleabihf@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-linux-arm-musleabihf@npm:0.130.0"
+"@oxc-parser/binding-linux-arm-musleabihf@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-linux-arm-musleabihf@npm:0.148.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-arm64-gnu@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-linux-arm64-gnu@npm:0.130.0"
+"@oxc-parser/binding-linux-arm64-gnu@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-linux-arm64-gnu@npm:0.148.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-arm64-musl@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-linux-arm64-musl@npm:0.130.0"
+"@oxc-parser/binding-linux-arm64-musl@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-linux-arm64-musl@npm:0.148.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-ppc64-gnu@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-linux-ppc64-gnu@npm:0.130.0"
+"@oxc-parser/binding-linux-ppc64-gnu@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-linux-ppc64-gnu@npm:0.148.0"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-riscv64-gnu@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-linux-riscv64-gnu@npm:0.130.0"
+"@oxc-parser/binding-linux-riscv64-gnu@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-linux-riscv64-gnu@npm:0.148.0"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-riscv64-musl@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-linux-riscv64-musl@npm:0.130.0"
+"@oxc-parser/binding-linux-riscv64-musl@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-linux-riscv64-musl@npm:0.148.0"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-s390x-gnu@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-linux-s390x-gnu@npm:0.130.0"
+"@oxc-parser/binding-linux-s390x-gnu@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-linux-s390x-gnu@npm:0.148.0"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-x64-gnu@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-linux-x64-gnu@npm:0.130.0"
+"@oxc-parser/binding-linux-x64-gnu@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-linux-x64-gnu@npm:0.148.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-x64-musl@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-linux-x64-musl@npm:0.130.0"
+"@oxc-parser/binding-linux-x64-musl@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-linux-x64-musl@npm:0.148.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-openharmony-arm64@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-openharmony-arm64@npm:0.130.0"
+"@oxc-parser/binding-openharmony-arm64@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-openharmony-arm64@npm:0.148.0"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-wasm32-wasi@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-wasm32-wasi@npm:0.130.0"
-  dependencies:
-    "@emnapi/core": "npm:1.10.0"
-    "@emnapi/runtime": "npm:1.10.0"
-    "@napi-rs/wasm-runtime": "npm:^1.1.4"
-  conditions: cpu=wasm32
-  languageName: node
-  linkType: hard
-
-"@oxc-parser/binding-win32-arm64-msvc@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-win32-arm64-msvc@npm:0.130.0"
+"@oxc-parser/binding-win32-arm64-msvc@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-win32-arm64-msvc@npm:0.148.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-win32-ia32-msvc@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-win32-ia32-msvc@npm:0.130.0"
+"@oxc-parser/binding-win32-ia32-msvc@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-win32-ia32-msvc@npm:0.148.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-win32-x64-msvc@npm:0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-parser/binding-win32-x64-msvc@npm:0.130.0"
+"@oxc-parser/binding-win32-x64-msvc@npm:0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-parser/binding-win32-x64-msvc@npm:0.148.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@oxc-project/types@npm:^0.130.0":
-  version: 0.130.0
-  resolution: "@oxc-project/types@npm:0.130.0"
-  checksum: 10/5f12923f32a3a9fdc8f26a275d10233a3d482e708d2035298a62b72aaa3857d26b5f16b2bea32896789d26bf61798fb22730f8e1cb37725a1951ad324526344f
+"@oxc-project/types@npm:^0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-project/types@npm:0.148.0"
+  checksum: 10/835b0479161cd80c7dee653b77d31f6d5239e20530cda8a10466bcbb17de08363777939c29670e82fb9d9eca89dc49030e50742051418d987ec70f62faa3317b
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-android-arm-eabi@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.19.1"
+"@oxc-resolver/binding-android-arm-eabi@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.24.2"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-android-arm64@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-android-arm64@npm:11.19.1"
+"@oxc-resolver/binding-android-arm64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-android-arm64@npm:11.24.2"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-darwin-arm64@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-darwin-arm64@npm:11.19.1"
+"@oxc-resolver/binding-darwin-arm64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-darwin-arm64@npm:11.24.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-darwin-x64@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-darwin-x64@npm:11.19.1"
+"@oxc-resolver/binding-darwin-x64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-darwin-x64@npm:11.24.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-freebsd-x64@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-freebsd-x64@npm:11.19.1"
+"@oxc-resolver/binding-freebsd-x64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-freebsd-x64@npm:11.24.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.19.1"
+"@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.24.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-arm-musleabihf@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.19.1"
+"@oxc-resolver/binding-linux-arm-musleabihf@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.24.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-arm64-gnu@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:11.19.1"
+"@oxc-resolver/binding-linux-arm64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:11.24.2"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-arm64-musl@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-linux-arm64-musl@npm:11.19.1"
+"@oxc-resolver/binding-linux-arm64-musl@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-arm64-musl@npm:11.24.2"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-ppc64-gnu@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.19.1"
+"@oxc-resolver/binding-linux-ppc64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.24.2"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-riscv64-gnu@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.19.1"
+"@oxc-resolver/binding-linux-riscv64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.24.2"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-riscv64-musl@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-linux-riscv64-musl@npm:11.19.1"
+"@oxc-resolver/binding-linux-riscv64-musl@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-riscv64-musl@npm:11.24.2"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-s390x-gnu@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-linux-s390x-gnu@npm:11.19.1"
+"@oxc-resolver/binding-linux-s390x-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-s390x-gnu@npm:11.24.2"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-x64-gnu@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:11.19.1"
+"@oxc-resolver/binding-linux-x64-gnu@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:11.24.2"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-linux-x64-musl@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-linux-x64-musl@npm:11.19.1"
+"@oxc-resolver/binding-linux-x64-musl@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-linux-x64-musl@npm:11.24.2"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-openharmony-arm64@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-openharmony-arm64@npm:11.19.1"
+"@oxc-resolver/binding-openharmony-arm64@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-openharmony-arm64@npm:11.24.2"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-wasm32-wasi@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-wasm32-wasi@npm:11.19.1"
+"@oxc-resolver/binding-wasm32-wasi@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-wasm32-wasi@npm:11.24.2"
   dependencies:
-    "@napi-rs/wasm-runtime": "npm:^1.1.1"
+    "@emnapi/core": "npm:1.11.2"
+    "@emnapi/runtime": "npm:1.11.2"
+    "@napi-rs/wasm-runtime": "npm:^1.1.6"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-win32-arm64-msvc@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:11.19.1"
+"@oxc-resolver/binding-win32-arm64-msvc@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:11.24.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxc-resolver/binding-win32-ia32-msvc@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-win32-ia32-msvc@npm:11.19.1"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@oxc-resolver/binding-win32-x64-msvc@npm:11.19.1":
-  version: 11.19.1
-  resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.19.1"
+"@oxc-resolver/binding-win32-x64-msvc@npm:11.24.2":
+  version: 11.24.2
+  resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.24.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -6003,12 +5987,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tybys/wasm-util@npm:^0.10.0, @tybys/wasm-util@npm:^0.10.1":
-  version: 0.10.2
-  resolution: "@tybys/wasm-util@npm:0.10.2"
+"@tybys/wasm-util@npm:^0.10.0, @tybys/wasm-util@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@tybys/wasm-util@npm:0.10.3"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10/d12f1dafe12d7a573c406b35ffef0038042b9cc9fbcc74d657267eb635499b956276afc05eebdbd81bea582e1c4c921421a1dd7243a93daaa8c8216b19395c23
+  checksum: 10/6cf39f7a2926b1c8bc6fe3f9f03318a33dd6dae81bdbd059983f9c6ee22d10a827f12564d648c05a2d4926e03c86cbe2799fb20609ee65e9efc39603039b4765
   languageName: node
   linkType: hard
 
@@ -7637,7 +7621,7 @@ __metadata:
     jest-light-runner: "npm:^0.7.12"
     jest-worker: "npm:^30.4.1"
     json5: "npm:^2.2.3"
-    knip: "npm:^6.14.2"
+    knip: "npm:^6.35.1"
     lint-staged: "npm:^17.0.0"
     mergeiterator: "npm:^1.4.4"
     open: "npm:^11.0.0"
@@ -10531,14 +10515,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"formatly@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "formatly@npm:0.3.0"
+"formatly@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "formatly@npm:0.7.0"
   dependencies:
     fd-package-json: "npm:^2.0.0"
+    package-manager-detector: "npm:^1.8.0"
   bin:
     formatly: bin/index.mjs
-  checksum: 10/0e5a9cbb826d93171b00c283e20e6a564a16e7bc3839e695790347a1f23e3536a88d613f5cabd07403d60b7bdffe179987c88b1fc2900a9be49eea01ffbe4244
+  checksum: 10/ceb4183c1ea114cbb6535106bcc4532f66eb2428bc3a035f09c88eda020aee555c64a40b4312bac6a2b647e500b9032f35a8dece54162f0e5b272f2f20700af1
   languageName: node
   linkType: hard
 
@@ -10782,12 +10767,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:4.14.0, get-tsconfig@npm:^4.8.1":
-  version: 4.14.0
-  resolution: "get-tsconfig@npm:4.14.0"
+"get-tsconfig@npm:4.14.3, get-tsconfig@npm:^4.8.1":
+  version: 4.14.3
+  resolution: "get-tsconfig@npm:4.14.3"
   dependencies:
     resolve-pkg-maps: "npm:^1.0.0"
-  checksum: 10/f5626971905ca386c9ddeb302504e8a2301b9c05641803267223ebd50b7c81aaf9324d29cf9f4e4ff3f245632c3392aa83719dc6cb3e98b4e4a1702a27c5cc5d
+  checksum: 10/ac18243ffd5c2e7c0cbecc11d053599c73a4c534a626988fe545b686695bf2fa789ba47bc2af87e30d85c657dbcadc26b4e3e328096894fde6a9229615c67253
   languageName: node
   linkType: hard
 
@@ -12883,28 +12868,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"knip@npm:^6.14.2":
-  version: 6.14.2
-  resolution: "knip@npm:6.14.2"
+"knip@npm:^6.35.1":
+  version: 6.35.1
+  resolution: "knip@npm:6.35.1"
   dependencies:
     fdir: "npm:^6.5.0"
-    formatly: "npm:^0.3.0"
-    get-tsconfig: "npm:4.14.0"
+    formatly: "npm:^0.7.0"
+    get-tsconfig: "npm:4.14.3"
     jiti: "npm:^2.7.0"
-    minimist: "npm:^1.2.8"
-    oxc-parser: "npm:^0.130.0"
-    oxc-resolver: "npm:^11.19.1"
-    picomatch: "npm:^4.0.4"
-    smol-toml: "npm:^1.6.1"
+    oxc-parser: "npm:^0.148.0"
+    oxc-resolver: "npm:11.24.2"
+    picomatch: "npm:^4.0.7"
+    smol-toml: "npm:^1.8.0"
     strip-json-comments: "npm:5.0.3"
-    tinyglobby: "npm:^0.2.16"
-    unbash: "npm:^3.0.0"
+    tinyglobby: "npm:^0.2.17"
+    unbash: "npm:^4.0.11"
     yaml: "npm:^2.9.0"
-    zod: "npm:^4.1.11"
+    zod: "npm:^4.4.3"
   bin:
     knip: bin/knip.js
     knip-bun: bin/knip-bun.js
-  checksum: 10/0c5e5aafc1242499fd2e3799da4b126733e03f83a70a682cb1c4d2244ae7b0518f3d258d066cfaa4c610a59684b6b999563d3c471e488515fce33c9269d1ecd7
+  checksum: 10/9f1cf5eafcbe685c58440c6d306ba2f7fdafb4fc835511455be800a698ecd0071eda90f7183bd2749086da46a062460292a52c2162225f1114371f8b606d4066
   languageName: node
   linkType: hard
 
@@ -13433,7 +13417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.6":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10/908491b6cc15a6c440ba5b22780a0ba89b9810e1aea684e253e43c4e3b8d56ec1dcdd7ea96dde119c29df59c936cde16062159eae4225c691e19c70b432b6e6f
@@ -14050,31 +14034,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oxc-parser@npm:^0.130.0":
-  version: 0.130.0
-  resolution: "oxc-parser@npm:0.130.0"
+"oxc-parser@npm:^0.148.0":
+  version: 0.148.0
+  resolution: "oxc-parser@npm:0.148.0"
   dependencies:
-    "@oxc-parser/binding-android-arm-eabi": "npm:0.130.0"
-    "@oxc-parser/binding-android-arm64": "npm:0.130.0"
-    "@oxc-parser/binding-darwin-arm64": "npm:0.130.0"
-    "@oxc-parser/binding-darwin-x64": "npm:0.130.0"
-    "@oxc-parser/binding-freebsd-x64": "npm:0.130.0"
-    "@oxc-parser/binding-linux-arm-gnueabihf": "npm:0.130.0"
-    "@oxc-parser/binding-linux-arm-musleabihf": "npm:0.130.0"
-    "@oxc-parser/binding-linux-arm64-gnu": "npm:0.130.0"
-    "@oxc-parser/binding-linux-arm64-musl": "npm:0.130.0"
-    "@oxc-parser/binding-linux-ppc64-gnu": "npm:0.130.0"
-    "@oxc-parser/binding-linux-riscv64-gnu": "npm:0.130.0"
-    "@oxc-parser/binding-linux-riscv64-musl": "npm:0.130.0"
-    "@oxc-parser/binding-linux-s390x-gnu": "npm:0.130.0"
-    "@oxc-parser/binding-linux-x64-gnu": "npm:0.130.0"
-    "@oxc-parser/binding-linux-x64-musl": "npm:0.130.0"
-    "@oxc-parser/binding-openharmony-arm64": "npm:0.130.0"
-    "@oxc-parser/binding-wasm32-wasi": "npm:0.130.0"
-    "@oxc-parser/binding-win32-arm64-msvc": "npm:0.130.0"
-    "@oxc-parser/binding-win32-ia32-msvc": "npm:0.130.0"
-    "@oxc-parser/binding-win32-x64-msvc": "npm:0.130.0"
-    "@oxc-project/types": "npm:^0.130.0"
+    "@oxc-parser/binding-android-arm-eabi": "npm:0.148.0"
+    "@oxc-parser/binding-android-arm64": "npm:0.148.0"
+    "@oxc-parser/binding-darwin-arm64": "npm:0.148.0"
+    "@oxc-parser/binding-darwin-x64": "npm:0.148.0"
+    "@oxc-parser/binding-freebsd-x64": "npm:0.148.0"
+    "@oxc-parser/binding-linux-arm-gnueabihf": "npm:0.148.0"
+    "@oxc-parser/binding-linux-arm-musleabihf": "npm:0.148.0"
+    "@oxc-parser/binding-linux-arm64-gnu": "npm:0.148.0"
+    "@oxc-parser/binding-linux-arm64-musl": "npm:0.148.0"
+    "@oxc-parser/binding-linux-ppc64-gnu": "npm:0.148.0"
+    "@oxc-parser/binding-linux-riscv64-gnu": "npm:0.148.0"
+    "@oxc-parser/binding-linux-riscv64-musl": "npm:0.148.0"
+    "@oxc-parser/binding-linux-s390x-gnu": "npm:0.148.0"
+    "@oxc-parser/binding-linux-x64-gnu": "npm:0.148.0"
+    "@oxc-parser/binding-linux-x64-musl": "npm:0.148.0"
+    "@oxc-parser/binding-openharmony-arm64": "npm:0.148.0"
+    "@oxc-parser/binding-win32-arm64-msvc": "npm:0.148.0"
+    "@oxc-parser/binding-win32-ia32-msvc": "npm:0.148.0"
+    "@oxc-parser/binding-win32-x64-msvc": "npm:0.148.0"
+    "@oxc-project/types": "npm:^0.148.0"
   dependenciesMeta:
     "@oxc-parser/binding-android-arm-eabi":
       optional: true
@@ -14108,42 +14091,39 @@ __metadata:
       optional: true
     "@oxc-parser/binding-openharmony-arm64":
       optional: true
-    "@oxc-parser/binding-wasm32-wasi":
-      optional: true
     "@oxc-parser/binding-win32-arm64-msvc":
       optional: true
     "@oxc-parser/binding-win32-ia32-msvc":
       optional: true
     "@oxc-parser/binding-win32-x64-msvc":
       optional: true
-  checksum: 10/4f1630db8d855627b5237fcf78ea6540ddf8cf7cfb764fca8c045980ac24672c8693998ff74783be53285ba0892afe321fdd0b70e61609c405fcb53df1fa13ed
+  checksum: 10/452fe0114afe61198f05a4e15acb60047167eb485958b6d66b98bb3c6bf968cf67c928737ab97b64824c27916835744a504d9f6e546b65fc0e76b48800f9fc51
   languageName: node
   linkType: hard
 
-"oxc-resolver@npm:^11.19.1":
-  version: 11.19.1
-  resolution: "oxc-resolver@npm:11.19.1"
+"oxc-resolver@npm:11.24.2":
+  version: 11.24.2
+  resolution: "oxc-resolver@npm:11.24.2"
   dependencies:
-    "@oxc-resolver/binding-android-arm-eabi": "npm:11.19.1"
-    "@oxc-resolver/binding-android-arm64": "npm:11.19.1"
-    "@oxc-resolver/binding-darwin-arm64": "npm:11.19.1"
-    "@oxc-resolver/binding-darwin-x64": "npm:11.19.1"
-    "@oxc-resolver/binding-freebsd-x64": "npm:11.19.1"
-    "@oxc-resolver/binding-linux-arm-gnueabihf": "npm:11.19.1"
-    "@oxc-resolver/binding-linux-arm-musleabihf": "npm:11.19.1"
-    "@oxc-resolver/binding-linux-arm64-gnu": "npm:11.19.1"
-    "@oxc-resolver/binding-linux-arm64-musl": "npm:11.19.1"
-    "@oxc-resolver/binding-linux-ppc64-gnu": "npm:11.19.1"
-    "@oxc-resolver/binding-linux-riscv64-gnu": "npm:11.19.1"
-    "@oxc-resolver/binding-linux-riscv64-musl": "npm:11.19.1"
-    "@oxc-resolver/binding-linux-s390x-gnu": "npm:11.19.1"
-    "@oxc-resolver/binding-linux-x64-gnu": "npm:11.19.1"
-    "@oxc-resolver/binding-linux-x64-musl": "npm:11.19.1"
-    "@oxc-resolver/binding-openharmony-arm64": "npm:11.19.1"
-    "@oxc-resolver/binding-wasm32-wasi": "npm:11.19.1"
-    "@oxc-resolver/binding-win32-arm64-msvc": "npm:11.19.1"
-    "@oxc-resolver/binding-win32-ia32-msvc": "npm:11.19.1"
-    "@oxc-resolver/binding-win32-x64-msvc": "npm:11.19.1"
+    "@oxc-resolver/binding-android-arm-eabi": "npm:11.24.2"
+    "@oxc-resolver/binding-android-arm64": "npm:11.24.2"
+    "@oxc-resolver/binding-darwin-arm64": "npm:11.24.2"
+    "@oxc-resolver/binding-darwin-x64": "npm:11.24.2"
+    "@oxc-resolver/binding-freebsd-x64": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-arm-gnueabihf": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-arm-musleabihf": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-arm64-gnu": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-arm64-musl": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-ppc64-gnu": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-riscv64-gnu": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-riscv64-musl": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-s390x-gnu": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-x64-gnu": "npm:11.24.2"
+    "@oxc-resolver/binding-linux-x64-musl": "npm:11.24.2"
+    "@oxc-resolver/binding-openharmony-arm64": "npm:11.24.2"
+    "@oxc-resolver/binding-wasm32-wasi": "npm:11.24.2"
+    "@oxc-resolver/binding-win32-arm64-msvc": "npm:11.24.2"
+    "@oxc-resolver/binding-win32-x64-msvc": "npm:11.24.2"
   dependenciesMeta:
     "@oxc-resolver/binding-android-arm-eabi":
       optional: true
@@ -14181,11 +14161,9 @@ __metadata:
       optional: true
     "@oxc-resolver/binding-win32-arm64-msvc":
       optional: true
-    "@oxc-resolver/binding-win32-ia32-msvc":
-      optional: true
     "@oxc-resolver/binding-win32-x64-msvc":
       optional: true
-  checksum: 10/a6c8fdb2ef4bf9bb84f28e58685457de427d31f74373c0fbd6d1106010cab33027fa3b4336b1b86d0df0a089cd73a6060b730b1b24974d56c59f6fa29c559f9d
+  checksum: 10/42e10840125f4b942a7cbcad757f1d882eb737cd6c96c13128eade6613c56a24727075e069b3dff145b3cd36e21fe5e4a1de19b5da09466864fa63d35aae71f3
   languageName: node
   linkType: hard
 
@@ -14305,10 +14283,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"package-manager-detector@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "package-manager-detector@npm:1.6.0"
-  checksum: 10/b38a9532198cefdb98a1b7131c42cbffa55d8b997d6117811cf83f00079fd57a572db2aa5e3db5e36bcd0af84d0bec5a7d6251142427314390ed99a3d76cd0a0
+"package-manager-detector@npm:^1.6.0, package-manager-detector@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "package-manager-detector@npm:1.8.0"
+  checksum: 10/5d79b8bf3d0d3da312ec08749c74a3b7e4d4139c259fe3561538772c65ece8ff733e002c67a4324b5c505d2ac625c121b94cf3d5135e1b4e43fed5bced148763
   languageName: node
   linkType: hard
 
@@ -14548,10 +14526,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "picomatch@npm:4.0.4"
-  checksum: 10/f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4, picomatch@npm:^4.0.7":
+  version: 4.0.7
+  resolution: "picomatch@npm:4.0.7"
+  checksum: 10/66e1df34bc39c72fa3756be4069f7887ea3e35e94bba1c3f6167763007698cb04b8a0a365161d186fda6e9571a2d3efb606b2966eb6a7dea6252911224dc2f48
   languageName: node
   linkType: hard
 
@@ -16037,10 +16015,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"smol-toml@npm:^1.6.1":
-  version: 1.6.1
-  resolution: "smol-toml@npm:1.6.1"
-  checksum: 10/9a0d86cc7f8abef429c915b373b9a1f369fe57a87efbbec46b967fb41dc28af753a2fa62c9c4848907c3b47c282be15c8854aa4e2942ef1fa86ff95a76d13856
+"smol-toml@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "smol-toml@npm:1.8.0"
+  checksum: 10/eb8aeeebd1c3e5de6069922c9a44bb40b9b3c534e685ccd0aa299b4d7307f1ec49471da57812bdbf1d21a0c09f1dd47eb0e814d0d34c892142187ccce2487ea9
   languageName: node
   linkType: hard
 
@@ -16812,13 +16790,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.16, tinyglobby@npm:^0.2.9":
-  version: 0.2.16
-  resolution: "tinyglobby@npm:0.2.16"
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17, tinyglobby@npm:^0.2.9":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
   dependencies:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.4"
-  checksum: 10/5c2c41b572ada38449e7c86a5fe034f204a1dbba577225a761a14f29f48dc3f2fc0d81a6c56fcc67c5a742cc3aa9fb5e2ca18dbf22b610b0bc0e549b34d5a0f8
+  checksum: 10/f85e8a217d675c3f78d5f0ad25ea4557e7e023ed13ddc2b014da10bd0312eea53a34cd52356af07ccdff777f1243012547656282a4ca70936f68bf5065fbaa71
   languageName: node
   linkType: hard
 
@@ -17262,10 +17240,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unbash@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "unbash@npm:3.0.0"
-  checksum: 10/935a86ce4c406af4ccae2cb4ae6fe8518761cb8a3669e1dab50031c46d3e036197ed674b0160ed7c6bcf89ec27b04be0c2b397ab2918a31bf12d55ba5991a635
+"unbash@npm:^4.0.11":
+  version: 4.0.11
+  resolution: "unbash@npm:4.0.11"
+  checksum: 10/f44bd9febbef85976623ade7c264bdf6c5b0f420f277d4ecf27a8290de49baade349254f4ef3cbbcf47c3ee3e01d64788d963b277b16ccc18aab50626fcd8a33
   languageName: node
   linkType: hard
 
@@ -18420,9 +18398,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.1.11":
-  version: 4.4.3
-  resolution: "zod@npm:4.4.3"
-  checksum: 10/804b9a42aa8f35f2b3c5a8dff906291cb749115f83ee2afe3576d70b5b5c53c965365c7f4967690647a9c54af9838ff232a85ff9577a0a36c44b68bc6cdefe36
+"zod@npm:^4.4.3":
+  version: 4.6.2
+  resolution: "zod@npm:4.6.2"
+  checksum: 10/5a89e9c364cb9982fe198736235039ea2438c7c9b9cafd639e0cb895eb30ce9ce7485d82fc940e483a048f1f9966eb3fa2a4181a1f07c17ef18a3e5c73757823
   languageName: node
   linkType: hard


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`knip` complains about a few more:
```
Unused exported types (6)
tsParseEntityNameFlags                  enum       …l-parser/src/plugins/typescript/index.ts:318:19
EstreeAccessorProperty               N  interface  packages/babel-parser/src/types.ts:292:18
EstreeTSEmptyBodyFunctionExpression  N  interface  packages/babel-parser/src/types.ts:333:18
EstreeTSAbstractPropertyDefinition   N  interface  packages/babel-parser/src/types.ts:344:18
EstreeTSAbstractAccessorProperty     N  interface  packages/babel-parser/src/types.ts:349:18
NodePath_Internal                       type       packages/babel-traverse/src/path/index.ts:423:54
```

However, removing those makes TypeScript complain with errors like
```
packages/babel-parser/src/plugin-utils.ts:146:14 - error TS4023: Exported variable 'mixinPlugins' has or is using name 'tsParseEntityNameFlags' from external module "/Users/nic/Documents/dev/github.com/babel/babel/packages/babel-parser/src/plugins/typescript/index" but cannot be named.
```

This PR is probably easier to review commit-by-commit.